### PR TITLE
feat(report): PR-3 — cron evaluator + main.go wiring

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -29,6 +29,7 @@ import (
 
 	einomodel "github.com/cloudwego/eino/components/model"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
@@ -115,6 +116,7 @@ import (
 
 	managerbizaudit "github.com/ongridio/ongrid/internal/manager/biz/audit"
 	manageraudtdata "github.com/ongridio/ongrid/internal/manager/data/audit/store"
+	managerbizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
 	managerreportdata "github.com/ongridio/ongrid/internal/manager/data/report/store"
 	managerserveraiops "github.com/ongridio/ongrid/internal/manager/server/aiops"
 	managerserveralert "github.com/ongridio/ongrid/internal/manager/server/alert"
@@ -1530,6 +1532,28 @@ func main() {
 
 	if chained := chainInvestigators(legacyInv, rcaInv); chained != nil {
 		alertUC.SetInvestigator(chained)
+	}
+
+	// Report scheduler (HLD-014): scheduled operational reports. Wired
+	// only when the chat runtime is the graph kernel — the reporter
+	// worker spawns through the same SpawnWorker seam the investigator
+	// uses. New tables / new goroutine; no impact on existing startup.
+	if reportRT, ok := aiopsRuntime.(*aiopschatruntime.Runtime); ok && reportRT != nil {
+		reportRepo := managerreportdata.NewRepo(db)
+		reportGen := managerbizreport.NewWorkerGenerator(
+			reportRepo,
+			managerreportdata.NewFactsCollector(db),
+			reportRT,
+			managerbizreport.GeneratorConfig{
+				DefaultLocale: firstNonEmpty(os.Getenv("ONGRID_DEFAULT_LOCALE"), "en"),
+			},
+			log,
+		)
+		reportUC := managerbizreport.NewUsecase(reportRepo, reportGen, uuid.NewString)
+		managerbizreport.NewScheduler(reportUC, log).Start(rootCtx)
+		log.Info("report: scheduler started")
+	} else {
+		log.Info("report: scheduler not wired (chat runtime is not the graph kernel)")
 	}
 
 	// Boot compensation pass for the structured RCA path: incidents that

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/shirou/gopsutil/v3 v3.23.6
 	github.com/singchia/geminio v1.2.3-rc.1

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=
 github.com/rivo/uniseg v0.4.6/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/manager/biz/report/cron.go
+++ b/internal/manager/biz/report/cron.go
@@ -1,0 +1,62 @@
+package report
+
+import (
+	"errors"
+	"time"
+
+	"github.com/robfig/cron/v3"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+// CronNext computes the next fire time strictly after `after`, in the
+// given timezone, for a standard 5-field cron spec. We use robfig/cron's
+// parser only — the scheduler runs its own ticker (HLD-014 §调度器), so
+// none of robfig's in-process scheduling machinery is used.
+//
+// The returned time carries `loc` so the caller can store it as UTC and
+// render local. A malformed spec is surfaced as ErrInvalid.
+func CronNext(spec string, loc *time.Location, after time.Time) (time.Time, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	sched, err := cron.ParseStandard(spec)
+	if err != nil {
+		return time.Time{}, errors.Join(errs.ErrInvalid, err)
+	}
+	return sched.Next(after.In(loc)), nil
+}
+
+// CronSpecForKind returns the default 5-field cron for a preset cadence.
+// The front-end may override the time-of-day; these are the sensible
+// defaults the chat-created path and tests use. Custom kind has no
+// default — the caller must supply CronSpec.
+//
+//	daily   → 09:00 every day
+//	weekly  → 09:00 every Monday
+//	monthly → 09:00 on the 1st
+func CronSpecForKind(kind string) (string, error) {
+	switch kind {
+	case model.KindDaily:
+		return "0 9 * * *", nil
+	case model.KindWeekly:
+		return "0 9 * * 1", nil
+	case model.KindMonthly:
+		return "0 9 1 * *", nil
+	case model.KindCustom:
+		return "", errors.Join(errs.ErrInvalid, errors.New("custom kind requires an explicit cron spec"))
+	default:
+		return "", errors.Join(errs.ErrInvalid, errors.New("unknown report kind"))
+	}
+}
+
+// ValidateCronSpec checks a spec parses, returning ErrInvalid on
+// failure. Used by the API layer (PR-4) to reject a bad custom cron at
+// create time rather than silently never firing.
+func ValidateCronSpec(spec string) error {
+	if _, err := cron.ParseStandard(spec); err != nil {
+		return errors.Join(errs.ErrInvalid, err)
+	}
+	return nil
+}

--- a/internal/manager/biz/report/cron_test.go
+++ b/internal/manager/biz/report/cron_test.go
@@ -1,0 +1,81 @@
+package report
+
+import (
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+func TestCronNext_WeeklyMonday9am(t *testing.T) {
+	loc := mustLoc(t, "Asia/Shanghai")
+	// After Mon 2026-06-08 10:00 → next Monday 9am = 2026-06-15 09:00.
+	after := time.Date(2026, 6, 8, 10, 0, 0, 0, loc)
+	next, err := CronNext("0 9 * * 1", loc, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 6, 15, 9, 0, 0, 0, loc)
+	if !next.Equal(want) {
+		t.Errorf("next = %s, want %s", next, want)
+	}
+}
+
+func TestCronNext_DailyStrictlyAfter(t *testing.T) {
+	loc := mustLoc(t, "Asia/Shanghai")
+	// Exactly at 9am → next is TOMORROW 9am (strictly after).
+	after := time.Date(2026, 6, 8, 9, 0, 0, 0, loc)
+	next, _ := CronNext("0 9 * * *", loc, after)
+	want := time.Date(2026, 6, 9, 9, 0, 0, 0, loc)
+	if !next.Equal(want) {
+		t.Errorf("daily next = %s, want %s", next, want)
+	}
+}
+
+func TestCronNext_RespectsTimezone(t *testing.T) {
+	sh := mustLoc(t, "Asia/Shanghai")
+	ny := mustLoc(t, "America/New_York")
+	after := time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC)
+	nextSH, _ := CronNext("0 9 * * *", sh, after)
+	nextNY, _ := CronNext("0 9 * * *", ny, after)
+	// 9am Shanghai and 9am New York are different absolute instants.
+	if nextSH.Equal(nextNY) {
+		t.Errorf("tz ignored: SH=%s NY=%s", nextSH, nextNY)
+	}
+	if nextSH.In(sh).Hour() != 9 || nextNY.In(ny).Hour() != 9 {
+		t.Errorf("local hour wrong: SH=%s NY=%s", nextSH.In(sh), nextNY.In(ny))
+	}
+}
+
+func TestCronNext_BadSpec(t *testing.T) {
+	if _, err := CronNext("not a cron", time.UTC, time.Now()); err == nil {
+		t.Error("expected error on bad spec")
+	}
+}
+
+func TestCronSpecForKind(t *testing.T) {
+	for _, kind := range []string{model.KindDaily, model.KindWeekly, model.KindMonthly} {
+		spec, err := CronSpecForKind(kind)
+		if err != nil {
+			t.Fatalf("%s: %v", kind, err)
+		}
+		if err := ValidateCronSpec(spec); err != nil {
+			t.Errorf("%s generated invalid spec %q: %v", kind, spec, err)
+		}
+	}
+	if _, err := CronSpecForKind(model.KindCustom); err == nil {
+		t.Error("custom should require explicit spec")
+	}
+	if _, err := CronSpecForKind("weekly-ish"); err == nil {
+		t.Error("unknown kind should error")
+	}
+}
+
+func TestValidateCronSpec(t *testing.T) {
+	if err := ValidateCronSpec("0 9 * * 1"); err != nil {
+		t.Errorf("valid spec rejected: %v", err)
+	}
+	if err := ValidateCronSpec("99 99 * * *"); err == nil {
+		t.Error("out-of-range spec accepted")
+	}
+}

--- a/internal/manager/biz/report/scheduler.go
+++ b/internal/manager/biz/report/scheduler.go
@@ -1,0 +1,114 @@
+package report
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+// defaultTick is how often the evaluator scans for due schedules. 1
+// minute matches cron's minimum granularity — a schedule never fires
+// later than ~1 min past its cron time.
+const defaultTick = time.Minute
+
+// Scheduler is the cron evaluator (HLD-014 §调度器). It owns its own
+// ticker — robfig/cron is used only to compute next-fire times, not to
+// schedule. On each tick it selects due schedules and fires them through
+// the Usecase, which handles dedup + re-arm.
+//
+// Concurrency: one Scheduler per manager process. A single goroutine
+// drives the ticks; each fire is synchronous within the tick so a slow
+// CreateReport/UpdateSchedule serialises rather than stampeding — the
+// report Generator already runs the LLM work in its own goroutine
+// (FireSchedule spawns it), so the tick loop never blocks on an LLM.
+type Scheduler struct {
+	uc   *Usecase
+	tick time.Duration
+	log  *slog.Logger
+}
+
+// NewScheduler builds the evaluator. A zero tick uses defaultTick.
+func NewScheduler(uc *Usecase, log *slog.Logger) *Scheduler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Scheduler{uc: uc, tick: defaultTick, log: log.With(slog.String("comp", "report-scheduler"))}
+}
+
+// Start launches the evaluator goroutine. It returns immediately; the
+// loop runs until ctx is cancelled (manager shutdown). Safe to call
+// once at startup.
+func (s *Scheduler) Start(ctx context.Context) {
+	go s.loop(ctx)
+}
+
+func (s *Scheduler) loop(ctx context.Context) {
+	t := time.NewTicker(s.tick)
+	defer t.Stop()
+	s.log.Info("report scheduler started", slog.Duration("tick", s.tick))
+	for {
+		select {
+		case <-ctx.Done():
+			s.log.Info("report scheduler stopped")
+			return
+		case now := <-t.C:
+			s.runOnce(ctx, now.UTC())
+		}
+	}
+}
+
+// runOnce fires every due schedule. A panic or error in one schedule is
+// contained so the rest of the batch still fires and the loop survives.
+func (s *Scheduler) runOnce(ctx context.Context, now time.Time) {
+	due, err := s.uc.repo.DueSchedules(ctx, now)
+	if err != nil {
+		s.log.Warn("due schedules query failed", slog.Any("err", err))
+		return
+	}
+	for _, sched := range due {
+		s.fireOne(ctx, sched, now)
+	}
+}
+
+func (s *Scheduler) fireOne(ctx context.Context, sched *model.ReportSchedule, now time.Time) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.Error("panic firing schedule",
+				slog.Uint64("schedule_id", sched.ID), slog.Any("panic", r))
+		}
+	}()
+
+	loc, err := loadLocation(sched.Timezone)
+	if err != nil {
+		s.log.Warn("bad schedule timezone — disabling",
+			slog.Uint64("schedule_id", sched.ID), slog.String("tz", sched.Timezone))
+		s.disable(ctx, sched)
+		return
+	}
+	next, err := CronNext(sched.CronSpec, loc, now)
+	if err != nil {
+		s.log.Warn("bad cron spec — disabling",
+			slog.Uint64("schedule_id", sched.ID), slog.String("spec", sched.CronSpec))
+		s.disable(ctx, sched)
+		return
+	}
+	if _, err := s.uc.FireSchedule(ctx, sched, now, next); err != nil {
+		// FireSchedule already re-armed where it could; log and move on.
+		s.log.Warn("fire schedule failed",
+			slog.Uint64("schedule_id", sched.ID), slog.Any("err", err))
+	}
+}
+
+// disable parks a schedule whose config can no longer be fired (bad tz /
+// cron). Better than re-selecting it every minute forever. The operator
+// sees enabled=false in the UI and fixes the spec.
+func (s *Scheduler) disable(ctx context.Context, sched *model.ReportSchedule) {
+	sched.Enabled = false
+	sched.NextFireAt = nil
+	if err := s.uc.repo.UpdateSchedule(ctx, sched); err != nil {
+		s.log.Warn("disable bad schedule failed",
+			slog.Uint64("schedule_id", sched.ID), slog.Any("err", err))
+	}
+}

