### PR TITLE
feat(imbridge): Telegram two-way bridge + sender allowlist (ADR-031)

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -94,6 +94,7 @@ import (
 	managerserverknowledge "github.com/ongridio/ongrid/internal/manager/server/knowledge"
 	managerbizimbridge "github.com/ongridio/ongrid/internal/manager/biz/imbridge"
 	managerbizimbridgefeishu "github.com/ongridio/ongrid/internal/manager/biz/imbridge/provider/feishu"
+	managerbizimbridgetelegram "github.com/ongridio/ongrid/internal/manager/biz/imbridge/provider/telegram"
 	managerimbridgedata "github.com/ongridio/ongrid/internal/manager/data/imbridge/store"
 	managerserverimbridge "github.com/ongridio/ongrid/internal/manager/server/imbridge"
 	managerbizgrafana "github.com/ongridio/ongrid/internal/manager/biz/grafana"
@@ -1287,6 +1288,10 @@ func main() {
 	// factory for provider — skipping" and the webhook path still
 	// works as fallback.
 	imbridgeStreamSupervisor.RegisterFactory("feishu", managerbizimbridgefeishu.NewStreamFactory(log))
+	// Telegram is stream-only (getUpdates long-poll, outbound → proxy-
+	// friendly behind GFW). Sender allowlist enforced in the provider
+	// (ADR-031).
+	imbridgeStreamSupervisor.RegisterFactory("telegram", managerbizimbridgetelegram.NewStreamFactory(log))
 	go imbridgeStreamSupervisor.Run(rootCtx)
 
 	// @-mention search backend (HLD: ChatInput @-popover). Wires

--- a/internal/manager/biz/imbridge/provider/telegram/client.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client.go
@@ -1,0 +1,135 @@
+// Package telegram is the Telegram Bot API provider for the IM bridge
+// (ADR-021 + ADR-031). Unlike Feishu (websocket stream) it long-polls
+// getUpdates — an OUTBOUND call, so it traverses the manager's
+// HTTP(S)_PROXY on GFW-restricted hosts (setWebhook would require Telegram
+// to reach the manager inbound, which is unreliable from mainland China).
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client is a minimal Telegram Bot API client. It uses a zero-value
+// http.Client (DefaultTransport), so it honors HTTP(S)_PROXY/NO_PROXY env —
+// the manager's proxy config carries it out to api.telegram.org. Per-call
+// timeouts come from the caller's context (long-poll vs. send differ).
+type Client struct {
+	token string
+	hc    *http.Client
+	base  string // API root; overridable in tests, defaults to the public API
+}
+
+// NewClient builds a client for one bot token.
+func NewClient(token string) *Client {
+	return &Client{token: token, hc: &http.Client{}, base: "https://api.telegram.org"}
+}
+
+func (c *Client) endpoint(method string) string {
+	return c.base + "/bot" + c.token + "/" + method
+}
+
+type apiResp struct {
+	OK          bool            `json:"ok"`
+	Result      json.RawMessage `json:"result"`
+	Description string          `json:"description"`
+	ErrorCode   int             `json:"error_code"`
+}
+
+func (c *Client) call(ctx context.Context, method string, body any) (json.RawMessage, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", method, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint(method), bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var env apiResp
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("%s decode: %w (body=%s)", method, err, truncate(raw, 200))
+	}
+	if !env.OK {
+		return nil, fmt.Errorf("telegram %s: %d %s", method, env.ErrorCode, env.Description)
+	}
+	return env.Result, nil
+}
+
+// Update is one getUpdates entry (only the fields the bridge consumes).
+type Update struct {
+	UpdateID int `json:"update_id"`
+	Message  *struct {
+		MessageID int `json:"message_id"`
+		From      *struct {
+			ID        int64  `json:"id"`
+			FirstName string `json:"first_name"`
+			Username  string `json:"username"`
+		} `json:"from"`
+		Chat *struct {
+			ID   int64  `json:"id"`
+			Type string `json:"type"`
+		} `json:"chat"`
+		Text string `json:"text"`
+	} `json:"message"`
+}
+
+// GetUpdates long-polls for messages from offset, waiting up to timeoutSec
+// server-side. ctx cancellation aborts the wait (supervisor shutdown).
+func (c *Client) GetUpdates(ctx context.Context, offset, timeoutSec int) ([]Update, error) {
+	res, err := c.call(ctx, "getUpdates", map[string]any{
+		"offset":          offset,
+		"timeout":         timeoutSec,
+		"allowed_updates": []string{"message"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var ups []Update
+	if err := json.Unmarshal(res, &ups); err != nil {
+		return nil, fmt.Errorf("getUpdates result: %w", err)
+	}
+	return ups, nil
+}
+
+// SendMessage posts text to chatID and returns the new message_id.
+func (c *Client) SendMessage(ctx context.Context, chatID, text string) (int, error) {
+	res, err := c.call(ctx, "sendMessage", map[string]any{"chat_id": chatID, "text": text})
+	if err != nil {
+		return 0, err
+	}
+	var m struct {
+		MessageID int `json:"message_id"`
+	}
+	if err := json.Unmarshal(res, &m); err != nil {
+		return 0, fmt.Errorf("sendMessage result: %w", err)
+	}
+	return m.MessageID, nil
+}
+
+// EditMessageText replaces the text of (chatID, messageID).
+func (c *Client) EditMessageText(ctx context.Context, chatID string, messageID int, text string) error {
+	_, err := c.call(ctx, "editMessageText", map[string]any{
+		"chat_id":    chatID,
+		"message_id": messageID,
+		"text":       text,
+	})
+	return err
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/internal/manager/biz/imbridge/provider/telegram/client.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Client is a minimal Telegram Bot API client. It uses a zero-value
@@ -117,13 +118,21 @@ func (c *Client) SendMessage(ctx context.Context, chatID, text string) (int, err
 	return m.MessageID, nil
 }
 
-// EditMessageText replaces the text of (chatID, messageID).
+// EditMessageText replaces the text of (chatID, messageID). Telegram 400s a
+// no-op edit ("message is not modified") when the new text already equals the
+// message's current content — harmless for progressive streaming, where a
+// throttled tick or the final flush can repeat the last chunk. Unlike Feishu,
+// Telegram rejects it, so we swallow that specific error as success; any other
+// 400/error still propagates.
 func (c *Client) EditMessageText(ctx context.Context, chatID string, messageID int, text string) error {
 	_, err := c.call(ctx, "editMessageText", map[string]any{
 		"chat_id":    chatID,
 		"message_id": messageID,
 		"text":       text,
 	})
+	if err != nil && strings.Contains(err.Error(), "message is not modified") {
+		return nil
+	}
 	return err
 }
 

--- a/internal/manager/biz/imbridge/provider/telegram/client_test.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client_test.go
@@ -1,0 +1,169 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/imbridge"
+)
+
+// testClient points a real Client at an httptest server (base URL override),
+// so we exercise the JSON request/response shaping without touching the net.
+func testClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient("123:ABC")
+	c.base = srv.URL
+	return c
+}
+
+func decode(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	body, _ := io.ReadAll(r.Body)
+	var in map[string]any
+	if err := json.Unmarshal(body, &in); err != nil {
+		t.Fatalf("bad request body %q: %v", body, err)
+	}
+	return in
+}
+
+func TestSendMessageReturnsID(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sendMessage") {
+			t.Errorf("path = %s, want .../sendMessage", r.URL.Path)
+		}
+		in := decode(t, r)
+		if in["chat_id"] != "999" || in["text"] != "hi" {
+			t.Errorf("body = %v, want chat_id=999 text=hi", in)
+		}
+		io.WriteString(w, `{"ok":true,"result":{"message_id":42}}`)
+	})
+	id, err := c.SendMessage(context.Background(), "999", "hi")
+	if err != nil || id != 42 {
+		t.Fatalf("SendMessage = %d, %v; want 42, nil", id, err)
+	}
+}
+
+func TestEditMessageText(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/editMessageText") {
+			t.Errorf("path = %s, want .../editMessageText", r.URL.Path)
+		}
+		in := decode(t, r)
+		if in["chat_id"] != "999" || in["message_id"].(float64) != 42 || in["text"] != "edited" {
+			t.Errorf("body = %v, want chat_id=999 message_id=42 text=edited", in)
+		}
+		io.WriteString(w, `{"ok":true,"result":{}}`)
+	})
+	if err := c.EditMessageText(context.Background(), "999", 42, "edited"); err != nil {
+		t.Fatalf("EditMessageText err = %v", err)
+	}
+}
+
+func TestGetUpdatesParses(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"ok":true,"result":[
+			{"update_id":7,"message":{"message_id":1,"from":{"id":5,"first_name":"Au"},"chat":{"id":999,"type":"private"},"text":"hello"}},
+			{"update_id":8,"edited_message":{"message_id":1,"text":"ignored"}}
+		]}`)
+	})
+	ups, err := c.GetUpdates(context.Background(), 0, 0)
+	if err != nil || len(ups) != 2 {
+		t.Fatalf("GetUpdates = %v, %v; want 2 updates", ups, err)
+	}
+	u := ups[0]
+	if u.UpdateID != 7 || u.Message == nil || u.Message.Text != "hello" || u.Message.Chat.ID != 999 || u.Message.From.ID != 5 {
+		t.Errorf("update[0] parsed wrong: %+v", u.Message)
+	}
+	// edited_message has no "message" → Message stays nil and handle() skips it.
+	if ups[1].Message != nil {
+		t.Errorf("update[1] should have nil Message (edited_message), got %+v", ups[1].Message)
+	}
+}
+
+func TestAPIErrorSurfacesCode(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"ok":false,"error_code":401,"description":"Unauthorized"}`)
+	})
+	_, err := c.SendMessage(context.Background(), "1", "x")
+	if err == nil || !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "Unauthorized") {
+		t.Errorf("want error mentioning 401/Unauthorized, got %v", err)
+	}
+}
+
+// TestSenderAdapter covers the bizbridge.Sender contract: SendText returns
+// the platform message id as a decimal string, and EditText routes it back
+// to editMessageText with the bound chatID.
+func TestSenderAdapter(t *testing.T) {
+	var sawEditChat string
+	var sawEditMsg float64
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			io.WriteString(w, `{"ok":true,"result":{"message_id":7}}`)
+		case strings.HasSuffix(r.URL.Path, "/editMessageText"):
+			in := decode(t, r)
+			sawEditChat = in["chat_id"].(string)
+			sawEditMsg = in["message_id"].(float64)
+			io.WriteString(w, `{"ok":true,"result":{}}`)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	})
+	s := senderAdapter{client: c, chatID: "999"}
+	id, err := s.SendText(context.Background(), "999", "chat_id", "hi")
+	if err != nil || id != "7" {
+		t.Fatalf("SendText = %q, %v; want \"7\", nil", id, err)
+	}
+	if err := s.EditText(context.Background(), id, "edited"); err != nil {
+		t.Fatalf("EditText err = %v", err)
+	}
+	if sawEditChat != "999" || sawEditMsg != 7 {
+		t.Errorf("editMessageText got chat=%q msg=%v; want 999, 7", sawEditChat, sawEditMsg)
+	}
+}
+
+func TestSenderAdapterRejectsNonNumericID(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("should not reach network for bad id")
+	})
+	s := senderAdapter{client: c, chatID: "999"}
+	if err := s.EditText(context.Background(), "not-a-number", "x"); err == nil {
+		t.Error("EditText with non-numeric id should error before calling the API")
+	}
+}
+
+// TestStreamClientAllowlist: NewStreamClient parses app.AllowFrom into the
+// sender set (separators + tg:/telegram: prefixes + dedup all handled).
+func TestStreamClientAllowlist(t *testing.T) {
+	app := &model.ImApp{AppSecret: "tok", AllowFrom: "tg:111, 222 333\n444;111"}
+	c := NewStreamClient(app, nil, nil)
+	for _, id := range []string{"111", "222", "333", "444"} {
+		if _, ok := c.allowed[id]; !ok {
+			t.Errorf("expected %s in allowlist, set=%v", id, c.allowed)
+		}
+	}
+	if _, ok := c.allowed["999"]; ok {
+		t.Error("999 must not be allowlisted")
+	}
+}
+
+// TestHandleDropsNonAllowlisted: an update from a sender NOT on the allowlist
+// must be dropped before the bridge is touched. We pass a nil bridge — an
+// allowed sender would panic on dispatch, so reaching the end cleanly proves
+// the gate fired for the stranger.
+func TestHandleDropsNonAllowlisted(t *testing.T) {
+	app := &model.ImApp{AppSecret: "tok", AllowFrom: "111"}
+	c := NewStreamClient(app, nil, nil)
+	var u Update
+	if err := json.Unmarshal([]byte(`{"update_id":1,"message":{"message_id":5,"from":{"id":999,"first_name":"Stranger"},"chat":{"id":999,"type":"private"},"text":"list all hosts"}}`), &u); err != nil {
+		t.Fatalf("seed update: %v", err)
+	}
+	c.handle(u) // sender 999 ∉ {111} → silent drop, must not deref nil bridge
+}

