### PR TITLE
docs(roadmap): expand ops, add Sandbox + Security; A renamed; proposal under Agent

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ across sections.
 
 ---
 
-## A · Causal RCA depth (HLD-013 Phase 3)
+## A · Root-cause RCA diagnosis (HLD-013 Phase 3)
 
 - **A.1** `✓` Phase 1 — investigator prompt as a causal traversal loop
   - `max_turns` 25 → 40
@@ -46,6 +46,12 @@ across sections.
   - `incident_resolutions` table + embedding store
   - `query_similar_incidents` BaseTool
   - resolve-modal in the incident UI closes the "seen this before" loop
+- **A.6** `□` RCA confidence calibration
+  - track per-incident confidence vs operator-marked correctness
+  - feed back into prompt / model selection
+- **A.7** `□` Root-cause graph visualisation
+  - render the causal chain as a node-edge graph alongside the report
+  - hovering a node opens the evidence (PromQL, log line, trace span)
 
 ---
 
@@ -85,6 +91,9 @@ across sections.
 - **C.2** `□` Chat → Grafana panel
   - natural-language description picks a panel + range + variables
   - either deep-link or embed inline in chat
+- **C.3** `□` Schema-aware autocomplete
+  - inline editor for hand-written queries
+  - suggests labels + functions from live `/api/v1/labels`
 
 ---
 
@@ -106,6 +115,41 @@ across sections.
   - 5–10 golden incidents annotated with expected tool set + answer keywords
   - `cmd/ongrid-eval` CLI
   - CI hook on prompt / persona / tool-description changes
+- **D.4** `□` Proposal and confirmation mediation
+  - **Purpose**: any agent-initiated mutating action — whether from chat,
+    SOP execution (K), or a watch task (L.3) — flows through one pipeline.
+  - **D.4.1** Proposal lifecycle
+    - `pending` → `approved` / `rejected` / `expired` / `executed` / `rolled-back`
+    - persisted in `mutating_proposal` (signed envelope)
+  - **D.4.2** `review_gate` sub-agent
+    - reviewer worker drafts the proposal, names the SOP step, surfaces
+      blast radius, attaches dry-run output
+  - **D.4.3** Approval policies
+    - severity tiers (`safe` auto / `mutating` operator / `dangerous` two-person)
+    - role gates (viewer never, user with scope, admin global)
+    - per-edge / per-resource overrides
+  - **D.4.4** IM-side approval
+    - Slack / Lark / Telegram message with `Approve` / `Reject` / `Defer`
+    - signed via short-lived token bound to the proposal
+  - **D.4.5** Proposal preview (dry-run diff)
+    - render the to-be-applied change before signing
+    - file-mode shows unified diff; service-mode shows pre/post state probe
+  - **D.4.6** Bulk batching
+    - one proposal, N edges, all-or-nothing or rolling
+    - per-edge confirmation can opt out
+  - **D.4.7** Expiry + auto-decline
+    - default 24h, configurable per policy
+    - expired proposals never silently execute
+  - **D.4.8** Delegation + on-call routing
+    - off-hours proposals route to current on-call (see G.10)
+    - delegate-when-busy with a fallback chain
+  - **D.4.9** Proposal audit trail
+    - hash-chained entries (ties into I.4)
+    - shareable proposal URL for retrospectives
+- **D.5** `□` Cost + token budget controls
+  - per-org / per-user monthly cap
+  - per-call hard timeout + token cap
+  - graceful degradation (smaller model / fewer iterations) before cutoff
 
 ---
 
@@ -128,6 +172,10 @@ across sections.
 - **E.5** `□` Reasoning timeline visualisation
   - chat toggle that renders
     `user → thought → tool_calls → tool_results → final` as a tree
+- **E.6** `□` Approval UI
+  - one-click approve / reject for D.4 proposals
+  - mobile-friendly card view
+  - swipe-through inbox for on-call shifts
 
 ---
 
@@ -223,6 +271,9 @@ across sections.
   - wholesale-purges plugin binaries + work dir
   - stops units unconditionally with a `pkill -9` fallback
   - PR #46, PR #47
+- **G.1.8** `□` Air-gapped install bundle
+  - one tarball, no outbound calls
+  - bundled docker images, mirror config, license check
 
 ### G.2 Edge lifecycle
 
@@ -234,6 +285,11 @@ across sections.
 - **G.2.4** `□` Offline upgrade bundle
   - internal-network customers
   - manager acts as the mirror
+- **G.2.5** `□` Bulk edge re-enrol
+  - rotate edge credentials / re-register across a fleet in one click
+- **G.2.6** `□` Edge fleet labels + selectors
+  - `env=prod`, `region=cn-east`, `role=db`
+  - selector applies to upgrades, SOP targets, alert routing
 
 ### G.3 Prometheus production hardening (parked)
 
@@ -257,90 +313,274 @@ across sections.
 - **G.4.3** `□` Self-diagnostic agent
   - periodic self-RCA against the manager's own metrics
 
