### PR TITLE
feat(web/i18n): auto-detect locale from timezone (and language) on first visit

### DIFF
--- a/web/src/i18n/locale.ts
+++ b/web/src/i18n/locale.ts
@@ -19,10 +19,49 @@ export type Locale = 'zh-CN' | 'en-US';
 const LOCALE_STORAGE_KEY = 'ongrid-locale';
 const LOCALE_CHANGE_EVENT = 'ongrid-locale-change';
 
+// Mainland-CN + HK/Macau timezones. The user's effective time zone is the
+// primary auto-detect signal because foreign visitors with zh-* set in
+// their browser (e.g. heritage speakers, students) still want the English
+// UI; conversely, an in-CN user whose browser is en-US (corp default)
+// still wants the Chinese UI.
+const CN_TIMEZONES = new Set<string>([
+  'Asia/Shanghai',
+  'Asia/Chongqing',
+  'Asia/Urumqi',
+  'Asia/Harbin',
+  'Asia/Hong_Kong',
+  'Asia/Macau',
+]);
+
+function autoDetectLocale(): Locale {
+  // Run only in the browser; SSR / unit-test envs fall back to zh-CN
+  // (preserves the old "Chinese-default" behaviour for non-browser paths).
+  if (typeof navigator === 'undefined' || typeof Intl === 'undefined') {
+    return 'zh-CN';
+  }
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+    if (CN_TIMEZONES.has(tz)) return 'zh-CN';
+    // Secondary signal: browser language. Treat as a tie-breaker for
+    // timezones we don't recognise but where the user clearly speaks
+    // Chinese (e.g. tz=UTC because of a misconfigured docker host).
+    const lang = (navigator.language || '').toLowerCase();
+    if (lang.startsWith('zh')) return 'zh-CN';
+  } catch {
+    /* Intl unavailable in this runtime — fall through */
+  }
+  return 'en-US';
+}
+
 export const getLocale = (): Locale => {
   if (typeof localStorage === 'undefined') return 'zh-CN';
   const v = localStorage.getItem(LOCALE_STORAGE_KEY);
-  return v === 'en-US' ? 'en-US' : 'zh-CN';
+  // User-explicit choice (set via the language switcher) ALWAYS wins.
+  if (v === 'en-US' || v === 'zh-CN') return v;
+  // First visit (or storage cleared): auto-detect from timezone +
+  // browser language. Applies on the login page too because the React
+  // SPA boots through this same hook before the route resolves.
+  return autoDetectLocale();
 };
 
 export const setLocale = (locale: Locale): void => {


### PR DESCRIPTION
## Summary

Web UI used to default to `zh-CN` unconditionally regardless of who the visitor is. Foreign new users opening the login page saw Chinese UI until they clicked the switcher.

`getLocale()` now does this on first visit (when no `localStorage['ongrid-locale']` is set):

1. **Timezone first**: tz in {Asia/Shanghai, Chongqing, Urumqi, Harbin, Hong_Kong, Macau} → `zh-CN`
2. **Browser language tie-break**: `navigator.language` starts with `zh` → `zh-CN` (catches misconfigured docker hosts running on tz=UTC but with zh browsers)
3. **Else** → `en-US`

Once user clicks the language switcher, the explicit `localStorage` value wins over auto-detect forever (until they clear it).

## Why timezone over `navigator.language`

Foreign zh-heritage speakers / students typically have their browser set to zh for browsing Chinese sites, but they want **English** UI for their ops console. Conversely, in-CN engineers with corporate en-US browser locale want **Chinese**. Timezone tracks where the user actually operates from — which is what we care about for an ops tool.

## Applies to login page too

The React SPA bootstraps through `useI18n()` before any route resolves, so the first paint of the login page uses the auto-detected locale.

## Test plan

- [ ] open https://101.34.63.91:8443 from a US tz browser → English UI
- [ ] open from CN tz browser → Chinese UI
- [ ] click switcher to English in CN tz → stays English (localStorage wins)
- [ ] clear localStorage → reload → auto-detect kicks in again
- [ ] unit env without `navigator`/`Intl` → falls back to zh-CN (preserves old non-browser behaviour)

## Files changed
`web/src/i18n/locale.ts` — `getLocale` + new `autoDetectLocale` helper + `CN_TIMEZONES` set.