### PR TITLE
feat(notify): per-type channel dispatch + Telegram; fix UI channels never delivering

### DIFF
--- a/deploy/install/.env.example
+++ b/deploy/install/.env.example
@@ -147,9 +147,10 @@ ONGRID_ALERT_DISK_USED_PERCENT=90
 ONGRID_ALERT_LOAD1=0
 
 # --- Outbound notifications (alerts / scheduled jobs / proactive AIOps) ---
-# Disabled by default. Set default channels to any enabled channel names below.
-ONGRID_NOTIFY_ENABLED=false
-ONGRID_NOTIFY_DEFAULT_CHANNELS=log
+# Enabled by default — any channel you configure (in the UI or below) delivers.
+# Set to false to mute all notifications.
+ONGRID_NOTIFY_ENABLED=true
+ONGRID_NOTIFY_DEFAULT_CHANNELS=
 ONGRID_NOTIFY_TIMEOUT=10s
 
 # Local dry-run sink. Useful before wiring real external channels.

--- a/internal/manager/biz/alert/channel_sender_test.go
+++ b/internal/manager/biz/alert/channel_sender_test.go
@@ -1,0 +1,59 @@
+package alert
+
+import (
+	"encoding/json"
+	"testing"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/alert"
+)
+
+func chWithConfig(name, typ string, cfg map[string]string) *model.Channel {
+	b, _ := json.Marshal(cfg)
+	return &model.Channel{Name: name, ChannelType: typ, ConfigJSON: string(b)}
+}
+
+func TestBuildSenderFromChannel(t *testing.T) {
+	types := []string{
+		model.ChannelTypeSlack, model.ChannelTypeFeishu, model.ChannelTypeDingTalk,
+		model.ChannelTypeWeCom, model.ChannelTypeTelegram, model.ChannelTypeWebhook,
+	}
+	for _, typ := range types {
+		ch := chWithConfig(typ+"-1", typ, map[string]string{"endpoint": "https://example.com/x", "secret": "s"})
+		s, err := buildSenderFromChannel(ch)
+		if err != nil {
+			t.Fatalf("%s: unexpected err %v", typ, err)
+		}
+		if s == nil || s.Name() != typ+"-1" {
+			t.Errorf("%s: bad sender %v", typ, s)
+		}
+	}
+
+	// Empty type falls back to the generic webhook sender.
+	if _, err := buildSenderFromChannel(chWithConfig("x", "", map[string]string{"endpoint": "https://x"})); err != nil {
+		t.Errorf("empty type: %v", err)
+	}
+	// Legacy "url" key still resolves an endpoint.
+	if _, err := buildSenderFromChannel(chWithConfig("l", "webhook", map[string]string{"url": "https://x"})); err != nil {
+		t.Errorf("legacy url key: %v", err)
+	}
+	// No endpoint → error (this is what channelHasDestination also guards).
+	if _, err := buildSenderFromChannel(chWithConfig("none", "slack", map[string]string{})); err == nil {
+		t.Error("expected error for missing endpoint")
+	}
+	// Unknown type → error.
+	if _, err := buildSenderFromChannel(chWithConfig("m", "mystery", map[string]string{"endpoint": "https://x"})); err == nil {
+		t.Error("expected error for unknown channel type")
+	}
+}
+
+// channelHasDestination must read the "endpoint" key the encoder actually
+// writes (the prior bug checked "url" only, so every persisted channel was
+// skipped).
+func TestChannelHasDestination_EndpointKey(t *testing.T) {
+	if !channelHasDestination(chWithConfig("a", "slack", map[string]string{"endpoint": "https://x"})) {
+		t.Error("endpoint key should count as a destination")
+	}
+	if channelHasDestination(chWithConfig("b", "slack", map[string]string{})) {
+		t.Error("empty config should not be a destination")
+	}
+}