--- a/internal/manager/biz/report/scheduler_test.go
+++ b/internal/manager/biz/report/scheduler_test.go
@@ -1,0 +1,131 @@
+package report
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+func TestCreateSchedule_ArmsNextFire(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	loc := mustLoc(t, "Asia/Shanghai")
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, loc)
+
+	s := &model.ReportSchedule{
+		ID:        1,
+		CreatedBy: 42,
+		Kind:      model.KindWeekly,
+		Timezone:  "Asia/Shanghai",
+	}
+	if err := uc.CreateSchedule(context.Background(), s, now); err != nil {
+		t.Fatal(err)
+	}
+	// Preset cron filled in.
+	if s.CronSpec != "0 9 * * 1" {
+		t.Errorf("cron spec = %q, want weekly default", s.CronSpec)
+	}
+	// next_fire_at armed to next Monday 9am.
+	if s.NextFireAt == nil {
+		t.Fatal("next_fire_at not armed")
+	}
+	want := time.Date(2026, 6, 15, 9, 0, 0, 0, loc)
+	if !s.NextFireAt.Equal(want) {
+		t.Errorf("next_fire_at = %s, want %s", s.NextFireAt, want)
+	}
+	// Defaults backfilled.
+	if s.ScopeJSON != "{}" || s.ChannelIDsJSON != "[]" || s.AgentPersona != model.DefaultReporterPersona {
+		t.Errorf("defaults not backfilled: %+v", s)
+	}
+}
+
+func TestCreateSchedule_CustomRequiresSpec(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	s := &model.ReportSchedule{ID: 1, Kind: model.KindCustom, Timezone: "UTC"}
+	if err := uc.CreateSchedule(context.Background(), s, time.Now()); err == nil {
+		t.Error("custom kind without cron spec should error")
+	}
+}
+
+func TestScheduler_RunOnce_FiresDue(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	loc := mustLoc(t, "Asia/Shanghai")
+
+	// A schedule due now (next_fire_at in the past).
+	past := time.Date(2026, 6, 8, 9, 0, 0, 0, loc)
+	s := &model.ReportSchedule{
+		ID:         1,
+		CreatedBy:  42,
+		Kind:       model.KindWeekly,
+		CronSpec:   "0 9 * * 1",
+		Timezone:   "Asia/Shanghai",
+		ScopeJSON:  "{}",
+		Enabled:    true,
+		NextFireAt: &past,
+	}
+	_ = repo.CreateSchedule(context.Background(), s)
+
+	sched := NewScheduler(uc, nil)
+	now := time.Date(2026, 6, 8, 9, 0, 30, 0, loc) // 30s after due
+	sched.runOnce(context.Background(), now)
+
+	// A report was created.
+	if len(repo.reports) != 1 {
+		t.Fatalf("expected 1 report fired, got %d", len(repo.reports))
+	}
+	// Schedule re-armed to a future fire.
+	got := repo.schedules[1]
+	if got.NextFireAt == nil || !got.NextFireAt.After(now) {
+		t.Errorf("schedule not re-armed forward: %+v", got.NextFireAt)
+	}
+}
+
+func TestScheduler_RunOnce_DisablesBadCron(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	past := time.Now().Add(-time.Hour)
+	s := &model.ReportSchedule{
+		ID:         1,
+		Kind:       model.KindCustom,
+		CronSpec:   "garbage spec",
+		Timezone:   "UTC",
+		ScopeJSON:  "{}",
+		Enabled:    true,
+		NextFireAt: &past,
+	}
+	_ = repo.CreateSchedule(context.Background(), s)
+
+	sched := NewScheduler(uc, nil)
+	sched.runOnce(context.Background(), time.Now())
+
+	got := repo.schedules[1]
+	if got.Enabled {
+		t.Error("bad-cron schedule should be disabled")
+	}
+	if got.NextFireAt != nil {
+		t.Error("disabled schedule should have nil next_fire_at")
+	}
+	if len(repo.reports) != 0 {
+		t.Error("no report should fire for a bad-cron schedule")
+	}
+}
+
+func TestScheduler_RunOnce_SkipsDisabled(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	past := time.Now().Add(-time.Hour)
+	s := &model.ReportSchedule{
+		ID: 1, Kind: model.KindWeekly, CronSpec: "0 9 * * 1",
+		Timezone: "UTC", Enabled: false, NextFireAt: &past,
+	}
+	_ = repo.CreateSchedule(context.Background(), s)
+	sched := NewScheduler(uc, nil)
+	sched.runOnce(context.Background(), time.Now())
+	if len(repo.reports) != 0 {
+		t.Error("disabled schedule should not fire")
+	}
+}