-### G.5 Security / sandbox
+### G.5 Backup, restore, disaster recovery
 
-- **G.5.1** `◯` microsandbox upgrade path
-  - only when a customer demands kernel isolation
-  - `host_bash` + `cmdpolicy` covers 90% of diagnostic surface
-- **G.5.2** `□` WebSSH (ADR-019)
-  - geminio stream + xterm.js
-  - exposed as a fallback inside SOP execution
-- **G.5.3** `□` Per-tool RBAC + audit replay
-  - ADR-022 gates by viewer role
-  - granularity needs to drop to per-tool
+- **G.5.1** `□` Manager state snapshot
+  - dump MySQL + Qdrant + objects to a single tarball
+  - configurable retention
+- **G.5.2** `□` One-command restore
+  - point a fresh manager at a snapshot tarball
+  - verifies schema version + edge re-handshake plan
+- **G.5.3** `□` Off-site replication
+  - rsync / S3 sync to a cold-standby region
+- **G.5.4** `□` Drill mode
+  - timed restore exercise from latest backup; report MTTR
+- **G.5.5** `□` Edge-side state checkpoint
+  - plugin work dir snapshot before upgrade (already partial via `.previous`)
 
-### G.6 Credentials and knowledge
+### G.6 HA and failover
 
-- **G.6.1** `✓` ADR-023 SSH key table + Git credentials dual rail
-- **G.6.2** `□` ADR-018 RepoFetcher
+- **G.6.1** `◯` Active-standby manager pair
+  - shared MySQL via DRBD / managed cluster
+  - VRRP / floating IP
+  - trigger: customer asks SLA or > 100 edges
+- **G.6.2** `◯` Multi-region read replica
+- **G.6.3** `□` Manager health gate
+  - `/healthz` deep-mode that exercises every dependency
+- **G.6.4** `□` Tunnel session migration
+  - move geminio sessions between manager replicas without edge reconnect
+
+### G.7 Alert lifecycle
+
+- **G.7.1** `□` Deduplication + grouping
+  - hash on `alertname + labels` window
+  - emit one notification per group, append details
+- **G.7.2** `□` Silencing
+  - operator-set time-bounded silence with reason field
+  - silences flow through D.4 if they touch dangerous classes
+- **G.7.3** `□` Correlation
+  - graph-walk linked alerts (same edge, same service, same incident)
+  - collapse into one incident artefact
+- **G.7.4** `□` Routing policy DSL
+  - per-team / per-severity / per-time-of-day routing
+  - escalation if not acknowledged within N min
+- **G.7.5** `□` Notification preferences
+  - per-user channels, do-not-disturb windows
+
+### G.8 On-call and maintenance windows
+
+- **G.8.1** `□` On-call schedule
+  - team + rotation calendar
+  - escalation chain
+  - integrates with G.7.4 routing
+- **G.8.2** `□` Maintenance window
+  - per-edge / per-fleet window
+  - suppresses alerts AND parks SOP execution proposals
+- **G.8.3** `□` Handover digest
+  - shift-change summary: open incidents, paused proposals, recent changes
+
+### G.9 Bulk operations and config drift
+
+- **G.9.1** `□` Multi-edge SOP execution
+  - apply the same playbook to a selector (G.2.6)
+  - per-edge dry-run result, rolling apply
+- **G.9.2** `□` Config-as-code (GitOps)
+  - alerts / SOPs / channels live in a Git repo
+  - manager reconciles
+- **G.9.3** `□` Configuration drift detection
+  - diff applied config vs desired
+  - surface as a low-severity incident
+- **G.9.4** `□` Asset inventory / CMDB
+  - one table: edge → host → installed packages → exposed ports → owner
+  - feed into RCA and topology
+
+### G.10 NOC view and operational dashboard
+
+- **G.10.1** `□` Single-pane status board
+  - all edges, all incidents, all open proposals
+  - colour-coded by severity
+- **G.10.2** `□` Kiosk mode
+  - wall-display friendly
+  - auto-rotate between fleets
+- **G.10.3** `□` Saved views per role
+  - "L1 triage", "DBA on-call", "network on-call"
+
+### G.11 Patch and vulnerability management
+
+- **G.11.1** `□` OS / package CVE scan
+  - per-edge inventory + CVE feed
+  - propose patch SOP through D.4
+- **G.11.2** `□` Edge agent self-update CVE awareness
+  - manager warns on outdated edge bin with known CVE
+
+### G.12 Postmortem and change management
+
+- **G.12.1** `□` Incident postmortem template
+  - auto-fill from incident timeline
+  - LLM-drafted narrative, operator edits
+- **G.12.2** `□` Change calendar
+  - lightweight "what's deploying when"
+  - cross-references SOP executions
+
+### G.13 Credentials and knowledge
+
+- **G.13.1** `✓` ADR-023 SSH key table + Git credentials dual rail
+- **G.13.2** `□` ADR-018 RepoFetcher
   - per-repo auth without re-introducing the token leakage that tabled
     the first revision
