### PR TITLE
docs: add open-core ROADMAP.md + ROADMAP.zh-CN.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,364 @@
+# Ongrid Roadmap
+
+_Last updated: 2026-06-06_
+
+Working roadmap for the open-core Ongrid project. Items merge user-driven
+ideas (2026-06-06 planning session) with the historical backlog scattered
+across ADRs, HLDs, PRDs, and prior planning memos.
+
+## Legend
+
+| Mark | Meaning |
+|---|---|
+| ✓ | Already landed — listed only as context for follow-ups |
+| ◐ | In progress |
+| □ | Queued, not started |
+| ◯ | Parked — explicitly deferred until a stated trigger condition |
+
+## Guiding principle
+
+Ongrid's moat is the `geminio` two-way tunnel + an AI agent that can take
+action on customer hosts. The three pillars (metrics / logs / traces) are
+the entry ticket, not the differentiator. Every roadmap item is judged
+against one question: **does this let the agent act, or surface a richer
+action in the incident timeline?** Pure-display features defer.
+
+Ordering inside each section is rough priority within the section, not
+across sections.
+
+---
+
+## A. Causal RCA depth (HLD-013 Phase 3)
+
+A1. ✓ Phase 1 — investigator prompt rewritten as a causal traversal loop;
+    `max_turns` 25 → 40; structured `根因/因果链/现象/置信度` output.
+
+A2. ✓ Phase 2 — `query_change_events` BaseTool reads HLD-010 audit log as
+    a "patient zero" candidate set; wired through `Registry.SetAuditLister`.
+
+A3. □ **Edge-side change watcher** — audit log only sees changes made
+    through Ongrid. Subscribe to `journald` + `dockerd events` + apt/dnf
+    history on the edge so external SSH / out-of-band deploys / container
+    churn show up as candidate root causes.
+
+A4. □ **Directed dependency edges + baselines** — topology graph today is
+    undirected; RCA can't always tell "upstream of" from "downstream of".
+    Add direction + per-metric baseline so prompts can reason about
+    anomaly position in the dep tree.
+
+A5. □ **Cross-session similar-incident retrieval** —
+    `incident_resolutions` table + embedding + `query_similar_incidents`
+    tool + resolve-modal in incident UI. Closes the
+    "we've seen this before" loop.
+
+---
+
+## B. Remote diagnostic action tools (Roadmap Step 3)
+
+B1. □ **Remote packet capture → object storage + UI render** ★
+    Killer feature: `capture_pcap(iface, bpf, duration)` BaseTool, tarball
+    uploaded to built-in MinIO/S3, incident timeline links to an embedded
+    pcap viewer (web wireshark or a simplified flow table). Nobody else
+    in the SaaS space ships this because they lack the secure two-way
+    tunnel.
+
+B2. □ **Network probes** — `probe_tcp` / `probe_http` / `probe_dns` /
+    `traceroute` / `mtr` as BaseTools. Currently doable via `host_bash`
+    but probes deserve first-class output schemas for incident timeline.
+
+B3. □ **File + log + kernel diagnostics** — `tail_file` / `grep_file` /
+    `strace` / `lsof` / `dmesg` / `sosreport` BaseTools.
+
+B4. ◐ **Network Layer-1 cmdpolicy expansion** — OVS / nft / conntrack /
+    ipset / ethtool / bpftool / `ip netns` read-side already shipped
+    (9 binaries, see `internal/edgeagent/cmdpolicy/policy.go`).
+
+B5. □ **Network Layer-2/3 skills** — `host_ovs_show`,
+    `host_netfilter_dump`, `host_conntrack_summary`, eBPF preset library
+    (preset IDs only — never raw `bpftrace -e <body>`).
+
+---
+
+## C. Natural-language querying
+
+C1. □ **LLM-generated PromQL / LogQL / TraceQL** — `chat_to_query`
+    BaseTool, schema-augmented context (label set + metric metadata),
+    dry-run preview before execution, frequently-hit patterns auto-saved
+    as templates. Lowers the floor for operators who don't speak query
+    DSLs yet.
+
+C2. □ **Chat → Grafana panel** — natural-language description picks a
+    panel + range + variable values and either deep-links or embeds the
+    panel inline in chat.
+
+---
+
+## D. Agent kernel quality
+
+D1. □ **Specialist sub-agents** — `specialist-network`, `specialist-disk`,
+    `specialist-process` personas; coordinator picks one by incident type
+    and constrains its tool bag. Activates the sub-agent framework that
+    currently sits idle.
+
+D2. □ **Critic loop** — primary ReAct finishes → critic LLM checks for
+    unevidenced claims, missed tool calls, broken causal chains → up to
+    2 corrective rounds. Industry reports +10–30% accuracy. Doubles
+    tokens, gate at `severity ≥ critical`.
+
+D3. □ **Eval / replay framework** — 5–10 golden incidents annotated with
+    expected tool set + answer keywords; `cmd/ongrid-eval` CLI; CI hook
+    on prompt / persona / tool-description changes.
+
+---
+
+## E. User-facing assistant UX
+
+E1. □ **Global Side Panel assistant** — floating button + `Cmd+K`,
+    available on every page, auto-seeds prompt with current page context.
+    Single biggest UX uplift; landing dock for everything else here.
+
+E2. □ **Multi-assistant / user-defined assistants** — each carries its
+    own prompt + tool subset + default scope. Side Panel switches
+    between them.
+
+E3. □ **Quick Action cards** — dynamic slot above the chat input;
+    page-context-aware "one-click ask" templates.
+
+E4. □ **Knowledge bookmarking** — pin useful agent answers to an
+    `agent_knowledge` table; detail pages get a "related knowledge"
+    panel; list pages get search.
+
+E5. □ **Reasoning timeline visualisation** — chat toggle that renders
+    `user → thought → tool_calls → tool_results → final answer` as a
+    tree, not flat text.
+
+---
+
+## F. Data and resource integrations
+
+### F1. Kubernetes
+
+F1.1. □ **K8s edge plugin** — installable as a node-level binary or a
+    single in-cluster pod with a service-account-driven kubectl; RBAC
+    manifests shipped.
+
+F1.2. □ **K8s BaseTool suite** — `kube_get_pods`, `kube_describe`,
+    `kube_logs` (streaming), `kube_events`, `kube_top`, `kube_exec`
+    (gated as dangerous).
+
+F1.3. □ **Operator / CRD deployment** — `OngridEdge` CRD, DaemonSet
+    mode, aligned with ADR-024 bundle upgrade.
+
+F1.4. □ **K8s topology** — Pod / Deployment / Service / Ingress as
+    topology nodes; blast-radius BFS spans K8s resources too.
+
+### F2. Cloud resources
+
+F2.1. □ **Read-only inventory tools** — AWS / GCP / Aliyun / Tencent
+    Cloud: EC2 / CVM list, VPCs and routes, security groups, RDS, LB,
+    object storage usage.
+
+F2.2. □ **Cloud-monitoring read-through** — CloudWatch / Stackdriver /
+    Aliyun CMS as RCA evidence sources; not a Prometheus replacement,
+    just fills the cloud-native resource gap.
+
+F2.3. □ **Cloud cost** — `cloud_cost_breakdown` BaseTool tied into
+    incidents so the expensive ones surface first.
+
+F2.4. □ **Per-org cloud credentials** — credential vault with rotation,
+    modelled on ADR-023 (Git credentials dual rail).
+
+### F3. LLM providers
+
+F3.1. □ **Ollama support** — Custom (OpenAI-compatible) provider hint
+    pre-fills `http://localhost:11434/v1`, auto-pulls the model list.
+    Marketing angle: zero outbound data.
+
+F3.2. □ **vLLM / SGLang / LMDeploy** preset support for self-hosted
+    GPU customers.
+
+F3.3. □ **Bedrock / Vertex** — enterprise-cloud customers; defer until
+    asked.
+
+### F4. IM / collaboration
+
+F4.1. ✓ Slack / Telegram / Lark two-way already shipped (ADR-021 /
+    ADR-031).
+
+F4.2. □ **DingTalk** — completes the CN big-three.
+
+F4.3. □ **Microsoft Teams** — required for overseas enterprise.
+
+F4.4. □ **WeCom (企业微信) two-way** — webhook-only today; bot mode
+    needed for chat-driven actions.
+
+### F5. Logs and traces (Roadmap Step 5)
+
+F5.1. ✓ Loki path already shipped (ADR-012).
+
+F5.2. □ **Tempo traces** — edge OTel collector reverse-proxied through
+    manager ingress, same pattern as the metrics path. Hold until a
+    real customer asks; storage + UX is a black hole otherwise.
+
+F5.3. □ **eBPF auto-tracing** (Pixie-inspired) — only after F5.2 is
+    live and stable.
+
+---
+
+## G. Engineering and operations
+
+### G1. Install / first-boot
+
+G1.1. □ **Port-conflict preflight** — `ss -tlnp | grep :443` first,
+    auto-bump to 8443 / 8080 on collision and propagate to
+    `ONGRID_PUBLIC_URL`.
+
+G1.2. □ **Co-tenant vs sole-tenant prompt** — preflight asks whether
+    this box runs other web services; the answer drives port and
+    public-URL choice.
+
+G1.3. □ **Internal vs public IP confirmation** — single-box self-test
+    users usually want the internal IP, not the cloud-metadata public IP.
+
+G1.4. □ **Mirror health check** — after writing `daemon.json` and
+    restarting docker, `docker pull hello-world` as a probe; roll back
+    or switch the mirror list on failure.
+
+G1.5. □ **`read -s` for admin password** — current prompt leaks into
+    `.bash_history`.
+
+G1.6. □ **First-boot guided wizard** — after install, the first UI
+    visit walks through admin reset → LLM provider → IM → first edge
+    install as one flow (PRD-001).
+
+G1.7. ✓ Uninstall script wholesale-purges plugin binaries and work
+    directory; stops units unconditionally with a `pkill -9` fallback
+    (PR #46, PR #47).
+
+### G2. Edge lifecycle
+
+G2.1. ✓ ADR-024 one-touch bundle upgrade with `.previous` rollback.
+
+G2.2. □ **Channels and canary** — stable / beta / canary, gated by
+    edge tags.
+
+G2.3. □ **Health-aware rollout** — auto-rollback if the post-upgrade
+    heartbeat doesn't come back green within 30s.
+
+G2.4. □ **Offline upgrade bundle** — internal-network customers,
+    manager acts as the mirror.
+
+### G3. Prometheus production hardening (parked)
+
+G3.1. ◯ nginx `/prometheus/` `auth_request` to close the remote_write
+    endpoint from the open internet.
+
+G3.2. ◯ `promwrite.Ingester` ring buffer + worker pool + bbolt DLQ.
+
+G3.3. ◯ VictoriaMetrics drop-in compose profile.
+
+G3.4. ◯ `install.sh` "built-in Prom / VictoriaMetrics / external TSDB"
+    selector.
+
+G3.5. ◯ Label whitelist to bound cardinality blow-ups.
+
+Trigger to unpark: > 100 edges per customer, an HA / SLA request,
+or `promwrite` write-timeout accumulation in manager logs.
+
+### G4. Self-observability (ADR-026)
+
+G4.1. ✓ `/metrics`, 6 self-alerts, dashboard already shipped.
+
+G4.2. □ **SLO board** — availability, tool success rate, RCA accuracy
+    (fed by D3 eval framework).
+
+G4.3. □ **Self-diagnostic agent** — periodic self-RCA against the
+    manager's own metrics.
+
+### G5. Security / sandbox
+
+G5.1. ◯ microsandbox upgrade path — only when a customer demands kernel
+    isolation; until then `host_bash` + `cmdpolicy` covers 90% of
+    diagnostic surface.
+
+G5.2. □ **WebSSH (ADR-019)** — geminio stream + xterm.js, exposed as
+    a fallback inside SOP execution.
+
+G5.3. □ **Per-tool RBAC + audit replay** — ADR-022 gates by viewer
+    role; granularity needs to drop to per-tool.
+
+### G6. Credentials / knowledge
+
+G6.1. ✓ ADR-023 SSH key table + Git credentials dual rail.
+
+G6.2. □ **ADR-018 RepoFetcher** — per-repo auth without re-introducing
+    the token leakage concerns ADR-018 (revised) tabled.
+
+G6.3. □ **Offline vault bundle** — for customers without outbound
+    internet; built-in vault + offline snapshot tarball.
+
+---
+
+## H. Ecosystem / late-stage
+
+H1. ◯ **Skill marketplace public listing** (ADR-017) — wait until skill
+    count crosses ~30.
+
+H2. □ **HLD-009 coordinator e2e evaluation** — currently a design;
+    becomes runnable once D3 eval framework is live.
+
+H3. □ **HLD-012 code-aware analysis** — combine a code repo with
+    incidents; PR diff → impact analysis.
+
+H4. ◯ **Open ecosystem** — plugin SDK docs and third-party BaseTool
+    registration; defer until the open-core split (ADR-030) has been
+    out long enough to attract contributors.
+
+---
+
+## I. SOP / Runbook execution loop
+
+The most ambitious chunk on the roadmap. Listed last on purpose:
+sections A–H either unblock SOP or have to be solid before SOP can
+ship safely. **Do not start until the diagnostic + action tools (B)
+and the agent kernel quality work (D) are in a reliable place** —
+otherwise the executable path becomes an outage generator instead of
+a moat.
+
+I1. □ **Tool.Class three-tier** — `safe` (read-only) / `mutating`
+    (state change) / `dangerous` (irreversible). Replaces today's
+    binary read/write split.
+
+I2. □ **SOP DSL** — YAML runbooks: `triggers / steps / approvals /
+    rollback`.
+
+I3. □ **Two-signature execution chain** — manager RSA signs, edge
+    verifies, both ends audit-log every step.
+
+I4. □ **`review_gate` sub-agent** — mutating step spawns a reviewer
+    worker → writes a `mutating_proposal` row → UI surfaces an action
+    card → operator signs → edge executes → timeline gets a
+    `mutating_action_executed` entry.
+
+I5. □ **Initial playbook library** — opening four:
+    `host_restart_service`, `disk_cleanup`, `log_rotate`,
+    `certificate_renew`.
+
+---
+
+## J. Periodic agent jobs
+
+Built on the same scheduler primitive; sized for "agent watches over
+time" workloads rather than synchronous chat.
+
+J1. □ **Inspection / 巡检** — scheduled (daily / weekly) sweeps of
+    every edge run a lightweight RCA: `top_load_anomaly`,
+    `dep_health_check`, `cert_expiry_check`; matches auto-create
+    incidents.
+
+J2. □ **Weekly / monthly digest** — cross-edge aggregate of alerts,
+    incidents, executed actions; LLM-written summary; IM-pushed.
+
+J3. □ **Watch tasks / proactive notification** — `create_watch
+    (condition, expire_at)` BaseTool; when the condition fires, push
+    back into the original session over SSE.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,364 +1,346 @@
 # Ongrid Roadmap
 
-_Last updated: 2026-06-06_
+_Last updated: 2026-06-06 · Chinese version: [`ROADMAP.zh-CN.md`](ROADMAP.zh-CN.md)_
 
-Working roadmap for the open-core Ongrid project. Items merge user-driven
-ideas (2026-06-06 planning session) with the historical backlog scattered
-across ADRs, HLDs, PRDs, and prior planning memos.
+Working roadmap for the open-core Ongrid project. Merges user-driven
+ideas from the 2026-06-06 planning session with the historical backlog
+scattered across ADRs, HLDs, PRDs, and prior planning memos.
 
 ## Legend
 
-| Mark | Meaning |
-|---|---|
-| ✓ | Already landed — listed only as context for follow-ups |
-| ◐ | In progress |
-| □ | Queued, not started |
-| ◯ | Parked — explicitly deferred until a stated trigger condition |
+- `✓` already landed — listed only as context for follow-ups
+- `◐` in progress
+- `□` queued, not started
+- `◯` parked — explicitly deferred until a stated trigger condition
 
 ## Guiding principle
 
-Ongrid's moat is the `geminio` two-way tunnel + an AI agent that can take
-action on customer hosts. The three pillars (metrics / logs / traces) are
-the entry ticket, not the differentiator. Every roadmap item is judged
-against one question: **does this let the agent act, or surface a richer
-action in the incident timeline?** Pure-display features defer.
+Ongrid's moat is the `geminio` two-way tunnel plus an AI agent that can
+take action on customer hosts. The three pillars (metrics / logs /
+traces) are the entry ticket, not the differentiator. Every roadmap
+item answers one question: **does this let the agent act, or surface a
+richer action in the incident timeline?** Pure-display features defer.
 
 Ordering inside each section is rough priority within the section, not
 across sections.
 
 ---
 
-## A. Causal RCA depth (HLD-013 Phase 3)
+## A · Causal RCA depth (HLD-013 Phase 3)
 
-A1. ✓ Phase 1 — investigator prompt rewritten as a causal traversal loop;
-    `max_turns` 25 → 40; structured `根因/因果链/现象/置信度` output.
-
-A2. ✓ Phase 2 — `query_change_events` BaseTool reads HLD-010 audit log as
-    a "patient zero" candidate set; wired through `Registry.SetAuditLister`.
-
-A3. □ **Edge-side change watcher** — audit log only sees changes made
-    through Ongrid. Subscribe to `journald` + `dockerd events` + apt/dnf
-    history on the edge so external SSH / out-of-band deploys / container
-    churn show up as candidate root causes.
-
-A4. □ **Directed dependency edges + baselines** — topology graph today is
-    undirected; RCA can't always tell "upstream of" from "downstream of".
-    Add direction + per-metric baseline so prompts can reason about
-    anomaly position in the dep tree.
-
-A5. □ **Cross-session similar-incident retrieval** —
-    `incident_resolutions` table + embedding + `query_similar_incidents`
-    tool + resolve-modal in incident UI. Closes the
-    "we've seen this before" loop.
+- **A.1** `✓` Phase 1 — investigator prompt as a causal traversal loop
+  - `max_turns` 25 → 40
+  - structured `root cause / causal chain / symptom / confidence` output
+- **A.2** `✓` Phase 2 — `query_change_events` BaseTool
+  - reads HLD-010 audit log as patient-zero candidates
+  - wired through `Registry.SetAuditLister`
+- **A.3** `□` Edge-side change watcher
+  - today's audit log only sees Ongrid-mediated changes
+  - subscribe to `journald` + `dockerd events` + `apt` / `dnf` history
+  - surfaces external SSH, out-of-band deploys, container churn
+- **A.4** `□` Directed dependency edges + baselines
+  - topology graph today is undirected — can't always tell upstream from downstream
+  - add direction + per-metric historical baseline
+  - feed both into the RCA prompt
+- **A.5** `□` Cross-session similar-incident retrieval
+  - `incident_resolutions` table + embedding store
+  - `query_similar_incidents` BaseTool
+  - resolve-modal in the incident UI closes the "seen this before" loop
 
 ---
 
-## B. Remote diagnostic action tools (Roadmap Step 3)
+## B · Remote diagnostic action tools (Roadmap Step 3)
 
-B1. □ **Remote packet capture → object storage + UI render** ★
-    Killer feature: `capture_pcap(iface, bpf, duration)` BaseTool, tarball
-    uploaded to built-in MinIO/S3, incident timeline links to an embedded
-    pcap viewer (web wireshark or a simplified flow table). Nobody else
-    in the SaaS space ships this because they lack the secure two-way
-    tunnel.
-
-B2. □ **Network probes** — `probe_tcp` / `probe_http` / `probe_dns` /
-    `traceroute` / `mtr` as BaseTools. Currently doable via `host_bash`
-    but probes deserve first-class output schemas for incident timeline.
-
-B3. □ **File + log + kernel diagnostics** — `tail_file` / `grep_file` /
-    `strace` / `lsof` / `dmesg` / `sosreport` BaseTools.
-
-B4. ◐ **Network Layer-1 cmdpolicy expansion** — OVS / nft / conntrack /
-    ipset / ethtool / bpftool / `ip netns` read-side already shipped
-    (9 binaries, see `internal/edgeagent/cmdpolicy/policy.go`).
-
-B5. □ **Network Layer-2/3 skills** — `host_ovs_show`,
-    `host_netfilter_dump`, `host_conntrack_summary`, eBPF preset library
-    (preset IDs only — never raw `bpftrace -e <body>`).
-
----
-
-## C. Natural-language querying
-
-C1. □ **LLM-generated PromQL / LogQL / TraceQL** — `chat_to_query`
-    BaseTool, schema-augmented context (label set + metric metadata),
-    dry-run preview before execution, frequently-hit patterns auto-saved
-    as templates. Lowers the floor for operators who don't speak query
-    DSLs yet.
-
-C2. □ **Chat → Grafana panel** — natural-language description picks a
-    panel + range + variable values and either deep-links or embeds the
-    panel inline in chat.
+- **B.1** `□` Remote packet capture → object storage + UI render ★
+  - `capture_pcap(iface, bpf, duration)` BaseTool
+  - tarball uploaded to built-in MinIO / S3
+  - incident timeline links to an embedded pcap viewer (web wireshark or
+    a simplified flow table)
+  - SaaS competitors can't ship this without a secure two-way tunnel
+- **B.2** `□` Network probes as first-class BaseTools
+  - `probe_tcp` / `probe_http` / `probe_dns`
+  - `traceroute` / `mtr`
+  - first-class output schemas so results render cleanly in the timeline
+- **B.3** `□` File, log, kernel diagnostics
+  - `tail_file`, `grep_file`
+  - `strace`, `lsof`, `dmesg`, `sosreport`
+- **B.4** `◐` Network Layer-1 — cmdpolicy expansion (shipped)
+  - 9 binaries: OVS / nft / conntrack / ipset / ethtool / bpftool / `ip netns`
+  - read-side only; write-side gated for SOP
+  - source: `internal/edgeagent/cmdpolicy/policy.go`
+- **B.5** `□` Network Layer-2/3 skills
+  - `host_ovs_show`, `host_netfilter_dump`, `host_conntrack_summary`
+  - eBPF preset library — preset IDs only, never raw `bpftrace -e <body>`
 
 ---
 
-## D. Agent kernel quality
+## C · Natural-language querying
 
-D1. □ **Specialist sub-agents** — `specialist-network`, `specialist-disk`,
-    `specialist-process` personas; coordinator picks one by incident type
-    and constrains its tool bag. Activates the sub-agent framework that
-    currently sits idle.
-
-D2. □ **Critic loop** — primary ReAct finishes → critic LLM checks for
-    unevidenced claims, missed tool calls, broken causal chains → up to
-    2 corrective rounds. Industry reports +10–30% accuracy. Doubles
-    tokens, gate at `severity ≥ critical`.
-
-D3. □ **Eval / replay framework** — 5–10 golden incidents annotated with
-    expected tool set + answer keywords; `cmd/ongrid-eval` CLI; CI hook
-    on prompt / persona / tool-description changes.
+- **C.1** `□` LLM-generated PromQL / LogQL / TraceQL
+  - `chat_to_query` BaseTool
+  - context augmented with label set + metric metadata
+  - dry-run preview before execution
+  - frequently-hit patterns auto-saved as templates
+  - lowers the floor for operators who don't speak query DSLs
+- **C.2** `□` Chat → Grafana panel
+  - natural-language description picks a panel + range + variables
+  - either deep-link or embed inline in chat
 
 ---
 
-## E. User-facing assistant UX
+## D · Agent kernel quality
 
-E1. □ **Global Side Panel assistant** — floating button + `Cmd+K`,
-    available on every page, auto-seeds prompt with current page context.
-    Single biggest UX uplift; landing dock for everything else here.
-
-E2. □ **Multi-assistant / user-defined assistants** — each carries its
-    own prompt + tool subset + default scope. Side Panel switches
-    between them.
-
-E3. □ **Quick Action cards** — dynamic slot above the chat input;
-    page-context-aware "one-click ask" templates.
-
-E4. □ **Knowledge bookmarking** — pin useful agent answers to an
-    `agent_knowledge` table; detail pages get a "related knowledge"
-    panel; list pages get search.
-
-E5. □ **Reasoning timeline visualisation** — chat toggle that renders
-    `user → thought → tool_calls → tool_results → final answer` as a
-    tree, not flat text.
+- **D.1** `□` Specialist sub-agents
+  - personas: `specialist-network`, `specialist-disk`, `specialist-process`
+  - coordinator dispatches by incident type, constrains tool bag
+  - activates the sub-agent framework that currently sits idle
+- **D.2** `□` Critic loop
+  - primary ReAct finishes → critic LLM audits for
+    - unevidenced claims
+    - missed tool calls
+    - broken causal chains
+  - up to 2 corrective rounds
+  - +10–30% accuracy in published reports
+  - doubles tokens — gate at `severity ≥ critical`
+- **D.3** `□` Eval / replay framework
+  - 5–10 golden incidents annotated with expected tool set + answer keywords
+  - `cmd/ongrid-eval` CLI
+  - CI hook on prompt / persona / tool-description changes
 
 ---
 
-## F. Data and resource integrations
+## E · User-facing assistant UX
 
-### F1. Kubernetes
-
-F1.1. □ **K8s edge plugin** — installable as a node-level binary or a
-    single in-cluster pod with a service-account-driven kubectl; RBAC
-    manifests shipped.
-
-F1.2. □ **K8s BaseTool suite** — `kube_get_pods`, `kube_describe`,
-    `kube_logs` (streaming), `kube_events`, `kube_top`, `kube_exec`
-    (gated as dangerous).
-
-F1.3. □ **Operator / CRD deployment** — `OngridEdge` CRD, DaemonSet
-    mode, aligned with ADR-024 bundle upgrade.
-
-F1.4. □ **K8s topology** — Pod / Deployment / Service / Ingress as
-    topology nodes; blast-radius BFS spans K8s resources too.
-
-### F2. Cloud resources
-
-F2.1. □ **Read-only inventory tools** — AWS / GCP / Aliyun / Tencent
-    Cloud: EC2 / CVM list, VPCs and routes, security groups, RDS, LB,
-    object storage usage.
-
-F2.2. □ **Cloud-monitoring read-through** — CloudWatch / Stackdriver /
-    Aliyun CMS as RCA evidence sources; not a Prometheus replacement,
-    just fills the cloud-native resource gap.
-
-F2.3. □ **Cloud cost** — `cloud_cost_breakdown` BaseTool tied into
-    incidents so the expensive ones surface first.
-
-F2.4. □ **Per-org cloud credentials** — credential vault with rotation,
-    modelled on ADR-023 (Git credentials dual rail).
-
-### F3. LLM providers
-
-F3.1. □ **Ollama support** — Custom (OpenAI-compatible) provider hint
-    pre-fills `http://localhost:11434/v1`, auto-pulls the model list.
-    Marketing angle: zero outbound data.
-
-F3.2. □ **vLLM / SGLang / LMDeploy** preset support for self-hosted
-    GPU customers.
-
-F3.3. □ **Bedrock / Vertex** — enterprise-cloud customers; defer until
-    asked.
-
-### F4. IM / collaboration
-
-F4.1. ✓ Slack / Telegram / Lark two-way already shipped (ADR-021 /
-    ADR-031).
-
-F4.2. □ **DingTalk** — completes the CN big-three.
-
-F4.3. □ **Microsoft Teams** — required for overseas enterprise.
-
-F4.4. □ **WeCom (企业微信) two-way** — webhook-only today; bot mode
-    needed for chat-driven actions.
-
-### F5. Logs and traces (Roadmap Step 5)
-
-F5.1. ✓ Loki path already shipped (ADR-012).
-
-F5.2. □ **Tempo traces** — edge OTel collector reverse-proxied through
-    manager ingress, same pattern as the metrics path. Hold until a
-    real customer asks; storage + UX is a black hole otherwise.
-
-F5.3. □ **eBPF auto-tracing** (Pixie-inspired) — only after F5.2 is
-    live and stable.
+- **E.1** `□` Global Side Panel assistant
+  - floating button + `Cmd+K` on every page
+  - auto-seeds prompt with current page context
+  - biggest single UX uplift; landing dock for E.2 through E.5
+- **E.2** `□` Multi-assistant / user-defined assistants
+  - per-assistant prompt + tool subset + default scope
+  - Side Panel switches between them
+- **E.3** `□` Quick Action cards
+  - dynamic slot above the chat input
+  - page-context-aware "one-click ask" templates
+- **E.4** `□` Knowledge bookmarking
+  - pin useful agent answers to `agent_knowledge`
+  - "related knowledge" panel on detail pages
+  - search on list pages
+- **E.5** `□` Reasoning timeline visualisation
+  - chat toggle that renders
+    `user → thought → tool_calls → tool_results → final` as a tree
 
 ---
 
-## G. Engineering and operations
+## F · Data and resource integrations
 
-### G1. Install / first-boot
+### F.1 Kubernetes
 
-G1.1. □ **Port-conflict preflight** — `ss -tlnp | grep :443` first,
-    auto-bump to 8443 / 8080 on collision and propagate to
-    `ONGRID_PUBLIC_URL`.
+- **F.1.1** `□` K8s edge plugin
+  - node-level binary OR single in-cluster pod with service-account kubectl
+  - RBAC manifests shipped
+- **F.1.2** `□` K8s BaseTool suite
+  - `kube_get_pods`, `kube_describe`
+  - `kube_logs` (streaming), `kube_events`, `kube_top`
+  - `kube_exec` gated as dangerous
+- **F.1.3** `□` Operator / CRD deployment
+  - `OngridEdge` CRD
+  - DaemonSet mode
+  - aligned with ADR-024 bundle upgrade
+- **F.1.4** `□` K8s topology
+  - Pod / Deployment / Service / Ingress as topology nodes
+  - blast-radius BFS spans K8s resources
 
-G1.2. □ **Co-tenant vs sole-tenant prompt** — preflight asks whether
-    this box runs other web services; the answer drives port and
-    public-URL choice.
+### F.2 Cloud resources
 
-G1.3. □ **Internal vs public IP confirmation** — single-box self-test
-    users usually want the internal IP, not the cloud-metadata public IP.
+- **F.2.1** `□` Read-only inventory tools
+  - AWS / GCP / Aliyun / Tencent Cloud
+  - EC2 or CVM list, VPCs, security groups, RDS, LB, object storage
+- **F.2.2** `□` Cloud-monitoring read-through
+  - CloudWatch / Stackdriver / Aliyun CMS as RCA evidence sources
+  - not a Prometheus replacement — fills the cloud-native resource gap
+- **F.2.3** `□` Cloud cost
+  - `cloud_cost_breakdown` BaseTool
+  - tied to incidents so the expensive ones surface first
+- **F.2.4** `□` Per-org cloud credentials
+  - credential vault with rotation
+  - modelled on ADR-023 (Git credentials dual rail)
 
-G1.4. □ **Mirror health check** — after writing `daemon.json` and
-    restarting docker, `docker pull hello-world` as a probe; roll back
-    or switch the mirror list on failure.
+### F.3 LLM providers
 
-G1.5. □ **`read -s` for admin password** — current prompt leaks into
-    `.bash_history`.
+- **F.3.1** `□` Ollama support
+  - Custom (OpenAI-compatible) hint pre-fills `http://localhost:11434/v1`
+  - auto-pulls the model list
+  - marketing angle: zero outbound data
+- **F.3.2** `□` vLLM / SGLang / LMDeploy presets
+  - self-hosted GPU customers
+- **F.3.3** `□` Bedrock / Vertex
+  - enterprise-cloud customers; defer until asked
 
-G1.6. □ **First-boot guided wizard** — after install, the first UI
-    visit walks through admin reset → LLM provider → IM → first edge
-    install as one flow (PRD-001).
+### F.4 IM and collaboration
 
-G1.7. ✓ Uninstall script wholesale-purges plugin binaries and work
-    directory; stops units unconditionally with a `pkill -9` fallback
-    (PR #46, PR #47).
+- **F.4.1** `✓` Slack / Telegram / Lark two-way (ADR-021 / ADR-031)
+- **F.4.2** `□` DingTalk — completes the CN big three
+- **F.4.3** `□` Microsoft Teams — overseas enterprise
+- **F.4.4** `□` WeCom (企业微信) two-way
+  - webhook-only today
+  - bot mode needed for chat-driven actions
 
-### G2. Edge lifecycle
+### F.5 Logs and traces (Roadmap Step 5)
 
-G2.1. ✓ ADR-024 one-touch bundle upgrade with `.previous` rollback.
-
-G2.2. □ **Channels and canary** — stable / beta / canary, gated by
-    edge tags.
-
-G2.3. □ **Health-aware rollout** — auto-rollback if the post-upgrade
-    heartbeat doesn't come back green within 30s.
-
-G2.4. □ **Offline upgrade bundle** — internal-network customers,
-    manager acts as the mirror.
-
-### G3. Prometheus production hardening (parked)
-
-G3.1. ◯ nginx `/prometheus/` `auth_request` to close the remote_write
-    endpoint from the open internet.
-
-G3.2. ◯ `promwrite.Ingester` ring buffer + worker pool + bbolt DLQ.
-
-G3.3. ◯ VictoriaMetrics drop-in compose profile.
-
-G3.4. ◯ `install.sh` "built-in Prom / VictoriaMetrics / external TSDB"
-    selector.
-
-G3.5. ◯ Label whitelist to bound cardinality blow-ups.
-
-Trigger to unpark: > 100 edges per customer, an HA / SLA request,
-or `promwrite` write-timeout accumulation in manager logs.
-
-### G4. Self-observability (ADR-026)
-
-G4.1. ✓ `/metrics`, 6 self-alerts, dashboard already shipped.
-
-G4.2. □ **SLO board** — availability, tool success rate, RCA accuracy
-    (fed by D3 eval framework).
-
-G4.3. □ **Self-diagnostic agent** — periodic self-RCA against the
-    manager's own metrics.
-
-### G5. Security / sandbox
-
-G5.1. ◯ microsandbox upgrade path — only when a customer demands kernel
-    isolation; until then `host_bash` + `cmdpolicy` covers 90% of
-    diagnostic surface.
-
-G5.2. □ **WebSSH (ADR-019)** — geminio stream + xterm.js, exposed as
-    a fallback inside SOP execution.
-
-G5.3. □ **Per-tool RBAC + audit replay** — ADR-022 gates by viewer
-    role; granularity needs to drop to per-tool.
-
-### G6. Credentials / knowledge
-
-G6.1. ✓ ADR-023 SSH key table + Git credentials dual rail.
-
-G6.2. □ **ADR-018 RepoFetcher** — per-repo auth without re-introducing
-    the token leakage concerns ADR-018 (revised) tabled.
-
-G6.3. □ **Offline vault bundle** — for customers without outbound
-    internet; built-in vault + offline snapshot tarball.
+- **F.5.1** `✓` Loki path (ADR-012)
+- **F.5.2** `□` Tempo traces
+  - edge OTel collector reverse-proxied through manager ingress
+  - same pattern as the metrics path
+  - hold until a real customer asks — storage + UX is a black hole
+- **F.5.3** `□` eBPF auto-tracing (Pixie-inspired)
+  - only after F.5.2 is live and stable
 
 ---
 
-## H. Ecosystem / late-stage
+## G · Engineering and operations
 
-H1. ◯ **Skill marketplace public listing** (ADR-017) — wait until skill
-    count crosses ~30.
+### G.1 Install / first-boot
 
-H2. □ **HLD-009 coordinator e2e evaluation** — currently a design;
-    becomes runnable once D3 eval framework is live.
+- **G.1.1** `□` Port-conflict preflight
+  - `ss -tlnp | grep :443` first
+  - auto-bump to `8443` / `8080` on collision
+  - propagate to `ONGRID_PUBLIC_URL`
+- **G.1.2** `□` Co-tenant vs sole-tenant prompt
+  - preflight asks whether this box runs other web services
+  - answer drives port and public-URL choice
+- **G.1.3** `□` Internal vs public IP confirmation
+  - single-box self-test users usually want the internal IP
+  - cloud-metadata default isn't always right
+- **G.1.4** `□` Mirror health check
+  - after `daemon.json` + docker restart, `docker pull hello-world`
+  - roll back or switch the mirror list on failure
+- **G.1.5** `□` `read -s` for admin password
+  - current prompt leaks into `.bash_history`
+- **G.1.6** `□` First-boot guided wizard
+  - admin reset → LLM provider → IM → first edge install in one flow
+  - aligns with PRD-001
+- **G.1.7** `✓` Uninstall script
+  - wholesale-purges plugin binaries + work dir
+  - stops units unconditionally with a `pkill -9` fallback
+  - PR #46, PR #47
 
-H3. □ **HLD-012 code-aware analysis** — combine a code repo with
-    incidents; PR diff → impact analysis.
+### G.2 Edge lifecycle
 
-H4. ◯ **Open ecosystem** — plugin SDK docs and third-party BaseTool
-    registration; defer until the open-core split (ADR-030) has been
-    out long enough to attract contributors.
+- **G.2.1** `✓` ADR-024 one-touch bundle upgrade with `.previous` rollback
+- **G.2.2** `□` Channels and canary
+  - stable / beta / canary, gated by edge tag
+- **G.2.3** `□` Health-aware rollout
+  - auto-rollback if post-upgrade heartbeat doesn't green within 30s
+- **G.2.4** `□` Offline upgrade bundle
+  - internal-network customers
+  - manager acts as the mirror
+
+### G.3 Prometheus production hardening (parked)
+
+- **G.3.1** `◯` nginx `/prometheus/` `auth_request`
+  - closes remote_write from the open internet
+- **G.3.2** `◯` `promwrite.Ingester` ring buffer + worker pool + bbolt DLQ
+- **G.3.3** `◯` VictoriaMetrics drop-in compose profile
+- **G.3.4** `◯` `install.sh` TSDB selector
+  - "built-in Prom / VictoriaMetrics / external TSDB"
+- **G.3.5** `◯` Label whitelist to bound cardinality blow-ups
+- **Trigger to unpark**
+  - > 100 edges per customer, OR
+  - an HA / SLA request, OR
+  - `promwrite` write-timeout accumulation in manager logs
+
+### G.4 Self-observability (ADR-026)
+
+- **G.4.1** `✓` `/metrics`, 6 self-alerts, dashboard
+- **G.4.2** `□` SLO board
+  - availability, tool success rate, RCA accuracy (fed by D.3)
+- **G.4.3** `□` Self-diagnostic agent
+  - periodic self-RCA against the manager's own metrics
+
+### G.5 Security / sandbox
+
+- **G.5.1** `◯` microsandbox upgrade path
+  - only when a customer demands kernel isolation
+  - `host_bash` + `cmdpolicy` covers 90% of diagnostic surface
+- **G.5.2** `□` WebSSH (ADR-019)
+  - geminio stream + xterm.js
+  - exposed as a fallback inside SOP execution
+- **G.5.3** `□` Per-tool RBAC + audit replay
+  - ADR-022 gates by viewer role
+  - granularity needs to drop to per-tool
+
+### G.6 Credentials and knowledge
+
+- **G.6.1** `✓` ADR-023 SSH key table + Git credentials dual rail
+- **G.6.2** `□` ADR-018 RepoFetcher
+  - per-repo auth without re-introducing the token leakage that tabled
+    the first revision
+- **G.6.3** `□` Offline vault bundle
+  - customers without outbound internet
+  - built-in vault + offline snapshot tarball
 
 ---
 
-## I. SOP / Runbook execution loop
+## H · Ecosystem / late-stage
+
+- **H.1** `◯` Skill marketplace public listing (ADR-017)
+  - unpark when the skill count crosses ~30
+- **H.2** `□` HLD-009 coordinator e2e evaluation
+  - currently a design
+  - becomes runnable once D.3 eval framework lands
+- **H.3** `□` HLD-012 code-aware analysis
+  - combine a code repo with incidents
+  - PR diff → impact analysis
+- **H.4** `◯` Open ecosystem
+  - plugin SDK docs + third-party BaseTool registration
+  - defer until open-core split (ADR-030) attracts contributors
+
+---
+
+## I · SOP / Runbook execution loop
 
 The most ambitious chunk on the roadmap. Listed last on purpose:
 sections A–H either unblock SOP or have to be solid before SOP can
-ship safely. **Do not start until the diagnostic + action tools (B)
-and the agent kernel quality work (D) are in a reliable place** —
+ship safely. **Do not start until B and D are in a reliable place** —
 otherwise the executable path becomes an outage generator instead of
 a moat.
 
-I1. □ **Tool.Class three-tier** — `safe` (read-only) / `mutating`
-    (state change) / `dangerous` (irreversible). Replaces today's
-    binary read/write split.
-
-I2. □ **SOP DSL** — YAML runbooks: `triggers / steps / approvals /
-    rollback`.
-
-I3. □ **Two-signature execution chain** — manager RSA signs, edge
-    verifies, both ends audit-log every step.
-
-I4. □ **`review_gate` sub-agent** — mutating step spawns a reviewer
-    worker → writes a `mutating_proposal` row → UI surfaces an action
-    card → operator signs → edge executes → timeline gets a
-    `mutating_action_executed` entry.
-
-I5. □ **Initial playbook library** — opening four:
-    `host_restart_service`, `disk_cleanup`, `log_rotate`,
-    `certificate_renew`.
+- **I.1** `□` Tool.Class three-tier
+  - `safe` (read-only) / `mutating` (state change) / `dangerous` (irreversible)
+  - replaces today's binary read/write split
+- **I.2** `□` SOP DSL
+  - YAML runbooks: `triggers` / `steps` / `approvals` / `rollback`
+- **I.3** `□` Two-signature execution chain
+  - manager RSA signs
+  - edge verifies
+  - both ends audit-log every step
+- **I.4** `□` `review_gate` sub-agent
+  - mutating step spawns a reviewer worker
+  - writes a `mutating_proposal` row
+  - UI surfaces an action card
+  - operator signs → edge executes
+  - timeline gets a `mutating_action_executed` entry
+- **I.5** `□` Initial playbook library
+  - `host_restart_service`
+  - `disk_cleanup`
+  - `log_rotate`
+  - `certificate_renew`
 
 ---
 
-## J. Periodic agent jobs
+## J · Periodic agent jobs
 
-Built on the same scheduler primitive; sized for "agent watches over
+Built on a shared scheduler primitive; sized for "agent watches over
 time" workloads rather than synchronous chat.
 
-J1. □ **Inspection / 巡检** — scheduled (daily / weekly) sweeps of
-    every edge run a lightweight RCA: `top_load_anomaly`,
-    `dep_health_check`, `cert_expiry_check`; matches auto-create
-    incidents.
-
-J2. □ **Weekly / monthly digest** — cross-edge aggregate of alerts,
-    incidents, executed actions; LLM-written summary; IM-pushed.
-
-J3. □ **Watch tasks / proactive notification** — `create_watch
-    (condition, expire_at)` BaseTool; when the condition fires, push
-    back into the original session over SSE.
+- **J.1** `□` Inspection (巡检)
+  - scheduled (daily / weekly) sweeps over every edge
+  - lightweight RCA: `top_load_anomaly`, `dep_health_check`, `cert_expiry_check`
+  - matches auto-create incidents
+- **J.2** `□` Weekly / monthly digest
+  - cross-edge aggregate of alerts, incidents, executed actions
+  - LLM-written summary
+  - IM-pushed
+- **J.3** `□` Watch tasks / proactive notification
+  - `create_watch(condition, expire_at)` BaseTool
+  - when the condition fires, push back into the original session over SSE

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,0 +1,339 @@
+# Ongrid 路线图
+
+_最近更新：2026-06-06 · English version: [`ROADMAP.md`](ROADMAP.md)_
+
+开源仓 Ongrid 的工作路线图。把 2026-06-06 规划讨论的新方向与散落在
+ADR / HLD / PRD / 历史规划备忘录里的 backlog 合到一起。
+
+## 图例
+
+- `✓` 已落地 —— 仅作为后续工作的背景列出
+- `◐` 进行中
+- `□` 已规划，尚未开始
+- `◯` Park —— 明确暂缓，等达到触发条件再启动
+
+## 指导原则
+
+Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**真动手**。
+三件套（指标 / 日志 / 链路）是入场券，不是差异化。每一条 roadmap 项都
+回答一个问题：**这事是不是让 agent 多一种动手能力、或者让 incident 时
+间线多一个动作？** 纯展示型功能让位。
+
+每个段落内的顺序是段内优先级，不跨段比较。
+
+---
+
+## A · 因果 RCA 深化（HLD-013 Phase 3）
+
+- **A.1** `✓` Phase 1 —— investigator prompt 改写为因果回溯循环
+  - `max_turns` 25 → 40
+  - 结构化输出 `根因 / 因果链 / 现象 / 置信度`
+- **A.2** `✓` Phase 2 —— `query_change_events` BaseTool
+  - 读 HLD-010 audit log 作为 "0 号病人" 候选
+  - 经 `Registry.SetAuditLister` 连入
+- **A.3** `□` 边端变更事件源
+  - 当前 audit log 只看得到走 Ongrid 的变更
+  - 订阅 `journald` + `dockerd events` + `apt` / `dnf` history
+  - 让外部 SSH、带外部署、容器 churn 也能进 RCA 候选集
+- **A.4** `□` 有向依赖边 + 基线
+  - 拓扑图当前无向 —— 分不清上下游
+  - 加方向 + 每指标历史基线
+  - 两者一起喂进 RCA prompt
+- **A.5** `□` 跨会话相似 incident 检索
+  - `incident_resolutions` 表 + embedding 库
+  - `query_similar_incidents` BaseTool
+  - 详情页 resolve modal 闭环 "见过这种情况"
+
+---
+
+## B · 远程诊断动作工具（Roadmap Step 3）
+
+- **B.1** `□` 远程抓包 → 对象存储 + 产品端渲染 ★
+  - `capture_pcap(iface, bpf, duration)` BaseTool
+  - tarball 上传到内置 MinIO / S3
+  - incident 时间线挂内嵌 pcap 查看器（web wireshark 或简化流表 UI）
+  - SaaS 同行不敢做 —— 没有安全的双向通道
+- **B.2** `□` 网络探测一类工具升一级公民
+  - `probe_tcp` / `probe_http` / `probe_dns`
+  - `traceroute` / `mtr`
+  - 各有自己的结构化输出 schema，时间线渲染干净
+- **B.3** `□` 文件 / 日志 / 内核诊断
+  - `tail_file`、`grep_file`
+  - `strace`、`lsof`、`dmesg`、`sosreport`
+- **B.4** `◐` 网络 Layer-1 —— cmdpolicy 扩展（已落地）
+  - 9 个 binary：OVS / nft / conntrack / ipset / ethtool / bpftool / `ip netns`
+  - 只开 read，write 留给 SOP 走双签
+  - 源码：`internal/edgeagent/cmdpolicy/policy.go`
+- **B.5** `□` 网络 Layer-2/3 skill
+  - `host_ovs_show`、`host_netfilter_dump`、`host_conntrack_summary`
+  - eBPF preset 库 —— 只放 preset id，永远不允许 `bpftrace -e <body>` 这种裸传
+
+---
+
+## C · 自然语言查询
+
+- **C.1** `□` LLM 生成 PromQL / LogQL / TraceQL
+  - `chat_to_query` BaseTool
+  - 上下文喂 label 集合 + 指标 metadata
+  - 执行前先 dry-run preview
+  - 高频 pattern 自动存模板
+  - 把不会写查询语言的运维门槛降下来
+- **C.2** `□` Chat → Grafana panel
+  - 自然语言描述 → 选 panel + range + 变量
+  - 直接 deep-link 或在 chat 里内嵌
+
+---
+
+## D · Agent 内核质量
+
+- **D.1** `□` 专家 sub-agent 分工
+  - persona：`specialist-network` / `specialist-disk` / `specialist-process`
+  - coordinator 按 incident 类型派单，并约束 tool bag
+  - 把现在闲置的 sub-agent 框架真用上
+- **D.2** `□` Critic loop（自我批判）
+  - 主 ReAct 跑完 → critic LLM 审
+    - 没证据的断言
+    - 应调没调的工具
+    - 断掉的因果链
+  - 最多 2 轮反馈
+  - 业界报 +10–30% 准确率
+  - token 翻倍 —— gate 在 `severity ≥ critical`
+- **D.3** `□` Eval / replay 框架
+  - 5–10 个 golden incident，标好期望 tool 集 + 关键词
+  - `cmd/ongrid-eval` CLI
+  - CI 钩子：改 prompt / persona / 工具描述时强跑
+
+---
+
+## E · 用户面 Agent 助理体验
+
+- **E.1** `□` 全局 Side Panel 助理
+  - 浮动按钮 + `Cmd+K`，任意页面唤起
+  - 自动拿当前页 context 当 seed prompt
+  - 体感提升最大；后面 E.2–E.5 都挂在这里
+- **E.2** `□` 多助理 / 用户自定义助理
+  - 每个助理自己的 prompt + 工具子集 + 默认 scope
+  - Side Panel 里切换
+- **E.3** `□` Quick Action 卡片
+  - chat 输入框上方动态插槽
+  - 按 page context 推荐 "一键问" 模板
+- **E.4** `□` Knowledge 收藏
+  - 有用的 agent 结论 📌 钉到 `agent_knowledge`
+  - 详情页 "相关知识" 面板
+  - 列表页搜索
+- **E.5** `□` 推理时间线可视化
+  - chat toggle 把
+    `user → thought → tool_calls → tool_results → final` 渲染成树
+
+---
+
+## F · 数据与资源接入
+
+### F.1 Kubernetes
+
+- **F.1.1** `□` K8s edge 插件
+  - 节点二进制 / 单 pod in-cluster 两种装法
+  - service-account 驱动 kubectl
+  - 出厂带 RBAC manifest
+- **F.1.2** `□` K8s BaseTool 套
+  - `kube_get_pods` / `kube_describe`
+  - `kube_logs`（streaming）/ `kube_events` / `kube_top`
+  - `kube_exec` 走 dangerous 等级
+- **F.1.3** `□` Operator / CRD 部署
+  - `OngridEdge` CRD
+  - DaemonSet 模式
+  - 跟 ADR-024 bundle upgrade 对齐
+- **F.1.4** `□` K8s 拓扑
+  - Pod / Deployment / Service / Ingress 作为拓扑节点
+  - blast radius BFS 跨 K8s 资源
+
+### F.2 云资源
+
+- **F.2.1** `□` 只读 inventory 工具
+  - AWS / GCP / 阿里云 / 腾讯云
+  - EC2 或 CVM 列表、VPC、安全组、RDS、LB、对象存储
+- **F.2.2** `□` 云监控 read-through
+  - CloudWatch / Stackdriver / 阿里云 CMS 作为 RCA 证据源
+  - 不替换 Prom —— 补云原生资源的盲区
+- **F.2.3** `□` 云成本
+  - `cloud_cost_breakdown` BaseTool
+  - 跟 incident 关联：贵的 incident 优先看
+- **F.2.4** `□` 多 org 云凭证
+  - credential vault + rotate
+  - 对齐 ADR-023（git 凭证双轨）
+
+### F.3 LLM provider
+
+- **F.3.1** `□` Ollama 适配
+  - Custom（OpenAI 兼容）卡片 hint 预填 `http://localhost:11434/v1`
+  - 自动 list 模型
+  - 卖点：零外发数据
+- **F.3.2** `□` vLLM / SGLang / LMDeploy preset
+  - 自有 GPU 的私有化客户
+- **F.3.3** `□` Bedrock / Vertex
+  - 企业云客户，等问到再做
+
+### F.4 IM / 协作
+
+- **F.4.1** `✓` Slack / Telegram / 飞书 双向（ADR-021 / ADR-031）
+- **F.4.2** `□` 钉钉 —— 把国内三件套补齐
+- **F.4.3** `□` Microsoft Teams —— 海外企业必备
+- **F.4.4** `□` 企业微信双向
+  - 当前只有 webhook outbound
+  - 想用 chat 下指令必须做 bot 模式
+
+### F.5 日志 / 链路（Roadmap Step 5）
+
+- **F.5.1** `✓` Loki 路径（ADR-012）
+- **F.5.2** `□` Tempo Traces
+  - 边端 OTel collector 反代到 manager ingress
+  - 跟 metrics 路径同 pattern
+  - 第一个客户问需求前不开 —— 存储 + UX 是个黑洞
+- **F.5.3** `□` eBPF 自动 trace（Pixie 启发）
+  - 必须先把 F.5.2 跑稳
+
+---
+
+## G · 工程化 & 运维
+
+### G.1 安装 / 首次开机
+
+- **G.1.1** `□` 端口冲突预检
+  - 先 `ss -tlnp | grep :443`
+  - 撞了自动 bump 到 `8443` / `8080`
+  - 同步传到 `ONGRID_PUBLIC_URL`
+- **G.1.2** `□` 共存 vs 独占问询
+  - preflight 问："这台机是不是只跑 ongrid"
+  - 答案决定端口和 public URL
+- **G.1.3** `□` 内网 vs 公网 IP 确认
+  - 单机自玩用户其实想要内网 IP
+  - 云 metadata 默认拿公网 IP 并不总对
+- **G.1.4** `□` mirror 健康检查
+  - 写完 `daemon.json` + restart docker 后 `docker pull hello-world`
+  - 失败就回滚或换备用 mirror 列表
+- **G.1.5** `□` `read -s` 隐藏管理员密码
+  - 当前会进 `.bash_history`
+- **G.1.6** `□` 首次开机引导 wizard
+  - admin 改密 → LLM provider → IM → 第一台 edge 安装 一条龙
+  - 对齐 PRD-001
+- **G.1.7** `✓` 卸载脚本
+  - 整目录 purge 插件二进制 + 工作目录
+  - 无条件 stop unit + `pkill -9` 兜底
+  - PR #46 / PR #47
+
+### G.2 边端生命周期
+
+- **G.2.1** `✓` ADR-024 一键 bundle 升级 + `.previous` 回滚
+- **G.2.2** `□` 升级 channel + canary
+  - stable / beta / canary，按 edge tag 灰度
+- **G.2.3** `□` 健康感知 rollout
+  - 升完 30s 心跳不绿自动回滚
+- **G.2.4** `□` 离线升级包
+  - 内网客户场景
+  - manager 当 mirror
+
+### G.3 Prometheus 生产硬化（已 park）
+
+- **G.3.1** `◯` nginx `/prometheus/` 加 `auth_request`
+  - 把 remote_write 接口从公网关上
+- **G.3.2** `◯` `promwrite.Ingester` ring buffer + worker pool + bbolt DLQ
+- **G.3.3** `◯` VictoriaMetrics drop-in compose profile
+- **G.3.4** `◯` `install.sh` TSDB 选型
+  - 内建 Prom / VictoriaMetrics / 外部 TSDB 三选一
+- **G.3.5** `◯` label whitelist 控基数
+- **触发条件（满足任一即 unpark）**
+  - 单客户 > 100 edges
+  - 客户主动问 HA / SLA
+  - manager 日志出现 `promwrite` 写超时累积
+
+### G.4 自观测（ADR-026）
+
+- **G.4.1** `✓` `/metrics`、6 条自身告警、自身 dashboard
+- **G.4.2** `□` SLO 板
+  - 可用率、工具成功率、RCA 准确率（数据来自 D.3）
+- **G.4.3** `□` 自诊断 agent
+  - 周期跑 self-RCA 对自家 manager
+
+### G.5 安全 / 沙箱
+
+- **G.5.1** `◯` microsandbox 升级路径
+  - 客户明确要求 kernel 级隔离时再启
+  - `host_bash` + `cmdpolicy` 当前覆盖 90% 诊断面
+- **G.5.2** `□` WebSSH（ADR-019）
+  - geminio stream + xterm.js
+  - 当 SOP 执行的兜底通道
+- **G.5.3** `□` Per-tool RBAC + audit replay
+  - ADR-022 当前到 viewer role 这层
+  - 颗粒度还要下到单个 tool
+
+### G.6 凭证 / 知识
+
+- **G.6.1** `✓` ADR-023 SSH key 表 + git 凭证双轨
+- **G.6.2** `□` ADR-018 RepoFetcher
+  - per-repo auth；不能把上一版被 park 的 token 泄漏问题带回来
+- **G.6.3** `□` 离线 vault 包
+  - 无外网客户场景
+  - 内置 vault + 离线快照 tarball
+
+---
+
+## H · 生态 / 后置
+
+- **H.1** `◯` Skill marketplace 公开化（ADR-017）
+  - skill 数量到 ~30 再 unpark
+- **H.2** `□` HLD-009 coordinator e2e evaluation 上线
+  - 当前只是设计
+  - D.3 eval 框架落地后才能跑
+- **H.3** `□` HLD-012 code-aware 分析
+  - 代码仓库结合 incident
+  - PR diff → 影响面分析
+- **H.4** `◯` 开源生态
+  - 插件 SDK 文档 + 第三方 BaseTool 注册
+  - 等开源拆分（ADR-030）孵化出贡献者再启
+
+---
+
+## I · SOP / Runbook 闭环
+
+整张 roadmap 里最大的工程。**故意放最后**：A–H 要么是 SOP 的前置依
+赖，要么是 SOP 安全上线的前提。**前面 B 和 D 没跑稳前不开 SOP** ——
+否则可执行路径会变成"产事故的引擎"而不是护城河。
+
+- **I.1** `□` Tool.Class 三级
+  - `safe`（只读）/ `mutating`（改状态）/ `dangerous`（不可回滚）
+  - 替换今天的二值 read / write 分流
+- **I.2** `□` SOP DSL
+  - YAML runbook：`triggers` / `steps` / `approvals` / `rollback`
+- **I.3** `□` 双签执行链路
+  - manager RSA 签
+  - edge 校验
+  - 两端 audit log 都打齐
+- **I.4** `□` `review_gate` sub-agent
+  - mutating step spawn reviewer worker
+  - 写 `mutating_proposal` 行
+  - UI 弹动作卡
+  - 操作者签 → edge 执行
+  - 时间线打 `mutating_action_executed`
+- **I.5** `□` 起手 playbook 库
+  - `host_restart_service`
+  - `disk_cleanup`
+  - `log_rotate`
+  - `certificate_renew`
+
+---
+
+## J · 周期性 Agent 任务
+
+共用一个调度器原语；面向"agent 长时间盯着"这种工作量，不是同步 chat。
+
+- **J.1** `□` 巡检
+  - 每天 / 每周扫所有 edge
+  - 跑轻量 RCA：`top_load_anomaly` / `dep_health_check` / `cert_expiry_check`
+  - 命中风险自动建 incident
+- **J.2** `□` 周报 / 月报
+  - 跨 edge 汇总告警、incident、执行过的动作
+  - LLM 写摘要
+  - IM 推送
+- **J.3** `□` 守望任务 / 主动推送
+  - `create_watch(condition, expire_at)` BaseTool
+  - 命中条件后 SSE 推回原 session


### PR DESCRIPTION
Working roadmap for the open-core repo. Two locales (EN + 中文), cross-linked. Sections A–H are the customer-visible value chain; SOP (I) and periodic agent jobs (J) — including SOP itself, inspection, weekly digest, and watch tasks — sit at the end per the 2026-06-06 planning call: they're either the most ambitious chunk (SOP needs the diagnostic + agent quality work to be solid first) or higher-level orchestrations built on top of everything before them.

Synthesis source:
- New items from 2026-06-06: capture_pcap → object storage, LLM → PromQL / LogQL, K8s adapter, cloud-resource read tools, Ollama provider, install-config polish, SOP, inspection, weekly digest.
- ADR / HLD / PRD inventory under ongrid-cloud/docs (ADR-001 through ADR-032, HLD-001 through HLD-013, PRD-001 / PRD-002, RFC-001).
- Parked-backlog memos: agent kernel (5 directions), assistant base caps (6), Prom hardening (5), Python sandbox / microVM (8 candidates), install.sh hardening (5), network research Layer-1 / 2 / 3.

Format: nested bullets with consistent ◯ park / □ queued / ◐ in progress / ✓ landed markers so every section stays scannable at a glance.