### PR TITLE
fix(aiops): Make log filtering compatible with both ssh.service and sshd.service

### DIFF
--- a/internal/manager/server/aiops/query_translate.go
+++ b/internal/manager/server/aiops/query_translate.go
@@ -71,7 +71,7 @@ var dialectGuide = map[string]string{
 - 严禁随意编造标签，只用上面列出的
 示例：
 "dev-host-3 最近 error 日志" → {device_id="3"} |~ "(?i)error"
-"sshd 服务的失败登录" → {unit="sshd.service"} |~ "(Failed|invalid)"
+"ssh 服务的失败登录" → {unit=~"sshd?\\.service"} |~ "(?i)(Failed|invalid)"
 "OOM 杀掉的进程" → {} |~ "(Out of memory|OOM|invoked oom-killer)"`,
 
 	"traceql": `TraceQL（Tempo 查询语言）。规则：

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -82,8 +82,8 @@ const LOGS_QUICK_CHIPS: { labelZh: string; labelEn: string; query: string; title
   },
   {
     labelZh: 'ssh 失败', labelEn: 'ssh failures',
-    query: '{unit="sshd.service"} |~ "(Failed|invalid)"',
-    titleZh: 'sshd 登录失败 / 非法用户', titleEn: 'sshd login failures / invalid users',
+    query: '{unit=~"sshd?\\.service"} |~ "(?i)(Failed|invalid)"',
+    titleZh: 'ssh 登录失败 / 非法用户', titleEn: 'ssh login failures / invalid users',
   },
 ];
 


### PR DESCRIPTION
fix issue #36 

This change makes the filter compatible with both unit name variants (ssh and sshd) and also makes matching for `failed` and `invalid` invalid case-insensitive.