-- **G.6.3** `□` Offline vault bundle
+- **G.13.3** `□` Offline vault bundle
   - customers without outbound internet
   - built-in vault + offline snapshot tarball
 
 ---
 
-## H · Ecosystem / late-stage
+## H · Sandbox and execution isolation
 
-- **H.1** `◯` Skill marketplace public listing (ADR-017)
+A common substrate for "agent wants to try something risky" — covers
+dry-run, capability gating, kernel isolation, and skill testing.
+Powered today by `cmdpolicy` + tool classes; this section sketches
+how it grows.
+
+- **H.1** `◯` microsandbox runtime (escape hatch)
+  - rootless + OCI single binary
+  - first plugin-style sandbox; switched on per customer who asks for
+    kernel isolation
+  - cmdpolicy + bash stays the default channel
+- **H.2** `◯` Python execution channel (script_python tool)
+  - parked until microsandbox lands (N+16 memo)
+  - seccomp + import allowlist + env scrub
+- **H.3** `□` Dry-run sandbox for SOP playbooks
+  - executes a playbook against a `--dry-run` shim
+  - returns expected diff, no real side-effects
+  - mandatory for `dangerous` class before D.4 confirmation
+- **H.4** `□` Browser sandbox for web-fetch tools
+  - ephemeral headless chromium in container
+  - no persistent cookies, per-call profile
+- **H.5** `□` Skill / playbook authoring sandbox
+  - skill author edits + tests against a synthetic edge fixture
+  - "publish" only after sandbox green
+- **H.6** `□` Per-tenant compute budget
+  - CPU / mem caps on agent + tool subprocesses
+  - rate limit per-user-per-minute
+- **H.7** `□` seccomp + capability profile library
+  - per-tool profile committed in-repo
+  - generator from `cmdpolicy` rules
+- **H.8** `□` Dangerous-class ephemeral container wrapper
+  - I/O-destructive commands run inside a throwaway container with
+    bind-mounted target dirs
+  - rollback by container delete
+
+---
+
+## I · Security and compliance
+
+- **I.1** `□` SSO / SAML / OIDC
+  - Okta / Azure AD / Google Workspace
+  - just-in-time user provisioning with role mapping
+- **I.2** `□` MFA enforcement
+  - TOTP minimum
+  - per-org policy: required / optional / off
+- **I.3** `□` Session management
+  - active sessions list per user
+  - revoke from admin UI
+  - IP allowlist per org
+- **I.4** `□` Tamper-evident audit log
+  - hash-chained rows (chain hash referenced in D.4 proposal envelope)
+  - daily root hash anchored to Git for external verification
+- **I.5** `□` Credential rotation policy
+  - LLM keys, IM tokens, Git deploy keys
+  - operator-defined rotate period; UI surfaces age
+- **I.6** `□` TLS cert auto-rotation
+  - manager via Let's Encrypt + self-signed fallback
+  - edge agents pull fresh manager cert on heartbeat
+- **I.7** `□` Edge binary vulnerability tracking
+  - bundled bin versions exposed via `/edge/inventory`
+  - CVE feed → action card
+- **I.8** `□` LLM PII filtering on prompts
+  - configurable redaction (IPs, emails, hostnames optional)
+  - on-prem mode pins all LLM traffic to self-hosted
+- **I.9** `□` Prompt-injection defense + output content filter
+  - tool descriptions tagged with trust level
+  - output scanned for leaked credentials before display
+- **I.10** `□` Rate limiting per user / org
+  - chat msgs / min, tool calls / hour, IM webhook / sec
+- **I.11** `□` Encryption at rest
+  - MySQL + Qdrant + object storage
+  - per-org KMS option for enterprise
+- **I.12** `□` Compliance evidence pack
+  - one-click export: audit log, access list, change history,
+    incident timelines
+  - SOC2 / ISO 27001 / 等保 friendly format
+- **I.13** `□` Per-org secrets vault
+  - encrypted at rest, scoped to org
+  - injected into SOP runtime via env
+- **I.14** `□` Anomalous-usage detection
+  - login from new geo, spike in dangerous tool calls
+  - notification + auto-quarantine option
+
+---
+
+## J · Ecosystem / late-stage
+
+- **J.1** `◯` Skill marketplace public listing (ADR-017)
   - unpark when the skill count crosses ~30
-- **H.2** `□` HLD-009 coordinator e2e evaluation
+- **J.2** `□` HLD-009 coordinator e2e evaluation
   - currently a design
   - becomes runnable once D.3 eval framework lands
-- **H.3** `□` HLD-012 code-aware analysis
+- **J.3** `□` HLD-012 code-aware analysis
   - combine a code repo with incidents
   - PR diff → impact analysis