--- a/internal/manager/biz/report/usecase.go
+++ b/internal/manager/biz/report/usecase.go
@@ -80,6 +80,42 @@ func NewUsecase(repo Repo, gen Generator, idGen IDGen) *Usecase {
 	return &Usecase{repo: repo, gen: gen, idGen: idGen}
 }
 
+// CreateSchedule validates a new schedule and arms its initial
+// next_fire_at, then persists it. Used by the API (PR-4) and the chat
+// tool. For preset kinds with an empty CronSpec, the default cron for
+// that kind is filled in; custom kind requires an explicit spec.
+//
+// `now` is the reference time the first next_fire_at is computed after
+// (injected so tests are deterministic; callers pass time.Now().UTC()).
+func (u *Usecase) CreateSchedule(ctx context.Context, s *model.ReportSchedule, now time.Time) error {
+	if s.CronSpec == "" && s.Kind != model.KindCustom {
+		spec, err := CronSpecForKind(s.Kind)
+		if err != nil {
+			return err
+		}
+		s.CronSpec = spec
+	}
+	loc, err := loadLocation(s.Timezone)
+	if err != nil {
+		return err
+	}
+	next, err := CronNext(s.CronSpec, loc, now)
+	if err != nil {
+		return err
+	}
+	if s.ScopeJSON == "" {
+		s.ScopeJSON = "{}"
+	}
+	if s.ChannelIDsJSON == "" {
+		s.ChannelIDsJSON = "[]"
+	}
+	if s.AgentPersona == "" {
+		s.AgentPersona = model.DefaultReporterPersona
+	}
+	s.NextFireAt = &next
+	return u.repo.CreateSchedule(ctx, s)
+}
+
 // FireSchedule generates one report for a due schedule and re-arms its
 // next_fire_at. Called by the evaluator (PR-3). Idempotent on the
 // (schedule_id, period_start) unique key: if two evaluator ticks race


