### PR TITLE
feat(report): PR-2b — reporter persona + worker generator (ReportFacts → ContentJSON)

### DIFF
--- a/agents/reporter.md
+++ b/agents/reporter.md
@@ -1,0 +1,66 @@
+---
+name: reporter
+description: 定时运维报告 worker，把已算好的事实数据写成带叙事的结构化报告（ContentJSON），不计算、不发明任何数字
+when_to_use: |
+  由 report 调度器 / 手动"立即生成"触发（非用户 chat spawn）。输入是一份
+  已经用 SQL 算好的 ReportFacts（incidents / actions / alerts / edges / hero
+  数字 + 环比 + sparkline）。worker 的职责是**把事实写成给人看的运维综述**：
+    • headline 一句话定调（本周整体如何）
+    • 叙事段点名具体实体、给因果（哪台机 / 哪个 incident / 时间重合）
+    • 下周建议（可执行、对应到具体 edge / incident）
+  worker **不重新计算任何数字**——hero / actions / incidents 的数值由系统
+  事后用 facts 覆写。
+tools: []
+---
+
+你是运维报告撰写 worker。输入是一份 `ReportFacts` JSON（系统已用 SQL 算好所有数字），
+你的唯一任务是把这些事实写成一份结构化的 **ContentJSON** 报告。
+
+## 铁律
+
+1. **绝不计算或发明数字**。hero 卡的数值、环比、sparkline、action 计数、incident
+   时长——全部已经在 ReportFacts 里给你了。你只负责文字（headline / 叙事 / 建议）。
+   系统会在你输出后用 facts 覆写所有数字字段，你编的数字会被丢弃，所以别浪费 token。
+2. **只输出 JSON**，不要 markdown 代码块外的任何解释文字。
+3. 叙事和建议里点名实体时，用 `{{entity:kind:id|显示名}}` 语法包裹，例如
+   `{{entity:edge:7|db-prod-3}}`、`{{entity:incident:1234|I-1234}}`。前端会渲染成
+   可点击的 chip。kind 取 `edge` / `incident`；id 用 ReportFacts 里的真实 id。
+4. **平稳也是信号**：周期内 0 incident / 0 action 时，照常写一份"本周平稳无异常"
+   的报告，headline 正向，叙事简短说明系统健康，建议可以为空数组。不要拒绝生成。
+5. 语言跟随系统给的 locale 指令（若有）；没有则用中文。
+
+## 输出 schema（ContentJSON）
+
+```json
+{
+  "version": "1",
+  "hero": [],                          // 留空数组——系统用 facts 覆写
+  "narrative": {
+    "headline": "一句话定调本周期整体状况",
+    "paragraphs": [
+      {
+        "text": "点名实体 + 给因果的叙事，可嵌 {{entity:edge:7|db-prod-3}} 这样的 token",
+        "entities": [{"key": "edge:7", "name": "db-prod-3"}]
+      }
+    ]
+  },
+  "key_incidents": [],                 // 可留空——系统用 facts 的 top-N 覆写；
+                                       // 若你要补 root_cause_snippet，按 id 给即可
+  "actions_summary": {},               // 留空对象——系统用 facts 覆写
+  "advice": [
+    {"text": "可执行的下周建议，对应到具体 {{entity:edge:7|db-prod-3}} 或 incident"}
+  ]
+}
+```
+
+## 写作要求
+
+- **headline**：像周报标题那句话，定调（"本周整体平稳" / "本周风险集中在 X"）。
+- **narrative**：2–4 段。点名具体实体（哪台机、哪个 incident），给因果链
+  （"X 的 iowait 三次突破阈值，最严重一次与 backup 时间重合，触发 I-1234"）。
+  有数据支撑才写，不要泛泛而谈。
+- **key_incidents**：你可以留空让系统填；若你想给某个 incident 加一句根因摘要，
+  按它的真实 id 在 key_incidents 里放 `{"id":1234,"root_cause_snippet":"..."}`。
+- **advice**：1–4 条，每条可执行、对应到具体实体。没有可建议的就给空数组，别硬凑。
+
+记住：你的价值是**叙事和洞察**，不是数字。把 facts 串成一个运维负责人愿意每周读一遍的故事。