-- **H.4** `◯` Open ecosystem
+- **J.4** `◯` Open ecosystem
   - plugin SDK docs + third-party BaseTool registration
   - defer until open-core split (ADR-030) attracts contributors
 
 ---
 
-## I · SOP / Runbook execution loop
+## K · SOP / Runbook execution loop
 
-The most ambitious chunk on the roadmap. Listed last on purpose:
-sections A–H either unblock SOP or have to be solid before SOP can
-ship safely. **Do not start until B and D are in a reliable place** —
-otherwise the executable path becomes an outage generator instead of
-a moat.
+The most ambitious chunk on the roadmap. Listed near the end on
+purpose: sections A–I either unblock SOP or have to be solid before
+SOP can ship safely. **Do not start until B (diagnostic tools), D
+(agent kernel + D.4 proposal mediation), H (sandbox), and I (security)
+are in a reliable place** — otherwise the executable path becomes an
+outage generator instead of a moat.
 
-- **I.1** `□` Tool.Class three-tier
+- **K.1** `□` Tool.Class three-tier
   - `safe` (read-only) / `mutating` (state change) / `dangerous` (irreversible)
   - replaces today's binary read/write split
-- **I.2** `□` SOP DSL
+- **K.2** `□` SOP DSL
   - YAML runbooks: `triggers` / `steps` / `approvals` / `rollback`
-- **I.3** `□` Two-signature execution chain
+- **K.3** `□` Two-signature execution chain
   - manager RSA signs
   - edge verifies
   - both ends audit-log every step
-- **I.4** `□` `review_gate` sub-agent
-  - mutating step spawns a reviewer worker
-  - writes a `mutating_proposal` row
-  - UI surfaces an action card
-  - operator signs → edge executes
-  - timeline gets a `mutating_action_executed` entry
-- **I.5** `□` Initial playbook library
+  - flows through D.4 for the operator confirmation half
+- **K.4** `□` Per-step rollback
+  - every mutating step declares its inverse (or `noop` if irreversible)
+  - aborted runs unwind in reverse order
+- **K.5** `□` Initial playbook library
   - `host_restart_service`
   - `disk_cleanup`
   - `log_rotate`
   - `certificate_renew`
+- **K.6** `□` Playbook marketplace (internal)
+  - share + import playbooks between orgs
+  - signed by author org
+- **K.7** `□` SOP execution timeline
+  - per-run view: step-by-step with logs, exit codes, diff before/after
+  - replayable for postmortem
 
 ---
 
-## J · Periodic agent jobs
+## L · Periodic agent jobs
 
 Built on a shared scheduler primitive; sized for "agent watches over
 time" workloads rather than synchronous chat.
 
-- **J.1** `□` Inspection (巡检)
+- **L.1** `□` Inspection (巡检)
   - scheduled (daily / weekly) sweeps over every edge
   - lightweight RCA: `top_load_anomaly`, `dep_health_check`, `cert_expiry_check`
   - matches auto-create incidents
-- **J.2** `□` Weekly / monthly digest
+- **L.2** `□` Weekly / monthly digest
   - cross-edge aggregate of alerts, incidents, executed actions
   - LLM-written summary
   - IM-pushed
-- **J.3** `□` Watch tasks / proactive notification
+- **L.3** `□` Watch tasks / proactive notification
   - `create_watch(condition, expire_at)` BaseTool
   - when the condition fires, push back into the original session over SSE
+- **L.4** `□` Capacity forecast
+  - extrapolate disk / memory / cardinality trends
+  - file a proposal (D.4) when a threshold projects within N days
+- **L.5** `□` Cost roll-up
+  - LLM token + storage + bandwidth attribution per org
+  - mailed monthly

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -23,7 +23,7 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
 
 ---
 
-## A · 因果 RCA 深化（HLD-013 Phase 3）
+## A · 根因 RCA 诊断（HLD-013 Phase 3）
 
 - **A.1** `✓` Phase 1 —— investigator prompt 改写为因果回溯循环
   - `max_turns` 25 → 40
@@ -43,6 +43,12 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
   - `incident_resolutions` 表 + embedding 库
   - `query_similar_incidents` BaseTool
   - 详情页 resolve modal 闭环 "见过这种情况"
+- **A.6** `□` RCA 置信度校准
+  - 每 incident 置信度 vs 运维标注的正确率，长期回流
+  - 调 prompt / 选择模型
+- **A.7** `□` 根因图可视化
+  - 因果链以节点-边图渲染在报告旁边
+  - hover 节点看证据（PromQL / 日志行 / trace span）
 
 ---
 
@@ -81,6 +87,9 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
 - **C.2** `□` Chat → Grafana panel
   - 自然语言描述 → 选 panel + range + 变量
   - 直接 deep-link 或在 chat 里内嵌
+- **C.3** `□` Schema 感知的自动补全
+  - 手写查询时的内嵌编辑器
+  - 从实时 `/api/v1/labels` 提示 label + function
 
 ---
 
