### PR TITLE
docs: correct image description + document offline-RAG model fetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,12 +364,22 @@ build-edge-bundle: ## [release] 打 ADR-024 edge upgrade bundle 到 dist/out/edg
 	@mkdir -p $(OUT)/edge-bundles
 	bash dist/build-edge-bundle.sh $(VERSION) linux-amd64 $(OUT)/edge-bundles
 
+.PHONY: fetch-embedding-model
+fetch-embedding-model: ## [release] 预拉 BGE 离线嵌入模型到 .cache/（幂等；package 会把它打进 tarball）
+	bash dist/fetch-embedding-model.sh
+
 .PHONY: package
 # Order matters: fetch-* / build-edge-all populate bin/ → docker-* bake
 # the images → recipe-time we rebuild the edge bundle (because dist/out
 # gets wiped first) and only then dist/package.sh assembles the
 # release tarball that includes the bundle as a sibling of the per-arch
 # edge binaries (ADR-024).
+#
+# NB: fetch-embedding-model is intentionally NOT a dep — pulling the BGE
+# model is slow/brittle over CN networks, so it stays a one-off step.
+# For offline RAG (ONGRID_EMBEDDING_PROVIDER=local) run
+# `make fetch-embedding-model` once before `make package`, otherwise
+# dist/package.sh warns and ships a tarball without the model.
 package: fetch-promtail fetch-otelcol fetch-node-exporter fetch-process-exporter build-edge-all docker-build docker-build-broker docker-build-web ## [release] 打 release tarball 到 dist/out/
 	@rm -rf dist/stage dist/out
 	@mkdir -p dist/stage dist/out

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make build            # 或 make build-ongrid / build-ongrid-edge
 cd web && npm ci && npm run build
 ```
 
-> 云端内嵌了一个本地 ONNX embedder（CGO），所以 `ongrid` 以 `CGO_ENABLED=1` 构建。`make help` 列出全部 target。
+> 云端内嵌了一个本地 ONNX embedder（CGO），所以 `ongrid` 以 `CGO_ENABLED=1` 构建。离线 RAG（`ONGRID_EMBEDDING_PROVIDER=local`）需先跑一次 `make fetch-embedding-model` 拉 BGE 模型，否则打包/运行会回退到联网下载。`make help` 列出全部 target。
 
 ### 本地起一套（Docker Compose）
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,8 +5,8 @@ development; production-style install assets live under `deploy/install/`.
 
 ## Contents
 
-- `Dockerfile.ongrid` — multi-stage build for the cloud service (`cmd/ongrid`). Final image is distroless, static, nonroot.
-- `Dockerfile.ongrid-edge` — same pattern for the edge agent (`cmd/ongrid-edge`). Exposes `9101` only for local `/metrics` debug; the agent dials out.
+- `Dockerfile.ongrid` — multi-stage build for the cloud service (`cmd/ongrid`). Final image is `debian:bookworm-slim`, nonroot — **not** distroless/static: the cloud binary is cgo-linked because the local ONNX embedder (fastembed-go → libonnxruntime) needs glibc + libstdc++ + libgomp, and the image bundles ONNX Runtime under `ONNX_PATH`.
+- `Dockerfile.ongrid-edge` — the edge agent (`cmd/ongrid-edge`) is pure-Go (`CGO_ENABLED=0`), so *its* image is distroless + static (`gcr.io/distroless/static-debian12:nonroot`) — the opposite of the cloud image, which carries the embedder. Exposes `9101` only for local `/metrics` debug; the agent dials out.
 - `docker-compose.yml` — spins up `mysql`, `ongrid`, `frontier`, `nginx`, `prometheus`, and `grafana` on the `ongrid_net` bridge. MySQL is the default backend; its data lives in the named volume `mysql_data`. `ongrid-edge` is intentionally excluded (edge runs on user hosts) — a commented stanza at the bottom shows how to run one for demos.
 - `install/` — production-style release package assets, with an install guide (`install/README.md`) covering package upload, install, upgrade, and verification on a target host.
 - `prometheus/prometheus.yml` — minimal scrape config: jobs `prometheus` and `ongrid-manager` -> `ongrid:9100/metrics`.


### PR DESCRIPTION
- Dockerfile.ongrid final image is debian:bookworm-slim + cgo-linked (local
  ONNX embedder needs libonnxruntime/glibc), NOT distroless/static — the
  README had it backwards. The edge image is the distroless/static one
  (pure Go, CGO_ENABLED=0).
- Add 'make fetch-embedding-model' target + note offline RAG
  (ONGRID_EMBEDDING_PROVIDER=local) needs it run once before packaging.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
