### PR TITLE
test(e2e): 加 E1 metric_raw evaluator + FakeProm 分 instant/range

### DIFF
--- a/docs/test/e2e-catalog.md
+++ b/docs/test/e2e-catalog.md
@@ -69,7 +69,7 @@
 
 | # | 用例 | 触发 | 关键断言点 | 优 | 实现 |
 |---|---|---|---|---|---|
-| E1 | metric_raw 规则 fire(PromQL) | 推 fake metric cpu>90 | `alert_incidents` 行 status=open | **P0** | |
+| E1 | metric_raw 规则 fire(PromQL) | 推 fake metric cpu>90 | `alert_incidents` 行 status=open | **P0** | ✅ `tests/e2e/alert_evaluator_test.go` |
 | E2 | device_offline 规则 fire | 停 edge 5min | incident 创建、target_type=edge | **P0** | |
 | E3 | incident → notification 投递 | E1 之后 | `notification_deliveries` status=ok | **P0** | |
 | E4 | 通知 cooldown | E1 紧接第二次 fire | 第二次不发(or throttled) | P1 | |

--- a/tests/e2e/alert_evaluator_test.go
+++ b/tests/e2e/alert_evaluator_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+// Catalog: E1 — metric_raw 告警评估器单条触发。流程：
+//   - 起 manager 把 ONGRID_ALERT_EVAL_INTERVAL 压到 2s（同时也是 rules 缓存
+//     刷新间隔 — main.go 把两者绑在同一个 cfg.Alert.EvaluatorInterval 上）
+//   - admin 登录 → POST /api/v1/alert-rules 创建一条 kind=metric_raw,
+//     scope=global 的规则，expr 唯一好认 "fake_e2e_metric > 50"
+//   - FakeProm.SetInstant 把这条 expr 的查询结果填成一个非空 vector
+//     条目（PromQL 的过滤语义本身就是"返回 → 命中"）
+//   - 等 5s（一次 rules 刷新 + 至少一次 evaluator tick）
+//   - GET /api/v1/alerts/incidents → 必须出现一条以我们 rule_key 为 rule 的
+//     incident
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/tests/e2e/testenv"
+)
+
+func TestAlert_MetricRawEvaluatorFires_E1(t *testing.T) {
+	env := testenv.Start(t,
+		testenv.WithEnv("ONGRID_ALERT_EVAL_INTERVAL", "2s"),
+		testenv.WithEnv("ONGRID_ALERT_ENABLED", "true"),
+	)
+	pair := env.LoginAdmin()
+
+	const (
+		ruleKey = "e2e_metric_raw_test"
+		expr    = "fake_e2e_metric > 50"
+	)
+
+	createStatus, body, err := env.DoJSON("POST", "/api/v1/alert-rules", map[string]any{
+		"rule_key":   ruleKey,
+		"kind":       "metric_raw",
+		"name":       "E2E metric_raw rule",
+		"scope_type": "global",
+		"join_mode":  "all",
+		"severity":   "warning",
+		"enabled":    true,
+		"spec":       map[string]any{"expr": expr},
+	}, pair.AccessToken)
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+	if createStatus != 200 && createStatus != 201 {
+		t.Fatalf("create rule: status=%d body=%v", createStatus, body)
+	}
+
+	// Tell FakeProm: when the evaluator runs our exact expression, return
+	// one "firing" series. Empty Labels = global series (no per-host
+	// breakdown), perfect for a scope=global rule which validateFiring
+	// does not require device_id for.
+	env.FakeProm().SetInstant(expr, []testenv.InstantEntry{
+		{Labels: map[string]string{}, Value: 95.0},
+	})
+
+	// Wait long enough for at least one rules refresh + one eval tick.
+	// Cache interval = EvalInterval (main.go 801) = 2s, so 5s = 2 refresh
+	// rounds, plenty of slack for the manager to compile + dispatch.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		status, list, err := env.DoJSON("GET", "/api/v1/alerts/incidents", nil, pair.AccessToken)
+		if err != nil {
+			t.Fatalf("list incidents: %v", err)
+		}
+		if status != 200 {
+			t.Fatalf("list incidents: status=%d body=%v", status, list)
+		}
+		if itemsHaveRule(list, ruleKey) {
+			return // 通过
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// Diagnostic: dump what we did see so the failure message is useful.
+	_, list, _ := env.DoJSON("GET", "/api/v1/alerts/incidents", nil, pair.AccessToken)
+	t.Fatalf("no incident with rule=%q within 15s; list=%v", ruleKey, list)
+}
+
+func itemsHaveRule(list map[string]any, ruleKey string) bool {
+	items, _ := list["items"].([]any)
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		if m == nil {
+			continue
+		}
+		if r, _ := m["rule"].(string); r == ruleKey {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e/alert_evaluator_test.go
+++ b/tests/e2e/alert_evaluator_test.go
@@ -56,10 +56,11 @@ func TestAlert_MetricRawEvaluatorFires_E1(t *testing.T) {
 		{Labels: map[string]string{}, Value: 95.0},
 	})
 
-	// Wait long enough for at least one rules refresh + one eval tick.
-	// Cache interval = EvalInterval (main.go 801) = 2s, so 5s = 2 refresh
-	// rounds, plenty of slack for the manager to compile + dispatch.
-	deadline := time.Now().Add(15 * time.Second)
+	// Wait long enough for: manager finishes startup (~10–15s on cold
+	// runs), one rules cache refresh + one eval tick (cache interval =
+	// EvalInterval = 2s, main.go 801). 45s window with 1s poll gives
+	// generous slack for the box's CPU contention.
+	deadline := time.Now().Add(45 * time.Second)
 	for time.Now().Before(deadline) {
 		status, list, err := env.DoJSON("GET", "/api/v1/alerts/incidents", nil, pair.AccessToken)
 		if err != nil {
@@ -76,9 +77,12 @@ func TestAlert_MetricRawEvaluatorFires_E1(t *testing.T) {
 
 	// Diagnostic: dump what we did see so the failure message is useful.
 	_, list, _ := env.DoJSON("GET", "/api/v1/alerts/incidents", nil, pair.AccessToken)
-	t.Fatalf("no incident with rule=%q within 15s; list=%v", ruleKey, list)
+	t.Fatalf("no incident with rule_key=%q within 45s; list=%v", ruleKey, list)
 }
 
+// itemsHaveRule scans the incidents list response for one whose rule_key
+// matches. The DTO field is rule_key (not rule) — caught by the first
+// E1 run where the assertion missed despite the incident actually firing.
 func itemsHaveRule(list map[string]any, ruleKey string) bool {
 	items, _ := list["items"].([]any)
 	for _, it := range items {
@@ -86,7 +90,7 @@ func itemsHaveRule(list map[string]any, ruleKey string) bool {
 		if m == nil {
 			continue
 		}
-		if r, _ := m["rule"].(string); r == ruleKey {
+		if r, _ := m["rule_key"].(string); r == ruleKey {
 			return true
 		}
 	}

--- a/tests/e2e/testenv/fakes.go
+++ b/tests/e2e/testenv/fakes.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -286,22 +287,37 @@ func (f *FakeTelegram) handle(w http.ResponseWriter, r *http.Request) {
 
 // ─── Fake Prometheus query backend ─────────────────────────────────────
 //
-// Minimal /api/v1/query_range that returns whatever the test injected via
-// SetSeries. Tests that want to drive alert rules push fake series in
-// before they trigger the evaluator tick.
+// Two endpoints with subtly different response shapes:
+//   /api/v1/query        → resultType="vector", value=[ts, "v"]   (instant)
+//   /api/v1/query_range  → resultType="matrix", values=[[ts,"v"]] (range)
+//
+// Alert evaluators use the instant variant (predicate baked into PromQL
+// returns the firing rows). Range is wired for grafana-shaped panels.
 
 type FakeProm struct {
 	server *httptest.Server
 
-	mu     sync.Mutex
-	series map[string][][2]any // query → [ [timestamp, value], ... ]
+	mu      sync.Mutex
+	series  map[string][][2]any         // for query_range: query → samples
+	instant map[string][]InstantEntry   // for query: query → entries
+}
+
+// InstantEntry is one vector entry the FakeProm returns for /api/v1/query.
+// Labels are emitted as the entry's "metric" map; Value is rendered as
+// the Prom-canonical [unix_ts, "<float-as-string>"] pair.
+type InstantEntry struct {
+	Labels map[string]string
+	Value  float64
 }
 
 func NewFakeProm() *FakeProm {
-	f := &FakeProm{series: map[string][][2]any{}}
+	f := &FakeProm{
+		series:  map[string][][2]any{},
+		instant: map[string][]InstantEntry{},
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/query_range", f.queryRange)
-	mux.HandleFunc("/api/v1/query", f.queryRange)
+	mux.HandleFunc("/api/v1/query", f.queryInstant)
 	f.server = httptest.NewServer(mux)
 	return f
 }
@@ -310,16 +326,28 @@ func (f *FakeProm) URL() string { return f.server.URL }
 func (f *FakeProm) Close()      { f.server.Close() }
 
 // SetSeries lets a test inject a canned response for an exact query
-// string. Subsequent matching /api/v1/query_range hits return this series.
-// Unmatched queries return an empty result (success, but no data).
+// string on /api/v1/query_range. Unmatched queries return an empty
+// matrix (success, no data).
 func (f *FakeProm) SetSeries(query string, samples [][2]any) {
 	f.mu.Lock()
 	f.series[query] = samples
 	f.mu.Unlock()
 }
 
+// SetInstant injects a canned vector response for /api/v1/query. Each
+// entry maps to one "firing" series in the alert evaluator's view (the
+// predicate is baked into the PromQL expression itself, so the very
+// presence of an entry means "the rule fires for this label set").
+//
+//	SetInstant("up == 0", []InstantEntry{{Labels: nil, Value: 0}})
+func (f *FakeProm) SetInstant(query string, entries []InstantEntry) {
+	f.mu.Lock()
+	f.instant[query] = entries
+	f.mu.Unlock()
+}
+
 func (f *FakeProm) queryRange(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query().Get("query")
+	q := readQueryParam(r)
 	f.mu.Lock()
 	samples := f.series[q]
 	f.mu.Unlock()
@@ -339,6 +367,44 @@ func (f *FakeProm) queryRange(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeOK(w, resp)
+}
+
+func (f *FakeProm) queryInstant(w http.ResponseWriter, r *http.Request) {
+	q := readQueryParam(r)
+	f.mu.Lock()
+	entries := f.instant[q]
+	f.mu.Unlock()
+	result := make([]any, 0, len(entries))
+	ts := time.Now().Unix()
+	for _, e := range entries {
+		metric := map[string]any{}
+		for k, v := range e.Labels {
+			metric[k] = v
+		}
+		valStr := strconv.FormatFloat(e.Value, 'f', -1, 64)
+		result = append(result, map[string]any{
+			"metric": metric,
+			"value":  []any{ts, valStr},
+		})
+	}
+	writeOK(w, map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "vector",
+			"result":     result,
+		},
+	})
+}
+
+// readQueryParam returns the PromQL expression: Prom accepts it either
+// on the query string (GET) or in form body (POST). The real client
+// sends POST application/x-www-form-urlencoded, so we parse both.
+func readQueryParam(r *http.Request) string {
+	if v := r.URL.Query().Get("query"); v != "" {
+		return v
+	}
+	_ = r.ParseForm()
+	return r.Form.Get("query")
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

补 e2e P0 第 5 条 — alert evaluator 端到端触发。这是上一轮我标记 \"deferred\" 的 E1，等到这一轮把 FakeProm 拆完整了之后落地。

**E1** (\`tests/e2e/alert_evaluator_test.go\`):
- 起 manager 把 \`ONGRID_ALERT_EVAL_INTERVAL=2s\`（eval tick + rules 缓存刷新同步压短）
- POST \`/api/v1/alert-rules\` 建一条 \`kind=metric_raw\`, \`scope=global\` 的规则，expr 唯一好认 \`fake_e2e_metric > 50\`
- \`FakeProm.SetInstant\` 让那条 expr 的 \`/api/v1/query\` 返回非空 vector
- 等 45s，每秒 GET \`/api/v1/alerts/incidents\`，出现 \`rule_key=<我们的>\` 算通过

**testenv/fakes.go FakeProm 升级**：
- 旧：\`/query\` 和 \`/query_range\` 都返 matrix shape — instant query 实际期望的是 vector + value=[ts,\"v\"]
- 新：\`/query\` → vector (instant) / \`/query_range\` → matrix (range)，分别 handler
- 新 \`SetInstant(expr, []InstantEntry)\` API（\`InstantEntry{Labels, Value}\`）
- \`readQueryParam\` 兼容 GET query + POST form（真实 prom client 是 POST form）

## scope=global 的取巧

evaluator pipeline 在 \`pipeline.go:182\` 由 \`e.prom != nil\` 全局 gate，只要 \`ONGRID_PROM_ENABLED=true\` 就启用（testenv 默认已开）。\`validateFiring\` 在 \`usecase.go:1472\` 只对 \`ScopeType=host\` 强制 \`device_id\` 非空 — global scope 不需要假 host 设备就能 fire，给 e2e 大大减小复杂度。

## 一个 commit 的小坑（留作记录）

第一次跑实际 fire 了但 assertion 失败 — \`incident\` DTO 字段名是 \`rule_key\` 我写成了 \`rule\`。日志里 \`incident already\` 那行救场。第二个 commit 修了字段 + 把 wait 从 15s 拉到 45s（冷启动第一次 eval 在 manager up 后 ~30s 才触发）。

## Test plan

- [x] 测试机 49.233.163.197 上 5/5 全绿: E1(33.6s) / B1(5.9s) / B2(8.9s) / G3(5.9s) / O1(5.9s)
- [x] catalog 实现列勾选
- [ ] PR review: 关注 \`FakeProm.queryInstant\` 的响应 shape 是否真和 \`internal/pkg/promquery/client.go\` 的 \`InstantResult\` decode 路径完全对齐（已通过 evaluator 闭环验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)