@@ -102,6 +111,40 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
   - 5–10 个 golden incident，标好期望 tool 集 + 关键词
   - `cmd/ongrid-eval` CLI
   - CI 钩子：改 prompt / persona / 工具描述时强跑
+- **D.4** `□` 提案 & 确认中介层
+  - **作用**：所有 agent 触发的 mutating 动作 —— chat、SOP 执行（K）、
+    守望任务（L.3）一律走同一条管道。
+  - **D.4.1** 提案生命周期
+    - `pending` → `approved` / `rejected` / `expired` / `executed` / `rolled-back`
+    - 落 `mutating_proposal` 表（签名信封）
+  - **D.4.2** `review_gate` sub-agent
+    - reviewer worker 起草提案、点名 SOP 步骤、暴露 blast radius、附 dry-run 输出
+  - **D.4.3** 审批策略
+    - 级别：`safe` 自动 / `mutating` 单人审 / `dangerous` 双签
+    - 角色：viewer 永远不行 / user 限 scope / admin 全局
+    - 支持 per-edge / per-resource 覆盖
+  - **D.4.4** IM 侧审批
+    - Slack / 飞书 / Telegram 消息带 `Approve` / `Reject` / `Defer` 按钮
+    - 短期 token 绑定到具体提案
+  - **D.4.5** 提案预览（dry-run diff）
+    - 签字前看到将要发生的变更
+    - 文件类显 unified diff；服务类显前后状态探测
+  - **D.4.6** 批量化
+    - 一份提案、N 个 edge，all-or-nothing 或滚动应用
+    - 每个 edge 可单独 opt out
+  - **D.4.7** 过期 + 自动 decline
+    - 默认 24h，按 policy 可调
+    - 过期提案绝不静默执行
+  - **D.4.8** 委派 + on-call 路由
+    - 非工作时间的提案路由到当班 on-call（接 G.10 on-call schedule）
+    - "忙了就交给下一档"的 fallback 链
+  - **D.4.9** 提案审计链
+    - hash-chain 条目（接 I.4）
+    - 提案 URL 可分享，事后复盘用
+- **D.5** `□` Token / 成本预算
+  - per-org / per-user 月度上限
+  - 单次硬超时 + token 上限
+  - 触上限前降级（小模型 / 少步数）而不是粗暴 abort
 
 ---
 
@@ -124,6 +167,10 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
 - **E.5** `□` 推理时间线可视化
   - chat toggle 把
     `user → thought → tool_calls → tool_results → final` 渲染成树
+- **E.6** `□` 审批 UI
+  - 一键 approve / reject D.4 提案
+  - 移动端友好卡片
+  - on-call 班次的 swipe 收件箱
 
 ---
 
@@ -220,6 +267,9 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
   - 整目录 purge 插件二进制 + 工作目录
   - 无条件 stop unit + `pkill -9` 兜底
   - PR #46 / PR #47
+- **G.1.8** `□` 离线 / 私有网络安装包
+  - 一个 tarball 不带任何外网调用
+  - 镜像内置、镜像仓配置、license 校验
 
 ### G.2 边端生命周期
 
@@ -231,6 +281,11 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
 - **G.2.4** `□` 离线升级包
   - 内网客户场景
   - manager 当 mirror
+- **G.2.5** `□` 批量重注册
+  - 一次性轮换 edge 凭证 / 跨 fleet 重新登记
+- **G.2.6** `□` Edge fleet 标签 + selector
+  - `env=prod`、`region=cn-east`、`role=db`
+  - selector 同时被升级、SOP 目标、告警路由消费
 
 ### G.3 Prometheus 生产硬化（已 park）
 
@@ -254,86 +309,267 @@ Ongrid 的护城河是 `geminio` 双向通道 + AI agent 能在客户机器上**
 - **G.4.3** `□` 自诊断 agent
   - 周期跑 self-RCA 对自家 manager
 
-### G.5 安全 / 沙箱
+### G.5 备份 / 恢复 / 容灾
 
-- **G.5.1** `◯` microsandbox 升级路径
-  - 客户明确要求 kernel 级隔离时再启
-  - `host_bash` + `cmdpolicy` 当前覆盖 90% 诊断面
-- **G.5.2** `□` WebSSH（ADR-019）
-  - geminio stream + xterm.js
-  - 当 SOP 执行的兜底通道
-- **G.5.3** `□` Per-tool RBAC + audit replay
-  - ADR-022 当前到 viewer role 这层
-  - 颗粒度还要下到单个 tool
+- **G.5.1** `□` Manager 全量快照
+  - MySQL + Qdrant + 对象存储 一并打包
+  - 可配置 retention
+- **G.5.2** `□` 一键 restore
+  - 新 manager 指向 snapshot tarball
+  - 校验 schema 版本 + edge 重握手计划
+- **G.5.3** `□` 异地复制
+  - rsync / S3 sync 到 cold standby region
+- **G.5.4** `□` 演练模式
+  - 定时从最新备份做 restore 演练，回报 MTTR
+- **G.5.5** `□` Edge 状态 checkpoint
+  - 升级前快照插件工作目录（`.previous` 已经做了一半）
 
