### PR TITLE
fix(release): harden package release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Build and publish release
-    runs-on: ubuntu-24.04
+  build:
+    name: Build ${{ matrix.arch }} package
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     env:
       FRONTIER_VERSION: v1.2.4
@@ -56,11 +67,6 @@ jobs:
           go-version: '1.25.x'
           cache: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,11 +89,67 @@ jobs:
           set -euo pipefail
           make fetch-embedding-model
 
-      - name: Build amd64 and arm64 packages
+      - name: Build ${{ matrix.arch }} package
         shell: bash
         run: |
           set -euo pipefail
-          make package-all
+          make package TARGET_OS=linux TARGET_ARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }}
+
+      - name: Verify package
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          arch="${{ matrix.arch }}"
+          test -s "dist/out/ongrid-${tag}-linux-${arch}.tar.xz"
+          test -s "dist/out/ongrid-${tag}-linux-${arch}.tar.xz.sha256"
+          (cd dist/out && sha256sum -c "ongrid-${tag}-linux-${arch}.tar.xz.sha256")
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ matrix.arch }}
+          path: |
+            dist/out/ongrid-${{ steps.tag.outputs.tag }}-linux-${{ matrix.arch }}.tar.xz
+            dist/out/ongrid-${{ steps.tag.outputs.tag }}-linux-${{ matrix.arch }}.tar.xz.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-24.04
+    needs: build
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release tag must match vMAJOR.MINOR.PATCH, got: $tag" >&2
+            exit 2
+          fi
+          version="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$version" != "$tag" ]]; then
+            echo "VERSION ($version) must match tag ($tag)" >&2
+            exit 2
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-assets-*
+          path: dist/out
+          merge-multiple: true
 
       - name: Verify release assets
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ docker-save: ## [release] docker save ongrid:$(VERSION) 到 stage
 # Promtail bundle (ADR-012 / ADR-015 logs plugin).
 # Cached under bin/<os>-<arch>/promtail to avoid re-downloading on every build.
 PROMTAIL_VERSION ?= 3.4.0
+FETCH_CURL_FLAGS ?= -fL --retry 3 --retry-all-errors --retry-delay 3 --connect-timeout 15 --speed-time 60 --speed-limit 1024 --show-error
 
 .PHONY: fetch-promtail
 fetch-promtail: ## [release] 下载 promtail 到 bin/<os>-<arch>/promtail (Grafana 只发 linux 版本)
@@ -273,7 +274,7 @@ fetch-promtail: ## [release] 下载 promtail 到 bin/<os>-<arch>/promtail (Grafa
 		zip=/tmp/promtail-$$os-$$arch.zip; \
 		url=https://github.com/grafana/loki/releases/download/v$(PROMTAIL_VERSION)/promtail-$$os-$$arch.zip; \
 		echo "[promtail] downloading $$url"; \
-		curl -fsL -o $$zip $$url || { echo "promtail download failed for $$target"; exit 1; }; \
+		curl $(FETCH_CURL_FLAGS) -o $$zip $$url || { echo "promtail download failed for $$target"; exit 1; }; \
 		unzip -p $$zip > $$dest; \
 		chmod +x $$dest; \
 		rm -f $$zip; \
@@ -301,7 +302,7 @@ fetch-otelcol: ## [release] 下载 otelcol-contrib 到 bin/<os>-<arch>/otelcol-c
 		tgz=/tmp/otelcol-contrib-$$os-$$arch.tar.gz; \
 		url=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTELCOL_VERSION)/otelcol-contrib_$(OTELCOL_VERSION)_$${os}_$${arch}.tar.gz; \
 		echo "[otelcol] downloading $$url"; \
-		curl -fsL -o $$tgz $$url || { echo "otelcol-contrib download failed for $$target"; exit 1; }; \
+		curl $(FETCH_CURL_FLAGS) -o $$tgz $$url || { echo "otelcol-contrib download failed for $$target"; exit 1; }; \
 		tar -xzf $$tgz -C $(BIN_DIR)/$$target otelcol-contrib || { echo "extract failed for $$target"; exit 1; }; \
 		chmod +x $$dest; \
 		rm -f $$tgz; \
@@ -336,7 +337,7 @@ fetch-node-exporter: ## [release] 下载 node_exporter 到 bin/<os>-<arch>/node_
 		tgz=/tmp/node_exporter-$$os-$$arch.tar.gz; \
 		url=https://github.com/prometheus/node_exporter/releases/download/v$(NODE_EXPORTER_VERSION)/node_exporter-$(NODE_EXPORTER_VERSION).$${os}-$${arch}.tar.gz; \
 		echo "[node_exporter] downloading $$url"; \
-		curl -fsL -o $$tgz $$url || { echo "node_exporter download failed for $$target"; exit 1; }; \
+		curl $(FETCH_CURL_FLAGS) -o $$tgz $$url || { echo "node_exporter download failed for $$target"; exit 1; }; \
 		tar -xzf $$tgz --strip-components=1 -C $(BIN_DIR)/$$target node_exporter-$(NODE_EXPORTER_VERSION).$${os}-$${arch}/node_exporter || { echo "extract failed for $$target"; exit 1; }; \
 		chmod +x $$dest; \
 		rm -f $$tgz; \
