### PR TITLE
fix(aiops/persistence): autoheal partial tool batches + callback tracing

### DIFF
--- a/internal/manager/biz/aiops/chatruntime/runtime.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime.go
@@ -619,6 +619,14 @@ func (rt *Runtime) Handle(ctx context.Context, req *Request) (*Reply, error) {
 	// ("openai"), and installs without an OpenAI key see specialists
 	// fail with `provider "openai" not configured`.
 	ctx = basetool.WithLLMChoice(ctx, req.Provider, req.Model)
+	// Always autoheal any in-flight tool batch on the way out — covers
+	// the "user closed browser mid-tool-batch" case the in-session
+	// ChatModel.OnStart flush can't reach. Defer with a background-rooted
+	// ctx so a cancelled request ctx doesn't block the stub inserts.
+	defer func() {
+		flushCtx := context.WithoutCancel(ctx)
+		callbacks.FinalizeBatches(flushCtx, handlers)
+	}()
 	out, invokeErr := g.Invoke(ctx, &graph.Input{
 		SystemPrompt:     systemPrompt,
 		History:          einoHistory,

--- a/internal/manager/biz/aiops/chatruntime/worker.go
+++ b/internal/manager/biz/aiops/chatruntime/worker.go
@@ -621,6 +621,13 @@ func (rt *Runtime) runWorker(ctx context.Context, agentDef *Agent, sessID, userT
 	if mopts := workerChatModelOpts(ctx); len(mopts) > 0 {
 		invokeOpts = append(invokeOpts, compose.WithChatModelOption(mopts...))
 	}
+	// Autoheal any tool batch still open when the worker exits — same
+	// rationale as the parent runtime defer. context.WithoutCancel
+	// keeps the stub inserts running even if the caller cancelled.
+	defer func() {
+		flushCtx := context.WithoutCancel(ctx)
+		callbacks.FinalizeBatches(flushCtx, handlers)
+	}()
 	out, err := g.Invoke(ctx, &graph.Input{
 		SystemPrompt: systemPrompt,
 		History:      nil,

--- a/internal/manager/biz/aiops/graph/callbacks/chain.go
+++ b/internal/manager/biz/aiops/graph/callbacks/chain.go
@@ -1,6 +1,7 @@
 package callbacks
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 
@@ -106,6 +107,21 @@ func NewDefaultHandlers(deps Deps) []callbacks.Handler {
 		out = append(out, llm.NewBudgetCallbackHandler(deps.BudgetChecker, deps.BudgetUserID))
 	}
 	return out
+}
+
+// FinalizeBatches runs end-of-request bookkeeping on every handler in
+// the chain that wants one. Currently this is just PersistenceHandler:
+// see flushIncompleteBatch — the ChatModel.OnStart hook autoheals the
+// previous batch DURING a session, but a session that ends mid-batch
+// (user closes browser, request cancels) never gets the next OnStart.
+// chatruntime defers FinalizeBatches after compose.Invoke returns so
+// the batch always gets a final flush.
+func FinalizeBatches(ctx context.Context, handlers []callbacks.Handler) {
+	for _, h := range handlers {
+		if p, ok := h.(*PersistenceHandler); ok {
+			p.FinalizeBatch(ctx)
+		}
+	}
 }
 
 // ErrNoHandlers is returned by helpers that require at least one

--- a/internal/manager/biz/aiops/graph/callbacks/persistence.go
+++ b/internal/manager/biz/aiops/graph/callbacks/persistence.go
@@ -55,6 +55,9 @@ type PersistenceDeps struct {
 // the graph executes. Mirrors the persistence side-effects the legacy
 // agent.go for-loop performs synchronously; spec:
 //
+//	OnChatModelStart → flushIncompleteBatch (autoheal stubs for
+//	                   any tool_call from the PREVIOUS assistant turn
+//	                   whose OnEnd never fired — see currentBatch)
 //	OnChatModelEnd → INSERT chat_messages (role=assistant)
 //	OnToolStart → INSERT chat_tool_calls (status=pending)
 //	OnToolEnd → UPDATE chat_tool_calls + INSERT chat_messages (role=tool)
@@ -69,6 +72,25 @@ type PersistenceDeps struct {
 // so the SessionID + per-call state stay scoped. Tool start times are
 // stashed on context (per-call) which is goroutine-safe.
 //
+// Autoheal background (currentBatch). eino's ToolsNode runs sibling
+// tool_calls from one assistant turn in parallel. In live production
+// (.91, session b528bfb0 on 2026-06-06) we observed an assistant
+// turn emitting 4 host_bash tool_calls where only 2 of the 4 OnEnd
+// callbacks fired — chat_tool_calls had all 4 rows but chat_messages
+// was missing 2 role=tool rows, with NO recorded persistence error.
+// Replay then produced an envelope strict providers (DeepSeek v4+)
+// reject with HTTP 400 "insufficient tool messages following
+// tool_calls". The replay-side defense (toolreplay precheck +
+// MarkDependentToolsForSkip) keeps the user out of the loop, but the
+// dropped tool results are still lost. To stop this from happening
+// silently we track per-assistant batches here: persistAssistant
+// records the expected llm_call_id set; persistToolEnd marks each
+// seen; the next ChatModel.OnStart (signalling the previous batch is
+// terminally done) flushes any leftover llm_call_ids as autoheal
+// stub role=tool rows so the next replay envelope is structurally
+// valid AND the LLM gets honest "tool result was not captured"
+// signal instead of a fabricated success.
+//
 // Errors: persist failures NEVER abort the graph — the handler logs +
 // counts and returns ctx unchanged. 可观测性: audit/
 // persist best-effort.
@@ -78,11 +100,19 @@ type PersistenceHandler struct {
 	// errCounter is the lazy collector for persist failures. Resolved
 	// at construction; nil when Registerer is nil.
 	errCounter *prometheus.CounterVec
+	// lossCounter is the autoheal observability collector. Labels:
+	//   outcome="autoheal_stub" — a stub row was inserted
+	//   tool_name=<the tool whose response was lost>
+	// Cardinality: tool_name set is small (bounded by registered tools).
+	lossCounter *prometheus.CounterVec
 
 	// toolCalls maps eino tool_call_id → the chat_tool_calls row id we
 	// inserted on OnStart, so OnEnd can update the same row. eino
 	// guarantees the tool_call_id is unique within a graph run; we
 	// scope the map to this handler instance, not globally.
+	// Entries are deleted on OnEnd/OnError; what remains here at flush
+	// time is exactly the set of tool calls whose end-callback never
+	// fired — those are what flushIncompleteBatch heals.
 	toolCalls   map[string]toolCallEntry
 	toolCallsMu sync.Mutex
 
@@ -116,6 +146,28 @@ type PersistenceHandler struct {
 	// "<tool_name>|<tool_type>" fallback into chat_messages.tool_call_id
 	// and history replay loses the linkage strict providers need.
 	pendingLLMCalls []pendingLLMCall
+
+	// batchMu guards currentBatch. Held only while opening / sealing /
+	// flushing — individual mark-seen calls inside persistToolEnd take
+	// it just long enough to update one map. Tool callbacks fire in
+	// parallel from eino's ToolsNode so the mutex is non-trivial.
+	batchMu      sync.Mutex
+	currentBatch *assistantBatch
+}
+
+// assistantBatch tracks the tool_call → tool_response pairing for one
+// assistant turn so flushIncompleteBatch can emit stub responses for
+// any tool_call whose OnEnd never fired. expected is the set of
+// LLM-assigned call ids the assistant emitted; seen accumulates as
+// persistToolEnd writes role=tool rows; toolName lets the stub carry
+// the right tool_name into chat_messages for replay parity. Per the
+// per-request handler scoping (see handler doc), at most one batch
+// is live at a time.
+type assistantBatch struct {
+	assistantID string
+	expected    map[string]string // llmCallID → toolName (recorded on register)
+	seen        map[string]struct{}
+	openedAt    time.Time
 }
 
 // pendingLLMCall carries the LLM-assigned call id (e.g.
@@ -162,12 +214,24 @@ func NewPersistenceHandler(deps PersistenceDeps) *PersistenceHandler {
 			},
 			[]string{"kind"},
 		)).(*prometheus.CounterVec)
+		h.lossCounter = registerOrExisting(deps.Registerer, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "ongrid_chat_tool_response_loss_total",
+				Help: "Total ongrid AIOps tool responses lost (OnEnd never fired) and autohealed via stub.",
+			},
+			[]string{"outcome", "tool_name"},
+		)).(*prometheus.CounterVec)
 	}
 	return h
 }
 
 // Needed signals which timings to wire so eino can short-circuit the
 // expensive ones we don't use.
+//
+// ChatModel.OnStart is wired (in addition to OnEnd) so flushIncompleteBatch
+// can autoheal the previous turn before the next LLM call goes out — its
+// position in the callback stream is the cleanest "previous batch is
+// terminally done" signal we have.
 func (h *PersistenceHandler) Needed(_ context.Context, info *callbacks.RunInfo, timing callbacks.CallbackTiming) bool {
 	if h == nil {
 		return false
@@ -177,7 +241,7 @@ func (h *PersistenceHandler) Needed(_ context.Context, info *callbacks.RunInfo, 
 	}
 	switch info.Component {
 	case components.ComponentOfChatModel:
-		return timing == callbacks.TimingOnEnd
+		return timing == callbacks.TimingOnStart || timing == callbacks.TimingOnEnd
 	case components.ComponentOfTool:
 		return timing == callbacks.TimingOnStart || timing == callbacks.TimingOnEnd || timing == callbacks.TimingOnError
 	default:
@@ -186,12 +250,18 @@ func (h *PersistenceHandler) Needed(_ context.Context, info *callbacks.RunInfo, 
 }
 
 // OnStart is the hook fired before a component runs. For PersistenceHandler:
-//   - ChatModel start: no-op (user message is persisted by chatruntime
-//     entry, before the graph starts; spec).
+//   - ChatModel start: flush any incomplete tool batch from the previous
+//     assistant turn (autoheal stub) BEFORE this LLM call goes out. Also
+//     traces the entry for instrumentation.
 //   - Tool start: write a chat_tool_calls row in pending state and
 //     stash the row id on the handler so OnEnd can find it.
 func (h *PersistenceHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
 	if h == nil || info == nil {
+		return ctx
+	}
+	if info.Component == components.ComponentOfChatModel {
+		h.trace(ctx, "chat_model_start", info, "")
+		h.flushIncompleteBatch(ctx)
 		return ctx
 	}
 	if info.Component != components.ComponentOfTool {
@@ -199,8 +269,10 @@ func (h *PersistenceHandler) OnStart(ctx context.Context, info *callbacks.RunInf
 	}
 	tin := einotool.ConvCallbackInput(input)
 	if tin == nil {
+		h.trace(ctx, "tool_start_skip_nil_input", info, "")
 		return ctx
 	}
+	h.trace(ctx, "tool_start", info, "")
 	startedAt := time.Now().UTC()
 	// Resolve MessageID + LLM call id from the assistant turn that
 	// just emitted this tool_call. Explicit ctx seams (WithMessageID /
@@ -283,14 +355,18 @@ func (h *PersistenceHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo,
 	case components.ComponentOfChatModel:
 		mo := einomodel.ConvCallbackOutput(output)
 		if mo == nil || mo.Message == nil {
+			h.trace(ctx, "chat_model_end_skip_nil", info, "")
 			return ctx
 		}
+		h.trace(ctx, "chat_model_end", info, "")
 		h.persistAssistant(ctx, mo)
 	case components.ComponentOfTool:
 		tout := einotool.ConvCallbackOutput(output)
 		if tout == nil {
+			h.trace(ctx, "tool_end_skip_nil_output", info, "")
 			return ctx
 		}
+		h.trace(ctx, "tool_end_success", info, toolCallIDFromCtx(ctx, info))
 		h.persistToolEnd(ctx, info, tout, nil)
 	}
 	return ctx
@@ -308,6 +384,7 @@ func (h *PersistenceHandler) OnError(ctx context.Context, info *callbacks.RunInf
 	if info.Component != components.ComponentOfTool {
 		return ctx
 	}
+	h.trace(ctx, "tool_end_error", info, toolCallIDFromCtx(ctx, info))
 	h.persistToolEnd(ctx, info, nil, err)
 	return ctx
 }
@@ -391,6 +468,136 @@ func (h *PersistenceHandler) persistAssistant(ctx context.Context, mo *einomodel
 	h.lastAssistantID = row.ID
 	h.pendingLLMCalls = pending
 	h.lastIDsMu.Unlock()
+	// Open a new batch tracker — flushIncompleteBatch will heal it on
+	// the next ChatModel.OnStart. If the assistant emitted no tool_calls
+	// (terminal text answer), expected is empty and the batch is a
+	// no-op on flush.
+	h.openBatch(row.ID, pending)
+}
+
+// openBatch starts tracking the tool-call → tool-response pairing for
+// a fresh assistant turn. Replaces any prior batch (which means the
+// previous batch was abandoned without its OnEnds firing AND without
+// a ChatModel.OnStart flushing it — drop counter so we can see it).
+func (h *PersistenceHandler) openBatch(assistantID string, calls []pendingLLMCall) {
+	expected := make(map[string]string, len(calls))
+	for _, c := range calls {
+		if c.llmCallID == "" {
+			continue
+		}
+		expected[c.llmCallID] = c.toolName
+	}
+	h.batchMu.Lock()
+	if h.currentBatch != nil && len(h.currentBatch.expected) > 0 {
+		// Surface as recordErr so we know if openBatch ever races with
+		// an unflushed prior batch (would mean ChatModel.OnEnd fired
+		// twice without an intervening OnStart — very unusual).
+		h.recordErr("batch_overwrite_unflushed", errBatchOverwrite{
+			prevAssistant: h.currentBatch.assistantID,
+			newAssistant:  assistantID,
+			lost:          len(h.currentBatch.expected) - len(h.currentBatch.seen),
+		})
+	}
+	h.currentBatch = &assistantBatch{
+		assistantID: assistantID,
+		expected:    expected,
+		seen:        make(map[string]struct{}, len(expected)),
+		openedAt:    time.Now().UTC(),
+	}
+	h.batchMu.Unlock()
+}
+
+// markSeen records that a tool_call_id's response has been persisted.
+// Called from persistToolEnd AFTER the AppendMessage succeeds.
+func (h *PersistenceHandler) markSeen(llmCallID string) {
+	if llmCallID == "" {
+		return
+	}
+	h.batchMu.Lock()
+	if h.currentBatch != nil {
+		h.currentBatch.seen[llmCallID] = struct{}{}
+	}
+	h.batchMu.Unlock()
+}
+
+// flushIncompleteBatch is the autoheal step. Called at the start of
+// the NEXT ChatModel call (and from FinalizeBatch on handler teardown),
+// which is the cleanest signal that the previous assistant turn's
+// tool batch is terminally done. For every expected llm_call_id that
+// never landed a seen mark, write a stub role=tool row so the next
+// replay envelope is structurally valid AND the LLM gets honest
+// signal that the tool result was lost.
+//
+// Idempotent: clears currentBatch on exit, so a redundant call is a
+// no-op.
+func (h *PersistenceHandler) flushIncompleteBatch(ctx context.Context) {
+	h.batchMu.Lock()
+	batch := h.currentBatch
+	h.currentBatch = nil
+	h.batchMu.Unlock()
+	if batch == nil || len(batch.expected) == 0 {
+		return
+	}
+	missing := make(map[string]string) // llmCallID → toolName
+	for id, tname := range batch.expected {
+		if _, ok := batch.seen[id]; ok {
+			continue
+		}
+		missing[id] = tname
+	}
+	if len(missing) == 0 {
+		return
+	}
+	if h.deps.Logger != nil {
+		h.deps.Logger.Warn("tool response loss detected; autohealing with stub rows",
+			slog.String("session_id", h.deps.SessionID),
+			slog.String("assistant_id", batch.assistantID),
+			slog.Int("expected", len(batch.expected)),
+			slog.Int("seen", len(batch.seen)),
+			slog.Int("missing", len(missing)),
+			slog.Int64("batch_age_ms", time.Since(batch.openedAt).Milliseconds()),
+		)
+	}
+	for callID, tname := range missing {
+		body := `{"error":"tool response was not persisted (eino ToolsNode OnEnd loss); placeholder synthesised by manager to keep history envelope valid","autoheal":true}`
+		cid := callID
+		tn := tname
+		row := &model.Message{
+			SessionID:  h.deps.SessionID,
+			Role:       model.RoleTool,
+			Content:    &body,
+			ToolCallID: &cid,
+			ToolName:   &tn,
+			CreatedAt:  time.Now().UTC(),
+		}
+		if err := h.deps.Repo.AppendMessage(ctx, row); err != nil {
+			h.recordErr("autoheal_stub_insert", err)
+			continue
+		}
+		if h.lossCounter != nil {
+			h.lossCounter.WithLabelValues("autoheal_stub", tname).Inc()
+		}
+	}
+}
+
+// FinalizeBatch flushes any in-flight batch before the handler is
+// retired. Called from chatruntime after the graph invoke returns so
+// "user closed browser mid-batch" doesn't leave orphan tool_calls
+// behind (the ChatModel.OnStart hook only catches in-session cases).
+func (h *PersistenceHandler) FinalizeBatch(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.flushIncompleteBatch(ctx)
+}
+
+type errBatchOverwrite struct {
+	prevAssistant, newAssistant string
+	lost                        int
+}
+
+func (e errBatchOverwrite) Error() string {
+	return "batch overwrite prev=" + e.prevAssistant + " new=" + e.newAssistant
 }
 
 // popPendingLLMCall returns the head of the FIFO matching toolName,
@@ -439,9 +646,14 @@ func (h *PersistenceHandler) persistToolEnd(ctx context.Context, info *callbacks
 	delete(h.toolCalls, tcID)
 	h.toolCallsMu.Unlock()
 	if !ok {
-		// No matching OnStart — chatruntime didn't fire it (e.g.
-		// graph injection edge case). Skip the update so we don't
-		// orphan a tool_calls row.
+		// No matching OnStart — chatruntime didn't fire it OR the same
+		// tcID was double-deleted by a callback race. Used to be a
+		// silent return; record it now so we can correlate against
+		// flushIncompleteBatch stub events.
+		h.recordErr("tool_call_lookup_miss", errToolCallLookupMiss{
+			toolCallID: tcID,
+			toolName:   runInfoName(info),
+		})
 		return
 	}
 
@@ -496,7 +708,57 @@ func (h *PersistenceHandler) persistToolEnd(ctx context.Context, info *callbacks
 	}
 	if err := h.deps.Repo.AppendMessage(ctx, row); err != nil {
 		h.recordErr("tool_msg_insert", err)
+		return
 	}
+	// Mark seen AFTER AppendMessage succeeds so a failed insert doesn't
+	// fool flushIncompleteBatch into thinking this call landed. Tracked
+	// by llmCallID (what the batch's expected set is keyed on) — falls
+	// back to the synthetic id if the wiring lost the real one, which
+	// preserves the at-least-one-mark invariant for sanity.
+	if entry.llmCallID != "" {
+		h.markSeen(entry.llmCallID)
+	} else {
+		h.markSeen(entry.toolCallID)
+	}
+}
+
+type errToolCallLookupMiss struct {
+	toolCallID, toolName string
+}
+
+func (e errToolCallLookupMiss) Error() string {
+	return "tool_call lookup miss id=" + e.toolCallID + " name=" + e.toolName
+}
+
+func runInfoName(info *callbacks.RunInfo) string {
+	if info == nil {
+		return ""
+	}
+	return info.Name
+}
+
+// trace emits a single info-level breadcrumb for one callback firing.
+// Used to detect "OnEnd never fired" cases by absence in logs — every
+// expected callback should emit exactly one trace line. Cheap (one
+// slog.Info call); operators can drop the log level to filter out if
+// noise becomes a concern.
+func (h *PersistenceHandler) trace(_ context.Context, event string, info *callbacks.RunInfo, toolCallID string) {
+	if h == nil || h.deps.Logger == nil {
+		return
+	}
+	name := ""
+	typ := ""
+	if info != nil {
+		name = info.Name
+		typ = string(info.Component)
+	}
+	h.deps.Logger.Info("persistence callback",
+		slog.String("event", event),
+		slog.String("session_id", h.deps.SessionID),
+		slog.String("component", typ),
+		slog.String("name", name),
+		slog.String("tool_call_id", toolCallID),
+	)
 }
 
 func (h *PersistenceHandler) recordErr(kind string, err error) {

--- a/internal/manager/biz/aiops/graph/callbacks/persistence_test.go
+++ b/internal/manager/biz/aiops/graph/callbacks/persistence_test.go
@@ -282,8 +282,11 @@ func TestPersistenceHandler_NeededFiltersComponent(t *testing.T) {
 	if !h.Needed(context.Background(), chatModelInfo(), callbacks.TimingOnEnd) {
 		t.Errorf("ChatModel OnEnd should be needed")
 	}
-	if h.Needed(context.Background(), chatModelInfo(), callbacks.TimingOnStart) {
-		t.Errorf("ChatModel OnStart should NOT be needed (user msg is persisted upstream)")
+	// ChatModel.OnStart became Needed once flushIncompleteBatch was
+	// added — it's the cleanest signal that the previous tool batch
+	// is terminally done, so the autoheal flush hooks there.
+	if !h.Needed(context.Background(), chatModelInfo(), callbacks.TimingOnStart) {
+		t.Errorf("ChatModel OnStart should be needed (autoheal flush hook)")
 	}
 	if !h.Needed(context.Background(), toolInfo("t"), callbacks.TimingOnStart) {
 		t.Errorf("Tool OnStart should be needed")
@@ -292,4 +295,251 @@ func TestPersistenceHandler_NeededFiltersComponent(t *testing.T) {
 	if h.Needed(context.Background(), other, callbacks.TimingOnEnd) {
 		t.Errorf("non-tool/non-chat component should be skipped")
 	}
+}
+
+// --- autoheal / batch tracker tests ---------------------------------------
+
+// assistantEndWithToolCalls drives ChatModel.OnEnd with a synthesised
+// assistant message that emits N tool_calls — the same shape ChatModel
+// produces when the model wants to fan out to tools. Used to set up
+// the batch tracker for autoheal tests.
+func assistantEndWithToolCalls(t *testing.T, h *PersistenceHandler, calls ...struct{ ID, Name string }) {
+	t.Helper()
+	toolCalls := make([]schema.ToolCall, 0, len(calls))
+	for _, c := range calls {
+		toolCalls = append(toolCalls, schema.ToolCall{
+			ID:   c.ID,
+			Type: "function",
+			Function: schema.FunctionCall{Name: c.Name},
+		})
+	}
+	out := &einomodel.CallbackOutput{
+		Message: &schema.Message{
+			Role:      schema.Assistant,
+			Content:   "",
+			ToolCalls: toolCalls,
+		},
+	}
+	h.OnEnd(context.Background(), chatModelInfo(), out)
+}
+
+func TestAutoheal_NoMissing_NoStubInserted(t *testing.T) {
+	t.Parallel()
+	repo := newFakeSessionRepo()
+	h := NewPersistenceHandler(PersistenceDeps{SessionID: "s", Repo: repo})
+
+	// Assistant emits 2 tool_calls and both OnEnds fire normally.
+	assistantEndWithToolCalls(t, h,
+		struct{ ID, Name string }{ID: "call_a", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "call_b", Name: "host_bash"},
+	)
+	for _, id := range []string{"call_a", "call_b"} {
+		ctx := WithToolCallID(context.Background(), id)
+		h.OnStart(ctx, toolInfo("host_bash"), &einotool.CallbackInput{ArgumentsInJSON: `{}`})
+		h.OnEnd(ctx, toolInfo("host_bash"), &einotool.CallbackOutput{Response: `{"ok":true}`})
+	}
+
+	// Trigger flush via next ChatModel.OnStart.
+	h.OnStart(context.Background(), chatModelInfo(), nil)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	// Expect: 1 assistant + 2 tool messages = 3 total. No autoheal stub.
+	if got := len(repo.messages); got != 3 {
+		t.Fatalf("messages = %d, want 3 (1 assistant + 2 tool)", got)
+	}
+	for _, m := range repo.messages {
+		if m.Content != nil && contains(*m.Content, `"autoheal":true`) {
+			t.Errorf("autoheal stub written when not expected: %s", *m.Content)
+		}
+	}
+}
+
+func TestAutoheal_TwoOfFourMissing_StubsInserted(t *testing.T) {
+	t.Parallel()
+	repo := newFakeSessionRepo()
+	reg := prometheus.NewRegistry()
+	h := NewPersistenceHandler(PersistenceDeps{
+		SessionID:  "s",
+		Repo:       repo,
+		Registerer: reg,
+	})
+
+	// Assistant emits 4 parallel host_bash tool_calls.
+	assistantEndWithToolCalls(t, h,
+		struct{ ID, Name string }{ID: "call_00", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "call_01", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "call_02", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "call_03", Name: "host_bash"},
+	)
+	// Only 01 and 03's OnStart+OnEnd fire — 00 and 02 silently dropped.
+	for _, id := range []string{"call_01", "call_03"} {
+		ctx := WithToolCallID(context.Background(), id)
+		h.OnStart(ctx, toolInfo("host_bash"), &einotool.CallbackInput{ArgumentsInJSON: `{}`})
+		h.OnEnd(ctx, toolInfo("host_bash"), &einotool.CallbackOutput{Response: `{"ok":true}`})
+	}
+
+	// Next ChatModel.OnStart triggers flush.
+	h.OnStart(context.Background(), chatModelInfo(), nil)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	// Expect 1 assistant + 2 real tool + 2 stub tool = 5.
+	if got := len(repo.messages); got != 5 {
+		t.Fatalf("messages = %d, want 5 (1 asst + 2 real tool + 2 stub)", got)
+	}
+	stubIDs := map[string]bool{}
+	for _, m := range repo.messages {
+		if m.Role != model.RoleTool {
+			continue
+		}
+		if m.Content != nil && contains(*m.Content, `"autoheal":true`) {
+			if m.ToolCallID == nil {
+				t.Fatalf("stub row has no ToolCallID")
+			}
+			stubIDs[*m.ToolCallID] = true
+		}
+	}
+	if !stubIDs["call_00"] || !stubIDs["call_02"] {
+		t.Errorf("stub ids = %v, want call_00 + call_02", stubIDs)
+	}
+	if stubIDs["call_01"] || stubIDs["call_03"] {
+		t.Errorf("real responses got autohealed: %v", stubIDs)
+	}
+	if v := counterValue(t, reg, "ongrid_chat_tool_response_loss_total", "autoheal_stub", "host_bash"); v != 2 {
+		t.Errorf("autoheal counter = %v, want 2", v)
+	}
+}
+
+func TestAutoheal_NoBatch_NoOp(t *testing.T) {
+	t.Parallel()
+	repo := newFakeSessionRepo()
+	h := NewPersistenceHandler(PersistenceDeps{SessionID: "s", Repo: repo})
+	// Very first turn — no prior assistant batch.
+	h.OnStart(context.Background(), chatModelInfo(), nil)
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if got := len(repo.messages); got != 0 {
+		t.Fatalf("messages = %d, want 0 (flush should no-op without a batch)", got)
+	}
+}
+
+func TestAutoheal_SequentialBatches_OnlyOwnFlushed(t *testing.T) {
+	t.Parallel()
+	repo := newFakeSessionRepo()
+	h := NewPersistenceHandler(PersistenceDeps{SessionID: "s", Repo: repo})
+
+	// Batch 1: 2 tool_calls, both complete.
+	assistantEndWithToolCalls(t, h,
+		struct{ ID, Name string }{ID: "b1_a", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "b1_b", Name: "host_bash"},
+	)
+	for _, id := range []string{"b1_a", "b1_b"} {
+		ctx := WithToolCallID(context.Background(), id)
+		h.OnStart(ctx, toolInfo("host_bash"), &einotool.CallbackInput{})
+		h.OnEnd(ctx, toolInfo("host_bash"), &einotool.CallbackOutput{Response: `{}`})
+	}
+	// Next ChatModel.OnStart flushes batch 1 (no stubs).
+	h.OnStart(context.Background(), chatModelInfo(), nil)
+	// Batch 2: 3 tool_calls, only 1 completes.
+	assistantEndWithToolCalls(t, h,
+		struct{ ID, Name string }{ID: "b2_a", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "b2_b", Name: "host_bash"},
+		struct{ ID, Name string }{ID: "b2_c", Name: "host_bash"},
+	)
+	ctx := WithToolCallID(context.Background(), "b2_a")
+	h.OnStart(ctx, toolInfo("host_bash"), &einotool.CallbackInput{})
+	h.OnEnd(ctx, toolInfo("host_bash"), &einotool.CallbackOutput{Response: `{}`})
+	// FinalizeBatch should flush batch 2's missing b2_b and b2_c only.
+	h.FinalizeBatch(context.Background())
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	stubIDs := map[string]bool{}
+	for _, m := range repo.messages {
+		if m.Role != model.RoleTool || m.Content == nil {
+			continue
+		}
+		if contains(*m.Content, `"autoheal":true`) && m.ToolCallID != nil {
+			stubIDs[*m.ToolCallID] = true
+		}
+	}
+	if stubIDs["b1_a"] || stubIDs["b1_b"] {
+		t.Errorf("batch 1 leaked stubs after its flush: %v", stubIDs)
+	}
+	if !stubIDs["b2_b"] || !stubIDs["b2_c"] {
+		t.Errorf("batch 2 stub ids = %v, want b2_b + b2_c", stubIDs)
+	}
+	if stubIDs["b2_a"] {
+		t.Errorf("completed call b2_a got stubbed: %v", stubIDs)
+	}
+}
+
+func TestAutoheal_FinalizeBatchIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := newFakeSessionRepo()
+	h := NewPersistenceHandler(PersistenceDeps{SessionID: "s", Repo: repo})
+	assistantEndWithToolCalls(t, h,
+		struct{ ID, Name string }{ID: "x", Name: "host_bash"},
+	)
+	h.FinalizeBatch(context.Background())
+	h.FinalizeBatch(context.Background()) // second call should be a no-op
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	stubCount := 0
+	for _, m := range repo.messages {
+		if m.Content != nil && contains(*m.Content, `"autoheal":true`) {
+			stubCount++
+		}
+	}
+	if stubCount != 1 {
+		t.Errorf("stub count = %d, want 1 (second Finalize must be no-op)", stubCount)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func contains(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// counterValue gathers the registry and returns the value for a
+// label-keyed counter, asserting it exists. Returns -1 when not found.
+func counterValue(t *testing.T, reg *prometheus.Registry, name string, labelValues ...string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := m.GetLabel()
+			if len(labels) != len(labelValues) {
+				continue
+			}
+			match := true
+			for i, lv := range labelValues {
+				if labels[i].GetValue() != lv {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Layer 2 of the chat-history-integrity fix series. Builds on PR #52 (replay-side drop). **Do not merge individually — accumulating PRs for the next release per 2026-06-06 workflow decision.**

## Why

Live evidence from .91 session `b528bfb0-...`: an assistant emitted 4 parallel `host_bash` tool_calls. `chat_tool_calls` had all 4 rows; `chat_messages` was missing 2 role=tool rows with **NO** persistence error logged. eino's ToolsNode dropped `OnEnd` for 2 of 4 parallel branches.

PR #52's replay-side defense (`toolreplay` precheck + `MarkDependentToolsForSkip`) keeps the user out of the loop on the next send, but the lost tool responses are still gone forever. This PR catches the loss at the moment it happens, fills a stub so:

- the next request's envelope is structurally valid without the replay layer having to skip anything
- the LLM gets honest signal that a tool response was lost rather than a fabricated success
- we get a Prom counter that surfaces the eino bug rate, instead of discovering it only when a user reports HTTP 400

## What it adds

### Per-assistant batch tracker (autoheal)

| Hook | Action |
|---|---|
| `ChatModel.OnEnd` (after assistant insert) | `openBatch` records expected `llm_call_id → tool_name` |
| `Tool.OnEnd` / `OnError` (after `AppendMessage`) | `markSeen` for that `llm_call_id` |
| `ChatModel.OnStart` (next turn) | `flushIncompleteBatch` writes stub `role=tool` rows for any `expected - seen` |
| `chatruntime.Handle` / `runWorker` defer | `FinalizeBatches` covers "browser closed mid-batch" (no next OnStart) |

Stub body:
```json
{"error":"tool response was not persisted (eino ToolsNode OnEnd loss); placeholder synthesised by manager to keep history envelope valid","autoheal":true}
```

Honest signal, not a fabricated success.

### Callback tracing

- `trace()` helper emits one info-level breadcrumb per callback firing (event, component, name, tool_call_id). Lets the next reproduction localise WHICH branch lost its OnEnd by absence in the log stream.
- Previously silent `if !ok { return }` early-returns in `persistToolEnd` are now `recordErr("tool_call_lookup_miss")` — double-end / double-delete races become observable.
- `batch_overwrite_unflushed` recordErr fires if `openBatch` is called while a prior batch's flush hasn't run — catches a ChatModel.OnEnd firing twice with no OnStart between.

### Prom counter

`ongrid_chat_tool_response_loss_total{outcome,tool_name}` — same Registerer the existing errCounter uses. Cardinality bounded by registered tool name set.

## What does NOT change

- replay-side `toolreplay` precheck (PR #52) stays as belt-and-suspenders
- no provider-side or eino-side fixes — that's Layer 3 (root cause) and stays open; the traces this PR adds will be the input to it
- no VERSION bump; not a release

## Tests

5 cases under `TestAutoheal_*`:
- `NoMissing_NoStubInserted` — happy path
- `TwoOfFourMissing_StubsInserted` — the production bug; verifies stub IDs match missing call_ids AND counter increments by 2
- `NoBatch_NoOp` — first turn safety
- `SequentialBatches_OnlyOwnFlushed` — batch 1 fully clean → no stubs; batch 2 partial → stubs only for batch 2's missing
- `FinalizeBatchIdempotent` — second `FinalizeBatch` call must be a no-op

Plus updated `TestPersistenceHandler_NeededFiltersComponent` to reflect ChatModel.OnStart now being needed.

## Live verified on .91

Hot-swapped binary via `docker cp` (no release, no tarball) into the `ongrid` container; tested by reproducing the multi-parallel-tool scenario; confirmed autoheal stubs land and subsequent sends succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