--- a/internal/manager/biz/alert/channel_sender_test.go
+++ b/internal/manager/biz/alert/channel_sender_test.go
@@ -19,7 +19,7 @@ func TestBuildSenderFromChannel(t *testing.T) {
 	}
 	for _, typ := range types {
 		ch := chWithConfig(typ+"-1", typ, map[string]string{"endpoint": "https://example.com/x", "secret": "s"})
-		s, err := buildSenderFromChannel(ch)
+		s, err := BuildSenderFromChannel(ch)
 		if err != nil {
 			t.Fatalf("%s: unexpected err %v", typ, err)
 		}
@@ -29,19 +29,19 @@ func TestBuildSenderFromChannel(t *testing.T) {
 	}
 
 	// Empty type falls back to the generic webhook sender.
-	if _, err := buildSenderFromChannel(chWithConfig("x", "", map[string]string{"endpoint": "https://x"})); err != nil {
+	if _, err := BuildSenderFromChannel(chWithConfig("x", "", map[string]string{"endpoint": "https://x"})); err != nil {
 		t.Errorf("empty type: %v", err)
 	}
 	// Legacy "url" key still resolves an endpoint.
-	if _, err := buildSenderFromChannel(chWithConfig("l", "webhook", map[string]string{"url": "https://x"})); err != nil {
+	if _, err := BuildSenderFromChannel(chWithConfig("l", "webhook", map[string]string{"url": "https://x"})); err != nil {
 		t.Errorf("legacy url key: %v", err)
 	}
 	// No endpoint → error (this is what channelHasDestination also guards).
-	if _, err := buildSenderFromChannel(chWithConfig("none", "slack", map[string]string{})); err == nil {
+	if _, err := BuildSenderFromChannel(chWithConfig("none", "slack", map[string]string{})); err == nil {
 		t.Error("expected error for missing endpoint")
 	}
 	// Unknown type → error.
-	if _, err := buildSenderFromChannel(chWithConfig("m", "mystery", map[string]string{"endpoint": "https://x"})); err == nil {
+	if _, err := BuildSenderFromChannel(chWithConfig("m", "mystery", map[string]string{"endpoint": "https://x"})); err == nil {
 		t.Error("expected error for unknown channel type")
 	}
 }

--- a/internal/manager/biz/alert/testutil_test.go
+++ b/internal/manager/biz/alert/testutil_test.go
@@ -32,6 +32,22 @@ func (f *fakeNotifier) Send(_ context.Context, msg notify.Message, channels ...s
 	return nil
 }
 
+// SendVia records the same way as Send (keyed by the sender's name) so
+// assertions on msgs/channels still work for the persisted-channel
+// dispatch path (MaybeNotify builds a typed sender then calls SendVia).
+func (f *fakeNotifier) SendVia(_ context.Context, msg notify.Message, sender notify.Sender) error {
+	f.msgs = append(f.msgs, msg)
+	name := ""
+	if sender != nil {
+		name = sender.Name()
+	}
+	f.channels = append(f.channels, []string{name})
+	if f.fail {
+		return errors.New("synthetic notify failure")
+	}
+	return nil
+}
+
 // fakeRepo is an in-memory implementation of biz.Repo sufficient to drive
 // every alert test. Only the subset RecordFiring + maybeNotify touches is
 // implemented; ListIncidents et al. return empty.

--- a/internal/manager/biz/alert/usecase.go
+++ b/internal/manager/biz/alert/usecase.go
@@ -21,6 +21,12 @@ import (
 // package's *Router satisfies it; tests stub it.
 type Notifier interface {
 	Send(ctx context.Context, msg notify.Message, channels ...string) error
+	// SendVia delivers through an explicitly-built sender — used for
+	// persisted channels whose Sender is constructed per-row from
+	// ChannelType + ConfigJSON (buildSenderFromChannel), rather than
+	// looked up by name. Keeps delivery on the Notifier seam so router
+	// gating + test stubs still apply.
+	SendVia(ctx context.Context, msg notify.Message, sender notify.Sender) error
 }
 
 // NoopHostMetricIngester is the post-Phase-3-final stand-in for the
@@ -1254,7 +1260,21 @@ func (u *Usecase) MaybeNotify(ctx context.Context, res *FiringResult, msg notify
 			deliveryID = id
 		}
 
-		sendErr := opts.Notifier.Send(ctx, msg, ch.Name)
+		var sendErr error
+		if ch.ID > 0 {
+			// Persisted channel: build the typed sender from its
+			// ChannelType + ConfigJSON, then deliver through the Notifier
+			// seam (SendVia) so router gating/timeout — and test stubs —
+			// still apply. (Synthetic rows, ID==0, bridge to the
+			// env-config notifier by name in the else branch.)
+			if sender, berr := buildSenderFromChannel(ch); berr != nil {
+				sendErr = berr
+			} else {
+				sendErr = opts.Notifier.SendVia(ctx, msg, sender)
+			}
+		} else {
+			sendErr = opts.Notifier.Send(ctx, msg, ch.Name)
+		}
 		if sendErr == nil {
 			anySuccess = true
 		} else {
@@ -1312,7 +1332,47 @@ func channelHasDestination(ch *model.Channel) bool {
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(cfg["url"]) != ""
+	return strings.TrimSpace(cfg["endpoint"]) != "" || strings.TrimSpace(cfg["url"]) != ""
+}
+
+// buildSenderFromChannel constructs a notify.Sender from a persisted
+// channel's ChannelType + ConfigJSON. Until this existed, UI/seeded
+// channels were never actually delivered: MaybeNotify sent by name to the
+// env-config Router (which only knows env-config channel names), and
+// ChannelType/ConfigJSON were stored but unused — so WeCom and every
+// hand-created channel silently no-op'd. The URL lives under the
+// "endpoint" key (encodeChannelConfig); "secret" is the optional signing /
+// credential field (it carries the chat_id for telegram).
+func buildSenderFromChannel(ch *model.Channel) (notify.Sender, error) {
+	cfg, err := ch.Config()
+	if err != nil {
+		return nil, fmt.Errorf("decode channel config: %w", err)
+	}
+	endpoint := strings.TrimSpace(cfg["endpoint"])
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(cfg["url"]) // defensive: legacy key
+	}
+	if endpoint == "" {
+		return nil, fmt.Errorf("channel %q has no endpoint", ch.Name)
+	}
+	secret := strings.TrimSpace(cfg["secret"])
+	switch ch.ChannelType {
+	case model.ChannelTypeSlack:
+		return notify.NewSlackSender(ch.Name, endpoint, nil), nil
+	case model.ChannelTypeFeishu:
+		return notify.NewFeishuSender(ch.Name, endpoint, secret, nil), nil
+	case model.ChannelTypeDingTalk:
+		return notify.NewDingTalkSender(ch.Name, endpoint, secret, nil), nil
+	case model.ChannelTypeWeCom:
+		return notify.NewWeComSender(ch.Name, endpoint, nil), nil
+	case model.ChannelTypeTelegram:
+		// endpoint = bot sendMessage URL; secret field carries the chat_id.
+		return notify.NewTelegramSender(ch.Name, endpoint, secret, nil), nil
+	case model.ChannelTypeWebhook, "":
+		return notify.NewGenericWebhookSender(ch.Name, endpoint, secret, nil), nil
+	default:
+		return nil, fmt.Errorf("unknown channel type %q", ch.ChannelType)
+	}
 }
 
 // resolveChannels picks the recipients for an incident. Resolver wins when

--- a/internal/manager/biz/alert/usecase.go
+++ b/internal/manager/biz/alert/usecase.go
@@ -23,7 +23,7 @@ type Notifier interface {
 	Send(ctx context.Context, msg notify.Message, channels ...string) error
 	// SendVia delivers through an explicitly-built sender — used for
 	// persisted channels whose Sender is constructed per-row from
-	// ChannelType + ConfigJSON (buildSenderFromChannel), rather than
+	// ChannelType + ConfigJSON (BuildSenderFromChannel), rather than
 	// looked up by name. Keeps delivery on the Notifier seam so router
 	// gating + test stubs still apply.
 	SendVia(ctx context.Context, msg notify.Message, sender notify.Sender) error
@@ -1267,7 +1267,7 @@ func (u *Usecase) MaybeNotify(ctx context.Context, res *FiringResult, msg notify
 			// seam (SendVia) so router gating/timeout — and test stubs —
 			// still apply. (Synthetic rows, ID==0, bridge to the
 			// env-config notifier by name in the else branch.)
-			if sender, berr := buildSenderFromChannel(ch); berr != nil {
+			if sender, berr := BuildSenderFromChannel(ch); berr != nil {
 				sendErr = berr
 			} else {
 				sendErr = opts.Notifier.SendVia(ctx, msg, sender)
@@ -1335,7 +1335,7 @@ func channelHasDestination(ch *model.Channel) bool {
 	return strings.TrimSpace(cfg["endpoint"]) != "" || strings.TrimSpace(cfg["url"]) != ""
 }
 
-// buildSenderFromChannel constructs a notify.Sender from a persisted
+// BuildSenderFromChannel constructs a notify.Sender from a persisted
 // channel's ChannelType + ConfigJSON. Until this existed, UI/seeded
 // channels were never actually delivered: MaybeNotify sent by name to the
 // env-config Router (which only knows env-config channel names), and
@@ -1343,7 +1343,7 @@ func channelHasDestination(ch *model.Channel) bool {
 // hand-created channel silently no-op'd. The URL lives under the
 // "endpoint" key (encodeChannelConfig); "secret" is the optional signing /
 // credential field (it carries the chat_id for telegram).
-func buildSenderFromChannel(ch *model.Channel) (notify.Sender, error) {
+func BuildSenderFromChannel(ch *model.Channel) (notify.Sender, error) {
 	cfg, err := ch.Config()
 	if err != nil {
 		return nil, fmt.Errorf("decode channel config: %w", err)

--- a/internal/manager/model/alert/model.go
+++ b/internal/manager/model/alert/model.go
@@ -192,6 +192,7 @@ const (
 	ChannelTypeFeishu   = "feishu"
 	ChannelTypeDingTalk = "dingtalk"
 	ChannelTypeWeCom    = "wecom"
+	ChannelTypeTelegram = "telegram"
 )
 
 const (

--- a/internal/manager/service/alert/service.go
+++ b/internal/manager/service/alert/service.go
@@ -534,7 +534,19 @@ func (s *Service) TestChannel(ctx context.Context, _ Caller, id uint64) (*Channe
 		DedupeKey:  fmt.Sprintf("channel-test-%d", channel.ID),
 		OccurredAt: time.Now().UTC(),
 	}
-	sendErr := s.notifier.Send(ctx, msg, channel.Name)
+	// Build the typed sender from the channel's ChannelType + ConfigJSON and
+	// send DIRECTLY — a manual test must attempt real delivery regardless of
+	// the global ONGRID_NOTIFY_ENABLED master switch (an operator testing a
+	// channel wants to know it works, not get a silent no-op). This also
+	// fixes the prior by-name path, which only matched env-config channel
+	// names and returned "channel not configured" for UI-created channels.
+	sender, berr := bizalert.BuildSenderFromChannel(channel)
+	if berr != nil {
+		return &ChannelTestResult{Accepted: false, Message: berr.Error()}, nil
+	}
+	sctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	sendErr := sender.Send(sctx, msg)
 	out := &ChannelTestResult{Accepted: sendErr == nil}
 	if sendErr != nil {
 		out.Message = sendErr.Error()

--- a/internal/manager/service/alert/service_test.go
+++ b/internal/manager/service/alert/service_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -352,11 +354,18 @@ func (f *fakeNotifier) Send(_ context.Context, msg notify.Message, channels ...s
 func TestServiceTestChannelHappyPath(t *testing.T) {
 	t.Parallel()
 
+	// TestChannel now builds a typed sender from the channel + POSTs directly
+	// (bypassing the global notify master switch), so point the endpoint at a
+	// real test server; a 200 means the delivery link works.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
 	repo := &channelRepoStub{rows: []*model.Channel{
-		{ID: 9, Name: "primary-feishu", ChannelType: model.ChannelTypeFeishu, Enabled: true, ConfigJSON: `{"endpoint":"https://hook.example.test/abc"}`},
+		{ID: 9, Name: "primary-feishu", ChannelType: model.ChannelTypeFeishu, Enabled: true, ConfigJSON: `{"endpoint":"` + srv.URL + `"}`},
 	}}
-	notifier := &fakeNotifier{}
-	svc := &Service{repo: repo, notifier: notifier, log: slog.Default()}
+	svc := &Service{repo: repo, notifier: &fakeNotifier{}, log: slog.Default()}
 	got, err := svc.TestChannel(context.Background(), Caller{}, 9)
 	if err != nil {
 		t.Fatalf("TestChannel() err = %v", err)
@@ -364,31 +373,31 @@ func TestServiceTestChannelHappyPath(t *testing.T) {
 	if !got.Accepted {
 		t.Fatalf("TestChannel().Accepted = false, want true; msg=%q", got.Message)
 	}
-	if len(notifier.msgs) != 1 || notifier.msgs[0].Severity != notify.SeverityInfo {
-		t.Fatalf("notifier received = %+v", notifier.msgs)
-	}
-	if len(notifier.channels) != 1 || notifier.channels[0] != "primary-feishu" {
-		t.Fatalf("notifier channels = %v, want [primary-feishu]", notifier.channels)
-	}
 }
 
 func TestServiceTestChannelReportsFailure(t *testing.T) {
 	t.Parallel()
 
+	// Real upstream failure (503) must surface as accepted=false with detail —
+	// not a silent no-op and not "channel not configured".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
 	repo := &channelRepoStub{rows: []*model.Channel{
-		{ID: 1, Name: "broken", ChannelType: model.ChannelTypeWebhook, Enabled: true, ConfigJSON: `{}`},
+		{ID: 1, Name: "broken", ChannelType: model.ChannelTypeWebhook, Enabled: true, ConfigJSON: `{"endpoint":"` + srv.URL + `"}`},
 	}}
-	notifier := &fakeNotifier{err: errors.New("upstream 503")}
-	svc := &Service{repo: repo, notifier: notifier, log: slog.Default()}
+	svc := &Service{repo: repo, notifier: &fakeNotifier{}, log: slog.Default()}
 	got, err := svc.TestChannel(context.Background(), Caller{}, 1)
 	if err != nil {
 		t.Fatalf("TestChannel() err = %v", err)
 	}
 	if got.Accepted {
-		t.Fatalf("TestChannel().Accepted = true, want false")
+		t.Fatalf("TestChannel().Accepted = true, want false (upstream 503)")
 	}
-	if !strings.Contains(got.Message, "upstream 503") {
-		t.Fatalf("TestChannel().Message = %q, want upstream error verbatim", got.Message)
+	if !strings.Contains(got.Message, "503") {
+		t.Fatalf("TestChannel().Message = %q, want 503 detail", got.Message)
 	}
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -126,11 +126,12 @@ type GrafanaConfig struct {
 // client.
 type NotificationConfig struct {
 	// Enabled gates all outbound notification sends.
-	// env: ONGRID_NOTIFY_ENABLED; default false.
+	// env: ONGRID_NOTIFY_ENABLED; default true (configured channels deliver
+	// out of the box; set false to mute all notifications).
 	Enabled bool
 	// DefaultChannels is the ordered channel name list used when a caller
 	// does not specify explicit destinations.
-	// env: ONGRID_NOTIFY_DEFAULT_CHANNELS; comma-separated; default "log".
+	// env: ONGRID_NOTIFY_DEFAULT_CHANNELS; comma-separated; default empty.
 	DefaultChannels []string
 	// Timeout is the per-channel send timeout.
 	// env: ONGRID_NOTIFY_TIMEOUT; default 10s.
@@ -414,7 +415,12 @@ func Load() (*Config, error) {
 	c.Grafana.BootstrapPassword = getEnv("ONGRID_GRAFANA_BOOTSTRAP_PASSWORD", "")
 	c.Grafana.TLSInsecure = getEnvBool("ONGRID_GRAFANA_TLS_INSECURE", false)
 
-	c.Notification.Enabled = getEnvBool("ONGRID_NOTIFY_ENABLED", false)
+	// Default ON: notifications are allowed out of the box, so any channel
+	// the operator configures (UI or env) delivers without flipping a
+	// master switch. Per-channel env enables (Slack/Feishu/... below) stay
+	// OFF by default on purpose — seeding an enabled-but-URL-less channel
+	// would clutter the UI; UI-created channels carry their own enabled flag.
+	c.Notification.Enabled = getEnvBool("ONGRID_NOTIFY_ENABLED", true)
 	// Default channels list defaults empty — operators can pin specific
 	// channel names per env if desired. The legacy "log" entry was
 	// removed alongside the log channel type.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -95,8 +95,8 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Prom.QueryURL != "" {
 		t.Errorf("Prom.QueryURL default = %q, want empty", cfg.Prom.QueryURL)
 	}
-	if cfg.Notification.Enabled {
-		t.Errorf("Notification.Enabled default = true, want false")
+	if !cfg.Notification.Enabled {
+		t.Errorf("Notification.Enabled default = false, want true (notifications allowed by default; configured channels deliver)")
 	}
 	if cfg.Notification.Timeout != 10*time.Second {
 		t.Errorf("Notification.Timeout default = %v, want 10s", cfg.Notification.Timeout)

--- a/internal/pkg/notify/notify.go
+++ b/internal/pkg/notify/notify.go
@@ -129,6 +129,32 @@ func (r *Router) Send(ctx context.Context, msg Message, channels ...string) erro
 	return errors.Join(errs...)
 }
 
+// SendVia delivers msg through an explicitly-constructed sender, rather
+// than looking one up by name. Used for DB-stored channels whose Sender is
+// built per-row from ChannelType + ConfigJSON (the env-config NewFromConfig
+// only pre-registers env channels by name). Honors the router's enabled
+// flag + timeout so it gates identically to Send.
+func (r *Router) SendVia(ctx context.Context, msg Message, sender Sender) error {
+	if r == nil || !r.enabled {
+		return nil
+	}
+	if sender == nil {
+		return errors.New("notify: nil sender")
+	}
+	if msg.Subject == "" {
+		return errors.New("notify: subject required")
+	}
+	if msg.Severity == "" {
+		msg.Severity = SeverityInfo
+	}
+	if msg.OccurredAt.IsZero() {
+		msg.OccurredAt = time.Now().UTC()
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	return sender.Send(sendCtx, msg)
+}
+
 // ChannelNames returns the configured channel names. It is intended for
 // readiness checks and diagnostics, not for exposing secrets.
 func (r *Router) ChannelNames() []string {

--- a/internal/pkg/notify/webhook.go
+++ b/internal/pkg/notify/webhook.go
@@ -78,6 +78,20 @@ func NewWeComSender(name, endpoint string, client *http.Client) Sender {
 	}, nil)
 }
 
+// NewTelegramSender posts to the Telegram Bot API sendMessage endpoint.
+// endpoint is the full https://api.telegram.org/bot<TOKEN>/sendMessage URL
+// (bot token in the path); chatID is the target chat, sent in the JSON
+// body. Telegram's auth model differs from the webhook channels — token in
+// the URL, chat_id in the body — so it doesn't use the secret/signing path.
+func NewTelegramSender(name, endpoint, chatID string, client *http.Client) Sender {
+	return newWebhookSender(name, endpoint, "", client, func(msg Message) (any, error) {
+		return map[string]any{
+			"chat_id": chatID,
+			"text":    formatText(msg),
+		}, nil
+	}, nil)
+}
+
 func newWebhookSender(
 	name string,
 	endpoint string,

--- a/web/src/pages/AlertRules.tsx
+++ b/web/src/pages/AlertRules.tsx
@@ -1716,16 +1716,18 @@ function KindPicker({
 const CHANNEL_TYPE_LABEL_ZH: Record<string, string> = {
   feishu: '飞书',
   dingtalk: '钉钉',
-  wecom: '企业微信',
+  wecom: '微信',
   slack: 'Slack',
+  telegram: 'Telegram',
   webhook: 'Webhook',
   log: '日志（本地）',
 };
 const CHANNEL_TYPE_LABEL_EN: Record<string, string> = {
   feishu: 'Feishu',
   dingtalk: 'DingTalk',
-  wecom: 'WeCom',
+  wecom: 'WeChat',
   slack: 'Slack',
+  telegram: 'Telegram',
   webhook: 'Webhook',
   log: 'Log (local)',
 };
@@ -1733,14 +1735,15 @@ const CHANNEL_TYPE_LABEL_EN: Record<string, string> = {
 // CHANNEL_TYPE_ORDER is the FIXED row order for the type-grouped
 // ChannelsField (Tencent Cloud Monitor's "通知方式" panel inspiration).
 // Each row shows one channel TYPE; the row's instances live inside.
-// Order: 飞书 → 企业微信 → 钉钉 → Slack → Webhook (IM-first, generic
-// last). `log` is intentionally absent — that channel type was removed
-// in 2026-05.
+// Order: 飞书 → 微信 → 钉钉 → Slack → Telegram → Webhook (IM-first,
+// generic last). `log` is intentionally absent — that channel type was
+// removed in 2026-05.
 const CHANNEL_TYPE_ORDER: Array<{ type: string; icon: typeof Webhook }> = [
   { type: 'feishu', icon: MessageSquareShare },
   { type: 'wecom', icon: MessageCircle },
   { type: 'dingtalk', icon: Send },
   { type: 'slack', icon: Slack },
+  { type: 'telegram', icon: Send },
   { type: 'webhook', icon: Webhook },
 ];
 

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -33,8 +33,8 @@ const RAIL_ITEMS: RailItem[] = [
   // /skills?tab=install so the whole skill story (loaded + installed)
   // lives on one page. The Settings route still redirects bookmarks.
   { to: 'llm', icon: KeyRound, labelZh: '模型', labelEn: 'LLM', hintZh: 'OpenAI / 兼容服务', hintEn: 'OpenAI / compatible providers' },
-  { to: 'communications', icon: Bell, labelZh: '通知', labelEn: 'Notifications', hintZh: '飞书 / 钉钉 / Slack / Webhook（告警推送）', hintEn: 'Feishu / DingTalk / Slack / Webhook (alert delivery)' },
-  { to: 'bots', icon: MessagesSquare, labelZh: '通信', labelEn: 'Communications', hintZh: '飞书 / 钉钉 bot 双向多轮', hintEn: 'Feishu / DingTalk bots — two-way multi-turn' },
+  { to: 'communications', icon: Bell, labelZh: '通知', labelEn: 'Notifications', hintZh: '飞书 / 钉钉 / 微信 / Slack / Telegram / Webhook（告警推送）', hintEn: 'Slack / Telegram / Feishu / DingTalk / WeChat / Webhook (alert delivery)' },
+  { to: 'bots', icon: MessagesSquare, labelZh: '渠道', labelEn: 'Channels', hintZh: '飞书 / 钉钉 bot 双向多轮', hintEn: 'Feishu / DingTalk bots — two-way multi-turn' },
   { to: 'preferences', icon: Gauge, labelZh: '偏好', labelEn: 'Preferences', hintZh: '默认时间窗 / 自动刷新', hintEn: 'Default time window / auto-refresh' },
 ];
 

--- a/web/src/pages/settings/Communications.tsx
+++ b/web/src/pages/settings/Communications.tsx
@@ -34,10 +34,11 @@ import { useI18n } from '@/i18n/locale';
 // every notification attempt with status — that's the audit trail.
 // Operators looking for delivery history should hit
 // 设置 → 告警事件 instead.
-type ChannelType = 'webhook' | 'slack' | 'feishu' | 'dingtalk' | 'wecom';
+type ChannelType = 'webhook' | 'slack' | 'feishu' | 'dingtalk' | 'wecom' | 'telegram';
 
 type TypeMeta = {
   type: ChannelType;
+  group: 'cn' | 'intl' | 'generic';
   labelZh: string;
   labelEn: string;
   icon: IconType;
@@ -49,6 +50,7 @@ type TypeMeta = {
 const TYPE_CARDS: TypeMeta[] = [
   {
     type: 'feishu',
+    group: 'cn',
     labelZh: '飞书',
     labelEn: 'Feishu',
     icon: MessageSquareShare,
@@ -58,6 +60,7 @@ const TYPE_CARDS: TypeMeta[] = [
   },
   {
     type: 'dingtalk',
+    group: 'cn',
     labelZh: '钉钉',
     labelEn: 'DingTalk',
     icon: Send,
@@ -67,15 +70,17 @@ const TYPE_CARDS: TypeMeta[] = [
   },
   {
     type: 'wecom',
-    labelZh: '企业微信',
-    labelEn: 'WeCom',
+    group: 'cn',
+    labelZh: '微信',
+    labelEn: 'WeChat',
     icon: MessageCircle,
-    hintZh: '企业微信群机器人 webhook（key 在 URL 里）。',
-    hintEn: 'WeCom group-bot webhook (key embedded in the URL).',
+    hintZh: '微信推送走企业微信群机器人 webhook（key 在 URL 里）；消费版微信没有群机器人接口。',
+    hintEn: 'WeChat delivery via a WeCom group-bot webhook (key in the URL); consumer WeChat has no bot API.',
     endpointPlaceholder: 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxx',
   },
   {
     type: 'slack',
+    group: 'intl',
     labelZh: 'Slack',
     labelEn: 'Slack',
     icon: Slack,
@@ -84,7 +89,18 @@ const TYPE_CARDS: TypeMeta[] = [
     endpointPlaceholder: 'https://hooks.slack.com/services/Txxx/Bxxx/xxx',
   },
   {
+    type: 'telegram',
+    group: 'intl',
+    labelZh: 'Telegram',
+    labelEn: 'Telegram',
+    icon: Send,
+    hintZh: 'Telegram bot sendMessage 接口；endpoint 填 https://api.telegram.org/bot<token>/sendMessage，secret 字段填 Chat ID。',
+    hintEn: 'Telegram bot sendMessage API; endpoint = https://api.telegram.org/bot<token>/sendMessage, put the Chat ID in the secret field.',
+    endpointPlaceholder: 'https://api.telegram.org/bot<token>/sendMessage',
+  },
+  {
     type: 'webhook',
+    group: 'generic',
     labelZh: 'Webhook',
     labelEn: 'Webhook',
     icon: Webhook,
@@ -94,10 +110,24 @@ const TYPE_CARDS: TypeMeta[] = [
   },
 ];
 
+// Locale-aware ordering: surface the channels most relevant to the UI
+// language first. English → Slack / Telegram first; Chinese → 飞书 / 钉钉 /
+// 微信 first. Webhook (generic) stays last either way. Within a group the
+// declaration order above is preserved (Array.prototype.sort is stable).
+const GROUP_RANK: Record<string, Record<TypeMeta['group'], number>> = {
+  'en-US': { intl: 0, cn: 1, generic: 2 },
+  'zh-CN': { cn: 0, intl: 1, generic: 2 },
+};
+function orderCardsByLocale(locale: string): TypeMeta[] {
+  const rank = GROUP_RANK[locale] ?? GROUP_RANK['zh-CN'];
+  return [...TYPE_CARDS].sort((a, b) => rank[a.group] - rank[b.group]);
+}
+
 type Toast = { kind: 'ok' | 'err'; text: string } | null;
 
 export default function SettingsCommunications() {
-  const { tr } = useI18n();
+  const { tr, locale } = useI18n();
+  const orderedCards = useMemo(() => orderCardsByLocale(locale), [locale]);
   const [items, setItems] = useState<Channel[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
@@ -200,7 +230,7 @@ export default function SettingsCommunications() {
             </div>
           </Card>
         ) : (
-          TYPE_CARDS.map((meta) => (
+          orderedCards.map((meta) => (
             <TypeCard
               key={meta.type}
               meta={meta}
@@ -392,7 +422,7 @@ function ChannelEditorModal({
   onClose(): void;
   onSaved(): void;
 }) {
-  const { tr } = useI18n();
+  const { tr, locale } = useI18n();
   const [form, setForm] = useState<ChannelInput>(() => ({
     name: channel?.name ?? '',
     type: channel?.type ?? presetType ?? 'webhook',
@@ -472,7 +502,7 @@ function ChannelEditorModal({
             disabled={mode === 'edit'}
             className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none disabled:opacity-60"
           >
-            {TYPE_CARDS.map((t) => (
+            {orderCardsByLocale(locale).map((t) => (
               <option key={t.type} value={t.type}>
                 {tr(t.labelZh, t.labelEn)} ({t.type})
               </option>


### PR DESCRIPTION
Mirror of ongridio/ongrid-cloud#5. UI-created notification channels (incl
WeCom) never delivered: MaybeNotify dispatched by name to the env-config
Router, and channelHasDestination checked cfg["url"] while the encoder writes
cfg["endpoint"]. Add buildSenderFromChannel (ChannelType+ConfigJSON -> sender,
+ new Telegram), deliver persisted channels via a new Notifier.SendVia seam,
fix the config-key check. Frontend: WeCom -> 微信/WeChat, add Telegram card,
rename IM-bots nav Communications -> Channels, locale-order the channel list.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
