### PR TITLE
fix(llm): auto-append /v1 to bare Custom (OpenAI-compatible) base URLs (Ollama stream error)

### DIFF
--- a/internal/pkg/llm/client.go
+++ b/internal/pkg/llm/client.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -259,6 +261,7 @@ func (c *openaiClient) effectiveCreds(ctx context.Context) (string, string, stri
 // transport always overrides — but we still feed it the raw key so the
 // (apiKey, baseURL) cache key stays stable across calls.
 func (c *openaiClient) sdkFor(apiKey, baseURL string) *openai.Client {
+	baseURL = normalizeOpenAIBaseURL(baseURL)
 	k := sdkKey{apiKey: apiKey, baseURL: baseURL}
 	c.sdkMu.Lock()
 	defer c.sdkMu.Unlock()
@@ -280,6 +283,41 @@ func (c *openaiClient) sdkFor(apiKey, baseURL string) *openai.Client {
 	sdk := openai.NewClientWithConfig(sdkCfg)
 	c.sdkCache[k] = sdk
 	return sdk
+}
+
+// normalizeOpenAIBaseURL prepares a user-supplied base URL for the
+// go-openai SDK. The SDK builds every request as
+// TrimRight(BaseURL,"/") + "/chat/completions" — it does NOT insert a
+// "/v1" version segment. OpenAI's own default base URL already ends in
+// "/v1", and so does every hosted provider's documented endpoint, so the
+// SDK works as long as the configured base URL carries that segment.
+//
+// Operators pointing the Custom (OpenAI-compatible) provider at a local
+// Ollama / LM Studio / vLLM box routinely paste just the bare address
+// they use everywhere else — e.g. "http://192.168.8.5:11434". The SDK
+// then POSTs to ".../chat/completions", which Ollama serves nothing on
+// (its OpenAI-compatible route is "/v1/chat/completions"), so the request
+// 404s and the chat surfaces a "stream error". When the base URL has no
+// path of its own we append "/v1" so the request lands on the
+// OpenAI-compatible route. A URL that already carries a path (".../v1",
+// ".../openai", a gateway prefix) is trusted verbatim — named providers
+// whose defaults include "/v1" are therefore untouched.
+func normalizeOpenAIBaseURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return s
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		// Malformed / scheme-less input: leave as-is so the SDK surfaces
+		// the real error rather than us silently reshaping garbage.
+		return s
+	}
+	if strings.Trim(u.Path, "/") == "" {
+		u.Path = "/v1"
+		return u.String()
+	}
+	return s
 }
 
 // zhipuJWTTransport rewrites the Authorization header on every outbound

