### PR TITLE
docs(readme): bump install links to v0.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Download the latest release, extract it, and run the installer (Ubuntu 22.04+, D
 
 ```bash
 # 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Extract
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Install
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 Mainland China** — if GitHub is slow, download step 1 from the CDN mirror instead (everything else is the same):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### Or run from source

--- a/README_DE.md
+++ b/README_DE.md
@@ -47,10 +47,10 @@ Laden Sie das aktuelle Release herunter, entpacken Sie es und führen Sie das In
 
 ```bash
 # 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Entpacken
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Installieren
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 Festlandchina** — Wenn GitHub langsam ist, laden Sie Schritt 1 stattdessen vom CDN-Mirror (alles andere ist identisch):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### Oder aus dem Quellcode ausführen

--- a/README_ES.md
+++ b/README_ES.md
@@ -47,10 +47,10 @@ Descarga la última release, descomprímela y ejecuta el instalador (Ubuntu 22.0
 
 ```bash
 # 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Descomprimir
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 China continental** — si GitHub va lento, descarga el paso 1 desde el mirror CDN (el resto es igual):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### O ejecutar desde el código fuente

--- a/README_FR.md
+++ b/README_FR.md
@@ -47,10 +47,10 @@ Téléchargez la dernière release, décompressez-la et exécutez le script d’
 
 ```bash
 # 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Décompresser
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Installer
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 Chine continentale** — si GitHub est lent, téléchargez l'étape 1 depuis le miroir CDN (le reste est identique) :
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### Ou exécuter depuis les sources

--- a/README_JA.md
+++ b/README_JA.md
@@ -47,10 +47,10 @@
 
 ```bash
 # 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. 展開
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. インストール
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 中国本土ユーザー** — GitHub が遅い場合は、手順 1 を CDN ミラーからダウンロード（他の手順は同じ）：
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### またはソースから実行

--- a/README_KO.md
+++ b/README_KO.md
@@ -47,10 +47,10 @@
 
 ```bash
 # 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. 압축 해제
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. 설치
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 중국 본토 사용자** — GitHub이 느리면 1단계를 CDN 미러에서 다운로드하세요(나머지는 동일):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### 또는 소스에서 실행

--- a/README_PT.md
+++ b/README_PT.md
@@ -47,10 +47,10 @@ Baixe a última release, descompacte e execute o instalador (Ubuntu 22.04+, Debi
 
 ```bash
 # 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Descompactar
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 China continental** — se o GitHub estiver lento, baixe o passo 1 do mirror CDN (o resto é igual):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### Ou executar a partir do código

--- a/README_RU.md
+++ b/README_RU.md
@@ -47,10 +47,10 @@
 
 ```bash
 # 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. Распаковка
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. Установка
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 Материковый Китай** — если GitHub медленный, скачайте шаг 1 с CDN-зеркала (остальное без изменений):
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### Или запустить из исходников

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -47,10 +47,10 @@
 
 ```bash
 # 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.2/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
 
 # 2. 解压
-tar -xf ongrid-v0.8.2-linux-amd64.tar.xz && cd ongrid-v0.8.2-linux-amd64
+tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
 
 # 3. 安装
 sudo ./install.sh
@@ -59,7 +59,7 @@ sudo ./install.sh
 **🇨🇳 中国大陆用户** — GitHub 较慢时，第 1 步改用 CDN 镜像下载（其余步骤完全相同）：
 
 ```bash
-wget https://ongrid.cloud/dl/ongrid-v0.8.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
 ```
 
 ### 或从源码运行


### PR DESCRIPTION
Follow-up to v0.8.3 release. README install commands (GitHub Releases + ongrid.cloud CDN) across all 9 locales were still on v0.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)