### PR TITLE
docs(readme): 适配 star history 深色主题

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,9 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_DE.md
+++ b/README_DE.md
@@ -87,4 +87,9 @@ Apache 2.0 — siehe [LICENSE](LICENSE).
 
 ## Star-Verlauf
 
-[![Star-Verlaufsdiagramm](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Star-Verlaufsdiagramm" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_ES.md
+++ b/README_ES.md
@@ -87,4 +87,9 @@ Apache 2.0 — ver [LICENSE](LICENSE).
 
 ## Historial de estrellas
 
-[![Gráfico del historial de estrellas](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Gráfico del historial de estrellas" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_FR.md
+++ b/README_FR.md
@@ -87,4 +87,9 @@ Apache 2.0 — voir [LICENSE](LICENSE).
 
 ## Historique des étoiles
 
-[![Graphique de l'historique des étoiles](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Graphique de l'historique des étoiles" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_JA.md
+++ b/README_JA.md
@@ -87,4 +87,9 @@ Apache 2.0 — [LICENSE](LICENSE) を参照。
 
 ## Star 履歴
 
-[![Star 履歴チャート](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Star 履歴チャート" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_KO.md
+++ b/README_KO.md
@@ -87,4 +87,9 @@ Apache 2.0 — [LICENSE](LICENSE) 참조.
 
 ## Star 기록
 
-[![Star 기록 차트](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Star 기록 차트" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_PT.md
+++ b/README_PT.md
@@ -87,4 +87,9 @@ Apache 2.0 — veja [LICENSE](LICENSE).
 
 ## Histórico de estrelas
 
-[![Gráfico do histórico de estrelas](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Gráfico do histórico de estrelas" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_RU.md
+++ b/README_RU.md
@@ -87,4 +87,9 @@ Apache 2.0 — см. [LICENSE](LICENSE).
 
 ## История звезд
 
-[![График истории звезд](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="График истории звезд" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -87,4 +87,9 @@ Apache 2.0 — 见 [LICENSE](LICENSE)。
 
 ## Star 趋势
 
-[![Star 趋势图](https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date)](https://www.star-history.com/#ongridio/ongrid&Date)
+<a href="https://www.star-history.com/#ongridio/ongrid&amp;Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date&amp;theme=dark" />
+    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=ongridio/ongrid&amp;type=Date" />
+  </picture>
+</a>


### PR DESCRIPTION
## Summary
- Replace the Star History Markdown image with a `<picture>` block in the main README and localized READMEs.
- Use the Star History dark SVG when the viewer prefers a dark color scheme, with the existing light SVG as fallback.
- Keep each locale-specific alt text and the Star History link.

## Validation
- `git diff --check`
- `curl -L -sS -o /dev/null -w 'light:%{http_code}\\n' 'https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date'` -> `light:200`\n- `curl -L -sS -o /dev/null -w 'dark:%{http_code}\\n' 'https://api.star-history.com/svg?repos=ongridio/ongrid&type=Date&theme=dark'` -> `dark:200`