### PR TITLE
fix(imbridge): dedup re-delivered events + bounded retry on telegram 429/5xx

### DIFF
--- a/internal/manager/biz/imbridge/bridge.go
+++ b/internal/manager/biz/imbridge/bridge.go
@@ -60,14 +60,24 @@ type Bridge struct {
 	// per-provider client cache so we don't rebuild HTTP / token
 	// state on every inbound event. Keyed by app_id.
 	feishuCache sync.Map // app_id -> *feishu.Client
-	log         *slog.Logger
+	// seen dedups re-delivered events (Telegram getUpdates replays the
+	// unacked batch on a poller reconnect) so the agent doesn't answer the
+	// same message twice. Keyed by (provider, app_id, event_id).
+	seen *dedupSet
+	log  *slog.Logger
 }
 
 func NewBridge(repo Repo, agent AgentSession, serviceUserID uint64, log *slog.Logger) *Bridge {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Bridge{repo: repo, agent: agent, serviceUserID: serviceUserID, log: log.With(slog.String("comp", "imbridge"))}
+	return &Bridge{
+		repo:          repo,
+		agent:         agent,
+		serviceUserID: serviceUserID,
+		seen:          newDedupSet(2048),
+		log:           log.With(slog.String("comp", "imbridge")),
+	}
 }
 
 // InboundMessage describes a normalized inbound event the bridge can
