### PR TITLE
feat(report): PR-5/6 — frontend list + detail + schedule mgmt + sidebar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,9 @@ const TracesPage = lazy(() => import('@/pages/Traces'));
 const AlertsPage = lazy(() => import('@/pages/Alerts'));
 const AlertRulesPage = lazy(() => import('@/pages/AlertRules'));
 const IncidentDetailPage = lazy(() => import('@/pages/IncidentDetail'));
+const ReportsPage = lazy(() => import('@/pages/Reports'));
+const ReportDetailPage = lazy(() => import('@/pages/ReportDetail'));
+const ReportSchedulesPage = lazy(() => import('@/pages/ReportSchedules'));
 const SkillsPage = lazy(() => import('@/pages/Skills'));
 const SkillRunPage = lazy(() => import('@/pages/SkillRun'));
 const AgentsPage = lazy(() => import('@/pages/Agents'));
@@ -96,6 +99,9 @@ export default function App() {
         <Route path="/alerts" element={<AlertsPage />} />
         <Route path="/alerts/rules" element={<AlertRulesPage />} />
         <Route path="/alerts/incidents/:id" element={<IncidentDetailPage />} />
+        <Route path="/reports" element={<ReportsPage />} />
+        <Route path="/reports/schedules" element={<ReportSchedulesPage />} />
+        <Route path="/reports/:id" element={<ReportDetailPage />} />
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/skills/:key" element={<SkillRunPage />} />
         <Route path="/agents" element={<AgentsPage />} />

--- a/web/src/api/reports.ts
+++ b/web/src/api/reports.ts
@@ -1,0 +1,173 @@
+import { request } from './client';
+
+// Reports API (HLD-014). Scheduled operational reports — list + detail
+// + manual generate + schedule CRUD. Backend routes under /v1/reports
+// and /v1/report-schedules.
+
+export type ReportStatus = 'pending' | 'generating' | 'ready' | 'failed';
+export type ReportKind = 'daily' | 'weekly' | 'monthly' | 'custom';
+
+export type ReportListItem = {
+  id: string;
+  title: string;
+  kind: ReportKind;
+  status: ReportStatus;
+  summary: string;
+  period_start: string;
+  period_end: string;
+  generated_at?: string;
+  created_at: string;
+};
+
+// --- ContentJSON shapes (mirror biz/report/content.go) ---
+
+export type HeroStat = {
+  key: string;
+  label: string;
+  value: number;
+  unit?: string;
+  delta_pct?: number;
+  sparkline?: number[];
+};
+
+export type EntityRef = { key: string; name: string };
+
+export type Paragraph = { text: string; entities?: EntityRef[] };
+
+export type Narrative = { headline: string; paragraphs?: Paragraph[] };
+
+export type KeyIncident = {
+  id: number;
+  title: string;
+  severity: string;
+  duration_min: number;
+  status: string;
+  root_cause_snippet?: string;
+};
+
+export type ToolCount = { tool: string; count: number };
+
+export type ActionsSummary = {
+  mutating_total: number;
+  mutating_approved: number;
+  safe_total: number;
+  by_tool?: ToolCount[];
+};
+
+export type Advice = { text: string };
+
+export type ReportContent = {
+  version: string;
+  hero: HeroStat[];
+  narrative: Narrative;
+  key_incidents?: KeyIncident[];
+  actions_summary: ActionsSummary;
+  advice?: Advice[];
+};
+
+export type DeliveryResult = {
+  channel_id: number;
+  channel_type?: string;
+  status: string;
+  sent_at?: string;
+  error?: string;
+  fallback_used?: boolean;
+};
+
+export type ReportDetail = ReportListItem & {
+  content?: ReportContent;
+  content_md: string;
+  timezone: string;
+  schedule_id?: number;
+  error_msg?: string;
+  share_token?: string;
+  delivery?: DeliveryResult[];
+};
+
+export type ReportSchedule = {
+  id: number;
+  name: string;
+  description: string;
+  kind: ReportKind;
+  cron_spec: string;
+  timezone: string;
+  scope_json: string;
+  channel_ids: number[];
+  in_app_visible: boolean;
+  agent_persona: string;
+  prompt_override?: string;
+  enabled: boolean;
+  next_fire_at?: string;
+  last_fire_at?: string;
+  last_report_id?: string;
+  created_at: string;
+};
+
+export type ScheduleInput = {
+  name: string;
+  description?: string;
+  kind: ReportKind;
+  cron_spec?: string;
+  timezone?: string;
+  scope_json?: string;
+  channel_ids?: number[];
+  in_app_visible?: boolean;
+  prompt_override?: string;
+};
+
+// --- reports ---
+
+export function listReports(params?: { status?: string; kind?: string; limit?: number }) {
+  const q = new URLSearchParams();
+  if (params?.status) q.set('status', params.status);
+  if (params?.kind) q.set('kind', params.kind);
+  if (params?.limit) q.set('limit', String(params.limit));
+  const qs = q.toString();
+  return request<{ reports: ReportListItem[] }>('GET', `/reports${qs ? `?${qs}` : ''}`);
+}
+
+export function getReport(id: string) {
+  return request<ReportDetail>('GET', `/reports/${id}`);
+}
+
+export function deleteReport(id: string) {
+  return request<void>('DELETE', `/reports/${id}`);
+}
+
+export function generateNow(body: { kind?: ReportKind; timezone?: string; scope_json?: string }) {
+  return request<ReportDetail>('POST', '/reports', body);
+}
+
+export function shareReport(id: string) {
+  return request<{ share_token: string; path: string }>('POST', `/reports/${id}/share`, {});
+}
+
+// --- schedules ---
+
+export function listSchedules() {
+  return request<{ schedules: ReportSchedule[] }>('GET', '/report-schedules');
+}
+
+export function getSchedule(id: number) {
+  return request<ReportSchedule>('GET', `/report-schedules/${id}`);
+}
+
+export function createSchedule(body: ScheduleInput) {
+  return request<ReportSchedule>('POST', '/report-schedules', body);
+}
+
+export function updateSchedule(id: number, body: ScheduleInput) {
+  return request<ReportSchedule>('PUT', `/report-schedules/${id}`, body);
+}
+
+export function deleteSchedule(id: number) {
+  return request<void>('DELETE', `/report-schedules/${id}`);
+}
+
+export function toggleSchedule(id: number, enabled: boolean) {
+  return request<ReportSchedule>('POST', `/report-schedules/${id}/toggle`, { enabled });
+}
+
+export function runScheduleNow(id: number) {
+  return request<ReportDetail>('POST', `/report-schedules/${id}/run-now`, {});
+}

--- a/web/src/components/ReportContent.tsx
+++ b/web/src/components/ReportContent.tsx
@@ -1,0 +1,254 @@
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/cn';
+import { useI18n } from '@/i18n/locale';
+import type {
+  ActionsSummary,
+  HeroStat,
+  KeyIncident,
+  Paragraph,
+  ReportContent as ReportContentT,
+} from '@/api/reports';
+
+// ReportContent renders a ContentJSON report body — the rich in-app
+// view (HLD-014 §前端渲染). Zero chart deps: count-up via rAF, sparkline
+// as inline SVG, entity chips via token parsing.
+
+// --- count-up hook (rAF, no deps) ---
+function useCountUp(target: number, durationMs = 800): number {
+  const [val, setVal] = useState(0);
+  const startRef = useRef<number | null>(null);
+  useEffect(() => {
+    startRef.current = null;
+    let raf = 0;
+    const step = (ts: number) => {
+      if (startRef.current === null) startRef.current = ts;
+      const p = Math.min(1, (ts - startRef.current) / durationMs);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - p, 3);
+      setVal(target * eased);
+      if (p < 1) raf = requestAnimationFrame(step);
+      else setVal(target);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [target, durationMs]);
+  return val;
+}
+
+function fmtNum(v: number): string {
+  return Number.isInteger(v) ? String(v) : v.toFixed(1);
+}
+
+// --- inline SVG sparkline ---
+function Sparkline({ points, className }: { points: number[]; className?: string }) {
+  if (!points || points.length < 2) return null;
+  const w = 60;
+  const h = 16;
+  const max = Math.max(...points, 1);
+  const min = Math.min(...points, 0);
+  const span = max - min || 1;
+  const step = w / (points.length - 1);
+  const d = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${(i * step).toFixed(1)},${(h - ((p - min) / span) * h).toFixed(1)}`)
+    .join(' ');
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} className={className} aria-hidden="true">
+      <path d={d} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function HeroCard({ stat }: { stat: HeroStat }) {
+  const animated = useCountUp(stat.value);
+  const delta = stat.delta_pct;
+  // Lower-is-better metrics (incidents/mttr) get green on a drop; we keep
+  // it simple — down = green, up = red. Neutral when ~0.
+  const deltaColor =
+    delta === undefined ? '' : delta < 0 ? 'text-emerald-400' : delta > 0 ? 'text-red-400' : 'text-zinc-500';
+  const arrow = delta === undefined ? '' : delta < 0 ? '↓' : delta > 0 ? '↑' : '→';
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+      <div className="flex items-baseline gap-1">
+        <span className="text-2xl font-semibold tabular-nums text-zinc-100">{fmtNum(animated)}</span>
+        {stat.unit && <span className="text-xs text-zinc-500">{stat.unit}</span>}
+      </div>
+      <div className="mt-0.5 text-[11px] uppercase tracking-wide text-zinc-500">{stat.label}</div>
+      <div className="mt-1.5 flex items-center justify-between">
+        {stat.sparkline && stat.sparkline.length >= 2 ? (
+          <Sparkline points={stat.sparkline} className="text-indigo-400" />
+        ) : (
+          <span />
+        )}
+        {delta !== undefined && (
+          <span className={cn('text-[11px] font-medium tabular-nums', deltaColor)}>
+            {arrow}
+            {Math.abs(delta).toFixed(0)}%
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// EntityText parses {{entity:kind:id|name}} tokens into clickable chips.
+const ENTITY_RE = /\{\{entity:([a-z]+):(\d+)\|([^}]*)\}\}/g;
+
+function entityHref(kind: string, id: string): string | null {
+  switch (kind) {
+    case 'edge':
+      return `/devices/${id}`;
+    case 'incident':
+      return `/alerts/incidents/${id}`;
+    default:
+      return null;
+  }
+}
+
+function EntityText({ text }: { text: string }) {
+  const parts: React.ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  ENTITY_RE.lastIndex = 0;
+  let i = 0;
+  while ((m = ENTITY_RE.exec(text)) !== null) {
+    if (m.index > last) parts.push(<Fragment key={`t${i}`}>{text.slice(last, m.index)}</Fragment>);
+    const [, kind, id, name] = m;
+    const href = entityHref(kind, id);
+    parts.push(
+      href ? (
+        <Link
+          key={`e${i}`}
+          to={href}
+          className="mx-0.5 inline-flex items-center rounded border border-indigo-500/40 bg-indigo-500/10 px-1 py-0.5 text-[12px] text-indigo-300 hover:bg-indigo-500/20"
+        >
+          {name}
+        </Link>
+      ) : (
+        <span key={`e${i}`} className="mx-0.5 rounded bg-zinc-800 px-1 text-[12px] text-zinc-300">
+          {name}
+        </span>
+      ),
+    );
+    last = m.index + m[0].length;
+    i++;
+  }
+  if (last < text.length) parts.push(<Fragment key="tail">{text.slice(last)}</Fragment>);
+  return <>{parts}</>;
+}
+
+const SEV_DOT: Record<string, string> = {
+  critical: 'bg-red-500',
+  warning: 'bg-amber-500',
+  info: 'bg-sky-500',
+};
+
+function IncidentRow({ ki }: { ki: KeyIncident }) {
+  return (
+    <Link
+      to={`/alerts/incidents/${ki.id}`}
+      className="flex items-center gap-2 rounded-md border border-zinc-800 bg-zinc-900/40 px-3 py-2 text-sm hover:border-zinc-700"
+    >
+      <span className={cn('h-2 w-2 shrink-0 rounded-full', SEV_DOT[ki.severity] ?? 'bg-zinc-600')} />
+      <span className="text-zinc-400">I-{ki.id}</span>
+      <span className="flex-1 truncate text-zinc-200">{ki.title}</span>
+      {ki.root_cause_snippet && (
+        <span className="hidden truncate text-xs text-zinc-500 md:inline">{ki.root_cause_snippet}</span>
+      )}
+      <span className="shrink-0 text-xs text-zinc-500">
+        {ki.duration_min}m · {ki.status}
+      </span>
+    </Link>
+  );
+}
+
+function ActionsPanel({ a }: { a: ActionsSummary }) {
+  const { tr } = useI18n();
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3 text-sm text-zinc-300">
+      <div>
+        {tr('变更动作', 'Mutating')}: <span className="font-medium text-zinc-100">{a.mutating_total}</span>
+        {a.mutating_total > 0 && (
+          <span className="text-zinc-500">
+            {' '}
+            ({tr('已批准', 'approved')} {a.mutating_approved})
+          </span>
+        )}
+        {' · '}
+        {tr('只读诊断', 'Read-only')}: <span className="font-medium text-zinc-100">{a.safe_total}</span>
+      </div>
+      {a.by_tool && a.by_tool.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {a.by_tool.map((t) => (
+            <span key={t.tool} className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-400">
+              {t.tool} ×{t.count}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ReportContentView({ content }: { content: ReportContentT }) {
+  const { tr } = useI18n();
+  const paras: Paragraph[] = content.narrative?.paragraphs ?? [];
+  return (
+    <div className="space-y-6">
+      {content.hero && content.hero.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {content.hero.map((h) => (
+            <HeroCard key={h.key} stat={h} />
+          ))}
+        </div>
+      )}
+
+      {content.narrative?.headline && (
+        <section>
+          <h2 className="mb-2 text-base font-semibold text-zinc-100">📝 {content.narrative.headline}</h2>
+          <div className="space-y-2 text-sm leading-relaxed text-zinc-300">
+            {paras.map((p, i) => (
+              <p key={i}>
+                <EntityText text={p.text} />
+              </p>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {content.key_incidents && content.key_incidents.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-zinc-400">🚨 {tr('关键 incidents', 'Key incidents')}</h3>
+          <div className="space-y-1.5">
+            {content.key_incidents.map((ki) => (
+              <IncidentRow key={ki.id} ki={ki} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {content.actions_summary && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-zinc-400">⚡ {tr('Agent 执行动作', 'Agent actions')}</h3>
+          <ActionsPanel a={content.actions_summary} />
+        </section>
+      )}
+
+      {content.advice && content.advice.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-zinc-400">🎯 {tr('下一步建议', 'Recommendations')}</h3>
+          <ul className="space-y-1.5 text-sm text-zinc-300">
+            {content.advice.map((a, i) => (
+              <li key={i} className="flex gap-2">
+                <span className="text-indigo-400">•</span>
+                <span>
+                  <EntityText text={a.text} />
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ReportContent.tsx
+++ b/web/src/components/ReportContent.tsx
@@ -193,8 +193,32 @@ function ActionsPanel({ a }: { a: ActionsSummary }) {
 export function ReportContentView({ content }: { content: ReportContentT }) {
   const { tr } = useI18n();
   const paras: Paragraph[] = content.narrative?.paragraphs ?? [];
+  const incidents = content.key_incidents ?? [];
+  const advice = content.advice ?? [];
+  const incidentCount = heroValue(content.hero, 'incidents');
+  // A calm report = no incidents this period. Drives the top banner.
+  const calm = incidents.length === 0 && incidentCount === 0;
+
   return (
     <div className="space-y-6">
+      {/* Status banner — makes a calm report read as intentional. */}
+      <div
+        className={cn(
+          'flex items-center gap-2.5 rounded-lg border px-4 py-2.5 text-sm',
+          calm
+            ? 'border-emerald-600/30 bg-emerald-500/10 text-emerald-200'
+            : 'border-amber-600/30 bg-amber-500/10 text-amber-100',
+        )}
+      >
+        <span className="text-base">{calm ? '✓' : '⚠'}</span>
+        <span>
+          {calm
+            ? tr('本周期运行平稳，未发生 incident', 'Smooth period — no incidents')
+            : tr(`本周期共 ${incidents.length} 项关键 incident`, `${incidents.length} key incident(s) this period`)}
+        </span>
+      </div>
+
+      {/* Hero stats */}
       {content.hero && content.hero.length > 0 && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {content.hero.map((h) => (
@@ -203,42 +227,53 @@ export function ReportContentView({ content }: { content: ReportContentT }) {
         </div>
       )}
 
+      {/* Narrative */}
       {content.narrative?.headline && (
         <section>
           <h2 className="mb-2 text-base font-semibold text-zinc-100">📝 {content.narrative.headline}</h2>
-          <div className="space-y-2 text-sm leading-relaxed text-zinc-300">
-            {paras.map((p, i) => (
-              <p key={i}>
-                <EntityText text={p.text} />
-              </p>
-            ))}
-          </div>
+          {paras.length > 0 && (
+            <div className="space-y-2 text-sm leading-relaxed text-zinc-300">
+              {paras.map((p, i) => (
+                <p key={i}>
+                  <EntityText text={p.text} />
+                </p>
+              ))}
+            </div>
+          )}
         </section>
       )}
 
-      {content.key_incidents && content.key_incidents.length > 0 && (
-        <section>
-          <h3 className="mb-2 text-sm font-medium text-zinc-400">🚨 {tr('关键 incidents', 'Key incidents')}</h3>
+      {/* Incidents — always shown, positive empty state when calm */}
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-zinc-400">🚨 {tr('关键 incidents', 'Key incidents')}</h3>
+        {incidents.length > 0 ? (
           <div className="space-y-1.5">
-            {content.key_incidents.map((ki) => (
+            {incidents.map((ki) => (
               <IncidentRow key={ki.id} ki={ki} />
             ))}
           </div>
-        </section>
-      )}
+        ) : (
+          <EmptyRow text={tr('本周期内无 incident', 'No incidents this period')} />
+        )}
+      </section>
 
-      {content.actions_summary && (
-        <section>
-          <h3 className="mb-2 text-sm font-medium text-zinc-400">⚡ {tr('Agent 执行动作', 'Agent actions')}</h3>
+      {/* Agent actions — always shown */}
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-zinc-400">⚡ {tr('Agent 执行动作', 'Agent actions')}</h3>
+        {content.actions_summary &&
+        (content.actions_summary.mutating_total > 0 || content.actions_summary.safe_total > 0) ? (
           <ActionsPanel a={content.actions_summary} />
-        </section>
-      )}
+        ) : (
+          <EmptyRow text={tr('本周期内 agent 未执行动作', 'No agent actions this period')} />
+        )}
+      </section>
 
-      {content.advice && content.advice.length > 0 && (
-        <section>
-          <h3 className="mb-2 text-sm font-medium text-zinc-400">🎯 {tr('下一步建议', 'Recommendations')}</h3>
+      {/* Recommendations */}
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-zinc-400">🎯 {tr('下一步建议', 'Recommendations')}</h3>
+        {advice.length > 0 ? (
           <ul className="space-y-1.5 text-sm text-zinc-300">
-            {content.advice.map((a, i) => (
+            {advice.map((a, i) => (
               <li key={i} className="flex gap-2">
                 <span className="text-indigo-400">•</span>
                 <span>
@@ -247,8 +282,22 @@ export function ReportContentView({ content }: { content: ReportContentT }) {
               </li>
             ))}
           </ul>
-        </section>
-      )}
+        ) : (
+          <EmptyRow text={tr('暂无建议，保持现状即可', 'No recommendations — keep steady')} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function heroValue(hero: HeroStat[] | undefined, key: string): number {
+  return hero?.find((h) => h.key === key)?.value ?? 0;
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return (
+    <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-900/20 px-3 py-3 text-sm text-zinc-500">
+      {text}
     </div>
   );
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   UsersRound,
   ChartLine,
   FileText,
+  FileBarChart,
   Waypoints,
   Siren,
   Wrench,
@@ -437,6 +438,7 @@ export function Sidebar() {
           <SidebarNavItem to="/logs" icon={FileText} label={tr('日志', 'Logs')} />
           <SidebarNavItem to="/traces" icon={Waypoints} label={tr('链路', 'Traces')} />
           <SidebarNavItem to="/alerts" icon={Siren} label={tr('告警', 'Alerts')} badge={incidentOpen} />
+          <SidebarNavItem to="/reports" icon={FileBarChart} label={tr('报告', 'Reports')} />
         </CollapsibleSection>
 
         <SectionLabel>{tr('会话', 'Sessions')}</SectionLabel>

--- a/web/src/pages/ReportDetail.tsx
+++ b/web/src/pages/ReportDetail.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, RefreshCw, Share2, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { fullDateTime } from '@/lib/format';
+import { usePoll } from '@/lib/usePoll';
+import { usePermissions } from '@/store/me';
+import { useI18n } from '@/i18n/locale';
+import { ReportContentView } from '@/components/ReportContent';
+import { deleteReport, getReport, shareReport, type ReportDetail } from '@/api/reports';
+
+export default function ReportDetailPage() {
+  const { id = '' } = useParams();
+  const { tr } = useI18n();
+  const { canMutate } = usePermissions();
+  const [report, setReport] = useState<ReportDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await getReport(id);
+      setReport(r);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+  // Poll while the report is still being generated.
+  usePoll(load, report && (report.status === 'pending' || report.status === 'generating') ? 4_000 : 0);
+
+  const onShare = useCallback(async () => {
+    const res = await shareReport(id);
+    const url = `${window.location.origin}${res.path}`;
+    setShareUrl(url);
+    void navigator.clipboard?.writeText(url).catch(() => {});
+  }, [id]);
+
+  const onDelete = useCallback(async () => {
+    if (!window.confirm(tr('删除这份报告？', 'Delete this report?'))) return;
+    await deleteReport(id);
+    window.location.href = '/reports';
+  }, [id, tr]);
+
+  if (loading) {
+    return (
+      <div className="py-20 text-center text-sm text-zinc-500">
+        <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
+        {tr('加载中…', 'Loading…')}
+      </div>
+    );
+  }
+  if (!report) {
+    return <div className="py-20 text-center text-sm text-zinc-500">{tr('报告不存在', 'Report not found')}</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <Link to="/reports" className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
+        <ArrowLeft size={13} /> {tr('返回报告列表', 'Back to reports')}
+      </Link>
+
+      {/* Gradient header (HLD-014 §前端渲染) */}
+      <div className="relative overflow-hidden rounded-xl border border-zinc-800 bg-gradient-to-br from-indigo-600/25 via-zinc-900 to-zinc-900 p-5">
+        <div
+          className="pointer-events-none absolute inset-0 opacity-30"
+          style={{
+            backgroundImage:
+              'radial-gradient(60% 80% at 20% 0%, rgba(99,102,241,0.35), transparent), radial-gradient(50% 60% at 90% 20%, rgba(139,92,246,0.25), transparent)',
+          }}
+        />
+        <div className="relative">
+          <h1 className="text-xl font-semibold text-zinc-50">{report.title}</h1>
+          <div className="mt-1 text-xs text-zinc-400">
+            {report.generated_at
+              ? tr(`生成于 ${fullDateTime(report.generated_at)}`, `Generated ${fullDateTime(report.generated_at)}`)
+              : tr('生成中…', 'Generating…')}
+            {' · '}
+            {report.timezone}
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            {canMutate && report.status === 'ready' && (
+              <button
+                type="button"
+                onClick={() => void onShare()}
+                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-200 hover:border-zinc-500"
+              >
+                <Share2 size={12} /> {tr('分享', 'Share')}
+              </button>
+            )}
+            {canMutate && (
+              <button
+                type="button"
+                onClick={() => void onDelete()}
+                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-400 hover:border-red-500/50 hover:text-red-300"
+              >
+                <Trash2 size={12} /> {tr('删除', 'Delete')}
+              </button>
+            )}
+          </div>
+          {shareUrl && (
+            <div className="mt-2 rounded border border-emerald-700/40 bg-emerald-900/20 px-2 py-1 text-[11px] text-emerald-200">
+              {tr('分享链接已复制：', 'Share link copied: ')}
+              {shareUrl}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        {report.status === 'failed' ? (
+          <div className="rounded-lg border border-red-700/40 bg-red-900/20 p-4 text-sm text-red-200">
+            <div className="font-medium">{tr('报告生成失败', 'Report generation failed')}</div>
+            {report.error_msg && <div className="mt-1 text-xs text-red-300/80">{report.error_msg}</div>}
+          </div>
+        ) : report.status !== 'ready' || !report.content ? (
+          <div className="py-12 text-center text-sm text-zinc-500">
+            <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
+            {tr('报告生成中，请稍候…', 'Report is being generated…')}
+          </div>
+        ) : (
+          <ReportContentView content={report.content} />
+        )}
+      </div>
+
+      {/* Delivery status panel (populated by PR-7) */}
+      {report.delivery && report.delivery.length > 0 && (
+        <div className="mt-8">
+          <h3 className="mb-2 text-sm font-medium text-zinc-400">{tr('投递状态', 'Delivery')}</h3>
+          <div className="space-y-1">
+            {report.delivery.map((d, i) => (
+              <div key={i} className="flex items-center gap-2 text-xs text-zinc-400">
+                <span
+                  className={cn(
+                    'h-1.5 w-1.5 rounded-full',
+                    d.status === 'sent' ? 'bg-emerald-500' : 'bg-red-500',
+                  )}
+                />
+                {d.channel_type ?? `channel ${d.channel_id}`} · {d.status}
+                {d.fallback_used && <span className="text-zinc-600">({tr('降级纯文本', 'plain-text fallback')})</span>}
+                {d.error && <span className="text-red-400/70">{d.error}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ReportDetail.tsx
+++ b/web/src/pages/ReportDetail.tsx
@@ -58,7 +58,9 @@ export default function ReportDetailPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-6">
+    <main className="anim-fade flex flex-1 flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        <div className="mx-auto max-w-4xl">
       <Link to="/reports" className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
         <ArrowLeft size={13} /> {tr('返回报告列表', 'Back to reports')}
       </Link>
@@ -147,6 +149,8 @@ export default function ReportDetailPage() {
           </div>
         </div>
       )}
-    </div>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/web/src/pages/ReportDetail.tsx
+++ b/web/src/pages/ReportDetail.tsx
@@ -59,36 +59,27 @@ export default function ReportDetailPage() {
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-6 py-5">
-        <div className="mx-auto max-w-4xl">
-      <Link to="/reports" className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
-        <ArrowLeft size={13} /> {tr('返回报告列表', 'Back to reports')}
-      </Link>
-
-      {/* Gradient header (HLD-014 §前端渲染) */}
-      <div className="relative overflow-hidden rounded-xl border border-zinc-800 bg-gradient-to-br from-indigo-600/25 via-zinc-900 to-zinc-900 p-5">
-        <div
-          className="pointer-events-none absolute inset-0 opacity-30"
-          style={{
-            backgroundImage:
-              'radial-gradient(60% 80% at 20% 0%, rgba(99,102,241,0.35), transparent), radial-gradient(50% 60% at 90% 20%, rgba(139,92,246,0.25), transparent)',
-          }}
-        />
-        <div className="relative">
-          <h1 className="text-xl font-semibold text-zinc-50">{report.title}</h1>
-          <div className="mt-1 text-xs text-zinc-400">
-            {report.generated_at
-              ? tr(`生成于 ${fullDateTime(report.generated_at)}`, `Generated ${fullDateTime(report.generated_at)}`)
-              : tr('生成中…', 'Generating…')}
-            {' · '}
-            {report.timezone}
+      <header className="app-header border-b border-zinc-800/60 px-6 py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <Link to="/reports" className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200">
+              <ArrowLeft size={12} /> {tr('返回报告', 'Back to reports')}
+            </Link>
+            <h1 className="mt-1 truncate text-base font-semibold text-zinc-100">{report.title}</h1>
+            <div className="mt-1.5 text-[11px] text-zinc-500">
+              {report.generated_at
+                ? tr(`生成于 ${fullDateTime(report.generated_at)}`, `Generated ${fullDateTime(report.generated_at)}`)
+                : tr('生成中…', 'Generating…')}
+              {' · '}
+              {report.timezone}
+            </div>
           </div>
-          <div className="mt-3 flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             {canMutate && report.status === 'ready' && (
               <button
                 type="button"
                 onClick={() => void onShare()}
-                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-200 hover:border-zinc-500"
+                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800"
               >
                 <Share2 size={12} /> {tr('分享', 'Share')}
               </button>
@@ -97,58 +88,58 @@ export default function ReportDetailPage() {
               <button
                 type="button"
                 onClick={() => void onDelete()}
-                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-400 hover:border-red-500/50 hover:text-red-300"
+                className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-400 hover:border-red-500/50 hover:text-red-300"
               >
                 <Trash2 size={12} /> {tr('删除', 'Delete')}
               </button>
             )}
           </div>
-          {shareUrl && (
-            <div className="mt-2 rounded border border-emerald-700/40 bg-emerald-900/20 px-2 py-1 text-[11px] text-emerald-200">
-              {tr('分享链接已复制：', 'Share link copied: ')}
-              {shareUrl}
+        </div>
+        {shareUrl && (
+          <div className="mt-2 rounded border border-emerald-700/40 bg-emerald-900/20 px-2 py-1 text-[11px] text-emerald-200">
+            {tr('分享链接已复制：', 'Share link copied: ')}
+            {shareUrl}
+          </div>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        <div className="mx-auto max-w-4xl">
+          {report.status === 'failed' ? (
+            <div className="rounded-lg border border-red-700/40 bg-red-900/20 p-4 text-sm text-red-200">
+              <div className="font-medium">{tr('报告生成失败', 'Report generation failed')}</div>
+              {report.error_msg && <div className="mt-1 text-xs text-red-300/80">{report.error_msg}</div>}
+            </div>
+          ) : report.status !== 'ready' || !report.content ? (
+            <div className="py-12 text-center text-sm text-zinc-500">
+              <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
+              {tr('报告生成中，请稍候…', 'Report is being generated…')}
+            </div>
+          ) : (
+            <ReportContentView content={report.content} />
+          )}
+
+          {/* Delivery status panel (PR-7) */}
+          {report.delivery && report.delivery.length > 0 && (
+            <div className="mt-8">
+              <h3 className="mb-2 text-sm font-medium text-zinc-400">{tr('投递状态', 'Delivery')}</h3>
+              <div className="space-y-1">
+                {report.delivery.map((d, i) => (
+                  <div key={i} className="flex items-center gap-2 text-xs text-zinc-400">
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 rounded-full',
+                        d.status === 'sent' ? 'bg-emerald-500' : 'bg-red-500',
+                      )}
+                    />
+                    {d.channel_type ?? `channel ${d.channel_id}`} · {d.status}
+                    {d.fallback_used && <span className="text-zinc-600">({tr('降级纯文本', 'plain-text fallback')})</span>}
+                    {d.error && <span className="text-red-400/70">{d.error}</span>}
+                  </div>
+                ))}
+              </div>
             </div>
           )}
-        </div>
-      </div>
-
-      <div className="mt-6">
-        {report.status === 'failed' ? (
-          <div className="rounded-lg border border-red-700/40 bg-red-900/20 p-4 text-sm text-red-200">
-            <div className="font-medium">{tr('报告生成失败', 'Report generation failed')}</div>
-            {report.error_msg && <div className="mt-1 text-xs text-red-300/80">{report.error_msg}</div>}
-          </div>
-        ) : report.status !== 'ready' || !report.content ? (
-          <div className="py-12 text-center text-sm text-zinc-500">
-            <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
-            {tr('报告生成中，请稍候…', 'Report is being generated…')}
-          </div>
-        ) : (
-          <ReportContentView content={report.content} />
-        )}
-      </div>
-
-      {/* Delivery status panel (populated by PR-7) */}
-      {report.delivery && report.delivery.length > 0 && (
-        <div className="mt-8">
-          <h3 className="mb-2 text-sm font-medium text-zinc-400">{tr('投递状态', 'Delivery')}</h3>
-          <div className="space-y-1">
-            {report.delivery.map((d, i) => (
-              <div key={i} className="flex items-center gap-2 text-xs text-zinc-400">
-                <span
-                  className={cn(
-                    'h-1.5 w-1.5 rounded-full',
-                    d.status === 'sent' ? 'bg-emerald-500' : 'bg-red-500',
-                  )}
-                />
-                {d.channel_type ?? `channel ${d.channel_id}`} · {d.status}
-                {d.fallback_used && <span className="text-zinc-600">({tr('降级纯文本', 'plain-text fallback')})</span>}
-                {d.error && <span className="text-red-400/70">{d.error}</span>}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
         </div>
       </div>
     </main>

--- a/web/src/pages/ReportSchedules.tsx
+++ b/web/src/pages/ReportSchedules.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowLeft, CalendarClock, Pencil, Play, Plus, Power, Trash2 } from 'lucide-react';
+import { ArrowLeft, Pencil, Play, Plus, Power, Trash2 } from 'lucide-react';
 import { Modal } from '@/components/Modal';
 import { cn } from '@/lib/cn';
 import { fullDateTime } from '@/lib/format';
@@ -74,16 +74,13 @@ export default function ReportSchedulesPage() {
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
-      <header className="app-header border-b border-zinc-800 px-6 py-4">
+      <header className="app-header border-b border-zinc-800/60 px-6 py-4">
         <Link to="/reports" className="mb-2 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
           <ArrowLeft size={13} /> {tr('返回报告', 'Back to reports')}
         </Link>
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h1 className="flex items-center gap-2 text-base font-semibold text-zinc-100">
-              <CalendarClock size={18} className="text-indigo-400" />
-              {tr('定时生成', 'Scheduled')}
-            </h1>
+            <h1 className="text-base font-semibold text-zinc-100">{tr('定时生成', 'Scheduled')}</h1>
             <p className="mt-0.5 text-xs text-zinc-500">
               {tr('按日/周/月定时自动生成报告并投递', 'Auto-generate and deliver reports on a daily/weekly/monthly cadence')}
             </p>

--- a/web/src/pages/ReportSchedules.tsx
+++ b/web/src/pages/ReportSchedules.tsx
@@ -73,35 +73,42 @@ export default function ReportSchedulesPage() {
   }, []);
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-6">
-      <Link to="/reports" className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
-        <ArrowLeft size={13} /> {tr('返回报告', 'Back to reports')}
-      </Link>
-
-      <div className="mb-5 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <CalendarClock size={20} className="text-indigo-400" />
-          <h1 className="text-lg font-semibold text-zinc-100">{tr('报告排程', 'Report schedules')}</h1>
+    <main className="anim-fade flex flex-1 flex-col overflow-hidden">
+      <header className="app-header border-b border-zinc-800 px-6 py-4">
+        <Link to="/reports" className="mb-2 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
+          <ArrowLeft size={13} /> {tr('返回报告', 'Back to reports')}
+        </Link>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="flex items-center gap-2 text-base font-semibold text-zinc-100">
+              <CalendarClock size={18} className="text-indigo-400" />
+              {tr('定时生成', 'Scheduled')}
+            </h1>
+            <p className="mt-0.5 text-xs text-zinc-500">
+              {tr('按日/周/月定时自动生成报告并投递', 'Auto-generate and deliver reports on a daily/weekly/monthly cadence')}
+            </p>
+          </div>
+          {canMutate && (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-2.5 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30"
+            >
+              <Plus size={12} /> {tr('新建', 'New')}
+            </button>
+          )}
         </div>
-        {canMutate && (
-          <button
-            type="button"
-            onClick={() => setCreating(true)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-3 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30"
-          >
-            <Plus size={13} /> {tr('新建排程', 'New schedule')}
-          </button>
-        )}
-      </div>
+      </header>
 
+      <div className="flex-1 overflow-y-auto px-6 py-5">
       {loading ? (
         <div className="py-16 text-center text-sm text-zinc-500">{tr('加载中…', 'Loading…')}</div>
       ) : items.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-zinc-800 py-16 text-center text-sm text-zinc-400">
-          {tr('还没有排程。新建一个日报/周报排程。', 'No schedules yet. Create a daily/weekly schedule.')}
+        <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-zinc-800 py-16 text-center text-sm text-zinc-400">
+          {tr('还没有定时任务。新建一个日报/周报定时生成。', 'No schedules yet. Create a daily/weekly scheduled report.')}
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="mx-auto max-w-3xl space-y-2">
           {items.map((s) => (
             <div key={s.id} className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5">
               <div className="flex items-center justify-between gap-2">
@@ -162,7 +169,8 @@ export default function ReportSchedulesPage() {
           }}
         />
       )}
-    </div>
+      </div>
+    </main>
   );
 }
 

--- a/web/src/pages/ReportSchedules.tsx
+++ b/web/src/pages/ReportSchedules.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, CalendarClock, Pencil, Play, Plus, Power, Trash2 } from 'lucide-react';
+import { Modal } from '@/components/Modal';
+import { cn } from '@/lib/cn';
+import { fullDateTime } from '@/lib/format';
+import { usePermissions } from '@/store/me';
+import { useI18n } from '@/i18n/locale';
+import { listChannels, type Channel } from '@/api/alerts';
+import {
+  createSchedule,
+  deleteSchedule,
+  listSchedules,
+  runScheduleNow,
+  toggleSchedule,
+  updateSchedule,
+  type ReportKind,
+  type ReportSchedule,
+  type ScheduleInput,
+} from '@/api/reports';
+
+const KINDS: { key: ReportKind; zh: string; en: string }[] = [
+  { key: 'daily', zh: '日报', en: 'Daily' },
+  { key: 'weekly', zh: '周报', en: 'Weekly' },
+  { key: 'monthly', zh: '月报', en: 'Monthly' },
+  { key: 'custom', zh: '自定义', en: 'Custom' },
+];
+
+const DEFAULT_TZ =
+  Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+
+export default function ReportSchedulesPage() {
+  const { tr } = useI18n();
+  const { canMutate } = usePermissions();
+  const [items, setItems] = useState<ReportSchedule[]>([]);
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<ReportSchedule | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [s, c] = await Promise.all([listSchedules(), listChannels().catch(() => ({ items: [] }))]);
+      setItems(s.schedules ?? []);
+      setChannels((c as { items: Channel[] }).items ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onToggle = useCallback(
+    async (s: ReportSchedule) => {
+      await toggleSchedule(s.id, !s.enabled);
+      void load();
+    },
+    [load],
+  );
+  const onDelete = useCallback(
+    async (s: ReportSchedule) => {
+      if (!window.confirm(tr('删除这个排程？', 'Delete this schedule?'))) return;
+      await deleteSchedule(s.id);
+      void load();
+    },
+    [load, tr],
+  );
+  const onRunNow = useCallback(async (s: ReportSchedule) => {
+    await runScheduleNow(s.id);
+    window.location.href = '/reports';
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <Link to="/reports" className="mb-4 inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300">
+        <ArrowLeft size={13} /> {tr('返回报告', 'Back to reports')}
+      </Link>
+
+      <div className="mb-5 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarClock size={20} className="text-indigo-400" />
+          <h1 className="text-lg font-semibold text-zinc-100">{tr('报告排程', 'Report schedules')}</h1>
+        </div>
+        {canMutate && (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-3 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30"
+          >
+            <Plus size={13} /> {tr('新建排程', 'New schedule')}
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="py-16 text-center text-sm text-zinc-500">{tr('加载中…', 'Loading…')}</div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-zinc-800 py-16 text-center text-sm text-zinc-400">
+          {tr('还没有排程。新建一个日报/周报排程。', 'No schedules yet. Create a daily/weekly schedule.')}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {items.map((s) => (
+            <div key={s.id} className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-zinc-100">{s.name || tr('(未命名)', '(unnamed)')}</span>
+                  <span className="rounded bg-zinc-800 px-1.5 py-0.5 text-[11px] text-zinc-400">
+                    {KINDS.find((k) => k.key === s.kind)?.[tr('zh', 'en') as 'zh' | 'en'] ?? s.kind}
+                  </span>
+                  {!s.enabled && (
+                    <span className="rounded bg-zinc-700/40 px-1.5 py-0.5 text-[11px] text-zinc-500">
+                      {tr('已停用', 'Disabled')}
+                    </span>
+                  )}
+                </div>
+                {canMutate && (
+                  <div className="flex items-center gap-1">
+                    <IconBtn title={tr('立即生成', 'Run now')} onClick={() => void onRunNow(s)}>
+                      <Play size={13} />
+                    </IconBtn>
+                    <IconBtn title={tr('编辑', 'Edit')} onClick={() => setEditing(s)}>
+                      <Pencil size={13} />
+                    </IconBtn>
+                    <IconBtn title={s.enabled ? tr('停用', 'Disable') : tr('启用', 'Enable')} onClick={() => void onToggle(s)}>
+                      <Power size={13} className={s.enabled ? 'text-emerald-400' : 'text-zinc-500'} />
+                    </IconBtn>
+                    <IconBtn title={tr('删除', 'Delete')} onClick={() => void onDelete(s)} danger>
+                      <Trash2 size={13} />
+                    </IconBtn>
+                  </div>
+                )}
+              </div>
+              <div className="mt-1 font-mono text-xs text-zinc-500">
+                {s.cron_spec} · {s.timezone}
+              </div>
+              {s.next_fire_at && (
+                <div className="mt-0.5 text-xs text-zinc-600">
+                  {tr('下次：', 'Next: ')}
+                  {fullDateTime(s.next_fire_at)}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {(creating || editing) && (
+        <ScheduleForm
+          channels={channels}
+          initial={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+          onSaved={() => {
+            setCreating(false);
+            setEditing(null);
+            void load();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function IconBtn({
+  children,
+  title,
+  onClick,
+  danger,
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClick(): void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={cn(
+        'rounded p-1.5 text-zinc-400 hover:bg-zinc-800',
+        danger ? 'hover:text-red-300' : 'hover:text-zinc-200',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ScheduleForm({
+  channels,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  channels: Channel[];
+  initial: ReportSchedule | null;
+  onClose(): void;
+  onSaved(): void;
+}) {
+  const { tr } = useI18n();
+  const [name, setName] = useState(initial?.name ?? '');
+  const [kind, setKind] = useState<ReportKind>(initial?.kind ?? 'weekly');
+  const [cron, setCron] = useState(initial?.cron_spec ?? '');
+  const [tz, setTz] = useState(initial?.timezone ?? DEFAULT_TZ);
+  const [chanIDs, setChanIDs] = useState<number[]>(initial?.channel_ids ?? []);
+  const [promptOverride, setPromptOverride] = useState(initial?.prompt_override ?? '');
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setErr(null);
+    const body: ScheduleInput = {
+      name,
+      kind,
+      timezone: tz,
+      channel_ids: chanIDs,
+      prompt_override: promptOverride || undefined,
+      // For custom kind the cron is required; for presets it's optional
+      // (backend fills the default) but we pass it through if set.
+      cron_spec: kind === 'custom' ? cron : cron || undefined,
+    };
+    try {
+      if (initial) await updateSchedule(initial.id, body);
+      else await createSchedule(body);
+      onSaved();
+    } catch (e) {
+      setErr((e as Error)?.message ?? tr('保存失败', 'Save failed'));
+    } finally {
+      setSaving(false);
+    }
+  }, [name, kind, tz, cron, chanIDs, promptOverride, initial, onSaved, tr]);
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      size="md"
+      title={initial ? tr('编辑排程', 'Edit schedule') : tr('新建排程', 'New schedule')}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+          >
+            {tr('取消', 'Cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={saving}
+            className="rounded-md border border-indigo-600 bg-indigo-600/20 px-3 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30 disabled:opacity-50"
+          >
+            {tr('保存', 'Save')}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <Field label={tr('名称', 'Name')}>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={tr('如：运维周报', 'e.g. Weekly ops report')}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label={tr('周期', 'Cadence')}>
+          <div className="flex gap-1.5">
+            {KINDS.map((k) => (
+              <button
+                key={k.key}
+                type="button"
+                onClick={() => setKind(k.key)}
+                className={cn(
+                  'rounded-md border px-2.5 py-1 text-xs',
+                  kind === k.key
+                    ? 'border-indigo-500 bg-indigo-500/15 text-indigo-200'
+                    : 'border-zinc-700 text-zinc-300 hover:border-zinc-500',
+                )}
+              >
+                {tr(k.zh, k.en)}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        {kind === 'custom' && (
+          <Field label={tr('Cron 表达式（5 段）', 'Cron (5-field)')}>
+            <input
+              value={cron}
+              onChange={(e) => setCron(e.target.value)}
+              placeholder="0 9 * * 1"
+              className={cn(inputCls, 'font-mono')}
+            />
+          </Field>
+        )}
+
+        <Field label={tr('时区', 'Timezone')}>
+          <input value={tz} onChange={(e) => setTz(e.target.value)} className={cn(inputCls, 'font-mono')} />
+        </Field>
+
+        <Field label={tr('投递渠道', 'Delivery channels')}>
+          {channels.length === 0 ? (
+            <p className="text-xs text-zinc-600">
+              {tr('暂无渠道，先到「设置 → 渠道」配置。', 'No channels — configure under Settings → Channels.')}
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {channels.map((c) => {
+                const on = chanIDs.includes(c.id);
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() =>
+                      setChanIDs((prev) => (on ? prev.filter((x) => x !== c.id) : [...prev, c.id]))
+                    }
+                    className={cn(
+                      'rounded-md border px-2 py-1 text-xs',
+                      on
+                        ? 'border-indigo-500 bg-indigo-500/15 text-indigo-200'
+                        : 'border-zinc-700 text-zinc-400 hover:border-zinc-500',
+                    )}
+                  >
+                    {c.name} <span className="text-zinc-600">({c.type})</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Field>
+
+        <Field label={tr('额外要求（可选）', 'Extra instructions (optional)')}>
+          <textarea
+            value={promptOverride}
+            onChange={(e) => setPromptOverride(e.target.value)}
+            rows={2}
+            placeholder={tr('如：重点关注数据库相关的风险', 'e.g. focus on database-related risks')}
+            className={cn(inputCls, 'resize-y')}
+          />
+        </Field>
+
+        {err && <div className="rounded border border-red-700/40 bg-red-900/20 px-2 py-1 text-[11px] text-red-200">{err}</div>}
+      </div>
+    </Modal>
+  );
+}
+
+const inputCls =
+  'w-full rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 placeholder:text-zinc-600 focus:border-indigo-500 focus:outline-none';
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-zinc-400">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { CalendarClock, FileText, Plus, RefreshCw, Settings } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { relativeTime } from '@/lib/format';
+import { usePoll } from '@/lib/usePoll';
+import { usePermissions } from '@/store/me';
+import { useI18n } from '@/i18n/locale';
+import { generateNow, listReports, type ReportListItem, type ReportStatus } from '@/api/reports';
+
+const POLL_MS = 20_000;
+
+const STATUS_STYLE: Record<ReportStatus, string> = {
+  ready: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  generating: 'bg-indigo-500/15 text-indigo-300 border-indigo-500/30',
+  pending: 'bg-zinc-700/40 text-zinc-300 border-zinc-600/40',
+  failed: 'bg-red-500/15 text-red-300 border-red-500/30',
+};
+
+export default function ReportsPage() {
+  const { tr } = useI18n();
+  const { canMutate } = usePermissions();
+  const navigate = useNavigate();
+  const [items, setItems] = useState<ReportListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await listReports({ limit: 50 });
+      setItems(res.reports ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+  usePoll(load, POLL_MS);
+
+  const onGenerate = useCallback(async () => {
+    setGenerating(true);
+    try {
+      const rpt = await generateNow({ kind: 'weekly' });
+      await load();
+      navigate(`/reports/${rpt.id}`);
+    } finally {
+      setGenerating(false);
+    }
+  }, [load, navigate]);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-5 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FileText size={20} className="text-indigo-400" />
+          <h1 className="text-lg font-semibold text-zinc-100">{tr('报告', 'Reports')}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/reports/schedules"
+            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:border-zinc-500 hover:bg-zinc-800"
+          >
+            <Settings size={13} /> {tr('排程', 'Schedules')}
+          </Link>
+          {canMutate && (
+            <button
+              type="button"
+              onClick={() => void onGenerate()}
+              disabled={generating}
+              className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-3 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30 disabled:opacity-50"
+            >
+              <Plus size={13} /> {tr('立即生成', 'Generate now')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="py-16 text-center text-sm text-zinc-500">
+          <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
+          {tr('加载中…', 'Loading…')}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-zinc-800 py-16 text-center">
+          <CalendarClock size={28} className="mx-auto mb-3 text-zinc-600" />
+          <p className="text-sm text-zinc-400">{tr('还没有报告', 'No reports yet')}</p>
+          <p className="mt-1 text-xs text-zinc-600">
+            {tr('排一个日报/周报，或点「立即生成」。', 'Schedule a daily/weekly report, or click Generate now.')}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {items.map((r) => (
+            <Link
+              key={r.id}
+              to={`/reports/${r.id}`}
+              className="block rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5 hover:border-zinc-700"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="truncate font-medium text-zinc-100">{r.title}</span>
+                <span
+                  className={cn(
+                    'shrink-0 rounded border px-1.5 py-0.5 text-[11px] font-medium',
+                    STATUS_STYLE[r.status],
+                  )}
+                >
+                  {r.status}
+                </span>
+              </div>
+              {r.summary && <p className="mt-1 truncate text-sm text-zinc-400">{r.summary}</p>}
+              <div className="mt-1.5 text-xs text-zinc-600">
+                {r.generated_at
+                  ? tr(`生成于 ${relativeTime(r.generated_at)}`, `Generated ${relativeTime(r.generated_at)}`)
+                  : tr(`创建于 ${relativeTime(r.created_at)}`, `Created ${relativeTime(r.created_at)}`)}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -17,6 +17,20 @@ const STATUS_STYLE: Record<ReportStatus, string> = {
   failed: 'bg-red-500/15 text-red-300 border-red-500/30',
 };
 
+const STATUS_FILTERS: { key: string; zh: string; en: string }[] = [
+  { key: '', zh: '全部', en: 'All' },
+  { key: 'ready', zh: '已就绪', en: 'Ready' },
+  { key: 'generating', zh: '生成中', en: 'Generating' },
+  { key: 'failed', zh: '失败', en: 'Failed' },
+];
+
+const KIND_FILTERS: { key: string; zh: string; en: string }[] = [
+  { key: '', zh: '全部', en: 'All' },
+  { key: 'daily', zh: '日报', en: 'Daily' },
+  { key: 'weekly', zh: '周报', en: 'Weekly' },
+  { key: 'monthly', zh: '月报', en: 'Monthly' },
+];
+
 export default function ReportsPage() {
   const { tr } = useI18n();
   const { canMutate } = usePermissions();
@@ -24,15 +38,21 @@ export default function ReportsPage() {
   const [items, setItems] = useState<ReportListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [kindFilter, setKindFilter] = useState('');
 
   const load = useCallback(async () => {
     try {
-      const res = await listReports({ limit: 50 });
+      const res = await listReports({
+        limit: 50,
+        status: statusFilter || undefined,
+        kind: kindFilter || undefined,
+      });
       setItems(res.reports ?? []);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [statusFilter, kindFilter]);
 
   useEffect(() => {
     void load();
@@ -51,74 +71,125 @@ export default function ReportsPage() {
   }, [load, navigate]);
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-6">
-      <div className="mb-5 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <FileText size={20} className="text-indigo-400" />
-          <h1 className="text-lg font-semibold text-zinc-100">{tr('报告', 'Reports')}</h1>
-        </div>
-        <div className="flex items-center gap-2">
-          <Link
-            to="/reports/schedules"
-            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:border-zinc-500 hover:bg-zinc-800"
-          >
-            <Settings size={13} /> {tr('排程', 'Schedules')}
-          </Link>
-          {canMutate && (
-            <button
-              type="button"
-              onClick={() => void onGenerate()}
-              disabled={generating}
-              className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-3 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30 disabled:opacity-50"
+    <main className="anim-fade flex flex-1 flex-col overflow-hidden">
+      <header className="app-header border-b border-zinc-800 px-6 py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="flex items-center gap-2 text-base font-semibold text-zinc-100">
+              <FileText size={18} className="text-indigo-400" />
+              {tr('报告', 'Reports')}
+            </h1>
+            <p className="mt-0.5 text-xs text-zinc-500">
+              {tr('定时或手动生成的运维报告', 'Scheduled and on-demand ops reports')}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              to="/reports/schedules"
+              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800"
             >
-              <Plus size={13} /> {tr('立即生成', 'Generate now')}
-            </button>
-          )}
+              <Settings size={12} /> {tr('定时生成', 'Scheduled')}
+            </Link>
+            {canMutate && (
+              <button
+                type="button"
+                onClick={() => void onGenerate()}
+                disabled={generating}
+                className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-2.5 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30 disabled:opacity-50"
+              >
+                <Plus size={12} /> {tr('立即生成', 'Generate now')}
+              </button>
+            )}
+          </div>
         </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-4 border-b border-zinc-800 px-6 py-3 text-xs text-zinc-400">
+        <FilterGroup label={tr('状态', 'Status')} options={STATUS_FILTERS} value={statusFilter} onChange={setStatusFilter} tr={tr} />
+        <FilterGroup label={tr('类型', 'Kind')} options={KIND_FILTERS} value={kindFilter} onChange={setKindFilter} tr={tr} />
       </div>
 
-      {loading ? (
-        <div className="py-16 text-center text-sm text-zinc-500">
-          <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
-          {tr('加载中…', 'Loading…')}
-        </div>
-      ) : items.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-zinc-800 py-16 text-center">
-          <CalendarClock size={28} className="mx-auto mb-3 text-zinc-600" />
-          <p className="text-sm text-zinc-400">{tr('还没有报告', 'No reports yet')}</p>
-          <p className="mt-1 text-xs text-zinc-600">
-            {tr('排一个日报/周报，或点「立即生成」。', 'Schedule a daily/weekly report, or click Generate now.')}
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {items.map((r) => (
-            <Link
-              key={r.id}
-              to={`/reports/${r.id}`}
-              className="block rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5 hover:border-zinc-700"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <span className="truncate font-medium text-zinc-100">{r.title}</span>
-                <span
-                  className={cn(
-                    'shrink-0 rounded border px-1.5 py-0.5 text-[11px] font-medium',
-                    STATUS_STYLE[r.status],
-                  )}
-                >
-                  {r.status}
-                </span>
-              </div>
-              {r.summary && <p className="mt-1 truncate text-sm text-zinc-400">{r.summary}</p>}
-              <div className="mt-1.5 text-xs text-zinc-600">
-                {r.generated_at
-                  ? tr(`生成于 ${relativeTime(r.generated_at)}`, `Generated ${relativeTime(r.generated_at)}`)
-                  : tr(`创建于 ${relativeTime(r.created_at)}`, `Created ${relativeTime(r.created_at)}`)}
-              </div>
-            </Link>
-          ))}
-        </div>
-      )}
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        {loading ? (
+          <div className="py-16 text-center text-sm text-zinc-500">
+            <RefreshCw size={18} className="mx-auto mb-2 animate-spin" />
+            {tr('加载中…', 'Loading…')}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-zinc-800 py-16 text-center">
+            <CalendarClock size={28} className="mx-auto mb-3 text-zinc-600" />
+            <p className="text-sm text-zinc-400">{tr('还没有报告', 'No reports yet')}</p>
+            <p className="mt-1 text-xs text-zinc-600">
+              {tr('设一个日报/周报定时生成，或点「立即生成」。', 'Set up a daily/weekly schedule, or click Generate now.')}
+            </p>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-3xl space-y-2">
+            {items.map((r) => (
+              <Link
+                key={r.id}
+                to={`/reports/${r.id}`}
+                className="block rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5 hover:border-zinc-700"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="truncate font-medium text-zinc-100">{r.title}</span>
+                  <span
+                    className={cn(
+                      'shrink-0 rounded border px-1.5 py-0.5 text-[11px] font-medium',
+                      STATUS_STYLE[r.status],
+                    )}
+                  >
+                    {r.status}
+                  </span>
+                </div>
+                {r.summary && <p className="mt-1 truncate text-sm text-zinc-400">{r.summary}</p>}
+                <div className="mt-1.5 text-xs text-zinc-600">
+                  {r.generated_at
+                    ? tr(`生成于 ${relativeTime(r.generated_at)}`, `Generated ${relativeTime(r.generated_at)}`)
+                    : tr(`创建于 ${relativeTime(r.created_at)}`, `Created ${relativeTime(r.created_at)}`)}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function FilterGroup({
+  label,
+  options,
+  value,
+  onChange,
+  tr,
+}: {
+  label: string;
+  options: { key: string; zh: string; en: string }[];
+  value: string;
+  onChange(v: string): void;
+  tr: (zh: string, en: string) => string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-zinc-500">{label}</span>
+      <div className="flex gap-1">
+        {options.map((o) => (
+          <button
+            key={o.key}
+            type="button"
+            onClick={() => onChange(o.key)}
+            className={cn(
+              'rounded px-2 py-0.5 text-[11px]',
+              value === o.key
+                ? 'bg-indigo-500/15 text-indigo-200'
+                : 'text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200',
+            )}
+          >
+            {tr(o.zh, o.en)}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { CalendarClock, FileText, Plus, RefreshCw, Settings } from 'lucide-react';
+import { CalendarClock, Plus, RefreshCw, Settings } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { relativeTime } from '@/lib/format';
 import { usePoll } from '@/lib/usePoll';
@@ -72,13 +72,10 @@ export default function ReportsPage() {
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
-      <header className="app-header border-b border-zinc-800 px-6 py-4">
+      <header className="app-header border-b border-zinc-800/60 px-6 py-4">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h1 className="flex items-center gap-2 text-base font-semibold text-zinc-100">
-              <FileText size={18} className="text-indigo-400" />
-              {tr('报告', 'Reports')}
-            </h1>
+            <h1 className="text-base font-semibold text-zinc-100">{tr('报告', 'Reports')}</h1>
             <p className="mt-0.5 text-xs text-zinc-500">
               {tr('定时或手动生成的运维报告', 'Scheduled and on-demand ops reports')}
             </p>


### PR DESCRIPTION
Frontend for **HLD-014** (combines the planned PR-5 + PR-6 since they share routes/api/sidebar — splitting would leave a broken intermediate build). Stacked on PR-4 (#60). Follows existing page patterns (lazy routes, `useI18n` tr(), `usePermissions` canMutate, `usePoll`, Modal, tailwind dark).

## What lands
- **`api/reports.ts`**: typed client mirroring PR-4 routes + ContentJSON shapes.
- **`components/ReportContent.tsx`**: the rich renderer — **zero chart deps**. Hero cards with rAF count-up + inline SVG sparkline + delta arrow (down=green/up=red); narrative with `{{entity:kind:id|name}}` tokens → clickable chips (edge→/devices, incident→/alerts/incidents); key incidents / actions panel / advice.
- **`pages/Reports.tsx`**: list (status chips, generate-now, schedules link), poll 20s.
- **`pages/ReportDetail.tsx`**: gradient header + share/delete; polls 4s while pending/generating; failed + delivery panels.
- **`pages/ReportSchedules.tsx`**: schedule list + create/edit modal (kind preset / custom cron / tz / channel multi-select / prompt override) + run-now / toggle / delete.
- **`App.tsx`**: /reports, /reports/schedules, /reports/:id.
- **`Sidebar.tsx`**: 报告 entry under the 监控告警 fold after 告警 (placement decided in review), FileBarChart icon.

`tsc -b` + `vite build` clean; all 4 report chunks emit.

## Compat
New pages + sidebar item only. RBAC mirrors backend — viewer sees read-only (canMutate gates buttons).

## Next
PR-7: IM delivery + Feishu card payload + delivery status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)