--- a/internal/manager/biz/imbridge/provider/telegram/client_test.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client_test.go
@@ -66,6 +66,19 @@ func TestEditMessageText(t *testing.T) {
 	}
 }
 
+// Telegram 400s a no-op edit; progressive streaming repeats the last chunk on
+// the final flush, so EditMessageText must treat "message is not modified" as
+// success — otherwise the whole inbound handling reports failure on a delivered
+// reply.
+func TestEditMessageTextNoopIsSuccess(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"ok":false,"error_code":400,"description":"Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message"}`)
+	})
+	if err := c.EditMessageText(context.Background(), "999", 42, "same"); err != nil {
+		t.Errorf("no-op edit should be treated as success, got %v", err)
+	}
+}
+
 func TestGetUpdatesParses(t *testing.T) {
 	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, `{"ok":true,"result":[

--- a/internal/manager/biz/imbridge/provider/telegram/stream.go
+++ b/internal/manager/biz/imbridge/provider/telegram/stream.go
@@ -1,0 +1,168 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	bizbridge "github.com/ongridio/ongrid/internal/manager/biz/imbridge"
+	model "github.com/ongridio/ongrid/internal/manager/model/imbridge"
+)
+
+// pollTimeoutSec is the server-side long-poll wait; the per-poll context
+// adds a buffer on top so a stalled connection still unblocks.
+const pollTimeoutSec = 25
+
+// StreamClient is the Telegram inbound loop. Telegram has no websocket
+// stream like Feishu, so we long-poll getUpdates (outbound → proxy-friendly).
+// Satisfies bizbridge.StreamClient; the StreamSupervisor adds
+// reconnect-with-backoff, so a poll error just returns here.
+type StreamClient struct {
+	app     *model.ImApp
+	bridge  *bizbridge.Bridge
+	client  *Client
+	allowed map[string]struct{} // sender user-id allowlist; see ADR-031
+	log     *slog.Logger
+}
+
+// NewStreamClient builds a Telegram stream client for one ImApp
+// (app_secret = bot token). The sender allowlist (app.AllowFrom) is
+// parsed once here — the bot is publicly discoverable, so any update
+// from a user NOT on the list is silently dropped in handle() before
+// it ever reaches the agent (ADR-031; consistent with OpenClaw's
+// allowFrom). validate() guarantees AllowFrom is non-empty for
+// Telegram, so an empty set here can only mean a malformed legacy row,
+// which correctly denies everyone.
+func NewStreamClient(app *model.ImApp, bridge *bizbridge.Bridge, log *slog.Logger) *StreamClient {
+	if log == nil {
+		log = slog.Default()
+	}
+	allowed := make(map[string]struct{})
+	for _, id := range bizbridge.ParseAllowFrom(app.AllowFrom) {
+		allowed[id] = struct{}{}
+	}
+	return &StreamClient{
+		app:     app,
+		bridge:  bridge,
+		client:  NewClient(app.AppSecret),
+		allowed: allowed,
+		log:     log.With(slog.String("provider", "telegram"), slog.Uint64("im_app_id", app.ID)),
+	}
+}
+
+// ProviderName satisfies bizbridge.StreamClient.
+func (c *StreamClient) ProviderName() string { return "telegram" }
+
+// Run long-polls getUpdates until ctx is cancelled. Each text message is
+// bridged to the agent on a detached goroutine (agent runs outlive a poll).
+// A poll error returns to the supervisor, which retries with backoff. Only
+// one poller may run per bot (Telegram rejects concurrent getUpdates) — the
+// supervisor guarantees one client per ImApp.
+func (c *StreamClient) Run(ctx context.Context) error {
+	c.log.Info("starting telegram getUpdates poll")
+	offset := 0
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		pollCtx, cancel := context.WithTimeout(ctx, (pollTimeoutSec+10)*time.Second)
+		ups, err := c.client.GetUpdates(pollCtx, offset, pollTimeoutSec)
+		cancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("getUpdates: %w", err)
+		}
+		for _, u := range ups {
+			if u.UpdateID >= offset {
+				offset = u.UpdateID + 1 // ack so this update isn't redelivered
+			}
+			c.handle(u)
+		}
+	}
+}
+
+func (c *StreamClient) handle(u Update) {
+	m := u.Message
+	if m == nil || m.Chat == nil || m.Text == "" {
+		return // S1: text-only DMs/groups; ignore non-text + edits
+	}
+	chatID := strconv.FormatInt(m.Chat.ID, 10)
+	openID, userName := "", ""
+	if m.From != nil {
+		openID = strconv.FormatInt(m.From.ID, 10)
+		userName = m.From.FirstName
+	}
+	// Access control: the bot is publicly reachable by username, so only
+	// allowlisted sender user IDs may converse. Anyone else is dropped
+	// SILENTLY — no reply, no placeholder, no agent run, no ack (mirrors
+	// OpenClaw allowFrom; a reply would confirm the bot exists + leak that
+	// it's an agent). We log at WARN with the sender's id so an admin can
+	// add a legitimate user to allow_from. See ADR-031.
+	if _, ok := c.allowed[openID]; !ok || m.From == nil {
+		c.log.Warn("telegram inbound from non-allowlisted sender — ignored",
+			slog.String("user_id", openID),
+			slog.String("user_name", userName),
+			slog.String("chat_id", chatID))
+		return
+	}
+	in := bizbridge.InboundMessage{
+		Provider:      model.ProviderTelegram,
+		AppID:         c.app.AppID,
+		ChatID:        chatID,
+		OpenID:        openID,
+		UserName:      userName,
+		Text:          m.Text,
+		EventID:       strconv.Itoa(u.UpdateID),
+		ReceiveIDType: "chat_id",
+	}
+	sender := senderAdapter{client: c.client, chatID: chatID}
+	// Detach: agent runs take 30s+; the poll loop must keep moving.
+	go func() {
+		if err := c.bridge.HandleInbound(context.Background(), sender, in); err != nil {
+			c.log.Warn("telegram bridge handle_inbound failed", slog.Any("err", err))
+		}
+	}()
+}
+
+// senderAdapter satisfies bizbridge.Sender. Telegram's editMessageText
+// needs chat_id + message_id, so chatID is bound per inbound chat and the
+// platform message id is round-tripped as a decimal string.
+type senderAdapter struct {
+	client *Client
+	chatID string
+}
+
+func (s senderAdapter) SendText(ctx context.Context, receiveID, _, text string) (string, error) {
+	chat := receiveID
+	if chat == "" {
+		chat = s.chatID
+	}
+	id, err := s.client.SendMessage(ctx, chat, text)
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(id), nil
+}
+
+func (s senderAdapter) EditText(ctx context.Context, messageID, text string) error {
+	mid, err := strconv.Atoi(messageID)
+	if err != nil {
+		return fmt.Errorf("telegram message id %q: %w", messageID, err)
+	}
+	return s.client.EditMessageText(ctx, s.chatID, mid, text)
+}
+
+// NewStreamFactory returns the bizbridge.StreamClientFactory main.go
+// registers for the "telegram" provider.
+func NewStreamFactory(log *slog.Logger) bizbridge.StreamClientFactory {
+	return func(app *model.ImApp, bridge *bizbridge.Bridge) (bizbridge.StreamClient, error) {
+		if app.AppSecret == "" {
+			return nil, fmt.Errorf("telegram: bot token (app_secret) required")
+		}
+		return NewStreamClient(app, bridge, log), nil
+	}
+}

