### PR TITLE
fix(edge/uninstall): stop units unconditionally + pkill fallback

### DIFF
--- a/deploy/install/edge/uninstall.sh
+++ b/deploy/install/edge/uninstall.sh
@@ -28,19 +28,23 @@ if [[ $EUID -ne 0 ]]; then
     exec sudo -E bash "$0" "$@"
 fi
 
-# Stop + disable the unit; ignore errors (e.g. unit not installed).
-if systemctl list-unit-files | grep -q '^ongrid-edge\.service'; then
-    systemctl disable --now ongrid-edge 2>/dev/null || true
-fi
+# Stop + disable units unconditionally. The previous "list-unit-files
+# | grep -q ^name.service" precondition silently skipped the stop on
+# hosts where the output formatting (leading whitespace, deprecated/
+# masked decorations, paged output) confused the anchored grep. The
+# uninstaller then went on to rm -f the binary while the supervisor
+# was still running — agent + every subprocess survived, printed [OK].
+# `systemctl stop` is safe to call on an unknown unit (logs to stderr,
+# returns non-zero) so we just suppress + ignore failures.
+systemctl stop    ongrid-edge ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
+systemctl disable ongrid-edge ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
 
-# Also stop the bundled exporters (installed alongside edge by
-# install-edge.sh). Best-effort — fine if either was never installed.
-if systemctl list-unit-files | grep -q '^ongrid-node-exporter\.service'; then
-    systemctl disable --now ongrid-node-exporter 2>/dev/null || true
-fi
-if systemctl list-unit-files | grep -q '^ongrid-process-exporter\.service'; then
-    systemctl disable --now ongrid-process-exporter 2>/dev/null || true
-fi
+# Defensive: if systemd never actually managed the agent (manual
+# install, broken unit file, etc.), kill the supervisor and any
+# subprocess plugins by binary path. Matches every plugin (promtail,
+# otelcol-contrib, node_exporter, process_exporter, ...) without
+# enumerating them.
+pkill -9 -f '/usr/local/bin/ongrid-edge|/usr/local/lib/ongrid-edge/' 2>/dev/null || true
 
 rm -f "$SERVICE_FILE" "$INSTALL_DIR/ongrid-edge"
 rm -f /etc/systemd/system/ongrid-node-exporter.service

--- a/deploy/install/edge/uninstall.sh
+++ b/deploy/install/edge/uninstall.sh
@@ -4,16 +4,24 @@
 # Usage:
 #   curl -k -sSL https://<server>/uninstall.sh | bash
 #
-# Stops the systemd unit (if present), removes the binary, env file,
-# log dir, and the service user. Idempotent — safe to re-run.
+# Wipes the agent end-to-end: systemd units (agent + bundled exporters),
+# binary, env, logs, bundled plugin binaries, plugin work dir (rendered
+# configs + subprocess logs + .upgrade stage dir), and the service user.
+# Idempotent — safe to re-run.
 
 set -euo pipefail
 
 INSTALL_DIR="/usr/local/bin"
-ENV_FILE="/etc/ongrid-edge/ongrid-edge.env"
+ENV_DIR="/etc/ongrid-edge"
 SERVICE_FILE="/etc/systemd/system/ongrid-edge.service"
 LOG_DIR="/var/log/ongrid-edge"
 SERVICE_USER="ongrid-edge"
+# Wholesale plugin dirs: bundled binaries (promtail, node_exporter,
+# process_exporter, ...) and plugin work state (configs + textfile
+# producer outputs + .upgrade stage). Both are agent-owned; leaving
+# either behind makes reinstall non-deterministic.
+PLUGIN_BIN_DIR="/usr/local/lib/ongrid-edge"
+PLUGIN_WORK_DIR="/var/lib/ongrid-edge"
 
 if [[ $EUID -ne 0 ]]; then
     echo "[INFO] re-executing with sudo"
@@ -37,10 +45,10 @@ fi
 rm -f "$SERVICE_FILE" "$INSTALL_DIR/ongrid-edge"
 rm -f /etc/systemd/system/ongrid-node-exporter.service
 rm -f /etc/systemd/system/ongrid-process-exporter.service
-rm -f /usr/local/lib/ongrid-edge/node_exporter
-rm -f /usr/local/lib/ongrid-edge/process_exporter
-rm -rf "$(dirname "$ENV_FILE")"
+rm -rf "$ENV_DIR"
 rm -rf "$LOG_DIR"
+rm -rf "$PLUGIN_BIN_DIR"
+rm -rf "$PLUGIN_WORK_DIR"
 
 systemctl daemon-reload 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
Follow-up to #46. The curl-pipe uninstaller printed `[OK]` on VM-0-10 while every agent process kept running and `rm -f` happily deleted the binary out from under them — `ps -ef | grep edge` after the script still showed the agent supervisor plus 4 subprocesses (promtail, otelcol-contrib, node_exporter, process_exporter).

## Root cause
The precondition

```sh
if systemctl list-unit-files | grep -q '^ongrid-edge\.service'; then
    systemctl disable --now ongrid-edge ...
fi
```

silently skips the stop branch on hosts where `list-unit-files` output has leading whitespace, deprecated/masked decorations, or paged formatting that confuses the anchored grep. `set -e` doesn't trip inside an `if` condition, so the script proceeds straight to the `rm` statements without ever asking systemd to terminate anything.

## Fix
- Drop the precondition. `systemctl stop` is safe to invoke against unknown unit names (logs to stderr, returns non-zero), suppressed via `2>/dev/null || true`.
- Add a `pkill -9 -f '/usr/local/bin/ongrid-edge|/usr/local/lib/ongrid-edge/'` belt-and-suspenders for any supervisor or plugin subprocess started outside systemd.

## Test plan
- [x] `bash -n uninstall.sh` clean
- [x] Hot-swapped onto the .91 manager nginx bind-mount; `curl -ks https://101.34.63.91/uninstall.sh` serves the new version
- [ ] User to re-run `curl -ks https://101.34.63.91/uninstall.sh | sudo bash` on VM-0-10 and confirm `ps -ef | grep edge` returns only the grep itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
