### PR TITLE
release(v0.7.168): sharper gif (gifski) + HD MP4 link + install bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Watch full demo in HD (MP4, 47 MB)</a></sub></p>
 
 ## Features
 
@@ -35,10 +36,10 @@ Download the latest release, extract it, and run the installer (Ubuntu 22.04+, D
 
 ```bash
 # 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Extract
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Install
 sudo ./install.sh

--- a/README_DE.md
+++ b/README_DE.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Vollständige Demo in HD ansehen (MP4, 47 MB)</a></sub></p>
 
 ## Funktionen
 
@@ -35,10 +36,10 @@ Laden Sie das aktuelle Release herunter, entpacken Sie es und führen Sie das In
 
 ```bash
 # 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Entpacken
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Installieren
 sudo ./install.sh

--- a/README_ES.md
+++ b/README_ES.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa en HD (MP4, 47 MB)</a></sub></p>
 
 ## Características
 
@@ -35,10 +36,10 @@ Descarga la última release, descomprímela y ejecuta el instalador (Ubuntu 22.0
 
 ```bash
 # 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Descomprimir
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_FR.md
+++ b/README_FR.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Voir la démo complète en HD (MP4, 47 MB)</a></sub></p>
 
 ## Fonctionnalités
 
@@ -35,10 +36,10 @@ Téléchargez la dernière release, décompressez-la et exécutez le script d’
 
 ```bash
 # 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Décompresser
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Installer
 sudo ./install.sh

--- a/README_JA.md
+++ b/README_JA.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ フル動画 (HD) を見る (MP4, 47 MB)</a></sub></p>
 
 ## 機能
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 展開
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. インストール
 sudo ./install.sh

--- a/README_KO.md
+++ b/README_KO.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 전체 HD 영상 보기 (MP4, 47 MB)</a></sub></p>
 
 ## 기능
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 압축 해제
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. 설치
 sudo ./install.sh

--- a/README_PT.md
+++ b/README_PT.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa em HD (MP4, 47 MB)</a></sub></p>
 
 ## Recursos
 
@@ -35,10 +36,10 @@ Baixe a última release, descompacte e execute o instalador (Ubuntu 22.04+, Debi
 
 ```bash
 # 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Descompactar
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_RU.md
+++ b/README_RU.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Смотреть полное демо в HD (MP4, 47 MB)</a></sub></p>
 
 ## Возможности
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Распаковка
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Установка
 sudo ./install.sh

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 观看高清完整视频 (MP4, 47 MB)</a></sub></p>
 
 ## 特性
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 解压
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. 安装
 sudo ./install.sh


### PR DESCRIPTION
## Summary
- Rebuilt `docs/assets/demo.gif` with gifski (900w / 12 fps / quality 75) — 9.8 MB, visibly sharper than the prior ffmpeg palettegen output at similar size
- Added a `▶ Watch full demo in HD (MP4, 47 MB)` link under the hero in all 9 READMEs, pointing at `releases/download/v0.7.168/Area2.mp4` (uploaded as a release asset)
- Bumped wget URL + tar filename `v0.7.167 → v0.7.168` across all 9 READMEs
- ongrid.cloud/dl/ mirror now hosts the v0.7.168 tarball + sha256

## Why not `<video>` directly in README
GitHub's markdown sanitizer strips `<video>` tags entirely for any URL outside the `user-images.githubusercontent.com` allowlist (release-asset URLs included). Verified by POSTing the candidate snippet to `/markdown` — rendered output was an empty `<p>`. So the hero stays a GIF; the HD MP4 is one click away.

## Test plan
- [x] gifski output renders in browser at the README's 100% width without obvious banding
- [x] `gh release view v0.7.168` shows `Area2.mp4` among assets
- [x] `curl -sI https://ongrid.cloud/dl/ongrid-v0.7.168-linux-amd64.tar.xz` → 200
- [x] Website QuickStart bumped to v0.7.168 and already deployed to ongrid.cloud

Generated with Claude Code.