-### G.6 凭证 / 知识
+### G.6 HA & failover
 
-- **G.6.1** `✓` ADR-023 SSH key 表 + git 凭证双轨
-- **G.6.2** `□` ADR-018 RepoFetcher
+- **G.6.1** `◯` Active-standby manager 对
+  - MySQL 共享（DRBD / 托管 cluster）
+  - VRRP / 浮动 IP
+  - 触发条件：客户问 SLA 或 > 100 edges
+- **G.6.2** `◯` 多区域只读副本
+- **G.6.3** `□` Manager 深层 `/healthz`
+  - 探每一个依赖
+- **G.6.4** `□` Tunnel session 迁移
+  - geminio 会话在 manager 副本之间漂移，edge 不重连
+
+### G.7 告警生命周期
+
+- **G.7.1** `□` 去重 + 分组
+  - 按 `alertname + labels` 哈希窗口
+  - 一组只发一条通知，详情追加
+- **G.7.2** `□` 静默（silence）
+  - 运维设置带 reason 的限时静默
+  - 涉及 dangerous 类别的静默走 D.4
+- **G.7.3** `□` 关联
+  - 图遍历找关联告警（同 edge / 同服务 / 同 incident）
+  - 合并到一个 incident artefact
+- **G.7.4** `□` 路由策略 DSL
+  - 按 team / severity / 时段 路由
+  - N 分钟无 ack 自动升级
+- **G.7.5** `□` 通知偏好
+  - 单用户配渠道、勿扰时段
+
+### G.8 On-call 与维护窗
+
+- **G.8.1** `□` On-call 排班
+  - 团队 + 轮值日历
+  - 升级链
+  - 接 G.7.4 路由
+- **G.8.2** `□` 维护窗
+  - per-edge / per-fleet
+  - 同时抑制告警 + 暂停 SOP 执行提案
+- **G.8.3** `□` 交班摘要
+  - 班次切换时的摘要：开着的 incident、挂起的提案、最近的变更
+
+### G.9 批量操作与配置漂移
+
+- **G.9.1** `□` 多 edge SOP 执行
+  - 一份 playbook 应用到 selector（G.2.6）
+  - 每 edge dry-run 结果，滚动应用
+- **G.9.2** `□` Config-as-code（GitOps）
+  - 告警 / SOP / 渠道存 Git 仓库
+  - manager 周期 reconcile
+- **G.9.3** `□` 配置漂移检测
+  - 实际配置 vs desired 的 diff
+  - 报为低优 incident
+- **G.9.4** `□` 资产清单 / CMDB
+  - 一张表：edge → 主机 → 已装包 → 暴露端口 → owner
+  - 喂回 RCA 和拓扑
+
+### G.10 NOC 视图与运营 dashboard
+
+- **G.10.1** `□` 单页全局状态板
+  - 所有 edge、所有 incident、所有挂起提案
+  - 按 severity 着色
+- **G.10.2** `□` Kiosk 模式
+  - 大屏友好
+  - 多 fleet 轮播
+- **G.10.3** `□` 按角色保存的视图
+  - "L1 triage"、"DBA on-call"、"网络 on-call"
+
+### G.11 补丁与漏洞
+
+- **G.11.1** `□` OS / package CVE 扫描
+  - 每 edge 的 inventory + CVE feed
+  - 通过 D.4 提案派生 patch SOP
+- **G.11.2** `□` Edge 自身二进制 CVE 感知
+  - manager 警告"装着的 edge bin 有已知 CVE"
+
+### G.12 复盘与变更管理
+
+- **G.12.1** `□` 事故复盘模板
+  - 从 incident 时间线自动填
+  - LLM 起草叙述，运维改
+- **G.12.2** `□` 变更日历
+  - 轻量"什么时候部署什么"
+  - 与 SOP 执行交叉引用
+
+### G.13 凭证 / 知识
+
+- **G.13.1** `✓` ADR-023 SSH key 表 + git 凭证双轨
+- **G.13.2** `□` ADR-018 RepoFetcher
   - per-repo auth；不能把上一版被 park 的 token 泄漏问题带回来
-- **G.6.3** `□` 离线 vault 包
+- **G.13.3** `□` 离线 vault 包
   - 无外网客户场景
   - 内置 vault + 离线快照 tarball
 
 ---
 
-## H · 生态 / 后置
+## H · 沙箱与执行隔离
 