--- a/internal/manager/biz/report/generator.go
+++ b/internal/manager/biz/report/generator.go
@@ -1,0 +1,303 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/chatruntime"
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+// WorkerSpawner is the narrow seam onto chatruntime.Runtime that the
+// generator uses to run the reporter persona. Mirrors the investigator's
+// WorkerSpawner so the wiring in main.go is the same shim. Kept as an
+// interface so tests inject a fake that returns canned ContentJSON
+// without standing up the whole graph kernel.
+type WorkerSpawner interface {
+	SpawnWorker(ctx context.Context, req chatruntime.SpawnRequest) (*chatruntime.Worker, error)
+}
+
+// GeneratorConfig tunes the worker generator.
+type GeneratorConfig struct {
+	// Persona is the reporter agent name (frontmatter `name`). Defaults
+	// to model.DefaultReporterPersona.
+	Persona string
+	// Timeout caps a single report generation. 0 → 120s (the project-
+	// wide LLM timeout floor).
+	Timeout time.Duration
+	// DefaultLocale is used when a report has no owner-locale signal
+	// (scheduled reports run headless — there's no Accept-Language).
+	// Empty → "en" per feedback_ai_output_locale (auto-triggered LLM
+	// output follows ONGRID_DEFAULT_LOCALE).
+	DefaultLocale string
+}
+
+// workerGenerator implements Generator: it turns a pending report into a
+// finished one by collecting facts, running the reporter worker, and
+// writing validated ContentJSON. Numbers are overwritten from facts
+// post-LLM (defense-in-depth) so a model that fiddles a figure can't
+// leak it into the report.
+type workerGenerator struct {
+	repo      Repo
+	facts     FactsCollector
+	spawner   WorkerSpawner
+	cfg       GeneratorConfig
+	log       *slog.Logger
+}
+
+// NewWorkerGenerator builds the real generator. A nil spawner or facts
+// collector is a wiring error and panics — main.go always supplies both.
+func NewWorkerGenerator(repo Repo, facts FactsCollector, spawner WorkerSpawner, cfg GeneratorConfig, log *slog.Logger) Generator {
+	if repo == nil || facts == nil || spawner == nil {
+		panic("report: nil dependency to NewWorkerGenerator")
+	}
+	if cfg.Persona == "" {
+		cfg.Persona = model.DefaultReporterPersona
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 120 * time.Second
+	}
+	if cfg.DefaultLocale == "" {
+		cfg.DefaultLocale = "en"
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &workerGenerator{repo: repo, facts: facts, spawner: spawner, cfg: cfg, log: log.With(slog.String("comp", "report-generator"))}
+}
+
+// Generate runs the full pipeline for one report id. Always reaches a
+// terminal state (ready/failed) — a panic or early return that left the
+// row "generating" would strand it in the UI.
+func (g *workerGenerator) Generate(ctx context.Context, reportID string) {
+	rpt, err := g.repo.GetReport(ctx, reportID)
+	if err != nil {
+		g.log.Warn("load report failed", slog.String("report_id", reportID), slog.Any("err", err))
+		return
+	}
+	if rpt.Status != model.StatusPending {
+		// Already handled (double-fire, restart re-attach). No-op.
+		return
+	}
+
+	rpt.Status = model.StatusGenerating
+	if err := g.repo.UpdateReport(ctx, rpt); err != nil {
+		g.log.Warn("flip generating failed", slog.String("report_id", reportID), slog.Any("err", err))
+		// Continue anyway — the worst case is the UI lags one state.
+	}
+
+	if err := g.generate(ctx, rpt); err != nil {
+		g.fail(ctx, rpt, err.Error())
+	}
+}
+
+func (g *workerGenerator) generate(ctx context.Context, rpt *model.Report) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), g.cfg.Timeout)
+	defer cancel()
+
+	period := Period{Start: rpt.PeriodStart, End: rpt.PeriodEnd}
+	prev := previousPeriod(period)
+	scope := ParseScope(rpt.ScopeJSON)
+
+	facts, err := g.facts.Collect(ctx, period, prev, scope)
+	if err != nil {
+		return fmt.Errorf("collect facts: %w", err)
+	}
+
+	prompt := g.buildPrompt(rpt, facts)
+	worker, err := g.spawner.SpawnWorker(ctx, chatruntime.SpawnRequest{
+		AgentName:   g.cfg.Persona,
+		Prompt:      prompt,
+		Background:  false, // sync — this goroutine owns the lifecycle
+		SessionKind: "report",
+		OwnerUserID: rpt.CreatedBy,
+		Locale:      g.localeFor(rpt),
+	})
+	if err != nil {
+		return fmt.Errorf("spawn worker: %w", err)
+	}
+	if worker == nil {
+		return fmt.Errorf("spawn worker: nil worker")
+	}
+	if sid := worker.SessionID; sid != "" {
+		rpt.AuditSessionID = &sid
+	}
+	if wid := worker.ID; wid != "" {
+		rpt.WorkerID = &wid
+	}
+	if werr := strings.TrimSpace(worker.Err); werr != "" {
+		return fmt.Errorf("worker: %s", werr)
+	}
+
+	content, err := ParseContent(extractJSON(worker.Result))
+	if err != nil {
+		return fmt.Errorf("parse content: %w", err)
+	}
+
+	// Defense-in-depth: overwrite every SQL-true field from facts so the
+	// LLM owns only prose. Hero + Actions are pure numbers; KeyIncidents
+	// ids/durations/status are SQL-true but we preserve the LLM's
+	// root-cause snippet by matching on id.
+	content.Hero = facts.Hero
+	content.Actions = facts.Actions
+	content.KeyIncidents = mergeIncidents(facts.Incidents, content.KeyIncidents)
+	content.Version = ContentVersion
+	content.Metadata = ContentMeta{
+		PeriodStart: period.Start.Format(time.RFC3339),
+		PeriodEnd:   period.End.Format(time.RFC3339),
+		DataSources: []string{"incidents", "audit_log", "proposals", "edges"},
+	}
+
+	rpt.ContentJSON = content.MustJSON()
+	rpt.ContentMD = content.RenderMarkdown(rpt.Title)
+	rpt.SummaryText = truncate(content.Narrative.Headline, 510)
+	rpt.Status = model.StatusReady
+	rpt.ErrorMsg = ""
+	now := time.Now().UTC()
+	rpt.GeneratedAt = &now
+	if err := g.repo.UpdateReport(ctx, rpt); err != nil {
+		return fmt.Errorf("persist ready report: %w", err)
+	}
+	g.log.Info("report ready",
+		slog.String("report_id", rpt.ID),
+		slog.Int("incidents", len(facts.Incidents)))
+	return nil
+}
+
+func (g *workerGenerator) fail(ctx context.Context, rpt *model.Report, reason string) {
+	rpt.Status = model.StatusFailed
+	rpt.ErrorMsg = truncate(reason, 2000)
+	// Use a background ctx so a cancelled/timed-out request still records
+	// the failure terminal state.
+	if err := g.repo.UpdateReport(context.WithoutCancel(ctx), rpt); err != nil {
+		g.log.Warn("persist failed report", slog.String("report_id", rpt.ID), slog.Any("err", err))
+	}
+	g.log.Warn("report generation failed", slog.String("report_id", rpt.ID), slog.String("reason", reason))
+}
+
+// buildPrompt renders the reporter worker's user message: the facts JSON
+// plus any per-schedule prompt override. The persona body carries the
+// ContentJSON schema + entity-token instructions; this is just the
+// payload + override.
+func (g *workerGenerator) buildPrompt(rpt *model.Report, facts *ReportFacts) string {
+	var b strings.Builder
+	b.WriteString("生成一份运维报告。下面是本周期已经算好的事实数据（数字均为准确值，禁止改动或新增数字）：\n\n```json\n")
+	b.WriteString(factsJSON(facts))
+	b.WriteString("\n```\n\n")
+	b.WriteString(fmt.Sprintf("报告周期：%s — %s（%s）。\n", rpt.PeriodStart.Format("2006-01-02"), rpt.PeriodEnd.Format("2006-01-02"), rpt.Kind))
+	if override := g.scheduleOverride(rpt); override != "" {
+		b.WriteString("\n额外要求：\n")
+		b.WriteString(override)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n按 persona 描述的 ContentJSON schema 输出，只输出 JSON。")
+	return b.String()
+}
+
+// scheduleOverride fetches the owning schedule's prompt_override, if any.
+// Manual reports (nil ScheduleID) have no override.
+func (g *workerGenerator) scheduleOverride(rpt *model.Report) string {
+	if rpt.ScheduleID == nil {
+		return ""
+	}
+	s, err := g.repo.GetSchedule(context.Background(), *rpt.ScheduleID)
+	if err != nil || s.PromptOverride == nil {
+		return ""
+	}
+	return strings.TrimSpace(*s.PromptOverride)
+}
+
+func (g *workerGenerator) localeFor(rpt *model.Report) string {
+	// Scheduled reports run headless; there's no per-request locale.
+	// Future: store an owner-locale snapshot on the schedule. For now
+	// the configured default wins.
+	return g.cfg.DefaultLocale
+}
+
+// --- helpers ---
+
+// previousPeriod returns the window immediately before p, of equal
+// length — used to compute period-over-period deltas.
+func previousPeriod(p Period) Period {
+	d := p.End.Sub(p.Start)
+	return Period{Start: p.Start.Add(-d), End: p.Start}
+}
+
+// mergeIncidents rebuilds KeyIncidents from SQL-true facts (top 5 by
+// duration), preserving any LLM-supplied root-cause snippet matched by
+// id. Caps at 5 to keep the report scannable.
+func mergeIncidents(facts []IncidentFact, llm []KeyIncident) []KeyIncident {
+	snippetByID := map[uint64]string{}
+	for _, k := range llm {
+		if k.RootCauseSnippet != "" {
+			snippetByID[k.ID] = k.RootCauseSnippet
+		}
+	}
+	sorted := append([]IncidentFact(nil), facts...)
+	// insertion sort by duration desc — small slices.
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j].DurationMin > sorted[j-1].DurationMin; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+		}
+	}
+	n := len(sorted)
+	if n > 5 {
+		n = 5
+	}
+	out := make([]KeyIncident, 0, n)
+	for _, f := range sorted[:n] {
+		out = append(out, KeyIncident{
+			ID:               f.ID,
+			Title:            f.Title,
+			Severity:         f.Severity,
+			DurationMin:      f.DurationMin,
+			Status:           f.Status,
+			RootCauseSnippet: snippetByID[f.ID],
+		})
+	}
+	return out
+}
+
+func factsJSON(f *ReportFacts) string {
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// extractJSON strips a leading ```json fence / trailing fence and any
+// prose around a single top-level object, so a chatty model still
+// yields parseable content. Mirrors the lenient parse in query_translate.
+func extractJSON(raw string) string {
+	s := strings.TrimSpace(raw)
+	if i := strings.Index(s, "```"); i >= 0 {
+		// drop opening fence (```json or ```)
+		rest := s[i+3:]
+		if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+			rest = rest[nl+1:]
+		}
+		if j := strings.Index(rest, "```"); j >= 0 {
+			rest = rest[:j]
+		}
+		s = strings.TrimSpace(rest)
+	}
+	if i := strings.IndexByte(s, '{'); i > 0 {
+		s = s[i:]
+	}
+	if j := strings.LastIndexByte(s, '}'); j >= 0 && j+1 < len(s) {
+		s = s[:j+1]
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/manager/biz/report/generator_test.go
+++ b/internal/manager/biz/report/generator_test.go
@@ -1,0 +1,238 @@
+package report
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/chatruntime"
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+// fakeFacts returns a canned ReportFacts.
+type fakeFacts struct {
+	facts *ReportFacts
+	err   error
+}
+
+func (f fakeFacts) Collect(context.Context, Period, Period, Scope) (*ReportFacts, error) {
+	return f.facts, f.err
+}
+
+// fakeSpawner returns a canned worker (Result / Err).
+type fakeSpawner struct {
+	result string
+	werr   string
+	spawnErr error
+	gotReq chatruntime.SpawnRequest
+}
+
+func (s *fakeSpawner) SpawnWorker(_ context.Context, req chatruntime.SpawnRequest) (*chatruntime.Worker, error) {
+	s.gotReq = req
+	if s.spawnErr != nil {
+		return nil, s.spawnErr
+	}
+	return &chatruntime.Worker{
+		ID:        "agent-deadbeef",
+		SessionID: "sess-1",
+		Result:    s.result,
+		Err:       s.werr,
+	}, nil
+}
+
+func sampleFacts() *ReportFacts {
+	d := -12.0
+	return &ReportFacts{
+		Hero: []HeroStat{
+			{Key: "incidents", Label: "Incidents", Value: 3, DeltaPct: &d, Sparkline: []int{1, 0, 2}},
+			{Key: "mttr_minutes", Label: "MTTR", Value: 60, Unit: "min"},
+		},
+		Incidents: []IncidentFact{
+			{ID: 1, Title: "CPU High", Severity: "warning", Status: "resolved", DeviceID: 7, DurationMin: 30},
+			{ID: 2, Title: "Disk Full", Severity: "critical", Status: "resolved", DeviceID: 9, DurationMin: 90},
+		},
+		Actions: ActionsSummary{MutatingTotal: 3, MutatingApproved: 2, SafeTotal: 5},
+	}
+}
+
+func pendingReport() *model.Report {
+	loc := time.UTC
+	return &model.Report{
+		ID:          "rpt-1",
+		CreatedBy:   42,
+		Title:       "周报 · test",
+		Kind:        model.KindWeekly,
+		PeriodStart: time.Date(2026, 6, 1, 0, 0, 0, 0, loc),
+		PeriodEnd:   time.Date(2026, 6, 8, 0, 0, 0, 0, loc),
+		Timezone:    "UTC",
+		Status:      model.StatusPending,
+		ScopeJSON:   "{}",
+	}
+}
+
+func newGenTestRepo(rpt *model.Report) *fakeRepo {
+	r := newFakeRepo()
+	r.reports[rpt.ID] = rpt
+	return r
+}
+
+func TestGenerator_HappyPath_OverwritesNumbersFromFacts(t *testing.T) {
+	rpt := pendingReport()
+	repo := newGenTestRepo(rpt)
+	// LLM returns valid ContentJSON but with WRONG/empty numbers — the
+	// generator must overwrite hero/actions/incidents from facts.
+	llmOut := "```json\n" + `{
+		"version":"1",
+		"hero":[{"key":"incidents","label":"Incidents","value":9999}],
+		"narrative":{"headline":"本周整体平稳","paragraphs":[
+			{"text":"{{entity:edge:7|db-prod-3}} 出现 IO 压力"}]},
+		"key_incidents":[{"id":2,"root_cause_snippet":"backup 重叠"}],
+		"actions_summary":{"mutating_total":0},
+		"advice":[{"text":"挪 backup 窗口"}]
+	}` + "\n```"
+	spawner := &fakeSpawner{result: llmOut}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: sampleFacts()}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+
+	got, _ := repo.GetReport(context.Background(), "rpt-1")
+	if got.Status != model.StatusReady {
+		t.Fatalf("status = %q, want ready (err=%q)", got.Status, got.ErrorMsg)
+	}
+	content, err := ParseContent(got.ContentJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hero overwritten from facts — the 9999 the LLM emitted is gone.
+	if len(content.Hero) != 2 || content.Hero[0].Value != 3 {
+		t.Errorf("hero not overwritten from facts: %+v", content.Hero)
+	}
+	// Actions overwritten from facts.
+	if content.Actions.MutatingTotal != 3 || content.Actions.MutatingApproved != 2 {
+		t.Errorf("actions not overwritten: %+v", content.Actions)
+	}
+	// KeyIncidents rebuilt from facts (sorted by duration desc: id2 90m, id1 30m),
+	// preserving the LLM snippet on id2.
+	if len(content.KeyIncidents) != 2 || content.KeyIncidents[0].ID != 2 {
+		t.Errorf("incidents not merged/sorted: %+v", content.KeyIncidents)
+	}
+	if content.KeyIncidents[0].RootCauseSnippet != "backup 重叠" {
+		t.Errorf("LLM snippet not preserved: %+v", content.KeyIncidents[0])
+	}
+	// Narrative (LLM-owned) survives.
+	if content.Narrative.Headline != "本周整体平稳" {
+		t.Errorf("headline lost: %q", content.Narrative.Headline)
+	}
+	// Markdown + summary populated.
+	if got.ContentMD == "" || got.SummaryText != "本周整体平稳" {
+		t.Errorf("md/summary not set: md=%d summary=%q", len(got.ContentMD), got.SummaryText)
+	}
+	if got.GeneratedAt == nil {
+		t.Error("generated_at not stamped")
+	}
+	// Worker/session ids captured.
+	if got.AuditSessionID == nil || *got.AuditSessionID != "sess-1" {
+		t.Errorf("audit session id not captured")
+	}
+	// Spawn used the report persona + report session kind + owner.
+	if spawner.gotReq.AgentName != model.DefaultReporterPersona {
+		t.Errorf("persona = %q", spawner.gotReq.AgentName)
+	}
+	if spawner.gotReq.SessionKind != "report" || spawner.gotReq.OwnerUserID != 42 {
+		t.Errorf("spawn req = %+v", spawner.gotReq)
+	}
+}
+
+func TestGenerator_SpawnError_MarksFailed(t *testing.T) {
+	rpt := pendingReport()
+	repo := newGenTestRepo(rpt)
+	spawner := &fakeSpawner{spawnErr: errors.New("boom")}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: sampleFacts()}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+
+	got, _ := repo.GetReport(context.Background(), "rpt-1")
+	if got.Status != model.StatusFailed {
+		t.Fatalf("status = %q, want failed", got.Status)
+	}
+	if got.ErrorMsg == "" {
+		t.Error("error_msg not set on failure")
+	}
+}
+
+func TestGenerator_WorkerErr_MarksFailed(t *testing.T) {
+	rpt := pendingReport()
+	repo := newGenTestRepo(rpt)
+	spawner := &fakeSpawner{werr: "exceeds max steps"}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: sampleFacts()}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+	got, _ := repo.GetReport(context.Background(), "rpt-1")
+	if got.Status != model.StatusFailed {
+		t.Errorf("status = %q, want failed", got.Status)
+	}
+}
+
+func TestGenerator_BadJSON_MarksFailed(t *testing.T) {
+	rpt := pendingReport()
+	repo := newGenTestRepo(rpt)
+	spawner := &fakeSpawner{result: "this is not json at all"}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: sampleFacts()}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+	got, _ := repo.GetReport(context.Background(), "rpt-1")
+	if got.Status != model.StatusFailed {
+		t.Errorf("status = %q, want failed", got.Status)
+	}
+}
+
+func TestGenerator_CalmReport_StillGenerates(t *testing.T) {
+	rpt := pendingReport()
+	repo := newGenTestRepo(rpt)
+	// 0 incidents, 0 actions — calm period. Facts all zero but hero present.
+	calmFacts := &ReportFacts{
+		Hero:    []HeroStat{{Key: "incidents", Label: "Incidents", Value: 0}},
+		Actions: ActionsSummary{},
+	}
+	llmOut := `{"version":"1","hero":[],"narrative":{"headline":"本周无异常，一切平稳"},"key_incidents":[],"actions_summary":{},"advice":[]}`
+	spawner := &fakeSpawner{result: llmOut}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: calmFacts}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+	got, _ := repo.GetReport(context.Background(), "rpt-1")
+	if got.Status != model.StatusReady {
+		t.Fatalf("calm report should be ready, got %q (%s)", got.Status, got.ErrorMsg)
+	}
+	if got.SummaryText != "本周无异常，一切平稳" {
+		t.Errorf("calm summary = %q", got.SummaryText)
+	}
+}
+
+func TestGenerator_NonPendingIsNoOp(t *testing.T) {
+	rpt := pendingReport()
+	rpt.Status = model.StatusReady // already done
+	repo := newGenTestRepo(rpt)
+	spawner := &fakeSpawner{result: "{}"}
+	gen := NewWorkerGenerator(repo, fakeFacts{facts: sampleFacts()}, spawner, GeneratorConfig{}, nil)
+
+	gen.Generate(context.Background(), "rpt-1")
+	// Spawner must not have been called.
+	if spawner.gotReq.AgentName != "" {
+		t.Error("generator ran on a non-pending report")
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	cases := map[string]string{
+		`{"a":1}`:                              `{"a":1}`,
+		"```json\n{\"a\":1}\n```":              `{"a":1}`,
+		"```\n{\"a\":1}\n```":                  `{"a":1}`,
+		"here you go:\n{\"a\":1}\nthat's it":   `{"a":1}`,
+	}
+	for in, want := range cases {
+		if got := extractJSON(in); got != want {
+			t.Errorf("extractJSON(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Third slice of **HLD-014**. Stacked on PR-2 (#57). The LLM half: turns SQL-computed `ReportFacts` into a finished `ContentJSON` report via a reporter agent worker, with every number overwritten from facts post-LLM as **defense-in-depth**.

## What lands
- **`agents/reporter.md`**: the reporter persona. Iron rule — never compute or invent numbers (hero/actions/incidents are SQL-true; the system overwrites them). LLM owns headline / narrative / advice only. `{{entity:kind:id|name}}` chip syntax. Calm 0-incident periods still produce a normal '本周平稳' report (locked decision). `tools: []` — pure writing, no tool loop.
- **`biz/report/generator.go`**: `workerGenerator` implements the PR-1 `Generator` seam. Pipeline: load → flip generating → collect facts → spawn reporter (sync, SessionKind=report, owner=created_by) → parse+validate ContentJSON → **overwrite Hero/Actions/KeyIncidents from facts** → render markdown+summary → MarkReady. Any failure → status=failed, always terminal. `WorkerSpawner` seam mirrors the investigator's (identical main.go shim). `context.WithoutCancel` on the terminal write.

## Tests
Happy-path with LLM emitting `value:9999` (asserts facts overwrite wins), spawn/worker/bad-JSON errors → failed, calm-report still ready, non-pending no-op, extractJSON fence stripping. `go build ./...` + vet clean.

## Compat
New packages only; no schema/behaviour change. Clean upgrade.

## Next
PR-3: cron evaluator goroutine + main.go wiring (facts collector + generator + usecase) so schedules actually fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)