### PR TITLE
feat(report): PR-4 — HTTP API + RBAC

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -118,6 +118,7 @@ import (
 	manageraudtdata "github.com/ongridio/ongrid/internal/manager/data/audit/store"
 	managerbizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
 	managerreportdata "github.com/ongridio/ongrid/internal/manager/data/report/store"
+	managerserverreport "github.com/ongridio/ongrid/internal/manager/server/report"
 	managerserveraiops "github.com/ongridio/ongrid/internal/manager/server/aiops"
 	managerserveralert "github.com/ongridio/ongrid/internal/manager/server/alert"
 	managerserveraudit "github.com/ongridio/ongrid/internal/manager/server/audit"
@@ -1534,10 +1535,13 @@ func main() {
 		alertUC.SetInvestigator(chained)
 	}
 
-	// Report scheduler (HLD-014): scheduled operational reports. Wired
-	// only when the chat runtime is the graph kernel — the reporter
+	// Report scheduler + API (HLD-014): scheduled operational reports.
+	// Wired only when the chat runtime is the graph kernel — the reporter
 	// worker spawns through the same SpawnWorker seam the investigator
-	// uses. New tables / new goroutine; no impact on existing startup.
+	// uses. New tables / new goroutine / new routes; no impact on
+	// existing startup. reportHandler stays nil when not wired so the
+	// route-mount block below skips it.
+	var reportHandler *managerserverreport.Handler
 	if reportRT, ok := aiopsRuntime.(*aiopschatruntime.Runtime); ok && reportRT != nil {
 		reportRepo := managerreportdata.NewRepo(db)
 		reportGen := managerbizreport.NewWorkerGenerator(
@@ -1549,11 +1553,13 @@ func main() {
 			},
 			log,
 		)
-		reportUC := managerbizreport.NewUsecase(reportRepo, reportGen, uuid.NewString)
+		reportUC := managerbizreport.NewUsecase(reportRepo, reportGen, uuid.NewString).
+			WithReadRepo(reportRepo)
 		managerbizreport.NewScheduler(reportUC, log).Start(rootCtx)
-		log.Info("report: scheduler started")
+		reportHandler = managerserverreport.NewHandler(reportUC)
+		log.Info("report: scheduler + API wired")
 	} else {
-		log.Info("report: scheduler not wired (chat runtime is not the graph kernel)")
+		log.Info("report: not wired (chat runtime is not the graph kernel)")
 	}
 
 	// Boot compensation pass for the structured RCA path: incidents that
@@ -1825,8 +1831,18 @@ func main() {
 			marketplaceHandler.Register(protected)
 			promProxyHandler.RegisterProtected(protected)
 			managerserveraudit.NewHandler(auditUC).Register(protected)
+			if reportHandler != nil {
+				reportHandler.Register(protected)
+			}
 		})
 	})
+
+	// Public (unauthenticated) report share route: /r/{token}. Mounted
+	// on the root mux outside the auth group so a shared report opens
+	// without a login (30-day TTL enforced in the biz layer).
+	if reportHandler != nil {
+		reportHandler.RegisterPublic(mux)
+	}
 
 	apiServer := httpserver.New(cfg.HTTPAddr, mux, log.With(slog.String("listener", "api")))
 