--- a/internal/manager/biz/imbridge/usecase.go
+++ b/internal/manager/biz/imbridge/usecase.go
@@ -38,14 +38,54 @@ type AppInput struct {
 	AppSecret   string
 	VerifyToken string
 	EncryptKey  string
+	AllowFrom   string // Telegram sender allowlist (numeric user IDs); see ParseAllowFrom
 	Enabled     bool
 }
 
+// ParseAllowFrom splits a raw allowlist (comma / space / newline / semicolon
+// separated) into normalized numeric Telegram user IDs. `telegram:` / `tg:`
+// prefixes are stripped (OpenClaw allowFrom compatibility). Non-numeric and
+// negative tokens are dropped — only positive user IDs are valid (group /
+// supergroup chat IDs are negative and don't belong in a sender allowlist).
+// Order-preserving + de-duplicated. Shared by validate() and the Telegram
+// provider's poll loop so the parse rule has exactly one definition.
+func ParseAllowFrom(raw string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\n' || r == '\t' || r == '\r' || r == ';'
+	})
+	for _, tok := range fields {
+		tok = strings.TrimSpace(tok)
+		tok = strings.TrimPrefix(tok, "telegram:")
+		tok = strings.TrimPrefix(tok, "tg:")
+		if tok == "" || !isNumericID(tok) {
+			continue
+		}
+		if _, dup := seen[tok]; dup {
+			continue
+		}
+		seen[tok] = struct{}{}
+		out = append(out, tok)
+	}
+	return out
+}
+
+func isNumericID(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
 func (in *AppInput) validate() error {
-	switch strings.ToLower(strings.TrimSpace(in.Provider)) {
-	case model.ProviderFeishu, model.ProviderDingTalk:
+	provider := strings.ToLower(strings.TrimSpace(in.Provider))
+	switch provider {
+	case model.ProviderFeishu, model.ProviderDingTalk, model.ProviderTelegram:
 	default:
-		return fmt.Errorf("%w: provider must be feishu or dingtalk", errs.ErrInvalid)
+		return fmt.Errorf("%w: provider must be feishu, dingtalk, or telegram", errs.ErrInvalid)
 	}
 	mode := strings.ToLower(strings.TrimSpace(in.Mode))
 	if mode == "" {
@@ -65,6 +105,21 @@ func (in *AppInput) validate() error {
 	// stream mode doesn't. Verify token is optional in both modes.
 	if mode == model.ModeWebhook && strings.TrimSpace(in.EncryptKey) == "" {
 		return fmt.Errorf("%w: encrypt_key required in webhook mode", errs.ErrInvalid)
+	}
+	// Telegram: poll/stream-only, and the bot is publicly discoverable by
+	// username, so it MUST carry a non-empty sender allowlist. An empty
+	// allowlist would let anyone on Telegram command a tool-equipped agent
+	// (ADR-031; OpenClaw issue #73756). Feishu/DingTalk skip this — they're
+	// gated by enterprise-tenant membership.
+	if provider == model.ProviderTelegram {
+		if mode != model.ModeStream {
+			return fmt.Errorf("%w: telegram only supports stream mode", errs.ErrInvalid)
+		}
+		ids := ParseAllowFrom(in.AllowFrom)
+		if len(ids) == 0 {
+			return fmt.Errorf("%w: telegram requires allow_from — at least one numeric Telegram user ID (the bot is publicly reachable; an empty allowlist would let anyone command the agent)", errs.ErrInvalid)
+		}
+		in.AllowFrom = strings.Join(ids, ",") // canonicalize stored form
 	}
 	return nil
 }
@@ -93,6 +148,7 @@ func (uc *UC) CreateApp(ctx context.Context, in AppInput) (*model.ImApp, error) 
 		AppSecret:   in.AppSecret,
 		VerifyToken: in.VerifyToken,
 		EncryptKey:  in.EncryptKey,
+		AllowFrom:   in.AllowFrom,
 		Enabled:     in.Enabled,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -122,6 +178,7 @@ func (uc *UC) UpdateApp(ctx context.Context, id uint64, in AppInput) (*model.ImA
 	}
 	cur.VerifyToken = in.VerifyToken
 	cur.EncryptKey = in.EncryptKey
+	cur.AllowFrom = in.AllowFrom
 	cur.Enabled = in.Enabled
 	cur.UpdatedAt = time.Now().UTC()
 	if err := uc.repo.UpdateApp(ctx, cur); err != nil {

--- a/internal/manager/biz/imbridge/usecase_allowfrom_test.go
+++ b/internal/manager/biz/imbridge/usecase_allowfrom_test.go
@@ -1,0 +1,69 @@
+package imbridge
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAllowFrom(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "12345", []string{"12345"}},
+		{"comma+space", "111, 222 , 333", []string{"111", "222", "333"}},
+		{"newline+semicolon", "111\n222;333", []string{"111", "222", "333"}},
+		{"strip prefixes", "telegram:111, tg:222, 333", []string{"111", "222", "333"}},
+		{"dedup preserves order", "222,111,222,111", []string{"222", "111"}},
+		// Security boundary: negative IDs (group/supergroup chat IDs) and
+		// non-numeric junk must NOT become allowed senders.
+		{"reject negative chat ids", "-1001234567890, 111", []string{"111"}},
+		{"reject non-numeric", "abc, 12a, , 111", []string{"111"}},
+		{"all junk -> empty (deny all)", "-1, abc, *, tg:", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseAllowFrom(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseAllowFrom(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// A Telegram app with no resolvable allowlist must fail validation — an
+// empty allowlist on a publicly-discoverable bot is the exact exposure
+// ADR-031 closes.
+func TestValidateTelegramRequiresAllowFrom(t *testing.T) {
+	base := AppInput{Provider: "telegram", Mode: "stream", Name: "tg", AppID: "bot", AppSecret: "tok"}
+
+	in := base
+	if err := in.validate(); err == nil {
+		t.Error("telegram with empty allow_from should be rejected")
+	}
+
+	in = base
+	in.AllowFrom = "-1, garbage" // nothing valid resolves
+	if err := in.validate(); err == nil {
+		t.Error("telegram with no VALID allow_from id should be rejected")
+	}
+
+	in = base
+	in.AllowFrom = "tg:8211893274"
+	if err := in.validate(); err != nil {
+		t.Errorf("telegram with a valid allow_from should pass: %v", err)
+	}
+	if in.AllowFrom != "8211893274" {
+		t.Errorf("allow_from should be canonicalized to %q, got %q", "8211893274", in.AllowFrom)
+	}
+
+	// Telegram is stream-only.
+	in = base
+	in.Mode = "webhook"
+	in.AllowFrom = "111"
+	if err := in.validate(); err == nil {
+		t.Error("telegram webhook mode should be rejected")
+	}
+}

--- a/internal/manager/model/imbridge/model.go
+++ b/internal/manager/model/imbridge/model.go
@@ -15,6 +15,10 @@ import (
 const (
 	ProviderFeishu   = "feishu"
 	ProviderDingTalk = "dingtalk"
+	// ProviderTelegram is stream-only: the manager long-polls getUpdates
+	// (outbound, proxy-friendly), there is no webhook path. app_id = bot
+	// username/id, app_secret = the BotFather token. See ADR-031.
+	ProviderTelegram = "telegram"
 )
 
 // Mode selects how inbound events reach the manager. Stream mode is
@@ -45,6 +49,14 @@ type ImApp struct {
 	AppSecret   string    `gorm:"column:app_secret;type:text;not null"`
 	VerifyToken string    `gorm:"column:verify_token;size:128"`
 	EncryptKey  string    `gorm:"column:encrypt_key;size:128"`
+	// AllowFrom is the sender allowlist for PUBLICLY-discoverable
+	// providers (Telegram): comma/space/newline-separated numeric
+	// Telegram user IDs. Only these users may converse with the bot;
+	// everyone else is silently ignored. EMPTY = deny-all for Telegram
+	// (a public bot with no allowlist is the exact "anyone can reach the
+	// platform" risk — see ADR-031, OpenClaw issue #73756). Unused by
+	// Feishu/DingTalk, which are gated by enterprise-tenant membership.
+	AllowFrom   string    `gorm:"column:allow_from;type:text"`
 	// IdleTimeoutSeconds is kept for legacy installs but is currently
 	// unused — sessions don't auto-rotate any more. Future "long
 	// conversation context window" work might re-introduce it as a

--- a/internal/manager/server/imbridge/http.go
+++ b/internal/manager/server/imbridge/http.go
@@ -311,6 +311,7 @@ type appDTO struct {
 	HasSecret          bool   `json:"has_secret"`
 	VerifyToken        string `json:"verify_token,omitempty"`
 	EncryptKey         string `json:"encrypt_key,omitempty"`
+	AllowFrom          string `json:"allow_from,omitempty"`
 	Enabled            bool   `json:"enabled"`
 	IdleTimeoutSeconds int    `json:"idle_timeout_seconds"`
 	CreatedAt          string `json:"created_at"`
@@ -327,6 +328,7 @@ func toAppDTO(a *model.ImApp) appDTO {
 		HasSecret:          a.AppSecret != "",
 		VerifyToken:        a.VerifyToken,
 		EncryptKey:         a.EncryptKey,
+		AllowFrom:          a.AllowFrom,
 		Enabled:            a.Enabled,
 		IdleTimeoutSeconds: a.IdleTimeoutSeconds,
 		CreatedAt:          a.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
@@ -342,6 +344,7 @@ type appPayload struct {
 	AppSecret   string `json:"app_secret,omitempty"`
 	VerifyToken string `json:"verify_token,omitempty"`
 	EncryptKey  string `json:"encrypt_key,omitempty"`
+	AllowFrom   string `json:"allow_from,omitempty"`
 	Enabled     bool   `json:"enabled"`
 }
 
@@ -354,6 +357,7 @@ func (p appPayload) toInput() bizbridge.AppInput {
 		AppSecret:   p.AppSecret,
 		VerifyToken: p.VerifyToken,
 		EncryptKey:  p.EncryptKey,
+		AllowFrom:   p.AllowFrom,
 		Enabled:     p.Enabled,
 	}
 }

--- a/web/src/api/imbridge.ts
+++ b/web/src/api/imbridge.ts
@@ -1,10 +1,12 @@
 import { request } from './client';
 
-// IM bridge app CRUD — admin endpoints for managing Feishu / DingTalk
-// bot registrations. Default mode is `stream` so manager
-// dials out; webhook is fallback for inbound-only environments.
+// IM bridge app CRUD — admin endpoints for managing Feishu / DingTalk /
+// Telegram bot registrations. Default mode is `stream` so manager dials
+// out; webhook is fallback for inbound-only environments. Telegram is
+// stream-only (getUpdates long-poll) and REQUIRES allow_from — a sender
+// allowlist — because the bot is publicly reachable (ADR-031).
 
-export type IMProvider = 'feishu' | 'dingtalk';
+export type IMProvider = 'feishu' | 'dingtalk' | 'telegram';
 export type IMMode = 'stream' | 'webhook';
 
 export type IMApp = {
@@ -16,6 +18,8 @@ export type IMApp = {
   has_secret: boolean;
   verify_token?: string;
   encrypt_key?: string;
+  // Telegram sender allowlist: comma-separated numeric Telegram user IDs.
+  allow_from?: string;
   enabled: boolean;
   idle_timeout_seconds: number;
   created_at: string;
@@ -31,6 +35,7 @@ export type IMAppPayload = {
   app_secret?: string;
   verify_token?: string;
   encrypt_key?: string;
+  allow_from?: string;
   enabled: boolean;
 };
 

--- a/web/src/pages/settings/IMApps.tsx
+++ b/web/src/pages/settings/IMApps.tsx
@@ -38,6 +38,13 @@ const PROVIDER_META: Record<IMProvider, { labelZh: string; labelEn: string; icon
     hintZh: '钉钉企业内部应用（落地，stream 实现 in progress）。',
     hintEn: 'DingTalk enterprise app (in progress — stream impl pending).',
   },
+  telegram: {
+    labelZh: 'Telegram',
+    labelEn: 'Telegram',
+    icon: Send,
+    hintZh: 'Telegram bot：app_id 填 bot 用户名，app_secret 填 BotFather 的 token。仅 stream 模式（getUpdates 长轮询，出站走代理）。⚠ bot 公开可搜，必须填 allow_from 白名单，否则任何人都能直接和 agent 对话。',
+    hintEn: 'Telegram bot: app_id = bot username, app_secret = the BotFather token. Stream-only (getUpdates long-poll, outbound via proxy). ⚠ the bot is publicly searchable — allow_from is REQUIRED, otherwise anyone could talk to the agent.',
+  },
 };
 
 export default function SettingsIMApps() {
@@ -87,8 +94,8 @@ export default function SettingsIMApps() {
             <span className="font-medium">{tr('通信 — IM 双向 bot', 'Communications — IM bots (two-way)')}</span>
           </div>
           {tr(
-            '配置飞书 / 钉钉机器人，群里 @bot 就能开多轮会话。推荐 ',
-            'Configure Feishu / DingTalk bots so users can @bot in a group and get multi-turn conversations. ',
+            '配置飞书 / 钉钉 / Telegram 机器人，群里 @bot 或私聊就能开多轮会话。推荐 ',
+            'Configure Feishu / DingTalk / Telegram bots so users can @bot in a group (or DM) and get multi-turn conversations. ',
           )}
           <b>{tr('stream 模式', 'Stream mode')}</b>
           {tr(
@@ -228,6 +235,7 @@ function IMAppEditor({
   const [appSecret, setAppSecret] = useState('');
   const [verifyToken, setVerifyToken] = useState(target?.verify_token ?? '');
   const [encryptKey, setEncryptKey] = useState(target?.encrypt_key ?? '');
+  const [allowFrom, setAllowFrom] = useState(target?.allow_from ?? '');
   const [enabled, setEnabled] = useState(target?.enabled ?? true);
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -257,6 +265,7 @@ function IMAppEditor({
         app_secret: appSecret.trim() || undefined,
         verify_token: verifyToken.trim() || undefined,
         encrypt_key: encryptKey.trim() || undefined,
+        allow_from: provider === 'telegram' ? allowFrom.trim() || undefined : undefined,
         enabled,
       };
       if (isCreate) {
@@ -309,12 +318,17 @@ function IMAppEditor({
           <Field label={tr('平台', 'Provider')}>
             <select
               value={provider}
-              onChange={(e) => setProvider(e.target.value as IMProvider)}
+              onChange={(e) => {
+                const p = e.target.value as IMProvider;
+                setProvider(p);
+                if (p === 'telegram') setMode('stream'); // telegram is stream-only
+              }}
               disabled={!isCreate}
               className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none disabled:opacity-50"
             >
               <option value="feishu">飞书 / Feishu</option>
               <option value="dingtalk">钉钉 / DingTalk</option>
+              <option value="telegram">Telegram</option>
             </select>
           </Field>
           <Field label={tr('模式', 'Mode')} hint={mode === 'stream'
@@ -326,7 +340,7 @@ function IMAppEditor({
               className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
             >
               <option value="stream">stream (推荐 / recommended)</option>
-              <option value="webhook">webhook</option>
+              {provider !== 'telegram' && <option value="webhook">webhook</option>}
             </select>
           </Field>
         </div>
@@ -344,7 +358,7 @@ function IMAppEditor({
           />
         </Field>
 
-        <Field label="app_id" hint={tr('飞书 app_id (cli_xxx) / 钉钉 AppKey', 'Feishu app_id (cli_xxx) / DingTalk AppKey')}>
+        <Field label="app_id" hint={tr('飞书 app_id (cli_xxx) / 钉钉 AppKey / Telegram bot 用户名', 'Feishu app_id (cli_xxx) / DingTalk AppKey / Telegram bot username')}>
           <input
             value={appID}
             onChange={(e) => setAppID(e.target.value)}
@@ -354,7 +368,7 @@ function IMAppEditor({
         </Field>
 
         <Field label="app_secret" hint={isCreate
-          ? tr('从平台开放后台拷贝', 'Copy from the open platform admin')
+          ? tr('从平台开放后台拷贝（Telegram 填 BotFather 的 token）', 'Copy from the platform admin (Telegram: the BotFather token)')
           : tr('留空 = 保留现值；填了 = 覆盖', 'Empty = keep existing; filled = overwrite')}>
           <div className="flex items-center gap-2">
             <input
@@ -376,6 +390,23 @@ function IMAppEditor({
             )}
           </div>
         </Field>
+
+        {provider === 'telegram' && (
+          <Field
+            label={tr('allow_from（发送者白名单）', 'allow_from (sender allowlist)')}
+            hint={tr(
+              '必填。逗号分隔的 Telegram 数字 user id，只有名单内的人能和 bot 对话，其他人一律静默忽略。给自己发消息给 @userinfobot 可查到自己的 id。',
+              'Required. Comma-separated numeric Telegram user IDs — only these may talk to the bot; everyone else is silently ignored. DM @userinfobot to find your own id.',
+            )}
+          >
+            <input
+              value={allowFrom}
+              onChange={(e) => setAllowFrom(e.target.value)}
+              placeholder="8211893274, 123456789"
+              className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 font-mono text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+            />
+          </Field>
+        )}
 
         {mode === 'webhook' && provider === 'feishu' && (
           <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## What

Adds **Telegram** as a third IM bridge provider — two-way, multi-turn, streaming conversations with the agent over Telegram (not just one-way notifications, which `notify_channels` already covers).

- **Stream-only via `getUpdates` long-poll.** Telegram has no websocket stream like Feishu. getUpdates is an *outbound* call, so it traverses the manager's `HTTPS_PROXY` on GFW-restricted hosts (`setWebhook` would need Telegram to reach the manager inbound — unreliable from mainland China). `validate()` rejects webhook mode for Telegram.
- Reuses the whole ADR-021 downstream: `HandleInbound` → agent runtime → progressive `streamEditor` (Telegram text is editable, like Feishu).

## Access control (the key risk)

A Telegram bot is **publicly discoverable by username**, so without a gate *anyone* could DM `@bot` and command a tool-equipped agent (enumerate hosts, read metrics/logs, run diagnostics). Feishu/DingTalk are masked from this by enterprise-tenant membership; Telegram is not.

Following **OpenClaw's `allowFrom` model** (and its issue #73756 — open bots = RCE risk for tool agents):

- `im_apps.allow_from` — a sender allowlist of numeric Telegram **user IDs** (`tg:` / `telegram:` prefixes normalized; negatives / junk rejected).
- Telegram **requires** a non-empty `allow_from` at create/update — an empty allowlist on a public bot is the exact exposure, so it's a config error.
- Non-allowlisted senders are dropped **silently** in the poll loop, before the bridge/agent is ever touched (no reply, no ack — no oracle). The sender's id is logged at WARN so an admin can allowlist them.

## Frontend

Provider option (forces stream, hides webhook), `app_id` / `app_secret` hints, and a required `allow_from` field shown only for Telegram.

## Tests

- `provider/telegram`: client request/response shaping (httptest), `senderAdapter` contract, allowlist set construction, and the silent-drop gate.
- `imbridge`: `ParseAllowFrom` edge cases (separators, prefix stripping, dedup, **negative/non-numeric rejection**) + Telegram validation (allow_from required, stream-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
