### PR TITLE
docs(readme): drop docker compose install until stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ English | [简体中文](./README_ZH.md) | [日本語](./README_JA.md) | [한국
 - 🔍 **Root-cause RCA** — walks topology, correlates m/l/t, pins the "why" to a source-code line
 - 🔒 **Zero inbound ports** — edge dials out; no port 22 / 80 / 443 on hosts
 - 💻 **Browser SSH** — reverse-tunnel shell into any host; no keys, no jumpbox, all audited
-- 🐳 **Self-host in one command** — `docker compose up` brings up the full stack
+- 🐳 **Self-host in one command** — `install.sh` brings up the full stack
 - 📊 **Built-in observability** — Prometheus + Loki + Tempo + Grafana wired; the agent writes the queries
 - 🧠 **Bring your own model** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, hot routing
 - 💬 **Two-way IM channels** — Slack / Telegram / Larksuite / DingTalk / WeCom, per-channel locale
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### Or run from source
-
-Local dev: set the admin account + one model API key, then bring up the full stack.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Integrations

--- a/README_DE.md
+++ b/README_DE.md
@@ -35,7 +35,7 @@
 - 🔍 **Grundursachen-RCA** — durchläuft die Topologie, korreliert Metriken/Logs/Traces, identifiziert eine Quellcode-Zeile
 - 🔒 **Null eingehende Ports** — der Edge wählt nach außen; kein Port 22 / 80 / 443 auf Hosts
 - 💻 **SSH im Browser** — Shell über Rückwärtstunnel, keine Schlüssel, kein Jumpbox, alles auditiert
-- 🐳 **Selbst-Hosting in einem Befehl** — `docker compose up` startet die gesamte Stack
+- 🐳 **Selbst-Hosting in einem Befehl** — `install.sh` startet die gesamte Stack
 - 📊 **Eingebaute Observability** — Prometheus + Loki + Tempo + Grafana bereit, der Agent schreibt die Queries
 - 🧠 **Eigenes Modell mitbringen** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, Hot-Routing
 - 💬 **Zweiwege-IM-Kanäle** — Slack / Telegram / Larksuite / DingTalk / WeCom, Sprache pro Kanal
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### Oder aus dem Quellcode ausführen
-
-Lokale Entwicklung: Admin-Konto und einen Modell-API-Key konfigurieren, dann die gesamte Stack starten.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Integrationen

--- a/README_ES.md
+++ b/README_ES.md
@@ -35,7 +35,7 @@
 - 🔍 **RCA de causa raíz** — recorre la topología, correlaciona métricas/logs/trazas, llega a una línea de código
 - 🔒 **Cero puertos entrantes** — el edge sale al exterior; ningún puerto 22 / 80 / 443 en hosts
 - 💻 **SSH en el navegador** — shell por túnel inverso, sin claves, sin jumpbox, todo auditado
-- 🐳 **Self-host en un comando** — `docker compose up` levanta toda la stack
+- 🐳 **Self-host en un comando** — `install.sh` levanta toda la stack
 - 📊 **Observabilidad integrada** — Prometheus + Loki + Tempo + Grafana listos, el agente escribe las queries
 - 🧠 **Trae tu propio modelo** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, enrutamiento en caliente
 - 💬 **Canales IM bidireccionales** — Slack / Telegram / Larksuite / DingTalk / WeCom, idioma por canal
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### O ejecutar desde el código fuente
-
-Desarrollo local: configura la cuenta de admin y una API key de modelo, y levanta todo el stack.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Integraciones

--- a/README_FR.md
+++ b/README_FR.md
@@ -35,7 +35,7 @@
 - 🔍 **RCA cause racine** — parcourt la topologie, corrèle métriques/logs/traces, identifie une ligne de code
 - 🔒 **Zéro port entrant** — l’edge sort vers l’extérieur ; aucun port 22 / 80 / 443 sur l’hôte
 - 💻 **SSH dans le navigateur** — shell par tunnel inverse, pas de clé, pas de jumpbox, tout audité
-- 🐳 **Auto-hébergeable en une commande** — `docker compose up` lance toute la stack
+- 🐳 **Auto-hébergeable en une commande** — `install.sh` lance toute la stack
 - 📊 **Observabilité intégrée** — Prometheus + Loki + Tempo + Grafana prêts, l’agent écrit les requêtes
 - 🧠 **Apportez votre modèle** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, routage à chaud
 - 💬 **Canaux IM bidirectionnels** — Slack / Telegram / Larksuite / DingTalk / WeCom, langue par canal
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### Ou exécuter depuis les sources
-
-Dev local : configurez le compte admin et une clé API de modèle, puis lancez la stack complète.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Intégrations

--- a/README_JA.md
+++ b/README_JA.md
@@ -35,7 +35,7 @@
 - 🔍 **根本原因 RCA** — トポロジーで影響範囲を分析、メトリクス/ログ/トレースを相関、ソースコード行まで
 - 🔒 **インバウンドポートゼロ** — edge はアウトバウンドのみ、ホストは 22 / 80 / 443 を開かない
 - 💻 **ブラウザ SSH** — 逆トンネルで対話シェル、鍵不要、踏み台不要、全コマンド監査
-- 🐳 **1 コマンドでセルフホスト** — `docker compose up` でフルスタック起動
+- 🐳 **1 コマンドでセルフホスト** — `install.sh` でフルスタック起動
 - 📊 **可観測性スタック組み込み** — Prometheus + Loki + Tempo + Grafana 自動配備、エージェントがクエリを書く
 - 🧠 **任意モデル持ち込み** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi、ホット切り替え
 - 💬 **双方向 IM チャネル** — Slack / Telegram / Larksuite / DingTalk / WeCom、チャネル別ロケール
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### またはソースから実行
-
-ローカル開発: 管理者アカウントとモデル API キーを設定し、フルスタックを起動します。
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## インテグレーション

--- a/README_KO.md
+++ b/README_KO.md
@@ -35,7 +35,7 @@
 - 🔍 **근본 원인 RCA** — 토폴로지로 영향 범위 분석, 메트릭/로그/트레이스 상관, 소스 코드 라인까지
 - 🔒 **인바운드 포트 0** — edge가 외부로 발신, 호스트는 22 / 80 / 443 미오픈
 - 💻 **브라우저 SSH** — 역방향 터널로 대화형 셸, 키 / 점프 호스트 불필요, 모든 명령 감사
-- 🐳 **한 줄로 셀프 호스팅** — `docker compose up`으로 전체 스택 기동
+- 🐳 **한 줄로 셀프 호스팅** — `install.sh`으로 전체 스택 기동
 - 📊 **가관측성 전체 스택 내장** — Prometheus + Loki + Tempo + Grafana 자동 배포, Agent가 쿼리 작성
 - 🧠 **원하는 모델 사용** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, 핫 라우팅
 - 💬 **양방향 IM 채널** — Slack / Telegram / Larksuite / DingTalk / WeCom, 채널별 로케일
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### 또는 소스에서 실행
-
-로컬 개발: 관리자 계정과 모델 API 키를 설정한 후 전체 스택을 기동합니다.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## 연동

--- a/README_PT.md
+++ b/README_PT.md
@@ -35,7 +35,7 @@
 - 🔍 **RCA de causa raiz** — percorre a topologia, correlaciona métricas/logs/traces, identifica uma linha de código
 - 🔒 **Zero portas de entrada** — o edge disca para fora; nenhuma porta 22 / 80 / 443 em hosts
 - 💻 **SSH no navegador** — shell por túnel reverso, sem chaves, sem jumpbox, tudo auditado
-- 🐳 **Self-host em um comando** — `docker compose up` sobe toda a stack
+- 🐳 **Self-host em um comando** — `install.sh` sobe toda a stack
 - 📊 **Observabilidade integrada** — Prometheus + Loki + Tempo + Grafana prontos, o agente escreve as queries
 - 🧠 **Traga seu próprio modelo** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, roteamento a quente
 - 💬 **Canais IM bidirecionais** — Slack / Telegram / Larksuite / DingTalk / WeCom, idioma por canal
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### Ou executar a partir do código
-
-Desenvolvimento local: configure a conta admin e uma API key de modelo, depois suba todo o stack.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Integrações

--- a/README_RU.md
+++ b/README_RU.md
@@ -35,7 +35,7 @@
 - 🔍 **Корневая RCA** — обходит топологию, коррелирует метрики/логи/трейсы, до строки исходного кода
 - 🔒 **Ноль входящих портов** — edge выходит наружу; нет порта 22 / 80 / 443 на хосте
 - 💻 **SSH в браузере** — оболочка через обратный туннель, без ключей, без jumpbox, в аудите
-- 🐳 **Self-host одной командой** — `docker compose up` поднимает весь стек
+- 🐳 **Self-host одной командой** — `install.sh` поднимает весь стек
 - 📊 **Встроенная observability** — Prometheus + Loki + Tempo + Grafana готовы, агент пишет запросы
 - 🧠 **Принесите свою модель** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, горячая маршрутизация
 - 💬 **Двусторонние IM-каналы** — Slack / Telegram / Larksuite / DingTalk / WeCom, локаль на канал
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### Или запустить из исходников
-
-Локальная разработка: настройте админ-аккаунт и API-ключ модели, затем поднимите весь стек.
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## Интеграции

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -35,7 +35,7 @@
 - 🔍 **根因 RCA** — 沿拓扑做爆炸半径分析, 跨指标/日志/链路相关到源码行
 - 🔒 **零入站端口** — edge 主动外联, host 不开 22 / 80 / 443
 - 💻 **浏览器 SSH** — 反向隧道开交互式 shell, 不用 key / 跳板机, 全程审计
-- 🐳 **一行命令自托管** — `docker compose up` 起整套栈
+- 🐳 **一行命令自托管** — `install.sh` 起整套栈
 - 📊 **可观测全栈内置** — Prometheus + Loki + Tempo + Grafana 自动起, Agent 自动写 query
 - 🧠 **自带任意模型** — Anthropic / OpenAI / GLM / DeepSeek / Gemini / Kimi, 热路由
 - 💬 **双向 IM 通道** — Slack / Telegram / Larksuite / DingTalk / WeCom, 按通道语言
@@ -69,15 +69,6 @@ wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-amd64.tar.xz
 
 # ARM64
 wget https://ongrid.cloud/dl/ongrid-v0.8.4-linux-arm64.tar.xz
-```
-
-### 或从源码运行
-
-本地开发：先配好管理员账号和一个模型 API key，再起整套栈。
-
-```bash
-cp deploy/.env.example deploy/.env
-make compose-up    # make compose-down to stop
 ```
 
 ## 集成


### PR DESCRIPTION
Removes the `### Or run from source` (make compose-up) install section from all 9 locale READMEs and repoints the feature bullet from `docker compose up` to `install.sh`. The compose path isn't stable yet — README stays on the tarball + install.sh route only. Will re-add compose once solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)