-- **H.1** `◯` Skill marketplace 公开化（ADR-017）
+"agent 想试一下危险操作"的公共底座 —— 覆盖 dry-run、capability 控制、
+内核隔离、skill 测试。今天靠 `cmdpolicy` + Tool.Class 撑着，这段是
+未来怎么长大的草图。
+
+- **H.1** `◯` microsandbox runtime（升级路径）
+  - rootless + OCI 单 binary
+  - 第一档插件式沙箱；客户主动要求 kernel 隔离才启
+  - cmdpolicy + bash 还是默认通道
+- **H.2** `◯` Python 执行通道（script_python tool）
+  - 等 microsandbox 落地后再开（N+16 memo）
+  - seccomp + import 白名单 + env 清洗
+- **H.3** `□` SOP playbook 的 dry-run 沙箱
+  - 用 `--dry-run` shim 跑 playbook
+  - 回返预期 diff，零真实副作用
+  - `dangerous` 类提案必须先通过 dry-run 才能进 D.4 签字
+- **H.4** `□` web-fetch 工具的浏览器沙箱
+  - 容器里的临时 headless chromium
+  - 无持久 cookie，per-call profile
+- **H.5** `□` Skill / playbook 创作沙箱
+  - skill 作者编辑 + 用合成 edge fixture 测试
+  - 沙箱绿了才能 publish
+- **H.6** `□` 每租户 compute 预算
+  - agent + tool 子进程 CPU / mem 上限
+  - per-user-per-minute 速率限制
+- **H.7** `□` seccomp + capability profile 库
+  - 每 tool 一份 profile，进仓
+  - 从 `cmdpolicy` 规则自动生成
+- **H.8** `□` Dangerous 类的临时容器包装
+  - I/O 破坏类命令塞进一次性容器
+  - bind-mount 目标目录
+  - 失败回滚 = 删容器
+
+---
+
+## I · 安全与合规
+
+- **I.1** `□` SSO / SAML / OIDC
+  - Okta / Azure AD / Google Workspace
+  - JIT 用户开通 + role mapping
+- **I.2** `□` MFA 强制
+  - 最低 TOTP
+  - per-org 策略：必须 / 可选 / 关闭
+- **I.3** `□` 会话管理
+  - 单用户活跃会话列表
+  - admin UI 撤销
+  - per-org IP 白名单
+- **I.4** `□` Tamper-evident audit log
+  - hash-chain 记录（D.4 提案信封会引用 chain hash）
+  - 每日 root hash 锚到 Git，供外部验证
+- **I.5** `□` 凭证轮换策略
+  - LLM key、IM token、git deploy key
+  - 运维设置轮换周期；UI 显示当前 key 的年龄
+- **I.6** `□` TLS 证书自动轮换
+  - manager 走 Let's Encrypt + 自签兜底
+  - edge agent 心跳时拉新 manager cert
+- **I.7** `□` 边端二进制漏洞跟踪
+  - 已装的 bundled bin 版本通过 `/edge/inventory` 暴露
+  - CVE feed → 动作卡
+- **I.8** `□` LLM prompt 的 PII 过滤
+  - 可配置脱敏（IP / 邮箱 / 主机名 可选）
+  - on-prem 模式把所有 LLM 流量绑在自托管
+- **I.9** `□` Prompt injection 防御 + 输出内容过滤
+  - 工具描述带信任级 tag
+  - 输出渲染前扫漏的凭证
+- **I.10** `□` 速率限制 per-user / per-org
+  - chat msg / min、tool call / hour、IM webhook / sec
+- **I.11** `□` 静态加密
+  - MySQL + Qdrant + 对象存储
+  - 企业版支持 per-org KMS
+- **I.12** `□` 合规证据包
+  - 一键导出：audit log、访问列表、变更历史、incident 时间线
+  - 适配 SOC2 / ISO 27001 / 等保
+- **I.13** `□` Per-org secrets vault
+  - 静态加密、scope 到 org
+  - SOP runtime 通过 env 注入
+- **I.14** `□` 异常使用检测
+  - 新地理位置登录、dangerous 工具调用激增
+  - 通知 + 可选自动隔离
+
+---
+
+## J · 生态 / 后置
+
+- **J.1** `◯` Skill marketplace 公开化（ADR-017）
   - skill 数量到 ~30 再 unpark
-- **H.2** `□` HLD-009 coordinator e2e evaluation 上线
+- **J.2** `□` HLD-009 coordinator e2e evaluation 上线
   - 当前只是设计
   - D.3 eval 框架落地后才能跑
-- **H.3** `□` HLD-012 code-aware 分析
+- **J.3** `□` HLD-012 code-aware 分析
   - 代码仓库结合 incident
   - PR diff → 影响面分析
-- **H.4** `◯` 开源生态
+- **J.4** `◯` 开源生态
   - 插件 SDK 文档 + 第三方 BaseTool 注册
   - 等开源拆分（ADR-030）孵化出贡献者再启
 
 ---
 
-## I · SOP / Runbook 闭环
+## K · SOP / Runbook 闭环
 
