### PR TITLE
release(v0.7.169): bump install URLs + adapter test followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Watch full demo in HD (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Watch full demo in HD (MP4, 18 MB)</a></sub></p>
 
 ## Features
 
@@ -36,10 +36,10 @@ Download the latest release, extract it, and run the installer (Ubuntu 22.04+, D
 
 ```bash
 # 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Extract
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Install
 sudo ./install.sh

--- a/README_DE.md
+++ b/README_DE.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Vollständige Demo in HD ansehen (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Vollständige Demo in HD ansehen (MP4, 18 MB)</a></sub></p>
 
 ## Funktionen
 
@@ -36,10 +36,10 @@ Laden Sie das aktuelle Release herunter, entpacken Sie es und führen Sie das In
 
 ```bash
 # 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Entpacken
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Installieren
 sudo ./install.sh

--- a/README_ES.md
+++ b/README_ES.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Ver demo completa en HD (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Ver demo completa en HD (MP4, 18 MB)</a></sub></p>
 
 ## Características
 
@@ -36,10 +36,10 @@ Descarga la última release, descomprímela y ejecuta el instalador (Ubuntu 22.0
 
 ```bash
 # 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Descomprimir
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_FR.md
+++ b/README_FR.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Voir la démo complète en HD (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Voir la démo complète en HD (MP4, 18 MB)</a></sub></p>
 
 ## Fonctionnalités
 
@@ -36,10 +36,10 @@ Téléchargez la dernière release, décompressez-la et exécutez le script d’
 
 ```bash
 # 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Décompresser
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Installer
 sudo ./install.sh

--- a/README_JA.md
+++ b/README_JA.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ フル動画 (HD) を見る (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ フル動画 (HD) を見る (MP4, 18 MB)</a></sub></p>
 
 ## 機能
 
@@ -36,10 +36,10 @@
 
 ```bash
 # 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. 展開
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. インストール
 sudo ./install.sh

--- a/README_KO.md
+++ b/README_KO.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ 전체 HD 영상 보기 (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ 전체 HD 영상 보기 (MP4, 18 MB)</a></sub></p>
 
 ## 기능
 
@@ -36,10 +36,10 @@
 
 ```bash
 # 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. 압축 해제
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. 설치
 sudo ./install.sh

--- a/README_PT.md
+++ b/README_PT.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Ver demo completa em HD (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Ver demo completa em HD (MP4, 18 MB)</a></sub></p>
 
 ## Recursos
 
@@ -36,10 +36,10 @@ Baixe a última release, descompacte e execute o instalador (Ubuntu 22.04+, Debi
 
 ```bash
 # 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Descompactar
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh

--- a/README_RU.md
+++ b/README_RU.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ Смотреть полное демо в HD (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ Смотреть полное демо в HD (MP4, 18 MB)</a></sub></p>
 
 ## Возможности
 
@@ -36,10 +36,10 @@
 
 ```bash
 # 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. Распаковка
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. Установка
 sudo ./install.sh

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,7 +15,7 @@
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Ongrid demo" width="100%" />
 </p>
-<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.168/Area2_hq.mp4">▶ 观看高清完整视频 (MP4, 18 MB)</a></sub></p>
+<p align="center"><sub><a href="https://github.com/ongridio/ongrid/releases/download/v0.7.169/Area2_hq.mp4">▶ 观看高清完整视频 (MP4, 18 MB)</a></sub></p>
 
 ## 特性
 
@@ -36,10 +36,10 @@
 
 ```bash
 # 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.7.168/ongrid-v0.7.168-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.7.169/ongrid-v0.7.169-linux-amd64.tar.xz
 
 # 2. 解压
-tar -xf ongrid-v0.7.168-linux-amd64.tar.xz && cd ongrid-v0.7.168-linux-amd64
+tar -xf ongrid-v0.7.169-linux-amd64.tar.xz && cd ongrid-v0.7.169-linux-amd64
 
 # 3. 安装
 sudo ./install.sh

--- a/internal/manager/biz/imbridge/adapter_test.go
+++ b/internal/manager/biz/imbridge/adapter_test.go
@@ -1,0 +1,105 @@
+package imbridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/llm"
+)
+
+// fakeDefaults stubs the LLMSettingsResolver surface the adapter needs.
+type fakeDefaults struct {
+	providers []llm.ProviderConfig
+	defID     string
+	err       error
+}
+
+func (f *fakeDefaults) ResolveProviders(_ context.Context) ([]llm.ProviderConfig, string, error) {
+	return f.providers, f.defID, f.err
+}
+
+// TestAdapter_runOptions_picksResolverDefault covers the v0.7.169 fix:
+// IM bridge must thread the cluster default_provider + <provider>_default_model
+// into agent.RunOptions instead of leaving them empty (which made agent.New
+// fall back to the hard-coded "gpt-5.4" model and end users saw
+// "助手执行失败" in Lark/Slack/Telegram).
+func TestAdapter_runOptions_picksResolverDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		defaults     LLMDefaultProvider
+		wantProvider string
+		wantModel    string
+	}{
+		{
+			name: "configured default points at a registered provider",
+			defaults: &fakeDefaults{
+				providers: []llm.ProviderConfig{
+					{ID: "custom", Model: "claude-opus-4-7"},
+					{ID: "zhipu", Model: "glm-4.7-flash"},
+				},
+				defID: "zhipu",
+			},
+			wantProvider: "zhipu",
+			wantModel:    "glm-4.7-flash",
+		},
+		{
+			name: "empty default falls back to the first provider in catalog",
+			defaults: &fakeDefaults{
+				providers: []llm.ProviderConfig{
+					{ID: "custom", Model: "claude-opus-4-7"},
+					{ID: "zhipu", Model: "glm-4.7-flash"},
+				},
+				defID: "",
+			},
+			wantProvider: "custom",
+			wantModel:    "claude-opus-4-7",
+		},
+		{
+			name: "default points at a provider that's no longer in the catalog falls back to first",
+			defaults: &fakeDefaults{
+				providers: []llm.ProviderConfig{
+					{ID: "zhipu", Model: "glm-4.7-flash"},
+				},
+				defID: "openai",
+			},
+			wantProvider: "zhipu",
+			wantModel:    "glm-4.7-flash",
+		},
+		{
+			name: "resolver error → zero RunOptions (agent fallback applies)",
+			defaults: &fakeDefaults{
+				err: errors.New("transient DB error"),
+			},
+			wantProvider: "",
+			wantModel:    "",
+		},
+		{
+			name: "empty catalog → zero RunOptions (no provider configured at all)",
+			defaults: &fakeDefaults{
+				providers: nil,
+			},
+			wantProvider: "",
+			wantModel:    "",
+		},
+		{
+			name:         "nil resolver → zero RunOptions (caller didn't wire it)",
+			defaults:     nil,
+			wantProvider: "",
+			wantModel:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewAiopsAdapter(nil, 1, tt.defaults, nil)
+			opts := a.runOptions(context.Background())
+			if opts.Provider != tt.wantProvider {
+				t.Errorf("provider = %q, want %q", opts.Provider, tt.wantProvider)
+			}
+			if opts.Model != tt.wantModel {
+				t.Errorf("model = %q, want %q", opts.Model, tt.wantModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
9 README install snippets bumped to v0.7.169. Catches the test file that missed PR #35's squash.