### PR TITLE
fix(report): align report generation with LLM configuration

### DIFF
--- a/cmd/ongrid/llm_default_test.go
+++ b/cmd/ongrid/llm_default_test.go
@@ -28,3 +28,14 @@ func TestPickProviderDefaultIgnoresUnavailablePreferred(t *testing.T) {
 		t.Fatalf("pickProviderDefault() = (%q, %q), want (deepseek, deepseek-v4-flash)", gotProvider, gotModel)
 	}
 }
+
+func TestPickProviderDefaultReturnsEmptyWithoutConfiguredProvider(t *testing.T) {
+	providers := []llm.ProviderConfig{
+		{ID: llm.ProviderDeepSeek, APIKey: "", Model: "deepseek-v4-flash"},
+	}
+
+	gotProvider, gotModel := pickProviderDefault(providers, llm.ProviderDeepSeek)
+	if gotProvider != "" || gotModel != "" {
+		t.Fatalf("pickProviderDefault() = (%q, %q), want empty default", gotProvider, gotModel)
+	}
+}

--- a/cmd/ongrid/llm_default_test.go
+++ b/cmd/ongrid/llm_default_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/llm"
+)
+
+func TestPickProviderDefaultFallsBackToConfiguredProvider(t *testing.T) {
+	providers := []llm.ProviderConfig{
+		{ID: llm.ProviderDeepSeek, APIKey: "sk-test", Model: "deepseek-v4-flash"},
+	}
+
+	gotProvider, gotModel := pickProviderDefault(providers, "")
+	if gotProvider != llm.ProviderDeepSeek || gotModel != "deepseek-v4-flash" {
+		t.Fatalf("pickProviderDefault() = (%q, %q), want (deepseek, deepseek-v4-flash)", gotProvider, gotModel)
+	}
+}
+
+func TestPickProviderDefaultIgnoresUnavailablePreferred(t *testing.T) {
+	providers := []llm.ProviderConfig{
+		{ID: llm.ProviderOpenAI, APIKey: "", Model: "gpt-5.4"},
+		{ID: llm.ProviderDeepSeek, APIKey: "sk-test", Model: "deepseek-v4-flash"},
+	}
+
+	gotProvider, gotModel := pickProviderDefault(providers, llm.ProviderOpenAI)
+	if gotProvider != llm.ProviderDeepSeek || gotModel != "deepseek-v4-flash" {
+		t.Fatalf("pickProviderDefault() = (%q, %q), want (deepseek, deepseek-v4-flash)", gotProvider, gotModel)
+	}
+}

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -2201,6 +2202,33 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
+// pickProviderDefault mirrors llm.MultiClient's catalog default:
+// use the configured default when it names an available provider, otherwise
+// pick the first configured provider by stable provider id. Background graph
+// workers, including reports, rely on this to match /v1/aiops/models.
+func pickProviderDefault(providers []llm.ProviderConfig, preferred string) (string, string) {
+	preferred = strings.TrimSpace(preferred)
+	available := make([]llm.ProviderConfig, 0, len(providers))
+	for _, p := range providers {
+		if strings.TrimSpace(p.ID) == "" || strings.TrimSpace(p.APIKey) == "" {
+			continue
+		}
+		available = append(available, p)
+	}
+	if preferred != "" {
+		for _, p := range available {
+			if p.ID == preferred {
+				return p.ID, p.Model
+			}
+		}
+	}
+	sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
+	if len(available) > 0 {
+		return available[0].ID, available[0].Model
+	}
+	return preferred, ""
+}
+
 // dedupeModels returns vals with empty strings dropped and duplicates
 // removed, preserving first-seen order. The OpenAI model catalog is built
 // as [configuredModel, "gpt-4o", "gpt-4-turbo"]; out-of-box the configured
