### PR TITLE
docs(readme): new positioning + sharper MP4 link (18 MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Watch full demo in HD (MP4, 47 MB)</a></sub></p>
 
 ## Features
 
@@ -35,10 +36,10 @@ Download the latest release, extract it, and run the installer (Ubuntu 22.04+, D
 
 ```bash
 # 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Extract
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Install
 sudo ./install.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **AI agent for understanding, diagnosing, and operating infrastructure.** *Observability, remote execution, knowledge base, agents and skills — all chat-driven. Drop it into Slack, Telegram, Lark, or wherever your team already lives.*
+> **An ops AI that understands your systems, finds the root cause, and actually fixes things.** *Monitoring, remote execution, knowledge base, specialist agents, an open skill ecosystem — all one prompt away. Drop it into Slack, Telegram, or Lark: it lives where your team lives.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Watch full demo in HD (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Watch full demo in HD (MP4, 18 MB)</a></sub></p>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **An ops AI that understands your systems, finds the root cause, and actually fixes things.** *Monitoring, remote execution, knowledge base, specialist agents, an open skill ecosystem — all one prompt away. Drop it into Slack, Telegram, or Lark: it lives where your team lives.*
+> **An ops AI that understands, finds the root cause, and fixes things.** *Monitoring, remote execution, knowledge base, specialist agents, an open skill ecosystem — all one prompt away. Drop it into Slack, Telegram, or Lark: it lives where your team lives.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_DE.md
+++ b/README_DE.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Vollständige Demo in HD ansehen (MP4, 47 MB)</a></sub></p>
 
 ## Funktionen
 
@@ -35,10 +36,10 @@ Laden Sie das aktuelle Release herunter, entpacken Sie es und führen Sie das In
 
 ```bash
 # 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Entpacken
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Installieren
 sudo ./install.sh

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **KI-Agent zum Verstehen, Diagnostizieren und Betreiben Ihrer Infrastruktur.** *Observability, Remote-Ausführung, Wissensbasis, Agenten und Skills —— alles per Chat. Einfach in Slack, Telegram, Lark oder die Chat-App einbinden, in der Ihr Team bereits unterwegs ist.*
+> **Eine Ops-KI, die Ihre Systeme versteht, die Grundursache findet und selbst Hand anlegt.** *Monitoring, Remote-Ausführung, Wissensbasis, Spezialisten-Agenten, Skill-Ökosystem —— alles per Chat-Befehl. Direkt in Slack, Telegram oder Lark — sie lebt dort, wo Ihr Team lebt.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Vollständige Demo in HD ansehen (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Vollständige Demo in HD ansehen (MP4, 18 MB)</a></sub></p>
 
 ## Funktionen
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Eine Ops-KI, die Ihre Systeme versteht, die Grundursache findet und selbst Hand anlegt.** *Monitoring, Remote-Ausführung, Wissensbasis, Spezialisten-Agenten, Skill-Ökosystem —— alles per Chat-Befehl. Direkt in Slack, Telegram oder Lark — sie lebt dort, wo Ihr Team lebt.*
+> **Eine Ops-KI, die versteht, die Ursache findet und behebt.** *Monitoring, Remote-Ausführung, Wissensbasis, Spezialisten-Agenten, Skill-Ökosystem —— alles per Chat-Befehl. Direkt in Slack, Telegram oder Lark — sie lebt dort, wo Ihr Team lebt.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Agente de IA para entender, diagnosticar y operar tu infraestructura.** *Observabilidad, ejecución remota, base de conocimiento, agentes y skills —— todo desde el chat. Llévalo a Slack, Telegram, Lark o a la app donde tu equipo ya vive.*
+> **Una IA de operaciones que entiende tus sistemas, encuentra la causa raíz y se pone manos a la obra.** *Monitorización, ejecución remota, base de conocimiento, agentes especialistas, ecosistema de skills —— todo a un mensaje de distancia. Cárgala en Slack, Telegram o Lark: vive donde vive tu equipo.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa en HD (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Ver demo completa en HD (MP4, 18 MB)</a></sub></p>
 
 ## Características
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa en HD (MP4, 47 MB)</a></sub></p>
 
 ## Características
 
@@ -35,10 +36,10 @@ Descarga la última release, descomprímela y ejecuta el instalador (Ubuntu 22.0
 
 ```bash
 # 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Descomprimir
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Una IA de operaciones que entiende tus sistemas, encuentra la causa raíz y se pone manos a la obra.** *Monitorización, ejecución remota, base de conocimiento, agentes especialistas, ecosistema de skills —— todo a un mensaje de distancia. Cárgala en Slack, Telegram o Lark: vive donde vive tu equipo.*
+> **Una IA de ops que entiende, encuentra la causa y arregla.** *Monitorización, ejecución remota, base de conocimiento, agentes especialistas, ecosistema de skills —— todo a un mensaje de distancia. Cárgala en Slack, Telegram o Lark: vive donde vive tu equipo.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Une IA d'ops qui comprend vos systèmes, trouve la cause racine et passe à l'action.** *Monitoring, exécution distante, base de connaissances, agents spécialistes, écosystème de skills —— tout à un message d'écart. Posez-la dans Slack, Telegram ou Lark : elle vit là où votre équipe vit.*
+> **Une IA d'ops qui comprend, trouve la cause et corrige.** *Monitoring, exécution distante, base de connaissances, agents spécialistes, écosystème de skills —— tout à un message d'écart. Posez-la dans Slack, Telegram ou Lark : elle vit là où votre équipe vit.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_FR.md
+++ b/README_FR.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Voir la démo complète en HD (MP4, 47 MB)</a></sub></p>
 
 ## Fonctionnalités
 
@@ -35,10 +36,10 @@ Téléchargez la dernière release, décompressez-la et exécutez le script d’
 
 ```bash
 # 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Décompresser
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Installer
 sudo ./install.sh

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Agent IA pour comprendre, diagnostiquer et exploiter votre infrastructure.** *Observabilité, exécution distante, base de connaissances, agents et skills —— le tout piloté par chat. Déposez-le dans Slack, Telegram, Lark ou l'app de discussion où votre équipe vit déjà.*
+> **Une IA d'ops qui comprend vos systèmes, trouve la cause racine et passe à l'action.** *Monitoring, exécution distante, base de connaissances, agents spécialistes, écosystème de skills —— tout à un message d'écart. Posez-la dans Slack, Telegram ou Lark : elle vit là où votre équipe vit.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Voir la démo complète en HD (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Voir la démo complète en HD (MP4, 18 MB)</a></sub></p>
 
 ## Fonctionnalités
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ フル動画 (HD) を見る (MP4, 47 MB)</a></sub></p>
 
 ## 機能
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 展開
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. インストール
 sudo ./install.sh

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **インフラを理解し、診断し、運用する AI エージェント。** *可観測性、リモート実行、ナレッジベース、エージェントとスキル —— すべてチャット駆動。Slack、Telegram、Lark、あるいはチームが既にいるチャットアプリにそのまま組み込めます。*
+> **システムを理解し、根本原因を突き止め、自ら手を動かして解決する運用 AI。** *監視、リモート実行、ナレッジベース、スペシャリストエージェント、各種スキル —— すべて一言で呼び出せる。Slack、Telegram、Lark にそのまま入る。チームのいる場所で動く。*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ フル動画 (HD) を見る (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ フル動画 (HD) を見る (MP4, 18 MB)</a></sub></p>
 
 ## 機能
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **システムを理解し、根本原因を突き止め、自ら手を動かして解決する運用 AI。** *監視、リモート実行、ナレッジベース、スペシャリストエージェント、各種スキル —— すべて一言で呼び出せる。Slack、Telegram、Lark にそのまま入る。チームのいる場所で動く。*
+> **システムを理解し、原因を突き止め、自ら直す運用 AI。** *監視、リモート実行、ナレッジベース、スペシャリストエージェント、各種スキル —— すべて一言で呼び出せる。Slack、Telegram、Lark にそのまま入る。チームのいる場所で動く。*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **인프라를 이해하고 진단하고 운영하는 AI 에이전트.** *가관측성, 원격 실행, 지식 베이스, 에이전트와 스킬 —— 모두 채팅으로 구동. Slack, Telegram, Lark, 혹은 팀이 이미 모여 있는 채팅 앱에 그대로 넣으세요.*
+> **시스템을 이해하고, 근본 원인을 찾아내고, 직접 손을 써서 해결하는 운영 AI.** *모니터링, 원격 실행, 지식 베이스, 전문가 에이전트, 각종 스킬 —— 모두 한 마디로 호출. Slack, Telegram, Lark 에 그대로 들어갑니다. 팀이 있는 곳에서 동작합니다.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 전체 HD 영상 보기 (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ 전체 HD 영상 보기 (MP4, 18 MB)</a></sub></p>
 
 ## 기능
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **시스템을 이해하고, 근본 원인을 찾아내고, 직접 손을 써서 해결하는 운영 AI.** *모니터링, 원격 실행, 지식 베이스, 전문가 에이전트, 각종 스킬 —— 모두 한 마디로 호출. Slack, Telegram, Lark 에 그대로 들어갑니다. 팀이 있는 곳에서 동작합니다.*
+> **이해하고, 원인을 짚고, 직접 고치는 운영 AI.** *모니터링, 원격 실행, 지식 베이스, 전문가 에이전트, 각종 스킬 —— 모두 한 마디로 호출. Slack, Telegram, Lark 에 그대로 들어갑니다. 팀이 있는 곳에서 동작합니다.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_KO.md
+++ b/README_KO.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 전체 HD 영상 보기 (MP4, 47 MB)</a></sub></p>
 
 ## 기능
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 압축 해제
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. 설치
 sudo ./install.sh

--- a/README_PT.md
+++ b/README_PT.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Uma IA de ops que entende seus sistemas, encontra a causa raiz e põe a mão na massa.** *Monitoramento, execução remota, base de conhecimento, agentes especialistas, ecossistema de skills —— tudo a um comando de distância. Coloque no Slack, Telegram ou Lark: ela vive onde sua equipe vive.*
+> **Uma IA de ops que entende, encontra a causa e corrige.** *Monitoramento, execução remota, base de conhecimento, agentes especialistas, ecossistema de skills —— tudo a um comando de distância. Coloque no Slack, Telegram ou Lark: ela vive onde sua equipe vive.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_PT.md
+++ b/README_PT.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa em HD (MP4, 47 MB)</a></sub></p>
 
 ## Recursos
 
@@ -35,10 +36,10 @@ Baixe a última release, descompacte e execute o instalador (Ubuntu 22.04+, Debi
 
 ```bash
 # 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Descompactar
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_PT.md
+++ b/README_PT.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Agente de IA para entender, diagnosticar e operar sua infraestrutura.** *Observabilidade, execução remota, base de conhecimento, agentes e skills —— tudo via chat. Coloque no Slack, Telegram, Lark ou no app onde sua equipe já vive.*
+> **Uma IA de ops que entende seus sistemas, encontra a causa raiz e põe a mão na massa.** *Monitoramento, execução remota, base de conhecimento, agentes especialistas, ecossistema de skills —— tudo a um comando de distância. Coloque no Slack, Telegram ou Lark: ela vive onde sua equipe vive.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Ver demo completa em HD (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Ver demo completa em HD (MP4, 18 MB)</a></sub></p>
 
 ## Recursos
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Ops-AI, который понимает ваши системы, находит первопричину и сам исправляет.** *Мониторинг, удалённое выполнение, база знаний, специалисты-агенты, экосистема skills —— всё одним сообщением. Поднимите в Slack, Telegram или Lark: он живёт там, где живёт ваша команда.*
+> **Ops-AI: понимает, находит причину и чинит.** *Мониторинг, удалённое выполнение, база знаний, специалисты-агенты, экосистема skills —— всё одним сообщением. Поднимите в Slack, Telegram или Lark: он живёт там, где живёт ваша команда.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_RU.md
+++ b/README_RU.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Смотреть полное демо в HD (MP4, 47 MB)</a></sub></p>
 
 ## Возможности
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. Распаковка
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. Установка
 sudo ./install.sh

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **AI-агент для понимания, диагностики и эксплуатации инфраструктуры.** *Observability, удалённое выполнение, база знаний, агенты и skills —— всё через чат. Поднимите в Slack, Telegram, Lark или в мессенджере, где команда уже общается.*
+> **Ops-AI, который понимает ваши системы, находит первопричину и сам исправляет.** *Мониторинг, удалённое выполнение, база знаний, специалисты-агенты, экосистема skills —— всё одним сообщением. Поднимите в Slack, Telegram или Lark: он живёт там, где живёт ваша команда.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ Смотреть полное демо в HD (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Смотреть полное демо в HD (MP4, 18 MB)</a></sub></p>
 
 ## Возможности
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,6 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 观看高清完整视频 (MP4, 47 MB)</a></sub></p>
 
 ## 特性
 
@@ -35,10 +36,10 @@
 
 ```bash
 # 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.167/ongrid-v0.7.167-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
 
 # 2. 解压
-tar -xf ongrid-v0.7.167-linux-amd64.tar.xz && cd ongrid-v0.7.167-linux-amd64
+tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
 
 # 3. 安装
 sudo ./install.sh

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **理解、诊断并运维基础设施的 AI Agent。** *可观测、远程执行、知识库、智能体与技能 —— 全部对话驱动。放进 Slack、Telegram、飞书，或者你团队已经常驻的任何聊天里。*
+> **一个看得懂系统、查得出根因、还能动手解决的运维 AI。** *监控、远程执行、知识库、专家智能体、各类技能——全都一句话调度。直接装进 Slack、Telegram、飞书：团队在哪儿，它就在哪儿。*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2.mp4">▶ 观看高清完整视频 (MP4, 47 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ 观看高清完整视频 (MP4, 18 MB)</a></sub></p>
 
 ## 特性
 


### PR DESCRIPTION
All 9 READMEs: new headline 'understands / finds root cause / actually fixes'; 3-clause tagline that names monitoring / remote-exec / KB / specialist agents / skill ecosystem. MP4 link bumped from 47MB original to 18MB CRF-18 1080p faststart (visually lossless).