-整张 roadmap 里最大的工程。**故意放最后**：A–H 要么是 SOP 的前置依
-赖，要么是 SOP 安全上线的前提。**前面 B 和 D 没跑稳前不开 SOP** ——
+整张 roadmap 里最大的工程。**故意放靠后**：A–I 要么是 SOP 的前置依
+赖，要么是 SOP 安全上线的前提。**前面 B（诊断工具）、D（agent 内核
+含 D.4 提案中介）、H（沙箱）、I（安全）四块没跑稳前不开 SOP** ——
 否则可执行路径会变成"产事故的引擎"而不是护城河。
 
-- **I.1** `□` Tool.Class 三级
+- **K.1** `□` Tool.Class 三级
   - `safe`（只读）/ `mutating`（改状态）/ `dangerous`（不可回滚）
   - 替换今天的二值 read / write 分流
-- **I.2** `□` SOP DSL
+- **K.2** `□` SOP DSL
   - YAML runbook：`triggers` / `steps` / `approvals` / `rollback`
-- **I.3** `□` 双签执行链路
+- **K.3** `□` 双签执行链路
   - manager RSA 签
   - edge 校验
   - 两端 audit log 都打齐
-- **I.4** `□` `review_gate` sub-agent
-  - mutating step spawn reviewer worker
-  - 写 `mutating_proposal` 行
-  - UI 弹动作卡
-  - 操作者签 → edge 执行
-  - 时间线打 `mutating_action_executed`
-- **I.5** `□` 起手 playbook 库
+  - 运维一侧的确认走 D.4
+- **K.4** `□` 单步回滚
+  - 每个 mutating step 声明逆操作（不可逆则声明 `noop`）
+  - 中止的执行按反序 unwind
+- **K.5** `□` 起手 playbook 库
   - `host_restart_service`
   - `disk_cleanup`
   - `log_rotate`
   - `certificate_renew`
+- **K.6** `□` Playbook 市场（内部）
+  - org 之间 share + import playbook
+  - 由作者 org 签名
+- **K.7** `□` SOP 执行时间线
+  - 单次执行视图：每步 logs / exit code / 前后 diff
+  - 可回放用于复盘
 
 ---
 
-## J · 周期性 Agent 任务
+## L · 周期性 Agent 任务
 
 共用一个调度器原语；面向"agent 长时间盯着"这种工作量，不是同步 chat。
 
-- **J.1** `□` 巡检
+- **L.1** `□` 巡检
   - 每天 / 每周扫所有 edge
   - 跑轻量 RCA：`top_load_anomaly` / `dep_health_check` / `cert_expiry_check`
   - 命中风险自动建 incident
-- **J.2** `□` 周报 / 月报
+- **L.2** `□` 周报 / 月报
   - 跨 edge 汇总告警、incident、执行过的动作
   - LLM 写摘要
   - IM 推送
-- **J.3** `□` 守望任务 / 主动推送
+- **L.3** `□` 守望任务 / 主动推送
   - `create_watch(condition, expire_at)` BaseTool
   - 命中条件后 SSE 推回原 session
+- **L.4** `□` 容量预测
+  - 磁盘 / 内存 / 基数 趋势外推
+  - 阈值预测在 N 天内会撞时通过 D.4 起提案
+- **L.5** `□` 成本汇总
+  - LLM token + 存储 + 带宽 按 org 归因
+  - 月度邮件


### PR DESCRIPTION
Follow-up to #48.

## Changes
- **A renamed**: "Causal RCA depth" → "Root-cause RCA diagnosis". Adds A.6 confidence calibration and A.7 root-cause graph viz.
- **D.4 (new)**: proposal & confirmation mediation now sits inside Agent kernel quality (D), per user direction. Covers lifecycle states, review_gate sub-agent, severity-tier approval policies, IM-side approval, dry-run preview, bulk batching, expiry, on-call delegation, hash-chained audit. Same pipeline serves chat, SOP, and watch tasks.
- **G greatly expanded**: + G.5 backup/restore/DR, G.6 HA/failover, G.7 alert lifecycle (dedup/silence/correlate/route), G.8 on-call + maintenance windows, G.9 bulk ops + GitOps + CMDB, G.10 NOC view, G.11 CVE management, G.12 postmortem + change calendar.
- **H (new)**: Sandbox and execution isolation — microsandbox, python channel (parked), playbook dry-run, browser sandbox, skill authoring sandbox, per-tenant compute budget, seccomp/cap profile library, dangerous-class container wrapper.
- **I (new)**: Security and compliance — SSO/SAML/OIDC, MFA, session mgmt + IP allowlist, tamper-evident audit log, credential rotation, TLS auto-rotation, edge bin CVE tracking, LLM PII filtering, prompt-injection defense, rate limiting, encryption at rest, compliance evidence pack, per-org secrets vault, anomalous-usage detection.
- **K (SOP)** focused on DSL / signing / rollback / playbook library; approval mediation moved to D.4.
- **L** gets L.4 capacity forecast (routes through D.4) + L.5 cost roll-up.

## Cross-references
K depends on B (diagnostic tools), D (agent kernel + D.4 proposal mediation), H (sandbox), I (security). L.4 routes its proposals through D.4.