### PR DESCRIPTION
Fourth slice of **HLD-014**. Stacked on PR-2b (#58). Makes schedules actually fire: a 1-min ticker goroutine selects due schedules and runs them through the Usecase. This is where the feature goes live at startup.

## What lands
- **go.mod**: `github.com/robfig/cron/v3` (parser only — the scheduler runs its own ticker; none of robfig's in-process scheduling is used). Single direct dep, minimal go.sum delta.
- **`cron.go`**: `CronNext` (next fire strictly after, tz-aware) + `CronSpecForKind` (daily=09:00, weekly=Mon 09:00, monthly=1st 09:00) + `ValidateCronSpec`.
- **`scheduler.go`**: `Scheduler.Start` launches the evaluator goroutine. Each tick: `DueSchedules(now)` → `fireOne` per schedule, **per-schedule panic recovery** so one bad schedule can't kill the loop. Unparseable tz/cron → **auto-disable** (enabled=false, next_fire_at=NULL) instead of re-selecting every minute forever.
- **`usecase.go`**: `CreateSchedule` validates + fills preset cron + arms initial next_fire_at + backfills defaults.
- **`main.go`**: wire repo + facts collector + worker generator + usecase + Start the scheduler, reusing the **same `*chatruntime.Runtime` SpawnWorker seam** the investigator uses. Guarded on the graph-kernel runtime. New goroutine + construction only — no change to existing startup.

## Tests
cron next/tz/preset/validate, CreateSchedule arming, scheduler runOnce fires-due / disables-bad-cron / skips-disabled / re-arms-forward. `go build ./...` + vet + report tests green.

## Compat
New dep + new tables + new goroutine; AutoMigrate adds only; zero impact on existing schema/startup. Clean upgrade.

## Next
PR-4: HTTP API + RBAC (schedule CRUD + manual generate + report list/detail/share).

🤖 Generated with [Claude Code](https://claude.com/claude-code)