### PR TITLE
docs(release): update v0.8.4 release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,21 +162,23 @@ jobs:
             (cd dist/out && sha256sum -c "ongrid-${tag}-linux-${arch}.tar.xz.sha256")
           done
 
-      - name: Write release notes
+      - name: Write release install notes
         shell: bash
         run: |
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
           cat > "$RUNNER_TEMP/release-notes.md" <<EOF
-          Install (Ubuntu 22.04+/Debian 12+/RHEL/Rocky 9):
+          ## Install
 
-          AMD64:
+          Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9 are supported.
+
+          ### AMD64
           \`\`\`bash
           wget https://github.com/ongridio/ongrid/releases/download/${tag}/ongrid-${tag}-linux-amd64.tar.xz
           tar -xf ongrid-${tag}-linux-amd64.tar.xz && cd ongrid-${tag}-linux-amd64 && sudo ./install.sh
           \`\`\`
 
-          ARM64:
+          ### ARM64
           \`\`\`bash
           wget https://github.com/ongridio/ongrid/releases/download/${tag}/ongrid-${tag}-linux-arm64.tar.xz
           tar -xf ongrid-${tag}-linux-arm64.tar.xz && cd ongrid-${tag}-linux-arm64 && sudo ./install.sh
@@ -190,6 +192,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
+          release_notes="$(cat "$RUNNER_TEMP/release-notes.md")"
           gh release create "$tag" \
             "dist/out/ongrid-${tag}-linux-amd64.tar.xz" \
             "dist/out/ongrid-${tag}-linux-amd64.tar.xz.sha256" \
@@ -197,4 +200,5 @@ jobs:
             "dist/out/ongrid-${tag}-linux-arm64.tar.xz.sha256" \
             --verify-tag \
             --title "Ongrid ${tag}" \
-            --notes-file "$RUNNER_TEMP/release-notes.md"
+            --generate-notes \
+            --notes "$release_notes"

--- a/README.md
+++ b/README.md
@@ -45,23 +45,30 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 
 Download the latest release for your server architecture (`linux-amd64` or `linux-arm64`), extract it, and run the installer (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+Choose the command for your server architecture:
+
+**AMD64**
 ```bash
-# 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    ARM64 servers: replace linux-amd64 with linux-arm64.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Extract
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Install
 sudo ./install.sh
 ```
 
-**🇨🇳 Mainland China** — if GitHub is slow, download step 1 from the CDN mirror instead (everything else is the same):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 Mainland China** — if GitHub is slow, use the matching CDN mirror URL instead:
 
 ```bash