@@ -2569,8 +2597,8 @@ func buildAIOpsRuntime(
 			for _, pc := range provCfgs {
 				addInner(pc.ID, pc.Model)
 			}
-			if resolvedDefault != "" {
-				defProv = resolvedDefault
+			if id, _ := pickProviderDefault(provCfgs, resolvedDefault); id != "" {
+				defProv = id
 			}
 		} else {
 			log.Warn("chatruntime: resolve providers for inner models", slog.Any("err", rerr))
@@ -2633,15 +2661,10 @@ func buildAIOpsRuntime(
 	if resolver != nil {
 		defaultResolver = func(rctx context.Context) (string, string) {
 			provCfgs, resolvedDefault, rerr := resolver.ResolveProviders(rctx)
-			if rerr != nil || resolvedDefault == "" {
+			if rerr != nil {
 				return "", ""
 			}
-			for _, pc := range provCfgs {
-				if pc.ID == resolvedDefault {
-					return resolvedDefault, pc.Model
-				}
-			}
-			return resolvedDefault, ""
+			return pickProviderDefault(provCfgs, resolvedDefault)
 		}
 	}
 	chatModel, err := llm.NewRoutingChatModel(llm.RoutingChatModelConfig{

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ongridio/ongrid/internal/pkg/authzmw"
 	"github.com/ongridio/ongrid/internal/pkg/config"
 	"github.com/ongridio/ongrid/internal/pkg/dbx"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/httpserver"
 	"github.com/ongridio/ongrid/internal/pkg/llm"
 	"github.com/ongridio/ongrid/internal/pkg/logger"
@@ -1544,14 +1545,13 @@ func main() {
 	}
 
 	// Report scheduler + API (HLD-014): scheduled operational reports.
-	// Wired only when the chat runtime is the graph kernel — the reporter
-	// worker spawns through the same SpawnWorker seam the investigator
-	// uses. New tables / new goroutine / new routes; no impact on
-	// existing startup. reportHandler stays nil when not wired so the
-	// route-mount block below skips it.
-	var reportHandler *managerserverreport.Handler
+	// Routes are mounted even when the LLM runtime is unavailable, so the
+	// UI can list existing reports and surface a clear not-configured
+	// error on generate instead of a route-level 404.
+	reportRepo := managerreportdata.NewRepo(db)
+	var reportGen managerbizreport.Generator
+	reportSchedulerReady := false
 	if reportRT, ok := aiopsRuntime.(*aiopschatruntime.Runtime); ok && reportRT != nil {
-		reportRepo := managerreportdata.NewRepo(db)
 		// Pass the prom query client for fleet resource trends; a typed-nil
 		// guard mirrors the tools wiring so a missing client stays a clean
 		// untyped nil (collector degrades Resource.Available=false).
@@ -1559,7 +1559,7 @@ func main() {
 		if promQueryClient != nil {
 			reportProm = promQueryClient
 		}
-		reportGen := managerbizreport.NewWorkerGenerator(
+		reportGen = managerbizreport.NewWorkerGenerator(
 			reportRepo,
 			managerreportdata.NewFactsCollector(db, reportProm),
 			reportRT,
@@ -1568,16 +1568,23 @@ func main() {
 				PublicURL:     cfg.PublicURL,
 			},
 			log,
-		).WithDeliverer(reportDelivererShim{channels: alertRepo, router: notifyRouter})
-		reportUC := managerbizreport.NewUsecase(reportRepo, reportGen, uuid.NewString).
-			WithReadRepo(reportRepo).
-			WithDefaultLocale(firstNonEmpty(os.Getenv("ONGRID_DEFAULT_LOCALE"), "en"))
-		managerbizreport.NewScheduler(reportUC, log).Start(rootCtx)
-		reportHandler = managerserverreport.NewHandler(reportUC)
-		log.Info("report: scheduler + API wired")
+		).
+			WithDeliverer(reportDelivererShim{channels: alertRepo, router: notifyRouter}).
+			WithReadyCheck(reportLLMReady(llmSettingsResolver))
+		reportSchedulerReady = true
+		log.Info("report: generator wired")
 	} else {
-		log.Info("report: not wired (chat runtime is not the graph kernel)")
+		reportGen = managerbizreport.NewUnavailableGenerator("LLM provider not configured")
+		log.Info("report: API wired without generator", slog.String("reason", "LLM provider not configured"))
 	}
+	reportUC := managerbizreport.NewUsecase(reportRepo, reportGen, uuid.NewString).
+		WithReadRepo(reportRepo).
+		WithDefaultLocale(firstNonEmpty(os.Getenv("ONGRID_DEFAULT_LOCALE"), "en"))
+	if reportSchedulerReady {
+		managerbizreport.NewScheduler(reportUC, log).Start(rootCtx)
+		log.Info("report: scheduler wired")
+	}
+	reportHandler := managerserverreport.NewHandler(reportUC)
 
 	// Boot compensation pass for the structured RCA path: incidents that
 	// fired while no LLM provider was configured had their auto-investigation
@@ -1879,18 +1886,14 @@ func main() {
 			marketplaceHandler.Register(protected)
 			promProxyHandler.RegisterProtected(protected)
 			managerserveraudit.NewHandler(auditUC).Register(protected)
-			if reportHandler != nil {
-				reportHandler.Register(protected)
-			}
+			reportHandler.Register(protected)
 		})
 	})
 
 	// Public (unauthenticated) report share route: /r/{token}. Mounted
 	// on the root mux outside the auth group so a shared report opens
 	// without a login (30-day TTL enforced in the biz layer).
-	if reportHandler != nil {
-		reportHandler.RegisterPublic(mux)
-	}
+	reportHandler.RegisterPublic(mux)
 
 	apiServer := httpserver.New(cfg.HTTPAddr, mux, log.With(slog.String("listener", "api")))
 
@@ -2202,6 +2205,34 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
+func knownLLMProviderIDs() []string {
+	return []string{
+		llm.ProviderOpenAI,
+		llm.ProviderAnthropic,
+		llm.ProviderZhipu,
+		llm.ProviderGemini,
+		llm.ProviderDeepSeek,
+		llm.ProviderKimi,
+		llm.ProviderCustom,
+	}
+}
+
+func reportLLMReady(resolver *managerbizsetting.LLMSettingsResolver) func(context.Context) error {
+	return func(ctx context.Context) error {
+		if resolver == nil {
+			return fmt.Errorf("%w: LLM provider not configured", errs.ErrNotWiredYet)
+		}
+		providers, resolvedDefault, err := resolver.ResolveProviders(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve LLM providers: %w", err)
+		}
+		if id, _ := pickProviderDefault(providers, resolvedDefault); id != "" {
+			return nil
+		}
+		return fmt.Errorf("%w: LLM provider not configured", errs.ErrNotWiredYet)
+	}
+}
+
 // pickProviderDefault mirrors llm.MultiClient's catalog default:
 // use the configured default when it names an available provider, otherwise
 // pick the first configured provider by stable provider id. Background graph
@@ -2226,7 +2257,7 @@ func pickProviderDefault(providers []llm.ProviderConfig, preferred string) (stri
 	if len(available) > 0 {
 		return available[0].ID, available[0].Model
 	}
-	return preferred, ""
+	return "", ""
 }
 
 // dedupeModels returns vals with empty strings dropped and duplicates
@@ -2620,9 +2651,6 @@ func buildAIOpsRuntime(
 			addInner(llm.ProviderGemini, firstNonEmpty(cfg.LLM.Gemini.Model, "gemini-2.5-pro"))
 		}
 	}
-	if len(innerModels) == 0 {
-		return nil, fmt.Errorf("chatruntime: no LLM provider configured")
-	}
 	// Pre-register an inner for every known provider id (incl. the generic
 	// "custom" endpoint) even if unconfigured at boot, so a provider whose key
 	// is added via the UI AFTER boot routes immediately — no restart. Only the
@@ -2630,13 +2658,13 @@ func buildAIOpsRuntime(
 	// dynamically by llmClient. Unconfigured providers never reach the picker
 	// (the /v1/aiops/models catalog gates on ResolveProviders), so they're
 	// never selected; a stray call to one fails cleanly at key resolution.
-	for _, id := range []string{
-		llm.ProviderOpenAI, llm.ProviderAnthropic, llm.ProviderZhipu,
-		llm.ProviderGemini, llm.ProviderDeepSeek, llm.ProviderKimi, llm.ProviderCustom,
-	} {
+	for _, id := range knownLLMProviderIDs() {
 		if _, ok := innerModels[id]; !ok {
 			addInner(id, "") // model supplied per-call (picker / DefaultResolver)
 		}
+	}
+	if len(innerModels) == 0 {
+		return nil, fmt.Errorf("chatruntime: no LLM provider configured")
 	}
 	if defProv == "" {
 		defProv = llm.ProviderOpenAI

--- a/internal/manager/biz/report/generator.go
+++ b/internal/manager/biz/report/generator.go
@@ -51,6 +51,7 @@ type workerGenerator struct {
 	facts     FactsCollector
 	spawner   WorkerSpawner
 	deliverer Deliverer // nil = in-app only
+	ready     func(context.Context) error
 	cfg       GeneratorConfig
 	log       *slog.Logger
 }
@@ -82,6 +83,20 @@ func NewWorkerGenerator(repo Repo, facts FactsCollector, spawner WorkerSpawner, 
 func (g *workerGenerator) WithDeliverer(d Deliverer) *workerGenerator {
 	g.deliverer = d
 	return g
+}
+
+// WithReadyCheck attaches a lightweight preflight used by manual and
+// scheduled triggers before creating a pending report row.
+func (g *workerGenerator) WithReadyCheck(fn func(context.Context) error) *workerGenerator {
+	g.ready = fn
+	return g
+}
+
+func (g *workerGenerator) Ready(ctx context.Context) error {
+	if g.ready == nil {
+		return nil
+	}
+	return g.ready(ctx)
 }
 
 // Generate runs the full pipeline for one report id. Always reaches a

--- a/internal/manager/biz/report/usecase.go
+++ b/internal/manager/biz/report/usecase.go
@@ -10,6 +10,7 @@ package report
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/report"
@@ -49,12 +50,34 @@ type Generator interface {
 	Generate(ctx context.Context, reportID string)
 }
 
+type readyChecker interface {
+	Ready(ctx context.Context) error
+}
+
 // nopGenerator leaves the report in pending — used until PR-2 wires the
 // real worker. Surfaced explicitly (not nil) so callers don't have to
 // nil-check on every fire.
 type nopGenerator struct{}
 
 func (nopGenerator) Generate(context.Context, string) {}
+
+type unavailableGenerator struct {
+	err error
+}
+
+// NewUnavailableGenerator returns a Generator that keeps report routes
+// mounted while generation is unavailable, for example when no LLM
+// provider is configured at startup.
+func NewUnavailableGenerator(reason string) Generator {
+	if reason == "" {
+		reason = "report generator unavailable"
+	}
+	return unavailableGenerator{err: fmt.Errorf("%w: %s", errs.ErrNotWiredYet, reason)}
+}
+
+func (g unavailableGenerator) Generate(context.Context, string) {}
+
+func (g unavailableGenerator) Ready(context.Context) error { return g.err }
 
 // Usecase is the report business logic.
 type Usecase struct {
@@ -142,6 +165,9 @@ func (u *Usecase) CreateSchedule(ctx context.Context, s *model.ReportSchedule, n
 // nextFireAt is computed by the caller (it owns the cron parser); we
 // take it as an argument so this layer stays free of the cron lib.
 func (u *Usecase) FireSchedule(ctx context.Context, s *model.ReportSchedule, fireAt, nextFireAt time.Time) (*model.Report, error) {
+	if err := u.ensureGeneratorReady(ctx); err != nil {
+		return nil, err
+	}
 	loc, err := loadLocation(s.Timezone)
 	if err != nil {
 		return nil, err
@@ -193,6 +219,9 @@ func (u *Usecase) GenerateNow(ctx context.Context, createdBy uint64, kind, tz, s
 	if _, err := loadLocation(tz); err != nil {
 		return nil, err
 	}
+	if err := u.ensureGeneratorReady(ctx); err != nil {
+		return nil, err
+	}
 	if locale == "" {
 		locale = u.defaultLocale
 	}
@@ -210,7 +239,7 @@ func (u *Usecase) GenerateNow(ctx context.Context, createdBy uint64, kind, tz, s
 		ErrorMsg:    "",
 		ContentJSON: "",
 		ContentMD:   "",
-		ScopeJSON: scopeJSON,
+		ScopeJSON:   scopeJSON,
 	}
 	if err := u.repo.CreateReport(ctx, rpt); err != nil {
 		return nil, err
@@ -223,21 +252,28 @@ func (u *Usecase) GenerateNow(ctx context.Context, createdBy uint64, kind, tz, s
 func (u *Usecase) buildPendingReport(s *model.ReportSchedule, p Period) *model.Report {
 	id := s.ID
 	return &model.Report{
-		ID:            u.idGen(),
-		ScheduleID:    &id,
-		CreatedBy:     s.CreatedBy,
-		Title:         TitleFor(s.Kind, p, u.defaultLocale),
-		Kind:          s.Kind,
-		PeriodStart:   p.Start,
-		PeriodEnd:     p.End,
-		Timezone:      s.Timezone,
-		Locale:        u.defaultLocale,
-		Status:        model.StatusPending,
-		ErrorMsg:      "",
-		ContentJSON:   "",
-		ContentMD:     "",
-		ScopeJSON: s.ScopeJSON,
+		ID:          u.idGen(),
+		ScheduleID:  &id,
+		CreatedBy:   s.CreatedBy,
+		Title:       TitleFor(s.Kind, p, u.defaultLocale),
+		Kind:        s.Kind,
+		PeriodStart: p.Start,
+		PeriodEnd:   p.End,
+		Timezone:    s.Timezone,
+		Locale:      u.defaultLocale,
+		Status:      model.StatusPending,
+		ErrorMsg:    "",
+		ContentJSON: "",
+		ContentMD:   "",
+		ScopeJSON:   s.ScopeJSON,
 	}
+}
+
+func (u *Usecase) ensureGeneratorReady(ctx context.Context) error {
+	if g, ok := u.gen.(readyChecker); ok {
+		return g.Ready(ctx)
+	}
+	return nil
 }
 
 // loadLocation resolves a schedule timezone, defaulting to UTC on empty.

--- a/internal/manager/biz/report/usecase_test.go
+++ b/internal/manager/biz/report/usecase_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync"
 	"testing"
@@ -242,6 +243,27 @@ func TestGenerateNow_NoScheduleNoDedup(t *testing.T) {
 	}
 	if len(repo.reports) != 2 {
 		t.Errorf("expected 2 manual reports, got %d", len(repo.reports))
+	}
+}
+
+func TestGenerateNow_GeneratorUnavailableDoesNotCreateReport(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, NewUnavailableGenerator("LLM provider not configured"), seqIDGen())
+	loc := mustLoc(t, "Asia/Shanghai")
+	p := Period{
+		Start: time.Date(2026, 6, 1, 0, 0, 0, 0, loc),
+		End:   time.Date(2026, 6, 8, 0, 0, 0, 0, loc),
+	}
+
+	rpt, err := uc.GenerateNow(context.Background(), 42, model.KindWeekly, "Asia/Shanghai", "{}", "zh", p)
+	if !errors.Is(err, errs.ErrNotWiredYet) {
+		t.Fatalf("GenerateNow err = %v, want ErrNotWiredYet", err)
+	}
+	if rpt != nil {
+		t.Fatalf("GenerateNow report = %+v, want nil", rpt)
+	}
+	if len(repo.reports) != 0 {
+		t.Fatalf("unavailable generator should not create report rows, got %d", len(repo.reports))
 	}
 }
 

--- a/internal/manager/server/report/dto.go
+++ b/internal/manager/server/report/dto.go
@@ -244,6 +244,8 @@ func errCode(err error) string {
 		return "forbidden"
 	case errors.Is(err, errs.ErrInvalid):
 		return "invalid"
+	case errors.Is(err, errs.ErrNotWiredYet):
+		return "not-wired-yet"
 	default:
 		return "internal"
 	}

--- a/internal/manager/server/report/http_test.go
+++ b/internal/manager/server/report/http_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func newTestHandler(t *testing.T) (*Handler, *gorm.DB) {
+	return newTestHandlerWithGenerator(t, nil)
+}
+
+func newTestHandlerWithGenerator(t *testing.T, gen bizreport.Generator) (*Handler, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
@@ -32,7 +36,7 @@ func newTestHandler(t *testing.T) (*Handler, *gorm.DB) {
 		t.Fatalf("migrate: %v", err)
 	}
 	repo := reportstore.NewRepo(db)
-	uc := bizreport.NewUsecase(repo, nil, func() string { return "rpt-" + time.Now().Format("150405.000000000") }).
+	uc := bizreport.NewUsecase(repo, gen, func() string { return "rpt-" + time.Now().Format("150405.000000000") }).
 		WithReadRepo(repo)
 	return NewHandler(uc), db
 }
@@ -127,6 +131,24 @@ func TestGenerateNow_AsUser_Accepted(t *testing.T) {
 	}
 }
 
+func TestGenerateNow_WhenLLMProviderMissing_ReturnsNotWired(t *testing.T) {
+	h, _ := newTestHandlerWithGenerator(t, bizreport.NewUnavailableGenerator("LLM provider not configured"))
+	w := serve(h, req("POST", "/v1/reports", `{"kind":"weekly","timezone":"UTC"}`, "user"))
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("generate status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var body errorBody
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != "not-wired-yet" {
+		t.Fatalf("error code = %q, want not-wired-yet", body.Code)
+	}
+	if !strings.Contains(body.Error, "LLM provider not configured") {
+		t.Fatalf("error body = %q, want LLM provider hint", body.Error)
+	}
+}
+
 func TestShareAndPublicRead(t *testing.T) {
 	h, _ := newTestHandler(t)
 	// Create a manual report.
@@ -163,4 +185,3 @@ func TestUnauthenticated401(t *testing.T) {
 		t.Errorf("unauthenticated status = %d, want 401", w.Code)
 	}
 }
-

--- a/web/src/pages/ReportSchedules.tsx
+++ b/web/src/pages/ReportSchedules.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/cn';
 import { fullDateTime } from '@/lib/format';
 import { usePermissions } from '@/store/me';
 import { useI18n } from '@/i18n/locale';
+import { ApiError } from '@/api/client';
 import { listChannels, type Channel } from '@/api/alerts';
 import {
   createSchedule,
@@ -37,6 +38,7 @@ export default function ReportSchedulesPage() {
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState<ReportSchedule | null>(null);
   const [creating, setCreating] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -68,9 +70,14 @@ export default function ReportSchedulesPage() {
     [load, tr],
   );
   const onRunNow = useCallback(async (s: ReportSchedule) => {
-    await runScheduleNow(s.id);
-    window.location.href = '/reports';
-  }, []);
+    setErr(null);
+    try {
+      await runScheduleNow(s.id);
+      window.location.href = '/reports';
+    } catch (e) {
+      setErr(reportActionError(e, tr));
+    }
+  }, [tr]);
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
@@ -98,77 +105,93 @@ export default function ReportSchedulesPage() {
       </header>
 
       <div className="flex-1 overflow-y-auto px-6 py-5">
-      {loading ? (
-        <div className="py-16 text-center text-sm text-zinc-500">{tr('加载中…', 'Loading…')}</div>
-      ) : items.length === 0 ? (
-        <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-zinc-800 py-16 text-center text-sm text-zinc-400">
-          {tr('还没有定时任务。新建一个日报/周报定时生成。', 'No schedules yet. Create a daily/weekly scheduled report.')}
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-          {items.map((s) => (
-            <div key={s.id} className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5">
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-zinc-100">{s.name || tr('(未命名)', '(unnamed)')}</span>
-                  <span className="rounded bg-zinc-800 px-1.5 py-0.5 text-[11px] text-zinc-400">
-                    {KINDS.find((k) => k.key === s.kind)?.[tr('zh', 'en') as 'zh' | 'en'] ?? s.kind}
-                  </span>
-                  {!s.enabled && (
-                    <span className="rounded bg-zinc-700/40 px-1.5 py-0.5 text-[11px] text-zinc-500">
-                      {tr('已停用', 'Disabled')}
+        {err && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+            <span>{err}</span>
+            <Link to="/settings/llm" className="shrink-0 font-medium text-amber-700 hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
+              {tr('去配置', 'Configure')}
+            </Link>
+          </div>
+        )}
+        {loading ? (
+          <div className="py-16 text-center text-sm text-zinc-500">{tr('加载中…', 'Loading…')}</div>
+        ) : items.length === 0 ? (
+          <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-zinc-800 py-16 text-center text-sm text-zinc-400">
+            {tr('还没有定时任务。新建一个日报/周报定时生成。', 'No schedules yet. Create a daily/weekly scheduled report.')}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+            {items.map((s) => (
+              <div key={s.id} className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3.5">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-zinc-100">{s.name || tr('(未命名)', '(unnamed)')}</span>
+                    <span className="rounded bg-zinc-800 px-1.5 py-0.5 text-[11px] text-zinc-400">
+                      {KINDS.find((k) => k.key === s.kind)?.[tr('zh', 'en') as 'zh' | 'en'] ?? s.kind}
                     </span>
+                    {!s.enabled && (
+                      <span className="rounded bg-zinc-700/40 px-1.5 py-0.5 text-[11px] text-zinc-500">
+                        {tr('已停用', 'Disabled')}
+                      </span>
+                    )}
+                  </div>
+                  {canMutate && (
+                    <div className="flex items-center gap-1">
+                      <IconBtn title={tr('立即生成', 'Run now')} onClick={() => void onRunNow(s)}>
+                        <Play size={13} />
+                      </IconBtn>
+                      <IconBtn title={tr('编辑', 'Edit')} onClick={() => setEditing(s)}>
+                        <Pencil size={13} />
+                      </IconBtn>
+                      <IconBtn title={s.enabled ? tr('停用', 'Disable') : tr('启用', 'Enable')} onClick={() => void onToggle(s)}>
+                        <Power size={13} className={s.enabled ? 'text-emerald-400' : 'text-zinc-500'} />
+                      </IconBtn>
+                      <IconBtn title={tr('删除', 'Delete')} onClick={() => void onDelete(s)} danger>
+                        <Trash2 size={13} />
+                      </IconBtn>
+                    </div>
                   )}
                 </div>
-                {canMutate && (
-                  <div className="flex items-center gap-1">
-                    <IconBtn title={tr('立即生成', 'Run now')} onClick={() => void onRunNow(s)}>
-                      <Play size={13} />
-                    </IconBtn>
-                    <IconBtn title={tr('编辑', 'Edit')} onClick={() => setEditing(s)}>
-                      <Pencil size={13} />
-                    </IconBtn>
-                    <IconBtn title={s.enabled ? tr('停用', 'Disable') : tr('启用', 'Enable')} onClick={() => void onToggle(s)}>
-                      <Power size={13} className={s.enabled ? 'text-emerald-400' : 'text-zinc-500'} />
-                    </IconBtn>
-                    <IconBtn title={tr('删除', 'Delete')} onClick={() => void onDelete(s)} danger>
-                      <Trash2 size={13} />
-                    </IconBtn>
+                <div className="mt-1 font-mono text-xs text-zinc-500">
+                  {s.cron_spec} · {s.timezone}
+                </div>
+                {s.next_fire_at && (
+                  <div className="mt-0.5 text-xs text-zinc-600">
+                    {tr('下次：', 'Next: ')}
+                    {fullDateTime(s.next_fire_at)}
                   </div>
                 )}
               </div>
-              <div className="mt-1 font-mono text-xs text-zinc-500">
-                {s.cron_spec} · {s.timezone}
-              </div>
-              {s.next_fire_at && (
-                <div className="mt-0.5 text-xs text-zinc-600">
-                  {tr('下次：', 'Next: ')}
-                  {fullDateTime(s.next_fire_at)}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
 
-      {(creating || editing) && (
-        <ScheduleForm
-          channels={channels}
-          initial={editing}
-          onClose={() => {
-            setCreating(false);
-            setEditing(null);
-          }}
-          onSaved={() => {
-            setCreating(false);
-            setEditing(null);
-            void load();
-          }}
-        />
-      )}
+        {(creating || editing) && (
+          <ScheduleForm
+            channels={channels}
+            initial={editing}
+            onClose={() => {
+              setCreating(false);
+              setEditing(null);
+            }}
+            onSaved={() => {
+              setCreating(false);
+              setEditing(null);
+              void load();
+            }}
+          />
+        )}
       </div>
     </main>
   );
+}
+
+function reportActionError(e: unknown, tr: (zh: string, en: string) => string): string {
+  if (e instanceof ApiError && e.code === 'not-wired-yet') {
+    return tr('当前未配置 LLM provider，请先配置模型后再生成报告。', 'No LLM provider is configured. Configure a model before generating reports.');
+  }
+  if (e instanceof ApiError) return e.message;
+  return (e as Error)?.message || tr('生成失败', 'Generation failed');
 }
 
 function IconBtn({

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -6,6 +6,7 @@ import { relativeTime } from '@/lib/format';
 import { usePoll } from '@/lib/usePoll';
 import { usePermissions } from '@/store/me';
 import { useI18n } from '@/i18n/locale';
+import { ApiError } from '@/api/client';
 import { generateNow, listReports, type ReportListItem, type ReportStatus } from '@/api/reports';
 
 const POLL_MS = 20_000;
@@ -56,6 +57,7 @@ export default function ReportsPage() {
   const [statusFilter, setStatusFilter] = useState('');
   const [kindFilter, setKindFilter] = useState('');
   const [page, setPage] = useState(0);
+  const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -83,14 +85,17 @@ export default function ReportsPage() {
 
   const onGenerate = useCallback(async () => {
     setGenerating(true);
+    setErr(null);
     try {
       const rpt = await generateNow({ kind: 'weekly' });
       await load();
       navigate(`/reports/${rpt.id}`);
+    } catch (e) {
+      setErr(reportActionError(e, tr));
     } finally {
       setGenerating(false);
     }
-  }, [load, navigate]);
+  }, [load, navigate, tr]);
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
@@ -129,6 +134,14 @@ export default function ReportsPage() {
       </div>
 
       <div className="flex flex-1 flex-col overflow-y-auto px-6 py-5">
+        {err && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+            <span>{err}</span>
+            <Link to="/settings/llm" className="shrink-0 font-medium text-amber-700 hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
+              {tr('去配置', 'Configure')}
+            </Link>
+          </div>
+        )}
         <div className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
           <table className="w-full table-fixed text-sm">
             <colgroup>
@@ -229,6 +242,14 @@ export default function ReportsPage() {
       </div>
     </main>
   );
+}
+
+function reportActionError(e: unknown, tr: (zh: string, en: string) => string): string {
+  if (e instanceof ApiError && e.code === 'not-wired-yet') {
+    return tr('当前未配置 LLM provider，请先配置模型后再生成报告。', 'No LLM provider is configured. Configure a model before generating reports.');
+  }
+  if (e instanceof ApiError) return e.message;
+  return (e as Error)?.message || tr('生成失败', 'Generation failed');
 }
 
 function FilterGroup({


### PR DESCRIPTION
## Summary

- Align report generation with the configured LLM catalog default so reports use the same default provider/model as the app model catalog.
- Keep report routes mounted even when no LLM provider is configured; manual generation now returns `not-wired-yet` instead of surfacing route-level 404.
- Add report generator readiness checks so an empty-key `default_provider` is not treated as usable, while newly configured providers can be used without another code change.
- Show an i18n-aware report-page prompt with light/dark styling when generation is blocked by missing LLM configuration.

## Validation

- `go test -race ./cmd/ongrid ./internal/manager/biz/report ./internal/manager/server/report ./internal/pkg/llm`
- `npm run typecheck`
- Built local `ongrid:dev` and `ongrid-web:dev`, restarted local `ongrid`/`nginx`.
- Verified `GET /api/v1/reports` is routed and authenticated, and authenticated `POST /api/v1/reports` returns `501` with `code=not-wired-yet` when no LLM provider key is configured.