@@ -109,6 +119,21 @@ func (b *Bridge) HandleInbound(ctx context.Context, sender Sender, msg InboundMe
 	if msg.Text == "" {
 		b.log.Debug("inbound has no text — ignoring", slog.String("event_id", msg.EventID))
 		return nil
+	}
+
+	// Dedup re-delivered events. Long-poll providers replay the unacked
+	// batch on a reconnect; without this the agent would answer the same
+	// message twice. Marked on entry (not on success) — a duplicate reply
+	// is worse than not re-running a message that already started. Events
+	// with no id (shouldn't happen for telegram/feishu) skip the check.
+	if msg.EventID != "" {
+		key := msg.Provider + ":" + msg.AppID + ":" + msg.EventID
+		if b.seen.seenOrAdd(key) {
+			b.log.Debug("inbound duplicate event — skipping",
+				slog.String("provider", msg.Provider),
+				slog.String("event_id", msg.EventID))
+			return nil
+		}
 	}
 
 	// 1. Resolve app + thread mapping (lazy create).

--- a/internal/manager/biz/imbridge/dedup.go
+++ b/internal/manager/biz/imbridge/dedup.go
@@ -1,0 +1,53 @@
+package imbridge
+
+import "sync"
+
+// dedupSet is a bounded, concurrency-safe set of recently-seen event keys.
+// It exists because long-poll providers (Telegram getUpdates) re-deliver
+// updates that weren't acked yet: the poll offset lives in the StreamClient,
+// which the supervisor recreates from offset 0 on every reconnect, so a tunnel
+// hiccup right after a batch arrives makes Telegram hand the same updates back
+// — and we'd run the agent + post a reply twice. The bridge (a process-lifetime
+// singleton) dedups by event id across those reconnects.
+//
+// Bounding uses a two-generation map: when cur fills, it becomes prev and a
+// fresh cur starts. That retains between cap and 2*cap of the most recent keys
+// with O(1) inserts and no per-entry timestamps. It is in-memory only — a full
+// manager restart resets it (and the Telegram offset), so a restart can still
+// reprocess the unacked backlog; that's a far rarer event than a reconnect.
+type dedupSet struct {
+	mu   sync.Mutex
+	cap  int
+	cur  map[string]struct{}
+	prev map[string]struct{}
+}
+
+func newDedupSet(capacity int) *dedupSet {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &dedupSet{
+		cap:  capacity,
+		cur:  make(map[string]struct{}, capacity),
+		prev: make(map[string]struct{}),
+	}
+}
+
+// seenOrAdd returns true if key was already recorded; otherwise it records the
+// key and returns false. The caller treats a true result as "duplicate, skip".
+func (d *dedupSet) seenOrAdd(key string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.cur[key]; ok {
+		return true
+	}
+	if _, ok := d.prev[key]; ok {
+		return true
+	}
+	if len(d.cur) >= d.cap {
+		d.prev = d.cur
+		d.cur = make(map[string]struct{}, d.cap)
+	}
+	d.cur[key] = struct{}{}
+	return false
+}

--- a/internal/manager/biz/imbridge/dedup_test.go
+++ b/internal/manager/biz/imbridge/dedup_test.go
@@ -1,0 +1,42 @@
+package imbridge
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDedupSetSeenOrAdd(t *testing.T) {
+	d := newDedupSet(8)
+	if d.seenOrAdd("a") {
+		t.Fatal("first 'a' should be new (false)")
+	}
+	if !d.seenOrAdd("a") {
+		t.Fatal("second 'a' should be a duplicate (true)")
+	}
+	if d.seenOrAdd("b") {
+		t.Fatal("'b' should be new")
+	}
+	if !d.seenOrAdd("b") {
+		t.Fatal("'b' repeat should be a duplicate")
+	}
+}
+
+// Keys must survive at least one generation rotation, and fall out after the
+// set has churned well past its capacity (bounded memory).
+func TestDedupSetBounded(t *testing.T) {
+	d := newDedupSet(2)
+	d.seenOrAdd("old")
+	// One full generation back: "old" is still remembered.
+	d.seenOrAdd("g1")
+	d.seenOrAdd("g2") // rotates: prev={old,g1}, cur={g2}
+	if !d.seenOrAdd("old") {
+		t.Error("'old' should still be seen one generation back")
+	}
+	// Churn well past 2*cap distinct keys → "old" drops out of both gens.
+	for i := 0; i < 12; i++ {
+		d.seenOrAdd(fmt.Sprintf("k%d", i))
+	}
+	if d.seenOrAdd("old") {
+		t.Error("'old' should have been evicted after heavy churn (bounded set)")
+	}
+}

--- a/internal/manager/biz/imbridge/provider/telegram/client.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client.go
@@ -13,7 +13,25 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
+
+// maxCallRetries bounds retries on rate-limit (429) and transient server (5xx)
+// responses. Network-level errors (resp err) are NOT retried here — they bubble
+// to the supervisor's reconnect-with-backoff, and for getUpdates the per-poll
+// context deadline is intentional stall detection.
+const maxCallRetries = 3
+
+// maxRetryWait caps how long a single retry will sleep, even if Telegram's
+// retry_after asks for longer (a multi-minute 429 should surface, not block a
+// poll loop indefinitely).
+const maxRetryWait = 60 * time.Second
+
+// backoffDelay is the wait for transient (5xx) retries when Telegram gives no
+// retry_after: 1s, 2s, 4s.
+func backoffDelay(attempt int) time.Duration {
+	return time.Duration(1<<uint(attempt)) * time.Second
+}
 
 // Client is a minimal Telegram Bot API client. It uses a zero-value
 // http.Client (DefaultTransport), so it honors HTTP(S)_PROXY/NO_PROXY env —
@@ -39,6 +57,9 @@ type apiResp struct {
 	Result      json.RawMessage `json:"result"`
 	Description string          `json:"description"`
 	ErrorCode   int             `json:"error_code"`
+	Parameters  *struct {
+		RetryAfter int `json:"retry_after"`
+	} `json:"parameters"`
 }
 
 func (c *Client) call(ctx context.Context, method string, body any) (json.RawMessage, error) {
@@ -46,25 +67,51 @@ func (c *Client) call(ctx context.Context, method string, body any) (json.RawMes
 	if err != nil {
 		return nil, fmt.Errorf("marshal %s: %w", method, err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint(method), bytes.NewReader(b))
-	if err != nil {
-		return nil, err
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint(method), bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := c.hc.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		// Retry rate-limit (429, honoring retry_after) + transient server
+		// errors (5xx) — decided on HTTP status before decoding, since a 5xx
+		// body may not even be valid JSON. Other 4xx (400/401/403) are hard
+		// errors; retrying won't help.
+		if attempt < maxCallRetries && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) {
+			wait := backoffDelay(attempt)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				var e apiResp
+				if json.Unmarshal(raw, &e) == nil && e.Parameters != nil && e.Parameters.RetryAfter > 0 {
+					wait = time.Duration(e.Parameters.RetryAfter) * time.Second
+				}
+			}
+			if wait > maxRetryWait {
+				wait = maxRetryWait
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		var env apiResp
+		if uerr := json.Unmarshal(raw, &env); uerr != nil {
+			return nil, fmt.Errorf("%s decode: %w (body=%s)", method, uerr, truncate(raw, 200))
+		}
+		if !env.OK {
+			return nil, fmt.Errorf("telegram %s: %d %s", method, env.ErrorCode, env.Description)
+		}
+		return env.Result, nil
 	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	raw, _ := io.ReadAll(resp.Body)
-	var env apiResp
-	if err := json.Unmarshal(raw, &env); err != nil {
-		return nil, fmt.Errorf("%s decode: %w (body=%s)", method, err, truncate(raw, 200))
-	}
-	if !env.OK {
-		return nil, fmt.Errorf("telegram %s: %d %s", method, env.ErrorCode, env.Description)
-	}
-	return env.Result, nil
 }
 
 // Update is one getUpdates entry (only the fields the bridge consumes).

--- a/internal/manager/biz/imbridge/provider/telegram/client_test.go
+++ b/internal/manager/biz/imbridge/provider/telegram/client_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/imbridge"
 )
@@ -154,6 +156,76 @@ func TestSenderAdapterRejectsNonNumericID(t *testing.T) {
 
 // TestStreamClientAllowlist: NewStreamClient parses app.AllowFrom into the
 // sender set (separators + tg:/telegram: prefixes + dedup all handled).
+// 429 with retry_after → wait + retry, then succeed.
+func TestCallRetriesOn429(t *testing.T) {
+	var calls int32
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			io.WriteString(w, `{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 1","parameters":{"retry_after":1}}`)
+			return
+		}
+		io.WriteString(w, `{"ok":true,"result":{"message_id":5}}`)
+	})
+	id, err := c.SendMessage(context.Background(), "1", "hi")
+	if err != nil || id != 5 {
+		t.Fatalf("after 429 retry: id=%d err=%v; want 5, nil", id, err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("want 2 calls (429 then 200), got %d", got)
+	}
+}
+
+// 5xx (even with a non-JSON body, as a proxy/nginx might return) → retry.
+func TestCallRetriesOn5xx(t *testing.T) {
+	var calls int32
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			io.WriteString(w, `<html>502 Bad Gateway</html>`)
+			return
+		}
+		io.WriteString(w, `{"ok":true,"result":{"message_id":9}}`)
+	})
+	id, err := c.SendMessage(context.Background(), "1", "hi")
+	if err != nil || id != 9 {
+		t.Fatalf("after 5xx retry: id=%d err=%v; want 9, nil", id, err)
+	}
+}
+
+// 4xx (other than 429) is a hard error — must NOT retry.
+func TestCallNoRetryOn4xx(t *testing.T) {
+	var calls int32
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}`)
+	})
+	if _, err := c.SendMessage(context.Background(), "1", "hi"); err == nil {
+		t.Fatal("400 should be a hard error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("400 must not retry; want 1 call, got %d", got)
+	}
+}
+
+// A cancelled context must short-circuit, not sleep out a long retry_after.
+func TestCallRetryRespectsContext(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		io.WriteString(w, `{"ok":false,"error_code":429,"description":"slow down","parameters":{"retry_after":30}}`)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err := c.SendMessage(ctx, "1", "hi"); err == nil {
+		t.Fatal("want error on cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("cancelled ctx should not sleep out retry_after; took %v", elapsed)
+	}
+}
+
 func TestStreamClientAllowlist(t *testing.T) {
 	app := &model.ImApp{AppSecret: "tok", AllowFrom: "tg:111, 222 333\n444;111"}
 	c := NewStreamClient(app, nil, nil)


### PR DESCRIPTION
## What

Closes the two reliability gaps found comparing our Telegram provider against OpenClaw's `getUpdates` implementation.

### 1. Duplicate processing (dedup)
The telegram poll **offset lives in the `StreamClient`**, which the supervisor recreates from offset `0` on every reconnect. So a tunnel hiccup right after a batch arrives makes Telegram **replay** those updates → the agent answers the same message twice (observed on the test env after a tunnel flap).

The `Bridge` (a process-lifetime singleton that *survives* reconnects) now dedups inbound events by `(provider, app_id, event_id)` using a bounded two-generation set (`newDedupSet(2048)` → retains cap..2×cap recent keys, O(1), no timestamps). Marked **on entry** — a duplicate reply is worse than not re-running an already-started message. In-memory only: a full manager restart can still reprocess the unacked backlog, but that's far rarer than a reconnect.

This mirrors OpenClaw's "persist watermark after dispatch" intent without a separate offset store.

### 2. No rate-limit / transient retry
`telegram.Client.call` now does **bounded (3×) retries**:
- **429** — honors `parameters.retry_after` (capped at 60s).
- **5xx** — 1/2/4s backoff; decided on **HTTP status** so a non-JSON 5xx body (proxy/nginx) still retries.
- Hard 4xx (400/401/403) → immediate error. Network errors aren't retried here — they bubble to the supervisor's reconnect-with-backoff, and for `getUpdates` the per-poll context deadline is intentional stall detection.
- Retry sleeps respect context cancellation.

## Why this is still simpler than OpenClaw
We stay stream-only + single-supervised-poller, so we keep dodging their worst bug classes (dual-poller 409s, webhook↔polling transition conflicts, stall-watchdog false positives). The 35s per-poll context deadline remains our stall detection — it can't fail to fire.

## Tests
- `dedup_test.go`: seen/new + bounded eviction.
- `client_test.go`: 429-then-success, 5xx-then-success (non-JSON body), no-retry on 4xx, cancelled-context short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