--- a/internal/manager/biz/report/query.go
+++ b/internal/manager/biz/report/query.go
@@ -1,0 +1,189 @@
+package report
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+// ReportFilter scopes a report list query. Zero value = all reports,
+// newest first.
+type ReportFilter struct {
+	Status string // "" = any
+	Kind   string // "" = any
+	Limit  int    // 0 → DefaultListLimit
+	Offset int
+}
+
+// DefaultListLimit caps an unbounded list query.
+const DefaultListLimit = 50
+
+// ShareTTL is how long a share token stays valid.
+const ShareTTL = 30 * 24 * time.Hour
+
+// ReadRepo is the read + delete surface the API needs beyond the core
+// Repo. Implemented by data/report/store.Repo. Split out so the
+// scheduler-only Repo interface (PR-1) stays minimal.
+type ReadRepo interface {
+	ListReports(ctx context.Context, f ReportFilter) ([]*model.Report, error)
+	DeleteReport(ctx context.Context, id string) error
+	ListSchedules(ctx context.Context, ownerID uint64, all bool) ([]*model.ReportSchedule, error)
+	DeleteSchedule(ctx context.Context, id uint64) error
+	GetReportByShareToken(ctx context.Context, token string) (*model.Report, error)
+}
+
+// WithReadRepo attaches the read surface to the Usecase. The scheduler
+// path (PR-1/3) doesn't need it; the API path (PR-4) does. Returns the
+// receiver for chaining.
+func (u *Usecase) WithReadRepo(rr ReadRepo) *Usecase {
+	u.read = rr
+	return u
+}
+
+// ListReports returns reports matching the filter.
+func (u *Usecase) ListReports(ctx context.Context, f ReportFilter) ([]*model.Report, error) {
+	if f.Limit <= 0 || f.Limit > 200 {
+		f.Limit = DefaultListLimit
+	}
+	return u.read.ListReports(ctx, f)
+}
+
+// GetReport returns one report by id.
+func (u *Usecase) GetReport(ctx context.Context, id string) (*model.Report, error) {
+	return u.repo.GetReport(ctx, id)
+}
+
+// DeleteReport removes a report.
+func (u *Usecase) DeleteReport(ctx context.Context, id string) error {
+	return u.read.DeleteReport(ctx, id)
+}
+
+// ListSchedules returns schedules. When all is false only the owner's
+// schedules are returned (used for non-admin callers).
+func (u *Usecase) ListSchedules(ctx context.Context, ownerID uint64, all bool) ([]*model.ReportSchedule, error) {
+	return u.read.ListSchedules(ctx, ownerID, all)
+}
+
+// GetSchedule returns one schedule by id.
+func (u *Usecase) GetSchedule(ctx context.Context, id uint64) (*model.ReportSchedule, error) {
+	return u.repo.GetSchedule(ctx, id)
+}
+
+// UpdateSchedule persists edits, re-validating + re-arming next_fire_at
+// when the cron / timezone changed. `now` anchors the re-arm.
+func (u *Usecase) UpdateSchedule(ctx context.Context, s *model.ReportSchedule, now time.Time) error {
+	if s.CronSpec == "" && s.Kind != model.KindCustom {
+		spec, err := CronSpecForKind(s.Kind)
+		if err != nil {
+			return err
+		}
+		s.CronSpec = spec
+	}
+	loc, err := loadLocation(s.Timezone)
+	if err != nil {
+		return err
+	}
+	next, err := CronNext(s.CronSpec, loc, now)
+	if err != nil {
+		return err
+	}
+	s.NextFireAt = &next
+	return u.repo.UpdateSchedule(ctx, s)
+}
+
+// SetScheduleEnabled toggles a schedule. Disabling clears next_fire_at;
+// enabling re-arms it from now.
+func (u *Usecase) SetScheduleEnabled(ctx context.Context, id uint64, enabled bool, now time.Time) (*model.ReportSchedule, error) {
+	s, err := u.repo.GetSchedule(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	s.Enabled = enabled
+	if !enabled {
+		s.NextFireAt = nil
+	} else {
+		loc, err := loadLocation(s.Timezone)
+		if err != nil {
+			return nil, err
+		}
+		next, err := CronNext(s.CronSpec, loc, now)
+		if err != nil {
+			return nil, err
+		}
+		s.NextFireAt = &next
+	}
+	if err := u.repo.UpdateSchedule(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// DeleteSchedule removes a schedule. Existing reports it produced are
+// kept (their schedule_id dangles, harmless — the artifact stands alone).
+func (u *Usecase) DeleteSchedule(ctx context.Context, id uint64) error {
+	return u.read.DeleteSchedule(ctx, id)
+}
+
+// RunNow generates a report immediately from a schedule's config,
+// without disturbing its next_fire_at. The report is created as a
+// manual (nil schedule_id) artifact so it never collides with the
+// scheduled window's dedup key.
+func (u *Usecase) RunNow(ctx context.Context, scheduleID uint64, now time.Time) (*model.Report, error) {
+	s, err := u.repo.GetSchedule(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+	loc, err := loadLocation(s.Timezone)
+	if err != nil {
+		return nil, err
+	}
+	var prev time.Time
+	if s.LastFireAt != nil {
+		prev = *s.LastFireAt
+	}
+	period, err := PeriodFor(s.Kind, now, loc, prev)
+	if err != nil {
+		return nil, err
+	}
+	return u.GenerateNow(ctx, s.CreatedBy, s.Kind, s.Timezone, s.ScopeJSON, period)
+}
+
+// ShareReport mints (or refreshes) a 30-day share token on a report and
+// returns it. The token grants unauthenticated read at /r/{token}.
+func (u *Usecase) ShareReport(ctx context.Context, id string, now time.Time) (string, error) {
+	rpt, err := u.repo.GetReport(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	token := randomToken()
+	exp := now.Add(ShareTTL)
+	rpt.ShareToken = &token
+	rpt.ShareExpiresAt = &exp
+	if err := u.repo.UpdateReport(ctx, rpt); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// GetSharedReport resolves a report by share token, enforcing the TTL.
+// Used by the public /r/{token} route.
+func (u *Usecase) GetSharedReport(ctx context.Context, token string, now time.Time) (*model.Report, error) {
+	rpt, err := u.read.GetReportByShareToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	if rpt.ShareExpiresAt == nil || now.After(*rpt.ShareExpiresAt) {
+		return nil, errExpiredShare
+	}
+	return rpt, nil
+}
+
+// randomToken returns a 32-char hex token (16 random bytes).
+func randomToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/manager/biz/report/usecase.go
+++ b/internal/manager/biz/report/usecase.go
@@ -58,10 +58,14 @@ func (nopGenerator) Generate(context.Context, string) {}
 
 // Usecase is the report business logic.
 type Usecase struct {
-	repo Repo
-	gen  Generator
+	repo  Repo
+	read  ReadRepo // attached via WithReadRepo for the API path; nil on the scheduler-only path
+	gen   Generator
 	idGen IDGen
 }
+
+// errExpiredShare is returned when a share token has passed its TTL.
+var errExpiredShare = errors.Join(errs.ErrNotFound, errors.New("share link expired"))
 
 // NewUsecase builds the Usecase. A nil Generator falls back to the
 // no-op (report stays pending — useful in PR-1 tests and before PR-2

--- a/internal/manager/data/report/store/read.go
+++ b/internal/manager/data/report/store/read.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	bizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+// Compile-time check that Repo satisfies the API read surface too.
+var _ bizreport.ReadRepo = (*Repo)(nil)
+
+// ListReports returns reports matching the filter, newest first.
+func (r *Repo) ListReports(ctx context.Context, f bizreport.ReportFilter) ([]*model.Report, error) {
+	q := r.db.WithContext(ctx).Model(&model.Report{})
+	if f.Status != "" {
+		q = q.Where("status = ?", f.Status)
+	}
+	if f.Kind != "" {
+		q = q.Where("kind = ?", f.Kind)
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = bizreport.DefaultListLimit
+	}
+	var rows []*model.Report
+	err := q.Order("created_at DESC").Limit(limit).Offset(f.Offset).Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *Repo) DeleteReport(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Where("id = ?", id).Delete(&model.Report{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return errs.ErrNotFound
+	}
+	return nil
+}
+
+// ListSchedules returns schedules. When all is false only ownerID's
+// rows are returned (non-admin scoping).
+func (r *Repo) ListSchedules(ctx context.Context, ownerID uint64, all bool) ([]*model.ReportSchedule, error) {
+	q := r.db.WithContext(ctx).Model(&model.ReportSchedule{})
+	if !all {
+		q = q.Where("created_by = ?", ownerID)
+	}
+	var rows []*model.ReportSchedule
+	if err := q.Order("created_at DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *Repo) DeleteSchedule(ctx context.Context, id uint64) error {
+	res := r.db.WithContext(ctx).Where("id = ?", id).Delete(&model.ReportSchedule{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return errs.ErrNotFound
+	}
+	return nil
+}
+
+// GetReportByShareToken resolves a report by its share token (TTL is
+// enforced in the biz layer).
+func (r *Repo) GetReportByShareToken(ctx context.Context, token string) (*model.Report, error) {
+	var rpt model.Report
+	err := r.db.WithContext(ctx).First(&rpt, "share_token = ?", token).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errs.ErrNotFound
+		}
+		return nil, err
+	}
+	return &rpt, nil
+}

--- a/internal/manager/server/report/dto.go
+++ b/internal/manager/server/report/dto.go
@@ -1,0 +1,250 @@
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+// reportListItem is the compact shape for the list view.
+type reportListItem struct {
+	ID          string     `json:"id"`
+	Title       string     `json:"title"`
+	Kind        string     `json:"kind"`
+	Status      string     `json:"status"`
+	Summary     string     `json:"summary"`
+	PeriodStart time.Time  `json:"period_start"`
+	PeriodEnd   time.Time  `json:"period_end"`
+	GeneratedAt *time.Time `json:"generated_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// reportDetail is the full shape for the detail view. ContentJSON is
+// emitted as raw JSON so the SPA renders the structured cards directly.
+type reportDetail struct {
+	reportListItem
+	Content    json.RawMessage `json:"content"`
+	ContentMD  string          `json:"content_md"`
+	Timezone   string          `json:"timezone"`
+	ScheduleID *uint64         `json:"schedule_id,omitempty"`
+	ErrorMsg   string          `json:"error_msg,omitempty"`
+	ShareToken *string         `json:"share_token,omitempty"`
+	Delivery   json.RawMessage `json:"delivery,omitempty"`
+}
+
+func toReportListItem(r *model.Report) reportListItem {
+	return reportListItem{
+		ID:          r.ID,
+		Title:       r.Title,
+		Kind:        r.Kind,
+		Status:      r.Status,
+		Summary:     r.SummaryText,
+		PeriodStart: r.PeriodStart,
+		PeriodEnd:   r.PeriodEnd,
+		GeneratedAt: r.GeneratedAt,
+		CreatedAt:   r.CreatedAt,
+	}
+}
+
+func toReportList(rows []*model.Report) []reportListItem {
+	out := make([]reportListItem, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, toReportListItem(r))
+	}
+	return out
+}
+
+func toReportDetail(r *model.Report) reportDetail {
+	d := reportDetail{
+		reportListItem: toReportListItem(r),
+		ContentMD:      r.ContentMD,
+		Timezone:       r.Timezone,
+		ScheduleID:     r.ScheduleID,
+		ErrorMsg:       r.ErrorMsg,
+		ShareToken:     r.ShareToken,
+	}
+	if r.ContentJSON != "" {
+		d.Content = json.RawMessage(r.ContentJSON)
+	}
+	if r.DeliveryJSON != "" {
+		d.Delivery = json.RawMessage(r.DeliveryJSON)
+	}
+	return d
+}
+
+// scheduleView is the schedule shape returned to the SPA. ChannelIDs is
+// decoded from the stored JSON for convenience.
+type scheduleView struct {
+	ID             uint64     `json:"id"`
+	Name           string     `json:"name"`
+	Description    string     `json:"description"`
+	Kind           string     `json:"kind"`
+	CronSpec       string     `json:"cron_spec"`
+	Timezone       string     `json:"timezone"`
+	ScopeJSON      string     `json:"scope_json"`
+	ChannelIDs     []uint64   `json:"channel_ids"`
+	InAppVisible   bool       `json:"in_app_visible"`
+	AgentPersona   string     `json:"agent_persona"`
+	PromptOverride string     `json:"prompt_override,omitempty"`
+	Enabled        bool       `json:"enabled"`
+	NextFireAt     *time.Time `json:"next_fire_at,omitempty"`
+	LastFireAt     *time.Time `json:"last_fire_at,omitempty"`
+	LastReportID   *string    `json:"last_report_id,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+}
+
+func toScheduleView(s *model.ReportSchedule) scheduleView {
+	v := scheduleView{
+		ID:           s.ID,
+		Name:         s.Name,
+		Description:  s.Description,
+		Kind:         s.Kind,
+		CronSpec:     s.CronSpec,
+		Timezone:     s.Timezone,
+		ScopeJSON:    s.ScopeJSON,
+		ChannelIDs:   decodeChannelIDs(s.ChannelIDsJSON),
+		InAppVisible: s.InAppVisible,
+		AgentPersona: s.AgentPersona,
+		Enabled:      s.Enabled,
+		NextFireAt:   s.NextFireAt,
+		LastFireAt:   s.LastFireAt,
+		LastReportID: s.LastReportID,
+		CreatedAt:    s.CreatedAt,
+	}
+	if s.PromptOverride != nil {
+		v.PromptOverride = *s.PromptOverride
+	}
+	return v
+}
+
+func toScheduleList(rows []*model.ReportSchedule) []scheduleView {
+	out := make([]scheduleView, 0, len(rows))
+	for _, s := range rows {
+		out = append(out, toScheduleView(s))
+	}
+	return out
+}
+
+// toModel builds a fresh ReportSchedule from a create request.
+func (req scheduleReq) toModel(ownerID uint64) *model.ReportSchedule {
+	s := &model.ReportSchedule{
+		CreatedBy:      ownerID,
+		Name:           req.Name,
+		Description:    req.Description,
+		Kind:           req.Kind,
+		CronSpec:       req.CronSpec,
+		Timezone:       firstNonEmpty(req.Timezone, "UTC"),
+		ScopeJSON:      firstNonEmpty(req.ScopeJSON, "{}"),
+		ChannelIDsJSON: encodeChannelIDs(req.ChannelIDs),
+		Enabled:        true,
+		InAppVisible:   true,
+	}
+	if req.InAppVisible != nil {
+		s.InAppVisible = *req.InAppVisible
+	}
+	if req.PromptOverride != "" {
+		po := req.PromptOverride
+		s.PromptOverride = &po
+	}
+	return s
+}
+
+// applyTo mutates an existing schedule with the request's fields.
+func (req scheduleReq) applyTo(s *model.ReportSchedule) {
+	if req.Name != "" {
+		s.Name = req.Name
+	}
+	s.Description = req.Description
+	if req.Kind != "" {
+		s.Kind = req.Kind
+	}
+	s.CronSpec = req.CronSpec // may be cleared to re-derive from kind
+	if req.Timezone != "" {
+		s.Timezone = req.Timezone
+	}
+	if req.ScopeJSON != "" {
+		s.ScopeJSON = req.ScopeJSON
+	}
+	s.ChannelIDsJSON = encodeChannelIDs(req.ChannelIDs)
+	if req.InAppVisible != nil {
+		s.InAppVisible = *req.InAppVisible
+	}
+	if req.PromptOverride != "" {
+		po := req.PromptOverride
+		s.PromptOverride = &po
+	} else {
+		s.PromptOverride = nil
+	}
+}
+
+func decodeChannelIDs(raw string) []uint64 {
+	if raw == "" {
+		return []uint64{}
+	}
+	var ids []uint64
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return []uint64{}
+	}
+	return ids
+}
+
+func encodeChannelIDs(ids []uint64) string {
+	if len(ids) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(ids)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// --- response helpers (mirror device/http.go) ---
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if body == nil {
+		return
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+type errorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(errs.HTTPStatus(err))
+	_ = json.NewEncoder(w).Encode(errorBody{Error: err.Error(), Code: errCode(err)})
+}
+
+func errCode(err error) string {
+	switch {
+	case errors.Is(err, errs.ErrNotFound):
+		return "not-found"
+	case errors.Is(err, errs.ErrUnauthorized):
+		return "unauthorized"
+	case errors.Is(err, errs.ErrForbidden):
+		return "forbidden"
+	case errors.Is(err, errs.ErrInvalid):
+		return "invalid"
+	default:
+		return "internal"
+	}
+}

--- a/internal/manager/server/report/http.go
+++ b/internal/manager/server/report/http.go
@@ -1,0 +1,364 @@
+// Package report is the HTTP surface for scheduled reports (HLD-014).
+// Mirrors the device handler's lean pattern — the chi-mounted Handler
+// talks straight to the biz Usecase, pulls the caller from tenantctx,
+// and gates writes on role via requireWriter. RBAC (ADR-022):
+// admin/user may CRUD schedules + trigger generation; viewer is
+// read-only. The public /r/{token} share route mounts separately
+// without auth.
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	bizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+const roleViewer = "viewer"
+
+// Handler serves the report API. uc is required; a nil uc makes every
+// route 503 (binary built without the report stack wired).
+type Handler struct {
+	uc  *bizreport.Usecase
+	now func() time.Time // injectable clock for tests
+}
+
+func NewHandler(uc *bizreport.Usecase) *Handler {
+	return &Handler{uc: uc, now: func() time.Time { return time.Now().UTC() }}
+}
+
+// Register mounts the authenticated routes.
+//
+//	GET    /v1/reports                       list
+//	POST   /v1/reports                       manual generate            (writer)
+//	GET    /v1/reports/{id}                  detail
+//	DELETE /v1/reports/{id}                  delete                     (writer)
+//	POST   /v1/reports/{id}/share            mint share token           (writer)
+//	GET    /v1/report-schedules              list
+//	POST   /v1/report-schedules              create                     (writer)
+//	GET    /v1/report-schedules/{id}         detail
+//	PUT    /v1/report-schedules/{id}         update                     (writer)
+//	DELETE /v1/report-schedules/{id}         delete                     (writer)
+//	POST   /v1/report-schedules/{id}/toggle  enable/disable             (writer)
+//	POST   /v1/report-schedules/{id}/run-now generate immediately       (writer)
+func (h *Handler) Register(r chi.Router) {
+	r.Get("/v1/reports", h.listReports)
+	r.With(h.requireWriter).Post("/v1/reports", h.generateNow)
+	r.Get("/v1/reports/{id}", h.getReport)
+	r.With(h.requireWriter).Delete("/v1/reports/{id}", h.deleteReport)
+	r.With(h.requireWriter).Post("/v1/reports/{id}/share", h.shareReport)
+
+	r.Get("/v1/report-schedules", h.listSchedules)
+	r.With(h.requireWriter).Post("/v1/report-schedules", h.createSchedule)
+	r.Get("/v1/report-schedules/{id}", h.getSchedule)
+	r.With(h.requireWriter).Put("/v1/report-schedules/{id}", h.updateSchedule)
+	r.With(h.requireWriter).Delete("/v1/report-schedules/{id}", h.deleteSchedule)
+	r.With(h.requireWriter).Post("/v1/report-schedules/{id}/toggle", h.toggleSchedule)
+	r.With(h.requireWriter).Post("/v1/report-schedules/{id}/run-now", h.runNow)
+}
+
+// RegisterPublic mounts the unauthenticated share route.
+//
+//	GET /r/{token}  shared report (read-only, 30d TTL)
+func (h *Handler) RegisterPublic(r chi.Router) {
+	r.Get("/r/{token}", h.sharedReport)
+}
+
+// requireWriter rejects viewer-role callers (ADR-022 read-only tier).
+func (h *Handler) requireWriter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t, ok := tenantctx.From(r.Context())
+		if !ok {
+			writeErr(w, errs.ErrUnauthorized)
+			return
+		}
+		if t.Role == roleViewer {
+			writeErr(w, errs.ErrForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// --- reports ---
+
+func (h *Handler) listReports(w http.ResponseWriter, r *http.Request) {
+	if !h.authed(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	f := bizreport.ReportFilter{
+		Status: q.Get("status"),
+		Kind:   q.Get("kind"),
+		Limit:  atoiDefault(q.Get("limit"), 50),
+		Offset: atoiDefault(q.Get("offset"), 0),
+	}
+	rows, err := h.uc.ListReports(r.Context(), f)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"reports": toReportList(rows)})
+}
+
+func (h *Handler) getReport(w http.ResponseWriter, r *http.Request) {
+	if !h.authed(w, r) {
+		return
+	}
+	rpt, err := h.uc.GetReport(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toReportDetail(rpt))
+}
+
+func (h *Handler) deleteReport(w http.ResponseWriter, r *http.Request) {
+	if err := h.uc.DeleteReport(r.Context(), chi.URLParam(r, "id")); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+type generateNowReq struct {
+	Kind      string `json:"kind"`
+	Timezone  string `json:"timezone"`
+	ScopeJSON string `json:"scope_json"`
+}
+
+func (h *Handler) generateNow(w http.ResponseWriter, r *http.Request) {
+	t, ok := tenantctx.From(r.Context())
+	if !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return
+	}
+	var req generateNowReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	if req.Kind == "" {
+		req.Kind = model.KindWeekly
+	}
+	if req.Timezone == "" {
+		req.Timezone = "UTC"
+	}
+	loc, err := time.LoadLocation(req.Timezone)
+	if err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	period, err := bizreport.PeriodFor(req.Kind, h.now(), loc, time.Time{})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	scope := req.ScopeJSON
+	if scope == "" {
+		scope = "{}"
+	}
+	rpt, err := h.uc.GenerateNow(r.Context(), t.UserID, req.Kind, req.Timezone, scope, period)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, toReportDetail(rpt))
+}
+
+func (h *Handler) shareReport(w http.ResponseWriter, r *http.Request) {
+	token, err := h.uc.ShareReport(r.Context(), chi.URLParam(r, "id"), h.now())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"share_token": token, "path": "/r/" + token})
+}
+
+func (h *Handler) sharedReport(w http.ResponseWriter, r *http.Request) {
+	rpt, err := h.uc.GetSharedReport(r.Context(), chi.URLParam(r, "token"), h.now())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toReportDetail(rpt))
+}
+
+// --- schedules ---
+
+func (h *Handler) listSchedules(w http.ResponseWriter, r *http.Request) {
+	t, ok := tenantctx.From(r.Context())
+	if !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return
+	}
+	rows, err := h.uc.ListSchedules(r.Context(), t.UserID, t.Role != roleViewer)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schedules": toScheduleList(rows)})
+}
+
+func (h *Handler) getSchedule(w http.ResponseWriter, r *http.Request) {
+	if !h.authed(w, r) {
+		return
+	}
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	s, err := h.uc.GetSchedule(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toScheduleView(s))
+}
+
+type scheduleReq struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Kind           string   `json:"kind"`
+	CronSpec       string   `json:"cron_spec"`
+	Timezone       string   `json:"timezone"`
+	ScopeJSON      string   `json:"scope_json"`
+	ChannelIDs     []uint64 `json:"channel_ids"`
+	InAppVisible   *bool    `json:"in_app_visible"`
+	PromptOverride string   `json:"prompt_override"`
+}
+
+func (h *Handler) createSchedule(w http.ResponseWriter, r *http.Request) {
+	t, ok := tenantctx.From(r.Context())
+	if !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return
+	}
+	var req scheduleReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	s := req.toModel(t.UserID)
+	if err := h.uc.CreateSchedule(r.Context(), s, h.now()); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toScheduleView(s))
+}
+
+func (h *Handler) updateSchedule(w http.ResponseWriter, r *http.Request) {
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	existing, err := h.uc.GetSchedule(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	var req scheduleReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	req.applyTo(existing)
+	if err := h.uc.UpdateSchedule(r.Context(), existing, h.now()); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toScheduleView(existing))
+}
+
+func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request) {
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if err := h.uc.DeleteSchedule(r.Context(), id); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+type toggleReq struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *Handler) toggleSchedule(w http.ResponseWriter, r *http.Request) {
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	var req toggleReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	s, err := h.uc.SetScheduleEnabled(r.Context(), id, req.Enabled, h.now())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toScheduleView(s))
+}
+
+func (h *Handler) runNow(w http.ResponseWriter, r *http.Request) {
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	rpt, err := h.uc.RunNow(r.Context(), id, h.now())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, toReportDetail(rpt))
+}
+
+// --- helpers ---
+
+func (h *Handler) authed(w http.ResponseWriter, r *http.Request) bool {
+	if _, ok := tenantctx.From(r.Context()); !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return false
+	}
+	return true
+}
+
+func pathID(r *http.Request) (uint64, error) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		return 0, errors.Join(errs.ErrInvalid, err)
+	}
+	return id, nil
+}
+
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+// compile-time guard keeps context import lint-clean across edits.
+var _ = context.Background

