### PR TITLE
feat(report): PR-2 — ReportFacts SQL collector + ContentJSON types + markdown renderer

### DIFF
--- a/internal/manager/biz/report/content.go
+++ b/internal/manager/biz/report/content.go
@@ -1,0 +1,220 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ContentJSON is the structured report body the reporter agent
+// produces and the SPA renders (HLD-014 §ContentJSON). It is the source
+// of truth for the rich in-app view; ContentMD is rendered from it as
+// the export / IM / search fallback.
+//
+// Anti-hallucination contract: the numeric fields (Hero values/deltas/
+// sparklines, the per-tool action counts) are computed in pure SQL by
+// the FactsCollector and handed to the LLM. The generator (PR-2b)
+// OVERWRITES Content.Hero and Content.Actions with the collected facts
+// after the LLM returns, so a model that fiddles a number can't leak it
+// into the report. The LLM owns only Narrative / KeyIncidents ordering
+// commentary / Advice.
+type Content struct {
+	Version      string         `json:"version"`
+	Hero         []HeroStat     `json:"hero"`
+	Narrative    Narrative      `json:"narrative"`
+	KeyIncidents []KeyIncident  `json:"key_incidents"`
+	Actions      ActionsSummary `json:"actions_summary"`
+	Advice       []Advice       `json:"advice"`
+	Metadata     ContentMeta    `json:"metadata"`
+}
+
+// HeroStat is one big-number card. Value/DeltaPct/Sparkline are SQL-
+// computed (never LLM). Unit is optional ("min", "%"); empty = bare
+// count. DeltaPct is the period-over-period change; nil = no prior
+// period to compare (rendered as "new" rather than an arrow).
+type HeroStat struct {
+	Key       string   `json:"key"`
+	Label     string   `json:"label"`
+	Value     float64  `json:"value"`
+	Unit      string   `json:"unit,omitempty"`
+	DeltaPct  *float64 `json:"delta_pct,omitempty"`
+	Sparkline []int    `json:"sparkline,omitempty"`
+}
+
+// Narrative is the LLM's prose. Paragraph.Text may embed entity tokens
+// `{{entity:kind:id|name}}` that the SPA renders as clickable chips;
+// Entities lists them for the renderer's convenience (markdown export
+// strips the token syntax to the display name).
+type Narrative struct {
+	Headline   string      `json:"headline"`
+	Paragraphs []Paragraph `json:"paragraphs"`
+}
+
+type Paragraph struct {
+	Text     string         `json:"text"`
+	Entities []EntityRef     `json:"entities,omitempty"`
+}
+
+type EntityRef struct {
+	Key  string `json:"key"`  // "edge:7" | "incident:1234"
+	Name string `json:"name"` // display name
+}
+
+// KeyIncident is a compact incident reference for the report's incident
+// list. Sourced from facts (ids, durations, status are SQL-true); the
+// LLM may set RootCauseSnippet from the RCA report when one exists.
+type KeyIncident struct {
+	ID               uint64 `json:"id"`
+	Title            string `json:"title"`
+	Severity         string `json:"severity"`
+	DurationMin      int    `json:"duration_min"`
+	Status           string `json:"status"`
+	RootCauseSnippet string `json:"root_cause_snippet,omitempty"`
+}
+
+// ActionsSummary is the agent-transparency panel. All counts SQL-true.
+type ActionsSummary struct {
+	MutatingTotal    int          `json:"mutating_total"`
+	MutatingApproved int          `json:"mutating_approved"`
+	SafeTotal        int          `json:"safe_total"`
+	ByTool           []ToolCount  `json:"by_tool,omitempty"`
+}
+
+type ToolCount struct {
+	Tool  string `json:"tool"`
+	Count int    `json:"count"`
+}
+
+// Advice is one forward-looking recommendation. LLM-authored. Text may
+// embed entity tokens like Narrative.
+type Advice struct {
+	Text string `json:"text"`
+}
+
+type ContentMeta struct {
+	PeriodStart string   `json:"period_start"`
+	PeriodEnd   string   `json:"period_end"`
+	DataSources []string `json:"data_sources,omitempty"`
+}
+
+// ContentVersion is the schema version stamped into freshly generated
+// reports; lets the SPA branch on shape if the schema evolves.
+const ContentVersion = "1"
+
+// ParseContent unmarshals a ContentJSON blob and validates it. Used by
+// the generator (PR-2b) to check the LLM output before persisting.
+func ParseContent(raw string) (*Content, error) {
+	var c Content
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		return nil, fmt.Errorf("report: content unmarshal: %w", err)
+	}
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// Validate enforces the minimal shape the SPA depends on. Lenient on
+// optional sections (a calm report may have empty KeyIncidents/Advice)
+// but strict on the spine: a headline must exist and hero cards must
+// each carry a key + label so the grid renders.
+func (c *Content) Validate() error {
+	if strings.TrimSpace(c.Narrative.Headline) == "" {
+		return fmt.Errorf("report: content missing narrative.headline")
+	}
+	for i, h := range c.Hero {
+		if h.Key == "" || h.Label == "" {
+			return fmt.Errorf("report: hero[%d] missing key/label", i)
+		}
+	}
+	return nil
+}
+
+// MustJSON serialises content; panics only on a programming error
+// (unmarshalable types can't occur with these concrete structs).
+func (c *Content) MustJSON() string {
+	b, err := json.Marshal(c)
+	if err != nil {
+		panic(fmt.Sprintf("report: content marshal: %v", err))
+	}
+	return string(b)
+}
+
+// RenderMarkdown produces the ContentMD fallback from structured
+// content. Used for export, IM plain-text fallback, and full-text
+// search. Entity tokens are flattened to their display name.
+func (c *Content) RenderMarkdown(title string) string {
+	var b strings.Builder
+	b.WriteString("# " + title + "\n\n")
+
+	if len(c.Hero) > 0 {
+		for _, h := range c.Hero {
+			b.WriteString(fmt.Sprintf("- **%s**: %s%s", h.Label, formatNum(h.Value), h.Unit))
+			if h.DeltaPct != nil {
+				b.WriteString(fmt.Sprintf(" (%+.0f%%)", *h.DeltaPct))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if c.Narrative.Headline != "" {
+		b.WriteString("## " + c.Narrative.Headline + "\n\n")
+	}
+	for _, p := range c.Narrative.Paragraphs {
+		b.WriteString(flattenEntities(p.Text) + "\n\n")
+	}
+
+	if len(c.KeyIncidents) > 0 {
+		b.WriteString("## 关键 incidents\n\n")
+		for _, ki := range c.KeyIncidents {
+			b.WriteString(fmt.Sprintf("- I-%d %s (%s, %dm, %s)\n",
+				ki.ID, ki.Title, ki.Severity, ki.DurationMin, ki.Status))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Agent 执行动作\n\n")
+	b.WriteString(fmt.Sprintf("- mutating: %d（已批准 %d）· 只读: %d\n\n",
+		c.Actions.MutatingTotal, c.Actions.MutatingApproved, c.Actions.SafeTotal))
+
+	if len(c.Advice) > 0 {
+		b.WriteString("## 下周建议\n\n")
+		for _, a := range c.Advice {
+			b.WriteString("- " + flattenEntities(a.Text) + "\n")
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// formatNum prints an integer without trailing .0, else a 1-decimal.
+func formatNum(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%.1f", v)
+}
+
+// flattenEntities rewrites `{{entity:kind:id|name}}` → `name` for the
+// markdown fallback (chips are an SPA-only affordance).
+func flattenEntities(s string) string {
+	for {
+		start := strings.Index(s, "{{entity:")
+		if start < 0 {
+			return s
+		}
+		end := strings.Index(s[start:], "}}")
+		if end < 0 {
+			return s // malformed; leave as-is
+		}
+		end += start
+		token := s[start+2 : end] // entity:kind:id|name
+		name := token
+		if bar := strings.LastIndex(token, "|"); bar >= 0 {
+			name = token[bar+1:]
+		}
+		s = s[:start] + name + s[end+2:]
+	}
+}

--- a/internal/manager/biz/report/content_test.go
+++ b/internal/manager/biz/report/content_test.go
@@ -1,0 +1,114 @@
+package report
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleContent() *Content {
+	d := -12.0
+	return &Content{
+		Version: ContentVersion,
+		Hero: []HeroStat{
+			{Key: "incidents", Label: "Incidents", Value: 23, DeltaPct: &d, Sparkline: []int{4, 7, 3}},
+			{Key: "mttr_minutes", Label: "MTTR", Value: 47, Unit: "min"},
+		},
+		Narrative: Narrative{
+			Headline: "本周整体平稳",
+			Paragraphs: []Paragraph{
+				{Text: "{{entity:edge:7|db-prod-3}} 三次突破 30%，触发 {{entity:incident:1234|I-1234}}。"},
+			},
+		},
+		KeyIncidents: []KeyIncident{
+			{ID: 1234, Title: "db-prod-3 IO 饱和", Severity: "warning", DurationMin: 47, Status: "resolved"},
+		},
+		Actions: ActionsSummary{MutatingTotal: 11, MutatingApproved: 11, SafeTotal: 47},
+		Advice:  []Advice{{Text: "把 {{entity:edge:7|db-prod-3}} backup 挪到 03:00"}},
+	}
+}
+
+func TestParseContent_RoundTrip(t *testing.T) {
+	raw := sampleContent().MustJSON()
+	got, err := ParseContent(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Narrative.Headline != "本周整体平稳" {
+		t.Errorf("headline lost: %q", got.Narrative.Headline)
+	}
+	if len(got.Hero) != 2 || got.Hero[0].DeltaPct == nil || *got.Hero[0].DeltaPct != -12 {
+		t.Errorf("hero delta lost: %+v", got.Hero)
+	}
+}
+
+func TestValidate_RejectsMissingHeadline(t *testing.T) {
+	c := sampleContent()
+	c.Narrative.Headline = "  "
+	if err := c.Validate(); err == nil {
+		t.Error("expected error for blank headline")
+	}
+}
+
+func TestValidate_RejectsHeroMissingKey(t *testing.T) {
+	c := sampleContent()
+	c.Hero[1].Key = ""
+	if err := c.Validate(); err == nil {
+		t.Error("expected error for hero without key")
+	}
+}
+
+func TestValidate_AllowsCalmReport(t *testing.T) {
+	// A 0-incident calm report: empty incidents/advice is fine, spine intact.
+	c := &Content{
+		Version:   ContentVersion,
+		Hero:      []HeroStat{{Key: "incidents", Label: "Incidents", Value: 0}},
+		Narrative: Narrative{Headline: "本周无异常，一切平稳"},
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("calm report should validate: %v", err)
+	}
+}
+
+func TestRenderMarkdown_FlattensEntities(t *testing.T) {
+	md := sampleContent().RenderMarkdown("周报 · 2026 W23")
+	if strings.Contains(md, "{{entity:") {
+		t.Errorf("entity tokens not flattened:\n%s", md)
+	}
+	if !strings.Contains(md, "db-prod-3") {
+		t.Errorf("entity display name lost:\n%s", md)
+	}
+	if !strings.Contains(md, "# 周报 · 2026 W23") {
+		t.Errorf("title missing:\n%s", md)
+	}
+	if !strings.Contains(md, "**Incidents**: 23 (-12%)") {
+		t.Errorf("hero delta not rendered:\n%s", md)
+	}
+}
+
+func TestFlattenEntities(t *testing.T) {
+	cases := map[string]string{
+		"plain text":                              "plain text",
+		"{{entity:edge:7|db-prod-3}} down":        "db-prod-3 down",
+		"a {{entity:incident:1|I-1}} b {{entity:edge:2|n2}} c": "a I-1 b n2 c",
+		"{{entity:malformed":                      "{{entity:malformed", // no closer → left as-is
+	}
+	for in, want := range cases {
+		if got := flattenEntities(in); got != want {
+			t.Errorf("flatten(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseScope(t *testing.T) {
+	s := ParseScope(`{"edge_ids":[7,9],"severity_min":"warning"}`)
+	if len(s.EdgeIDs) != 2 || s.SeverityMin != "warning" {
+		t.Errorf("scope parse: %+v", s)
+	}
+	// Empty / malformed → zero scope (full coverage), no panic.
+	if got := ParseScope(""); len(got.EdgeIDs) != 0 {
+		t.Errorf("empty scope should be zero: %+v", got)
+	}
+	if got := ParseScope("not json"); len(got.EdgeIDs) != 0 {
+		t.Errorf("malformed scope should degrade to zero: %+v", got)
+	}
+}

--- a/internal/manager/biz/report/facts.go
+++ b/internal/manager/biz/report/facts.go
@@ -1,0 +1,83 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ReportFacts is the deterministic, SQL-computed input handed to the
+// reporter agent (HLD-014 §数据收集). The agent narrates these facts —
+// it never computes the numbers. Every count, duration, and sparkline
+// here comes from a query against incidents / audit / proposals / edges
+// over the report's period; the agent's only freedom is prose
+// (narrative + advice) and incident ordering commentary.
+type ReportFacts struct {
+	Period     Period `json:"-"`
+	PrevPeriod Period `json:"-"`
+
+	// Hero is the pre-computed big-number set with period-over-period
+	// deltas and per-bucket sparklines. Copied verbatim into
+	// Content.Hero by the generator — the agent cannot alter it.
+	Hero []HeroStat `json:"hero"`
+
+	// Incidents are the period's incidents, newest-impact first. The
+	// agent picks the top-N to feature and may attach a root-cause
+	// snippet from the linked RCA report.
+	Incidents []IncidentFact `json:"incidents"`
+
+	// Actions is the agent-action summary (mutating proposals + safe
+	// tool calls) over the period.
+	Actions ActionsSummary `json:"actions"`
+
+	// AlertCounts is the period's alert event volume by severity.
+	AlertCounts map[string]int `json:"alert_counts"`
+
+	// Edges is the fleet snapshot at period end.
+	Edges EdgeFact `json:"edges"`
+}
+
+// IncidentFact is one incident's SQL-true facts. DurationMin is
+// resolved_at - first_fired_at (or now - first_fired_at if still open).
+type IncidentFact struct {
+	ID          uint64 `json:"id"`
+	Title       string `json:"title"`
+	Severity    string `json:"severity"`
+	Status      string `json:"status"`
+	DeviceID    uint64 `json:"device_id,omitempty"`
+	DurationMin int    `json:"duration_min"`
+}
+
+// EdgeFact is the fleet snapshot. Online is the count online at period
+// end; Total is registered (non-deleted) edges.
+type EdgeFact struct {
+	Online int `json:"online"`
+	Total  int `json:"total"`
+}
+
+// Scope is the parsed ReportSchedule.ScopeJSON. v1 honours EdgeIDs and
+// SeverityMin; FleetTags is parsed but a no-op until G.2.6 edge tags
+// land. An empty Scope means full coverage.
+type Scope struct {
+	FleetTags   []string `json:"fleet_tags,omitempty"`
+	EdgeIDs     []uint64 `json:"edge_ids,omitempty"`
+	SeverityMin string   `json:"severity_min,omitempty"`
+}
+
+// ParseScope reads a ScopeJSON blob. Empty / "{}" / invalid → zero
+// Scope (full coverage) rather than an error — a malformed scope should
+// degrade to "show everything", not block report generation.
+func ParseScope(raw string) Scope {
+	var s Scope
+	if raw == "" {
+		return s
+	}
+	_ = json.Unmarshal([]byte(raw), &s) // best-effort; zero value on failure
+	return s
+}
+
+// FactsCollector runs the pure-SQL collection. Implemented by
+// data/report/store.FactsCollector. Period and prev are pre-computed by
+// the Usecase (PeriodFor); scope filters the queries.
+type FactsCollector interface {
+	Collect(ctx context.Context, period, prev Period, scope Scope) (*ReportFacts, error)
+}

--- a/internal/manager/data/report/store/facts.go
+++ b/internal/manager/data/report/store/facts.go
@@ -1,0 +1,319 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+
+	bizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
+)
+
+// FactsCollector implements bizreport.FactsCollector with pure SQL over
+// the alert / audit / proposal / edge tables. No LLM, no mutation —
+// read-only aggregation that produces the deterministic numbers the
+// reporter agent narrates. Lives in the data layer because it queries
+// tables owned by other domains; it touches them read-only and never
+// imports their biz packages.
+type FactsCollector struct {
+	db *gorm.DB
+}
+
+func NewFactsCollector(db *gorm.DB) *FactsCollector { return &FactsCollector{db: db} }
+
+var _ bizreport.FactsCollector = (*FactsCollector)(nil)
+
+// severityRank orders severities for the SeverityMin filter.
+var severityRank = map[string]int{"info": 0, "warning": 1, "critical": 2}
+
+// Collect runs the aggregation. Each sub-query degrades independently:
+// a failure in one source (e.g. the proposals table empty on installs
+// without the SOP feature) returns its zero value rather than aborting
+// the whole report — a report with partial facts beats no report.
+func (c *FactsCollector) Collect(ctx context.Context, period, prev bizreport.Period, scope bizreport.Scope) (*bizreport.ReportFacts, error) {
+	facts := &bizreport.ReportFacts{
+		Period:      period,
+		PrevPeriod:  prev,
+		AlertCounts: map[string]int{},
+	}
+
+	incidents, err := c.collectIncidents(ctx, period, scope)
+	if err != nil {
+		return nil, err
+	}
+	facts.Incidents = incidents
+
+	facts.Actions = c.collectActions(ctx, period)
+	facts.AlertCounts = c.collectAlertCounts(ctx, period, scope)
+	facts.Edges = c.collectEdges(ctx)
+
+	facts.Hero = c.buildHero(ctx, period, prev, scope, incidents, facts.Actions)
+	return facts, nil
+}
+
+// incidentRow is the projection for the incident aggregation.
+type incidentRow struct {
+	ID           uint64
+	RuleName     string
+	Severity     string
+	Status       string
+	DeviceID     *uint64
+	FirstFiredAt time.Time
+	ResolvedAt   *time.Time
+}
+
+func (c *FactsCollector) collectIncidents(ctx context.Context, p bizreport.Period, scope bizreport.Scope) ([]bizreport.IncidentFact, error) {
+	q := c.db.WithContext(ctx).
+		Table("alert_incidents").
+		Select("id, rule_name, severity, status, device_id, first_fired_at, resolved_at").
+		Where("deleted_at IS NULL").
+		Where("first_fired_at >= ? AND first_fired_at < ?", p.Start, p.End)
+	q = applyEdgeScope(q, scope)
+	q = applySeverityScope(q, scope)
+
+	var rows []incidentRow
+	if err := q.Order("first_fired_at DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]bizreport.IncidentFact, 0, len(rows))
+	for _, r := range rows {
+		f := bizreport.IncidentFact{
+			ID:          r.ID,
+			Title:       r.RuleName,
+			Severity:    r.Severity,
+			Status:      r.Status,
+			DurationMin: durationMinutes(r.FirstFiredAt, r.ResolvedAt, p.End),
+		}
+		if r.DeviceID != nil {
+			f.DeviceID = *r.DeviceID
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// collectActions counts agent actions over the period. Mutating actions
+// come from chat_mutating_proposals (decision approve/reject/pending);
+// safe-tool count is a coarse proxy from audit_logs success rows scoped
+// to agent-driven resource changes. Best-effort — empty on installs
+// without the proposal feature.
+func (c *FactsCollector) collectActions(ctx context.Context, p bizreport.Period) bizreport.ActionsSummary {
+	var sum bizreport.ActionsSummary
+
+	type propRow struct {
+		ToolName string
+		Decision string
+		Cnt      int
+	}
+	var props []propRow
+	_ = c.db.WithContext(ctx).
+		Table("chat_mutating_proposals").
+		Select("tool_name, decision, COUNT(*) as cnt").
+		Where("created_at >= ? AND created_at < ?", p.Start, p.End).
+		Group("tool_name, decision").
+		Find(&props).Error
+
+	byTool := map[string]int{}
+	for _, pr := range props {
+		sum.MutatingTotal += pr.Cnt
+		if pr.Decision == "approve" {
+			sum.MutatingApproved += pr.Cnt
+		}
+		byTool[pr.ToolName] += pr.Cnt
+	}
+	for tool, cnt := range byTool {
+		sum.ByTool = append(sum.ByTool, bizreport.ToolCount{Tool: tool, Count: cnt})
+	}
+	sortToolCounts(sum.ByTool)
+
+	// Safe-tool proxy: audit success rows in the window. Coarse but
+	// avoids a dependency on per-tool-call telemetry not yet persisted.
+	var safe int64
+	_ = c.db.WithContext(ctx).
+		Table("audit_logs").
+		Where("occurred_at >= ? AND occurred_at < ?", p.Start, p.End).
+		Where("status = ?", "success").
+		Count(&safe).Error
+	sum.SafeTotal = int(safe)
+	return sum
+}
+
+func (c *FactsCollector) collectAlertCounts(ctx context.Context, p bizreport.Period, scope bizreport.Scope) map[string]int {
+	type sevRow struct {
+		Severity string
+		Cnt      int
+	}
+	q := c.db.WithContext(ctx).
+		Table("alert_incidents").
+		Select("severity, COUNT(*) as cnt").
+		Where("deleted_at IS NULL").
+		Where("first_fired_at >= ? AND first_fired_at < ?", p.Start, p.End)
+	q = applyEdgeScope(q, scope)
+	var rows []sevRow
+	_ = q.Group("severity").Find(&rows).Error
+	out := map[string]int{}
+	for _, r := range rows {
+		out[r.Severity] = r.Cnt
+	}
+	return out
+}
+
+func (c *FactsCollector) collectEdges(ctx context.Context) bizreport.EdgeFact {
+	var f bizreport.EdgeFact
+	var total, online int64
+	_ = c.db.WithContext(ctx).Table("edges").Where("deleted_at IS NULL").Count(&total).Error
+	_ = c.db.WithContext(ctx).Table("edges").Where("deleted_at IS NULL AND status = ?", "online").Count(&online).Error
+	f.Total = int(total)
+	f.Online = int(online)
+	return f
+}
+
+// buildHero computes the big-number cards with period-over-period deltas
+// and daily-bucket sparklines. All numbers SQL-true.
+func (c *FactsCollector) buildHero(ctx context.Context, p, prev bizreport.Period, scope bizreport.Scope, incidents []bizreport.IncidentFact, actions bizreport.ActionsSummary) []bizreport.HeroStat {
+	// Resolved count + MTTR over this period.
+	resolved, mttr := resolvedAndMTTR(incidents)
+	prevResolved := c.countIncidents(ctx, prev, scope)
+
+	hero := []bizreport.HeroStat{
+		{
+			Key:       "incidents",
+			Label:     "Incidents",
+			Value:     float64(len(incidents)),
+			DeltaPct:  deltaPct(float64(len(incidents)), float64(prevResolved)),
+			Sparkline: c.dailyIncidentBuckets(ctx, p, scope),
+		},
+		{
+			Key:   "mttr_minutes",
+			Label: "MTTR",
+			Value: float64(mttr),
+			Unit:  "min",
+		},
+		{
+			Key:   "actions",
+			Label: "Actions",
+			Value: float64(actions.MutatingTotal + actions.SafeTotal),
+		},
+		{
+			Key:   "resolved",
+			Label: "Resolved",
+			Value: float64(resolved),
+		},
+	}
+	return hero
+}
+
+func (c *FactsCollector) countIncidents(ctx context.Context, p bizreport.Period, scope bizreport.Scope) int {
+	q := c.db.WithContext(ctx).Table("alert_incidents").
+		Where("deleted_at IS NULL").
+		Where("first_fired_at >= ? AND first_fired_at < ?", p.Start, p.End)
+	q = applyEdgeScope(q, scope)
+	var n int64
+	_ = q.Count(&n).Error
+	return int(n)
+}
+
+// dailyIncidentBuckets returns a per-day incident count series across
+// the period (for the sparkline). Capped at 31 buckets so a custom
+// long-range schedule doesn't produce an unwieldy series.
+func (c *FactsCollector) dailyIncidentBuckets(ctx context.Context, p bizreport.Period, scope bizreport.Scope) []int {
+	const maxBuckets = 31
+	days := int(p.End.Sub(p.Start).Hours()/24 + 0.5)
+	if days < 1 {
+		days = 1
+	}
+	if days > maxBuckets {
+		days = maxBuckets
+	}
+	buckets := make([]int, days)
+	span := p.End.Sub(p.Start)
+	if span <= 0 {
+		return buckets
+	}
+	// One COUNT per bucket keeps it portable across MySQL/SQLite without
+	// date-function dialect differences. days is small (≤31).
+	for i := 0; i < days; i++ {
+		bStart := p.Start.Add(time.Duration(i) * span / time.Duration(days))
+		bEnd := p.Start.Add(time.Duration(i+1) * span / time.Duration(days))
+		q := c.db.WithContext(ctx).Table("alert_incidents").
+			Where("deleted_at IS NULL").
+			Where("first_fired_at >= ? AND first_fired_at < ?", bStart, bEnd)
+		q = applyEdgeScope(q, scope)
+		var n int64
+		_ = q.Count(&n).Error
+		buckets[i] = int(n)
+	}
+	return buckets
+}
+
+// --- helpers ---
+
+func applyEdgeScope(q *gorm.DB, scope bizreport.Scope) *gorm.DB {
+	if len(scope.EdgeIDs) > 0 {
+		return q.Where("device_id IN ?", scope.EdgeIDs)
+	}
+	return q
+}
+
+func applySeverityScope(q *gorm.DB, scope bizreport.Scope) *gorm.DB {
+	if scope.SeverityMin == "" {
+		return q
+	}
+	min, ok := severityRank[scope.SeverityMin]
+	if !ok {
+		return q
+	}
+	allowed := make([]string, 0, 3)
+	for sev, rank := range severityRank {
+		if rank >= min {
+			allowed = append(allowed, sev)
+		}
+	}
+	return q.Where("severity IN ?", allowed)
+}
+
+func durationMinutes(start time.Time, resolved *time.Time, periodEnd time.Time) int {
+	end := periodEnd
+	if resolved != nil {
+		end = *resolved
+	}
+	d := end.Sub(start)
+	if d < 0 {
+		return 0
+	}
+	return int(d.Minutes())
+}
+
+func resolvedAndMTTR(incidents []bizreport.IncidentFact) (resolved, mttrMin int) {
+	var total int
+	for _, in := range incidents {
+		if in.Status == "resolved" {
+			resolved++
+			total += in.DurationMin
+		}
+	}
+	if resolved > 0 {
+		mttrMin = total / resolved
+	}
+	return resolved, mttrMin
+}
+
+// deltaPct returns the period-over-period percentage change, or nil when
+// there's no prior value to compare against (renders as "new").
+func deltaPct(cur, prev float64) *float64 {
+	if prev == 0 {
+		return nil
+	}
+	d := (cur - prev) / prev * 100
+	return &d
+}
+
+func sortToolCounts(tc []bizreport.ToolCount) {
+	// Simple insertion sort by count desc — slices are tiny (#tools).
+	for i := 1; i < len(tc); i++ {
+		for j := i; j > 0 && tc[j].Count > tc[j-1].Count; j-- {
+			tc[j], tc[j-1] = tc[j-1], tc[j]
+		}
+	}
+}

--- a/internal/manager/data/report/store/facts_test.go
+++ b/internal/manager/data/report/store/facts_test.go
@@ -1,0 +1,208 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	bizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
+)
+
+// The facts collector queries tables owned by other domains by name.
+// For the test we create minimal tables with just the columns the
+// collector reads — this keeps the test decoupled from the full
+// alert/audit/edge models while exercising the real SQL.
+func newFactsDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	stmts := []string{
+		`CREATE TABLE alert_incidents (
+			id INTEGER PRIMARY KEY, rule_name TEXT, severity TEXT, status TEXT,
+			device_id INTEGER, first_fired_at DATETIME, resolved_at DATETIME,
+			deleted_at DATETIME)`,
+		`CREATE TABLE chat_mutating_proposals (
+			id TEXT PRIMARY KEY, tool_name TEXT, decision TEXT, created_at DATETIME)`,
+		`CREATE TABLE audit_logs (
+			id INTEGER PRIMARY KEY, occurred_at DATETIME, status TEXT)`,
+		`CREATE TABLE edges (id INTEGER PRIMARY KEY, status TEXT, deleted_at DATETIME)`,
+	}
+	for _, s := range stmts {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	}
+	return db
+}
+
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}
+
+func TestFactsCollector_Collect(t *testing.T) {
+	db := newFactsDB(t)
+	ctx := context.Background()
+
+	period := bizreport.Period{
+		Start: mustParse(t, "2026-06-01T00:00:00Z"),
+		End:   mustParse(t, "2026-06-08T00:00:00Z"),
+	}
+	prev := bizreport.Period{
+		Start: mustParse(t, "2026-05-25T00:00:00Z"),
+		End:   mustParse(t, "2026-06-01T00:00:00Z"),
+	}
+
+	// 3 incidents in period, 2 resolved (durations 30 + 90 → MTTR 60),
+	// 1 still open. 1 incident in prev period (for delta).
+	db.Exec(`INSERT INTO alert_incidents VALUES
+		(1,'CPU High','warning','resolved',7,'2026-06-02T10:00:00Z','2026-06-02T10:30:00Z',NULL),
+		(2,'Disk Full','critical','resolved',9,'2026-06-04T08:00:00Z','2026-06-04T09:30:00Z',NULL),
+		(3,'OOM','warning','open',7,'2026-06-06T12:00:00Z',NULL,NULL),
+		(4,'Old','warning','resolved',7,'2026-05-28T00:00:00Z','2026-05-28T00:10:00Z',NULL)`)
+
+	// proposals: 2 approved restart_service + 1 rejected disk_cleanup in period.
+	db.Exec(`INSERT INTO chat_mutating_proposals VALUES
+		('p1','restart_service','approve','2026-06-03T00:00:00Z'),
+		('p2','restart_service','approve','2026-06-03T01:00:00Z'),
+		('p3','disk_cleanup','reject','2026-06-05T00:00:00Z')`)
+
+	db.Exec(`INSERT INTO audit_logs VALUES
+		(1,'2026-06-02T00:00:00Z','success'),
+		(2,'2026-06-03T00:00:00Z','success'),
+		(3,'2026-06-03T00:00:00Z','failure')`)
+
+	db.Exec(`INSERT INTO edges VALUES (1,'online',NULL),(2,'online',NULL),(3,'offline',NULL)`)
+
+	fc := NewFactsCollector(db)
+	facts, err := fc.Collect(ctx, period, prev, bizreport.Scope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(facts.Incidents) != 3 {
+		t.Errorf("incidents = %d, want 3", len(facts.Incidents))
+	}
+	// MTTR over the 2 resolved = (30+90)/2 = 60.
+	var mttr float64
+	var incidentsHero, resolvedHero, actionsHero *bizreport.HeroStat
+	for i := range facts.Hero {
+		switch facts.Hero[i].Key {
+		case "mttr_minutes":
+			mttr = facts.Hero[i].Value
+		case "incidents":
+			incidentsHero = &facts.Hero[i]
+		case "resolved":
+			resolvedHero = &facts.Hero[i]
+		case "actions":
+			actionsHero = &facts.Hero[i]
+		}
+	}
+	if mttr != 60 {
+		t.Errorf("MTTR = %v, want 60", mttr)
+	}
+	if incidentsHero == nil || incidentsHero.Value != 3 {
+		t.Errorf("incidents hero = %+v, want 3", incidentsHero)
+	}
+	// delta vs prev (1 incident): (3-1)/1*100 = 200%.
+	if incidentsHero.DeltaPct == nil || *incidentsHero.DeltaPct != 200 {
+		t.Errorf("incidents delta = %+v, want 200", incidentsHero.DeltaPct)
+	}
+	if resolvedHero == nil || resolvedHero.Value != 2 {
+		t.Errorf("resolved hero = %+v, want 2", resolvedHero)
+	}
+	// actions = mutating(3) + safe(2 success audit) = 5.
+	if actionsHero == nil || actionsHero.Value != 5 {
+		t.Errorf("actions hero = %+v, want 5", actionsHero)
+	}
+
+	if facts.Actions.MutatingTotal != 3 || facts.Actions.MutatingApproved != 2 {
+		t.Errorf("actions = %+v, want total 3 approved 2", facts.Actions)
+	}
+	if facts.Edges.Online != 2 || facts.Edges.Total != 3 {
+		t.Errorf("edges = %+v, want online 2 total 3", facts.Edges)
+	}
+	if facts.AlertCounts["warning"] != 2 || facts.AlertCounts["critical"] != 1 {
+		t.Errorf("alert counts = %+v", facts.AlertCounts)
+	}
+	// sparkline has 7 daily buckets (7-day period).
+	if len(incidentsHero.Sparkline) != 7 {
+		t.Errorf("sparkline len = %d, want 7", len(incidentsHero.Sparkline))
+	}
+}
+
+func TestFactsCollector_EdgeScopeFilter(t *testing.T) {
+	db := newFactsDB(t)
+	ctx := context.Background()
+	period := bizreport.Period{
+		Start: mustParse(t, "2026-06-01T00:00:00Z"),
+		End:   mustParse(t, "2026-06-08T00:00:00Z"),
+	}
+	db.Exec(`INSERT INTO alert_incidents VALUES
+		(1,'A','warning','resolved',7,'2026-06-02T10:00:00Z','2026-06-02T10:30:00Z',NULL),
+		(2,'B','warning','resolved',9,'2026-06-03T10:00:00Z','2026-06-03T10:30:00Z',NULL)`)
+
+	fc := NewFactsCollector(db)
+	// Scope to device 7 only.
+	facts, err := fc.Collect(ctx, period, period, bizreport.Scope{EdgeIDs: []uint64{7}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(facts.Incidents) != 1 || facts.Incidents[0].DeviceID != 7 {
+		t.Errorf("edge scope not applied: %+v", facts.Incidents)
+	}
+}
+
+func TestFactsCollector_SeverityScopeFilter(t *testing.T) {
+	db := newFactsDB(t)
+	ctx := context.Background()
+	period := bizreport.Period{
+		Start: mustParse(t, "2026-06-01T00:00:00Z"),
+		End:   mustParse(t, "2026-06-08T00:00:00Z"),
+	}
+	db.Exec(`INSERT INTO alert_incidents VALUES
+		(1,'A','info','resolved',7,'2026-06-02T10:00:00Z','2026-06-02T10:30:00Z',NULL),
+		(2,'B','warning','resolved',7,'2026-06-03T10:00:00Z','2026-06-03T10:30:00Z',NULL),
+		(3,'C','critical','resolved',7,'2026-06-04T10:00:00Z','2026-06-04T10:30:00Z',NULL)`)
+
+	fc := NewFactsCollector(db)
+	// severity_min=warning → drop the info incident.
+	facts, _ := fc.Collect(ctx, period, period, bizreport.Scope{SeverityMin: "warning"})
+	if len(facts.Incidents) != 2 {
+		t.Errorf("severity scope: got %d incidents, want 2 (warning+critical)", len(facts.Incidents))
+	}
+}
+
+func TestFactsCollector_EmptyPeriodNoError(t *testing.T) {
+	db := newFactsDB(t)
+	ctx := context.Background()
+	period := bizreport.Period{
+		Start: mustParse(t, "2026-06-01T00:00:00Z"),
+		End:   mustParse(t, "2026-06-08T00:00:00Z"),
+	}
+	// No data at all — a calm report's facts. Must not error.
+	fc := NewFactsCollector(db)
+	facts, err := fc.Collect(ctx, period, period, bizreport.Scope{})
+	if err != nil {
+		t.Fatalf("empty period should not error: %v", err)
+	}
+	if len(facts.Incidents) != 0 || facts.Actions.MutatingTotal != 0 {
+		t.Errorf("expected zero facts, got %+v", facts)
+	}
+	// Hero still present (all zeros), so the calm report renders cards.
+	if len(facts.Hero) != 4 {
+		t.Errorf("hero cards = %d, want 4 even when empty", len(facts.Hero))
+	}
+}


### PR DESCRIPTION
Second slice of **HLD-014 scheduled reports**. Stacked on PR-1 (#56) — base branch is `feat/reports-pr1-model`, retarget to main after PR-1 merges.

The deterministic, no-LLM foundation: the **anti-hallucination contract** where every number a report shows is computed in SQL, and the LLM only narrates.

## What lands
- **`biz/report/facts.go`**: `ReportFacts` (SQL-computed input to the reporter agent) + `FactsCollector` interface + `Scope` parsing (edge_ids + severity_min honoured; fleet_tags parsed, no-op until G.2.6).
- **`biz/report/content.go`**: `ContentJSON` Go types (Hero / Narrative / KeyIncidents / Actions / Advice) + `ParseContent`/`Validate` (strict on spine: headline + hero key/label; lenient on optional sections so a 0-incident calm report passes per the locked decision) + `RenderMarkdown` (ContentMD fallback; flattens `{{entity:kind:id|name}}` chip tokens to display name for export/IM/search).
- **`data/report/store/facts.go`**: pure-SQL collector over `alert_incidents` / `chat_mutating_proposals` / `audit_logs` / `edges`. Per-day sparkline buckets (≤31, portable across MySQL/SQLite via per-bucket COUNT — no date-fn dialect). Each sub-query degrades to zero independently so a missing proposals table never aborts a report.

## Tests
content validate/render/entity-flatten/scope-parse + SQL collector against in-memory sqlite (MTTR math, period-over-period delta, edge + severity scope filters, calm-empty-period non-error, 7-day sparkline). `go build ./...` + vet clean.

## Next
PR-2b: reporter persona + worker spawn wiring (ReportFacts → ContentJSON via LLM), with Hero/Actions overwritten from facts post-LLM as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)