--- a/internal/pkg/llm/client_test.go
+++ b/internal/pkg/llm/client_test.go
@@ -57,7 +57,12 @@ func sampleChatResponse(content string, toolCalls []map[string]any) []byte {
 func fakeServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, Config) {
 	t.Helper()
 	mux := http.NewServeMux()
+	// A bare base URL (srv.URL) is normalized to ".../v1" before it
+	// reaches the SDK, mirroring how a real OpenAI-compatible server
+	// (Ollama et al.) exposes "/v1/chat/completions". Mount both so the
+	// fake answers regardless of whether the caller pre-versioned the URL.
 	mux.HandleFunc("/chat/completions", handler)
+	mux.HandleFunc("/v1/chat/completions", handler)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv, Config{
@@ -411,4 +416,88 @@ func sortedCopy(in []string) []string {
 		}
 	}
 	return out
+}
+
+func TestNormalizeOpenAIBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Bare Ollama / LM Studio / vLLM address — the exact shape an
+		// operator pastes from the box's homepage. Must gain "/v1".
+		{"ollama bare", "http://192.168.8.5:11434", "http://192.168.8.5:11434/v1"},
+		{"ollama trailing slash", "http://192.168.8.5:11434/", "http://192.168.8.5:11434/v1"},
+		{"localhost bare", "http://localhost:1234", "http://localhost:1234/v1"},
+		{"whitespace bare", "  http://host:11434  ", "http://host:11434/v1"},
+		// Already carries a path — trusted verbatim.
+		{"already v1", "http://192.168.8.5:11434/v1", "http://192.168.8.5:11434/v1"},
+		{"openrouter", "https://openrouter.ai/api/v1", "https://openrouter.ai/api/v1"},
+		{"gateway prefix", "https://gw.example.com/openai", "https://gw.example.com/openai"},
+		{"zhipu v4", "https://open.bigmodel.cn/api/paas/v4", "https://open.bigmodel.cn/api/paas/v4"},
+		// Degenerate input — left untouched so the SDK surfaces the real error.
+		{"empty", "", ""},
+		{"scheme-less", "192.168.8.5:11434", "192.168.8.5:11434"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeOpenAIBaseURL(tc.in); got != tc.want {
+				t.Fatalf("normalizeOpenAIBaseURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOllamaBareBaseURLReproduction reproduces the field bug
+// (https://github.com/ongridio/ongrid/pull/54): an operator points the
+// Custom provider at a bare Ollama address "http://host:11434" (no /v1).
+//
+// The fake mimics Ollama exactly: it is a Go mux, so any unregistered
+// route — including the "/chat/completions" go-openai would hit for a
+// bare base URL — returns Go's stock "404 page not found", which is byte
+// for byte what real Ollama (gin) returns. The OpenAI-compatible route
+// lives only at "/v1/chat/completions".
+//
+// Part 1 documents the pre-fix failure: a raw POST to the bare
+// "/chat/completions" 404s. Part 2 verifies the fix: our client, handed
+// the bare base URL, normalizes to "/v1" and completes the chat.
+func TestOllamaBareBaseURLReproduction(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(sampleChatResponse("pong from ollama", nil))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Part 1 — the bug: bare path 404s with Ollama's exact body.
+	resp, err := http.Post(srv.URL+"/chat/completions", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("probe POST: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("bare /chat/completions status = %d, want 404 (Ollama serves nothing here)", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "404 page not found") {
+		t.Fatalf("bare /chat/completions body = %q, want Ollama-style \"404 page not found\"", string(body))
+	}
+
+	// Part 2 — the fix: bare base URL, client normalizes to /v1 and succeeds.
+	client := newTestClient(t, Config{
+		APIKey:  "ollama", // keyless local server — placeholder key
+		Model:   "deepseek-r1:7b",
+		BaseURL: srv.URL, // bare http://host:port, exactly as the operator pasted
+		Timeout: 2 * time.Second,
+	}, nil)
+	out, err := client.Chat(context.Background(), ChatReq{
+		Messages: []Message{{Role: "user", Content: "你是"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat with bare Ollama base URL failed (fix not working): %v", err)
+	}
+	if out.Assistant.Content != "pong from ollama" {
+		t.Fatalf("content = %q, want %q", out.Assistant.Content, "pong from ollama")
+	}
 }


### PR DESCRIPTION
## 背景

用户把 **自定义（OpenAI 兼容）** provider 指向本地 Ollama，Base URL 填了 `http://192.168.8.5:11434`（模型 `deepseek-r1:7b`），chat 报 `stream error` / "LLM provider 报错"。

## 根因

go-openai SDK 把每个请求拼成 `TrimRight(BaseURL,"/") + "/chat/completions"`，**不会**自动插入 `/v1`。OpenAI 自带默认 base URL 以及各家托管厂商的文档端点本身就带 `/v1`，所以正常工作。但运维把 Custom provider 接本地 Ollama / LM Studio / vLLM 时，习惯直接粘贴裸地址 `http://host:11434`，SDK 于是 POST 到 `.../chat/completions` —— Ollama 的 OpenAI 兼容路由在 `/v1/chat/completions`，裸路径返回 404，前端兜底显示 `stream error`。

（UI 占位符虽已示范 `http://localhost:11434/v1`，但用户照旧粘贴裸地址，所以需要后端容错。）

## 改动

- `normalizeOpenAIBaseURL`：在 SDK 唯一入口 `sdkFor` 处，**仅当 base URL 自身没有 path 时**补 `/v1`。
- 已带 path 的（`.../v1`、`.../openai`、网关前缀、智谱 `/api/paas/v4`）原样信任 —— 命名 provider 不受影响。
- 空 / 无 scheme 的畸形输入不动，交给 SDK 暴露真实错误。
- 单测覆盖 10 个 case；测试 fake server 同时挂 `/chat/completions` 与 `/v1/chat/completions`。

## 验证

`go test ./internal/pkg/llm/` 全绿（含 `TestOllamaBareBaseURLReproduction`：用模拟 Ollama 的 fake 复现裸 URL 404 → 修复后跑通）。

> ⚠️ 待办：尚未部署测试环境，也未拿到用户 manager 日志的 raw error 确认。机制已证，但该用户那条具体报错是不是这个 404 仍需日志核实。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