-# ARM64 servers: replace linux-amd64 with linux-arm64.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### Or run from source

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Download the latest release for your server architecture (`linux-amd64` or `linu
 ```bash
 # 1. Download latest release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    ARM64 servers: replace linux-amd64 with linux-arm64.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Extract
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Install
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64 servers: replace linux-amd64 with linux-arm64.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### Or run from source

--- a/README_DE.md
+++ b/README_DE.md
@@ -45,23 +45,30 @@
 
 Laden Sie das aktuelle Release für Ihre Serverarchitektur (`linux-amd64` oder `linux-arm64`) herunter, entpacken Sie es und führen Sie das Installationsskript aus (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+Wählen Sie den Befehl für Ihre Serverarchitektur:
+
+**AMD64**
 ```bash
-# 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    ARM64-Server: linux-amd64 durch linux-arm64 ersetzen.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Entpacken
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Installieren
 sudo ./install.sh
 ```
 
-**🇨🇳 Festlandchina** — Wenn GitHub langsam ist, laden Sie Schritt 1 stattdessen vom CDN-Mirror (alles andere ist identisch):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 Festlandchina** — Wenn GitHub langsam ist, verwenden Sie die passende CDN-Mirror-URL für Ihre Architektur:
 
 ```bash
-# ARM64-Server: linux-amd64 durch linux-arm64 ersetzen.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### Oder aus dem Quellcode ausführen

--- a/README_DE.md
+++ b/README_DE.md
@@ -48,10 +48,10 @@ Laden Sie das aktuelle Release für Ihre Serverarchitektur (`linux-amd64` oder `
 ```bash
 # 1. Aktuelles Release herunterladen (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    ARM64-Server: linux-amd64 durch linux-arm64 ersetzen.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Entpacken
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Installieren
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64-Server: linux-amd64 durch linux-arm64 ersetzen.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### Oder aus dem Quellcode ausführen

--- a/README_ES.md
+++ b/README_ES.md
@@ -45,23 +45,30 @@
 
 Descarga la última release para la arquitectura de tu servidor (`linux-amd64` o `linux-arm64`), descomprímela y ejecuta el instalador (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+Elige el comando para la arquitectura de tu servidor:
+
+**AMD64**
 ```bash
-# 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    Servidores ARM64: reemplaza linux-amd64 por linux-arm64.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Descomprimir
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Instalar
 sudo ./install.sh
 ```
 
-**🇨🇳 China continental** — si GitHub va lento, descarga el paso 1 desde el mirror CDN (el resto es igual):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 China continental** — si GitHub va lento, usa la URL del mirror CDN que coincida con tu arquitectura:
 
 ```bash
-# Servidores ARM64: reemplaza linux-amd64 por linux-arm64.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### O ejecutar desde el código fuente

--- a/README_ES.md
+++ b/README_ES.md
@@ -48,10 +48,10 @@ Descarga la última release para la arquitectura de tu servidor (`linux-amd64` o
 ```bash
 # 1. Descarga la última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    Servidores ARM64: reemplaza linux-amd64 por linux-arm64.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Descomprimir
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # Servidores ARM64: reemplaza linux-amd64 por linux-arm64.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### O ejecutar desde el código fuente

--- a/README_FR.md
+++ b/README_FR.md
@@ -48,10 +48,10 @@ Téléchargez la dernière release adaptée à l’architecture de votre serveur
 ```bash
 # 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    Serveurs ARM64 : remplacez linux-amd64 par linux-arm64.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Décompresser
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Installer
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # Serveurs ARM64 : remplacez linux-amd64 par linux-arm64.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### Ou exécuter depuis les sources

--- a/README_FR.md
+++ b/README_FR.md
@@ -45,23 +45,30 @@
 
 Téléchargez la dernière release adaptée à l’architecture de votre serveur (`linux-amd64` ou `linux-arm64`), décompressez-la et exécutez le script d’installation (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9) :
 
+Choisissez la commande adaptée à l’architecture de votre serveur :
+
+**AMD64**
 ```bash
-# 1. Téléchargez la dernière release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    Serveurs ARM64 : remplacez linux-amd64 par linux-arm64.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Décompresser
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Installer
 sudo ./install.sh
 ```
 
-**🇨🇳 Chine continentale** — si GitHub est lent, téléchargez l'étape 1 depuis le miroir CDN (le reste est identique) :
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 Chine continentale** — si GitHub est lent, utilisez l’URL du miroir CDN correspondant à votre architecture :
 
 ```bash
-# Serveurs ARM64 : remplacez linux-amd64 par linux-arm64.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### Ou exécuter depuis les sources

--- a/README_JA.md
+++ b/README_JA.md
@@ -45,23 +45,30 @@
 
 サーバーのアーキテクチャ（`linux-amd64` または `linux-arm64`）に合う最新リリースをダウンロードし、展開してインストーラーを実行します（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）：
 
+サーバーのアーキテクチャに合うコマンドを選択してください：
+
+**AMD64**
 ```bash
-# 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-#    ARM64 サーバーでは linux-amd64 を linux-arm64 に置き換えてください。
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. 展開
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. インストール
 sudo ./install.sh
 ```
 
-**🇨🇳 中国本土ユーザー** — GitHub が遅い場合は、手順 1 を CDN ミラーからダウンロード（他の手順は同じ）：
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 中国本土ユーザー** — GitHub が遅い場合は、アーキテクチャに合う CDN ミラー URL を使用してください：
 
 ```bash
-# ARM64 サーバーでは linux-amd64 を linux-arm64 に置き換えてください。
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### またはソースから実行

--- a/README_JA.md
+++ b/README_JA.md
@@ -48,10 +48,10 @@
 ```bash
 # 1. 最新リリースをダウンロード（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
 #    ARM64 サーバーでは linux-amd64 を linux-arm64 に置き換えてください。
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. 展開
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. インストール
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64 サーバーでは linux-amd64 を linux-arm64 に置き換えてください。
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### またはソースから実行

--- a/README_KO.md
+++ b/README_KO.md
@@ -48,10 +48,10 @@
 ```bash
 # 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    ARM64 서버는 linux-amd64를 linux-arm64로 바꾸세요.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. 압축 해제
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. 설치
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64 서버는 linux-amd64를 linux-arm64로 바꾸세요.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### 또는 소스에서 실행

--- a/README_KO.md
+++ b/README_KO.md
@@ -45,23 +45,30 @@
 
 서버 아키텍처(`linux-amd64` 또는 `linux-arm64`)에 맞는 최신 릴리스를 다운로드하고 압축을 푼 다음 설치 스크립트를 실행하세요 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+서버 아키텍처에 맞는 명령을 선택하세요:
+
+**AMD64**
 ```bash
-# 1. 최신 릴리스 다운로드 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    ARM64 서버는 linux-amd64를 linux-arm64로 바꾸세요.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. 압축 해제
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. 설치
 sudo ./install.sh
 ```
 
-**🇨🇳 중국 본토 사용자** — GitHub이 느리면 1단계를 CDN 미러에서 다운로드하세요(나머지는 동일):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 중국 본토 사용자** — GitHub이 느리면 아키텍처에 맞는 CDN 미러 URL을 사용하세요:
 
 ```bash
-# ARM64 서버는 linux-amd64를 linux-arm64로 바꾸세요.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### 또는 소스에서 실행

--- a/README_PT.md
+++ b/README_PT.md
@@ -48,10 +48,10 @@ Baixe a última release para a arquitetura do seu servidor (`linux-amd64` ou `li
 ```bash
 # 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    Servidores ARM64: substitua linux-amd64 por linux-arm64.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Descompactar
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Instalar
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # Servidores ARM64: substitua linux-amd64 por linux-arm64.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### Ou executar a partir do código

--- a/README_PT.md
+++ b/README_PT.md
@@ -45,23 +45,30 @@
 
 Baixe a última release para a arquitetura do seu servidor (`linux-amd64` ou `linux-arm64`), descompacte e execute o instalador (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+Escolha o comando para a arquitetura do seu servidor:
+
+**AMD64**
 ```bash
-# 1. Baixe a última release (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    Servidores ARM64: substitua linux-amd64 por linux-arm64.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Descompactar
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Instalar
 sudo ./install.sh
 ```
 
-**🇨🇳 China continental** — se o GitHub estiver lento, baixe o passo 1 do mirror CDN (o resto é igual):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 China continental** — se o GitHub estiver lento, use a URL do mirror CDN correspondente à sua arquitetura:
 
 ```bash
-# Servidores ARM64: substitua linux-amd64 por linux-arm64.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### Ou executar a partir do código

--- a/README_RU.md
+++ b/README_RU.md
@@ -45,23 +45,30 @@
 
 Скачайте последний релиз для архитектуры вашего сервера (`linux-amd64` или `linux-arm64`), распакуйте и запустите скрипт установки (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9):
 
+Выберите команду для архитектуры вашего сервера:
+
+**AMD64**
 ```bash
-# 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
-#    ARM64-серверы: замените linux-amd64 на linux-arm64.
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. Распаковка
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. Установка
 sudo ./install.sh
 ```
 
-**🇨🇳 Материковый Китай** — если GitHub медленный, скачайте шаг 1 с CDN-зеркала (остальное без изменений):
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 Материковый Китай** — если GitHub медленный, используйте URL CDN-зеркала для вашей архитектуры:
 
 ```bash
-# ARM64-серверы: замените linux-amd64 на linux-arm64.
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### Или запустить из исходников

--- a/README_RU.md
+++ b/README_RU.md
@@ -48,10 +48,10 @@
 ```bash
 # 1. Скачайте последний релиз (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9)
 #    ARM64-серверы: замените linux-amd64 на linux-arm64.
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. Распаковка
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. Установка
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64-серверы: замените linux-amd64 на linux-arm64.
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### Или запустить из исходников

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,10 +48,10 @@
 ```bash
 # 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
 #    ARM64 服务器：把 linux-amd64 替换成 linux-arm64。
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.3/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # 2. 解压
-tar -xf ongrid-v0.8.3-linux-amd64.tar.xz && cd ongrid-v0.8.3-linux-amd64
+tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
 
 # 3. 安装
 sudo ./install.sh
@@ -61,7 +61,7 @@ sudo ./install.sh
 
 ```bash
 # ARM64 服务器：把 linux-amd64 替换成 linux-arm64。
-wget https://ongrid.cloud/dl/ongrid-v0.8.3-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 ```
 
 ### 或从源码运行

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -45,23 +45,30 @@
 
 按服务器架构下载最新 release（`linux-amd64` 或 `linux-arm64`），解压后运行安装脚本（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）：
 
+按服务器架构选择对应命令：
+
+**AMD64**
 ```bash
-# 1. 下载最新 release（Ubuntu 22.04+、Debian 12+、RHEL/Rocky 9）
-#    ARM64 服务器：把 linux-amd64 替换成 linux-arm64。
 wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-amd64.tar.xz
-
-# 2. 解压
 tar -xf ongrid-v0.8.4-linux-amd64.tar.xz && cd ongrid-v0.8.4-linux-amd64
-
-# 3. 安装
 sudo ./install.sh
 ```
 
-**🇨🇳 中国大陆用户** — GitHub 较慢时，第 1 步改用 CDN 镜像下载（其余步骤完全相同）：
+**ARM64**
+```bash
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.4/ongrid-v0.8.4-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.4-linux-arm64.tar.xz && cd ongrid-v0.8.4-linux-arm64
+sudo ./install.sh
+```
+
+**🇨🇳 中国大陆用户** — GitHub 较慢时，选择对应架构的 CDN 镜像地址下载：
 
 ```bash
-# ARM64 服务器：把 linux-amd64 替换成 linux-arm64。
+# AMD64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
+
+# ARM64
+wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
 ```
 
 ### 或从源码运行


### PR DESCRIPTION
## Summary

- update README install commands from `v0.8.3` to `v0.8.4` across all localized README files
- split server install examples into explicit AMD64 and ARM64 command blocks
- prepend install guidance to tag-triggered GitHub Releases while still using generated release notes

## Why

The current docs still point users at the older v0.8.3 package and require users to manually substitute architecture names. The release workflow also only had a static install block, so generated releases did not clearly combine install guidance with the PR/commit change list.

## Validation

- `git diff --check`
- workflow YAML parse check via Ruby `YAML.load_file`
- confirmed no `v0.8.3` remains in `README*.md`
