### PR TITLE
fix(install): banner reads ONGRID_PUBLIC_URL from .env not shell var

### DIFF
--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -711,10 +711,14 @@ if [[ $HEALTH_OK -eq 0 ]]; then
 fi
 
 # ---------- detect host address for banner ----------
-# Prefer the host from ONGRID_PUBLIC_URL (the address edges actually use);
-# otherwise the LAN/egress IP. `hostname -f` is a last resort — stock cloud
-# images often return a useless 'localhost.localdomain' that no one can reach.
-HOST_HINT="$(printf '%s' "${ONGRID_PUBLIC_URL:-}" | sed -E 's#^[a-zA-Z]+://##; s#[:/].*$##')"
+# Source of truth is $ENV_FILE: that's the value the manager and the edges
+# actually use (whether typed at the prompt, taken from an exported env, or
+# auto-detected from cloud metadata). The earlier `fill_blank` writes it to
+# .env but does NOT export to the current shell, so reading `$ONGRID_PUBLIC_URL`
+# would come back empty. Read the file. Fall back to hostname / route only
+# when .env genuinely has no value.
+HOST_FROM_ENV="$(grep -E '^ONGRID_PUBLIC_URL=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- | sed -E 's#^[a-zA-Z]+://##; s#[:/].*$##')"
+HOST_HINT="$HOST_FROM_ENV"
 if [[ -z "$HOST_HINT" || "$HOST_HINT" == localhost* ]]; then
     HOST_HINT="$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -Ev '^(127\.|$)' | head -1 || true)"
 fi


### PR DESCRIPTION
## Symptom

User installed on a Tencent VM; cloud metadata detection wrote the right value to .env but the completion banner showed the internal NIC IP:

```
.env:     ONGRID_PUBLIC_URL=https://101.34.63.91   ← correct (public)
Banner:   Web UI:          https://10.0.4.17/      ← wrong (internal NIC)
          API URL:         https://10.0.4.17/api/v1
          Tunnel endpoint: 10.0.4.17:40012
```

## Root cause

The prompt block (line ~615) calls `fill_blank` to write `ONGRID_PUBLIC_URL` into .env but never exports the resolved value to the current shell. The banner block (line ~717) reads `${ONGRID_PUBLIC_URL:-}` which is empty in this shell, falls through to `hostname -I`, which on Tencent / Aliyun cloud VMs returns the internal NIC address (10.0.4.17 here).

## Fix

Read `ONGRID_PUBLIC_URL` from `$ENV_FILE` directly. .env is the canonical source of truth — that's what the manager process reads at boot, what edges receive when configured from the manager UI, and what survives reinstalls. Removes any race between 'value written' and 'value visible'.

## Functional impact

**None** — downstream behaviour was always correct because the manager reads .env at boot. **Edges connect just fine** with the existing build; this commit fixes a display lie in the install banner, not the actual wiring.

## Test plan

- [ ] re-run install.sh on a cloud VM where `ONGRID_PUBLIC_URL` was empty before; banner now shows the same value as .env
- [ ] re-run with `ONGRID_PUBLIC_URL=https://ops.example.com` already exported; banner shows ops.example.com
- [ ] re-run on a host with no cloud metadata + no env var; banner falls through to hostname -I as before