@@ -357,7 +358,7 @@ fetch-process-exporter: ## [release] 下载 process-exporter 到 bin/<os>-<arch>
 		tgz=/tmp/process_exporter-$$os-$$arch.tar.gz; \
 		url=https://github.com/ncabatoff/process-exporter/releases/download/v$(PROCESS_EXPORTER_VERSION)/process-exporter-$(PROCESS_EXPORTER_VERSION).$${os}-$${arch}.tar.gz; \
 		echo "[process_exporter] downloading $$url"; \
-		curl -fsL -o $$tgz $$url || { echo "process-exporter download failed for $$target"; exit 1; }; \
+		curl $(FETCH_CURL_FLAGS) -o $$tgz $$url || { echo "process-exporter download failed for $$target"; exit 1; }; \
 		tar -xzf $$tgz --strip-components=1 -C $(BIN_DIR)/$$target process-exporter-$(PROCESS_EXPORTER_VERSION).$${os}-$${arch}/process-exporter || { echo "extract failed for $$target"; exit 1; }; \
 		mv $(BIN_DIR)/$$target/process-exporter $$dest; \
 		chmod +x $$dest; \

--- a/dist/fetch-embedding-model.sh
+++ b/dist/fetch-embedding-model.sh
@@ -20,38 +20,38 @@ warn() { printf '[fetch-emb] warn: %s\n' "$*" >&2; }
 die()  { printf '[fetch-emb] error: %s\n' "$*" >&2; exit 1; }
 
 # The bundle layout fastembed-go expects under CacheDir/<EmbeddingModel>/
-# is a flat directory of these files. We download them straight from the
-# Qdrant fastembed model mirror on HuggingFace (mirrors of the BAAI bge
-# weights, pre-quantized to int8 ONNX).
+# is the extracted qdrant-fastembed tarball. Keep this URL aligned with
+# github.com/anush008/fastembed-go@v1.0.0's downloadFromGcs implementation.
 MODEL=fast-bge-small-zh-v1.5
-HF_BASE=https://huggingface.co/Qdrant/bge-small-zh-v1.5-onnx-Q/resolve/main
+FASTEMBED_BASE=${ONGRID_FASTEMBED_BASE:-https://storage.googleapis.com/qdrant-fastembed}
 TARGET="$DEST/$MODEL"
 
-# Files fastembed-go reads — verified against an actual cache populated
-# by NewFlagEmbedding(BGESmallZH). If upstream renames any of these,
-# fastembed will hit "missing file" and we'll see it on first manager
-# boot — easy to spot.
 FILES=(model_optimized.onnx tokenizer_config.json special_tokens_map.json
        config.json tokenizer.json vocab.txt ort_config.json)
 
 mkdir -p "$TARGET"
+missing=0
 for f in "${FILES[@]}"; do
-    if [[ -s "$TARGET/$f" ]]; then
-        log "$f already present — skipping"
-        continue
-    fi
-    log "fetching $f"
-    if ! curl -fL --retry 3 --connect-timeout 15 -o "$TARGET/$f" "$HF_BASE/$f"; then
-        warn "failed to fetch $f from $HF_BASE — try ONGRID_HF_MIRROR=https://hf-mirror.com (CN-friendly)"
-        if [[ -n "${ONGRID_HF_MIRROR:-}" ]]; then
-            alt="${ONGRID_HF_MIRROR%/}/Qdrant/bge-small-zh-v1.5-onnx-Q/resolve/main/$f"
-            log "retrying via mirror: $alt"
-            curl -fL --retry 3 --connect-timeout 15 -o "$TARGET/$f" "$alt"
-        else
-            die "no mirror configured + upstream unreachable"
-        fi
+    if [[ ! -s "$TARGET/$f" ]]; then
+        missing=1
+        break
     fi
 done
+
+if [[ "$missing" -eq 0 ]]; then
+    log "$MODEL already present — skipping"
+else
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' EXIT
+    url="${FASTEMBED_BASE%/}/${MODEL}.tar.gz"
+    log "fetching $url"
+    curl -fL --retry 3 --connect-timeout 15 -o "$tmp" "$url" || die "failed to fetch $url"
+    rm -rf "$TARGET"
+    tar -xzf "$tmp" -C "$DEST"
+    for f in "${FILES[@]}"; do
+        [[ -s "$TARGET/$f" ]] || die "downloaded model missing $f"
+    done
+fi
 
 log "cached $TARGET ($(du -sh "$TARGET" | awk '{print $1}'))"
 log "next \`make package\` will bundle this under embeddings/$MODEL/"


### PR DESCRIPTION
## Summary

- fetch the bundled embedding model from the fastembed source archive
- build amd64 and arm64 server packages on native GitHub runners
- add bounded retries and timeouts for release dependency downloads

## Why

The release package workflow was vulnerable to slow cross-architecture emulation and unbounded dependency downloads. This makes the package build path more predictable for version-tag releases.

## Validation

- `git diff --check origin/main...HEAD`
- GitHub Actions Release workflow succeeded for `v0.8.4`: https://github.com/ongridio/ongrid/actions/runs/27197054717
