### PR TITLE
docs: unify the tagline / positioning across READMEs + (paired with description + website)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **An ops AI that understands, finds the root cause, and fixes things.** *Monitoring, remote execution, knowledge base, specialist agents, Bash, files, and more skills — issue commands directly from Slack, Telegram, or Lark.*
+> **An ops AI Agent that understands your infrastructure, finds the root cause, and fixes it — right from Slack or Telegram.** *Monitoring · remote execution · knowledge base · specialist agents · Bash · files — and more.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Eine Ops-KI, die versteht, die Ursache findet und behebt.** *Monitoring, Remote-Ausführung, Wissensbasis, Spezialisten-Agenten, Bash, Dateien und weitere Skills —— Befehle direkt aus Slack, Telegram oder Lark.*
+> **Ein Ops-KI-Agent, der deine Infrastruktur versteht, die Ursache findet und sie behebt — direkt aus Slack oder Telegram.** *Monitoring · Remote-Ausführung · Wissensdatenbank · Spezialisten-Agenten · Bash · Dateien — und mehr.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Una IA de ops que entiende, encuentra la causa y arregla.** *Monitorización, ejecución remota, base de conocimiento, agentes especialistas, Bash, archivos y demás skills —— da órdenes directamente desde Slack, Telegram o Lark.*
+> **Un agente de IA de ops que entiende tu infraestructura, encuentra la causa raíz y la soluciona — directamente desde Slack o Telegram.** *Monitorización · ejecución remota · base de conocimiento · agentes especialistas · Bash · archivos — y más.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Une IA d'ops qui comprend, trouve la cause et corrige.** *Monitoring, exécution distante, base de connaissances, agents spécialistes, Bash, fichiers et autres skills —— donnez les ordres directement depuis Slack, Telegram ou Lark.*
+> **Un agent IA d'ops qui comprend votre infrastructure, trouve la cause racine et la corrige — directement depuis Slack ou Telegram.** *Supervision · exécution à distance · base de connaissances · agents spécialisés · Bash · fichiers — et plus encore.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **システムを理解し、原因を突き止め、自ら直す運用 AI。** *監視、リモート実行、ナレッジベース、スペシャリストエージェント、Bash、ファイルなど各種スキル —— Slack、Telegram、Lark から直接指示を送る。*
+> **インフラを理解し、原因を突き止め、自ら直す運用 AI エージェント — Slack や Telegram から直接。** *監視 · リモート実行 · ナレッジベース · 専門エージェント · Bash · ファイル — ほか多数。*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **이해하고, 원인을 짚고, 직접 고치는 운영 AI.** *모니터링, 원격 실행, 지식 베이스, 전문가 에이전트, Bash, 파일 등 각종 스킬 —— Slack, Telegram, Lark 에서 직접 명령을 내린다.*
+> **인프라를 이해하고, 근본 원인을 찾아내고, 직접 고치는 운영 AI 에이전트 — Slack과 Telegram에서 바로.** *모니터링 · 원격 실행 · 지식 베이스 · 전문 에이전트 · Bash · 파일 — 그 외 다수.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_PT.md
+++ b/README_PT.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Uma IA de ops que entende, encontra a causa e corrige.** *Monitoramento, execução remota, base de conhecimento, agentes especialistas, Bash, arquivos e outras skills —— dê os comandos direto do Slack, Telegram ou Lark.*
+> **Um agente de IA de ops que entende sua infraestrutura, encontra a causa raiz e a corrige — direto do Slack ou Telegram.** *Monitoramento · execução remota · base de conhecimento · agentes especialistas · Bash · arquivos — e mais.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **Ops-AI: понимает, находит причину и чинит.** *Мониторинг, удалённое выполнение, база знаний, специалисты-агенты, Bash, файлы и другие skills —— отдавайте команды прямо из Slack, Telegram или Lark.*
+> **ИИ-агент для эксплуатации, который понимает вашу инфраструктуру, находит первопричину и устраняет её — прямо из Slack или Telegram.** *Мониторинг · удалённое выполнение · база знаний · специализированные агенты · Bash · файлы — и не только.*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,6 +1,6 @@
 # <img src="web/public/ongrid-logo.svg" alt="" width="40" align="absmiddle" style="vertical-align: middle;" /> Ongrid
 
-> **一个看得懂系统、查得出根因、还能动手解决的运维 AI。** *监控、远程执行、知识库、专家智能体、Bash、文件等各类技能 —— 直接通过飞书、Slack、Telegram 下达指令。*
+> **懂你的系统和基础设施、查得出根因、还能动手修复的 AI Agent，直接在飞书和钉钉里指挥。** *监控 · 远程执行 · 知识库 · 专家 Agent · Bash · 文件 —— 等更多技能。*
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ongridio/ongrid)](https://goreportcard.com/report/github.com/ongridio/ongrid)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
Unifies the headline + subtitle across all 9 README locales to one consistent 'ops AI Agent' positioning. Paired with the GitHub repo description + website hero (updated separately). Channels localized per audience (Slack/Telegram for non-CN, 飞书/钉钉 for ZH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)