--- a/internal/manager/server/report/http_test.go
+++ b/internal/manager/server/report/http_test.go
@@ -1,0 +1,166 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/go-chi/chi/v5"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	bizreport "github.com/ongridio/ongrid/internal/manager/biz/report"
+	reportstore "github.com/ongridio/ongrid/internal/manager/data/report/store"
+	reportmodel "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+func newTestHandler(t *testing.T) (*Handler, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := reportstore.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	repo := reportstore.NewRepo(db)
+	uc := bizreport.NewUsecase(repo, nil, func() string { return "rpt-" + time.Now().Format("150405.000000000") }).
+		WithReadRepo(repo)
+	return NewHandler(uc), db
+}
+
+func req(method, path, body, role string) *http.Request {
+	r := httptest.NewRequest(method, path, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	ctx := tenantctx.With(r.Context(), tenantctx.Tenant{UserID: 42, Role: role})
+	return r.WithContext(ctx)
+}
+
+func serve(h *Handler, r *http.Request) *httptest.ResponseRecorder {
+	router := chi.NewRouter()
+	h.Register(router)
+	h.RegisterPublic(router)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	return w
+}
+
+func TestCreateSchedule_AsUser(t *testing.T) {
+	h, _ := newTestHandler(t)
+	body := `{"name":"Weekly Ops","kind":"weekly","timezone":"Asia/Shanghai"}`
+	w := serve(h, req("POST", "/v1/report-schedules", body, "user"))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var got scheduleView
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CronSpec != "0 9 * * 1" {
+		t.Errorf("cron spec = %q, want weekly default", got.CronSpec)
+	}
+	if got.NextFireAt == nil {
+		t.Error("next_fire_at not armed")
+	}
+	if !got.Enabled {
+		t.Error("schedule should be enabled by default")
+	}
+}
+
+func TestCreateSchedule_ViewerForbidden(t *testing.T) {
+	h, _ := newTestHandler(t)
+	w := serve(h, req("POST", "/v1/report-schedules", `{"kind":"weekly"}`, "viewer"))
+	if w.Code != http.StatusForbidden {
+		t.Errorf("viewer create status = %d, want 403", w.Code)
+	}
+}
+
+func TestListSchedules_ViewerReadOnly(t *testing.T) {
+	h, db := newTestHandler(t)
+	// Seed a schedule directly through the usecase.
+	repo := reportstore.NewRepo(db)
+	uc := bizreport.NewUsecase(repo, nil, func() string { return "x" }).WithReadRepo(repo)
+	s := &reportmodel.ReportSchedule{CreatedBy: 42, Name: "seed", Kind: reportmodel.KindWeekly, Timezone: "UTC"}
+	if err := uc.CreateSchedule(context.Background(), s, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	w := serve(h, req("GET", "/v1/report-schedules", "", "viewer"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("viewer list status = %d", w.Code)
+	}
+	var resp struct {
+		Schedules []scheduleView `json:"schedules"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Schedules) != 1 {
+		t.Errorf("viewer should see schedules, got %d", len(resp.Schedules))
+	}
+}
+
+func TestGenerateNow_ViewerForbidden(t *testing.T) {
+	h, _ := newTestHandler(t)
+	w := serve(h, req("POST", "/v1/reports", `{"kind":"weekly"}`, "viewer"))
+	if w.Code != http.StatusForbidden {
+		t.Errorf("viewer generate status = %d, want 403", w.Code)
+	}
+}
+
+func TestGenerateNow_AsUser_Accepted(t *testing.T) {
+	h, _ := newTestHandler(t)
+	w := serve(h, req("POST", "/v1/reports", `{"kind":"weekly","timezone":"UTC"}`, "user"))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("generate status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var d reportDetail
+	_ = json.Unmarshal(w.Body.Bytes(), &d)
+	if d.Status != "pending" {
+		t.Errorf("manual report status = %q, want pending", d.Status)
+	}
+}
+
+func TestShareAndPublicRead(t *testing.T) {
+	h, _ := newTestHandler(t)
+	// Create a manual report.
+	w := serve(h, req("POST", "/v1/reports", `{"kind":"weekly"}`, "user"))
+	var d reportDetail
+	_ = json.Unmarshal(w.Body.Bytes(), &d)
+
+	// Share it.
+	w = serve(h, req("POST", "/v1/reports/"+d.ID+"/share", "", "user"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("share status = %d", w.Code)
+	}
+	var sh struct {
+		Token string `json:"share_token"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &sh)
+	if sh.Token == "" {
+		t.Fatal("no share token returned")
+	}
+
+	// Public read with NO auth context.
+	pub := httptest.NewRequest("GET", "/r/"+sh.Token, nil)
+	w = serve(h, pub)
+	if w.Code != http.StatusOK {
+		t.Errorf("public share read status = %d, want 200", w.Code)
+	}
+}
+
+func TestUnauthenticated401(t *testing.T) {
+	h, _ := newTestHandler(t)
+	r := httptest.NewRequest("GET", "/v1/reports", nil) // no tenant ctx
+	w := serve(h, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated status = %d, want 401", w.Code)
+	}
+}
+


### PR DESCRIPTION
Fifth slice of **HLD-014**. Stacked on PR-3 (#59). The operator-facing API — backend now closes the loop end-to-end.

## What lands
- **`biz/report/query.go`**: `ReadRepo` seam + Usecase read/CRUD (ListReports, GetReport, DeleteReport, ListSchedules, UpdateSchedule w/ cron re-arm, SetScheduleEnabled, DeleteSchedule, RunNow, share mint + TTL-checked resolve).
- **`data/report/store/read.go`**: list/delete + share-token lookup.
- **`server/report`**: lean chi handler (mirrors `device/http.go`) → Usecase directly. RBAC per ADR-022 — admin/user CRUD via `requireWriter`, viewer read-only. Public `/r/{token}` share route mounts without auth (30d TTL in biz). DTOs emit ContentJSON as raw JSON for the SPA.
- **`main.go`**: construct + mount on protected group + public share on root mux. nil-guarded.

## API
```
GET/POST/DELETE /v1/reports[/{id}]   /v1/reports/{id}/share
GET/POST/PUT/DELETE /v1/report-schedules[/{id}]  .../toggle  .../run-now
GET /r/{token}  (public)
```

## Tests
create-as-user arms cron+next_fire, viewer 403 on writes / 200 on lists, generate-now → pending, share → public read no-auth, unauthenticated 401. build + vet green.

## Next
PR-5: frontend report list + detail page (existing page patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)