### PR TITLE
fix(rca): use default LLM model for automatic analysis

### DIFF
--- a/cmd/ongrid/llm_default_test.go
+++ b/cmd/ongrid/llm_default_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/ongridio/ongrid/internal/pkg/llm"
 )
 
+type fakeLLMProviderCatalog struct {
+	providers []llm.ProviderInfo
+}
+
+func (f fakeLLMProviderCatalog) Providers() []llm.ProviderInfo {
+	return f.providers
+}
+
+func TestHasConfiguredLLMProviderAcceptsNonOpenAIProvider(t *testing.T) {
+	catalog := fakeLLMProviderCatalog{providers: []llm.ProviderInfo{
+		{ID: llm.ProviderDeepSeek, Model: "deepseek-v4-flash"},
+	}}
+
+	if !hasConfiguredLLMProvider(catalog) {
+		t.Fatalf("hasConfiguredLLMProvider() = false, want true for non-OpenAI provider")
+	}
+}
+
+func TestHasConfiguredLLMProviderReturnsFalseWithoutProviders(t *testing.T) {
+	if hasConfiguredLLMProvider(fakeLLMProviderCatalog{}) {
+		t.Fatalf("hasConfiguredLLMProvider() = true, want false without providers")
+	}
+}
+
 func TestPickProviderDefaultFallsBackToConfiguredProvider(t *testing.T) {
 	providers := []llm.ProviderConfig{
 		{ID: llm.ProviderDeepSeek, APIKey: "sk-test", Model: "deepseek-v4-flash"},

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1415,13 +1415,13 @@ func main() {
 			llmClient,
 			toolsReg,
 			alertRepo,
-			aiopsinvestigator.Config{Model: cfg.OpenAI.Model},
+			aiopsinvestigator.Config{},
 			log,
 		)
 		defer legacy.Close()
 		legacyInv = legacy
 		log.Info("alert: legacy AI initial-diagnosis investigator wired",
-			slog.String("model", cfg.OpenAI.Model))
+			slog.String("model_source", "llm_default"))
 	} else {
 		log.Info("alert: legacy AI investigator disabled (no LLM)")
 	}
@@ -1447,73 +1447,21 @@ func main() {
 					maxCC = n
 				}
 			}
-			// The RCA summarizer (structured-report extraction) must use the
-			// configured DEFAULT chat provider + its model. The old code
-			// defaulted SummarizerModel to cfg.OpenAI.Model (gpt-4o) with an
-			// empty provider, so on a non-OpenAI deployment (e.g. zhipu/GLM)
-			// the summarize call shipped model=gpt-4o to the zhipu endpoint →
-			// 400 "模型不存在". The extractor then fell back to an unstructured
-			// report every time, which surfaced as the RCA "总是在转圈".
-			// Mirror buildAIOpsRuntime's default-provider resolution.
-			defSumProvider, defSumModel := llm.ProviderOpenAI, firstNonEmpty(cfg.OpenAI.Model, "gpt-5.4")
-			switch cfg.LLM.Default {
-			case llm.ProviderZhipu:
-				defSumProvider, defSumModel = llm.ProviderZhipu, firstNonEmpty(cfg.LLM.Zhipu.Model, "glm-4.7")
-			case llm.ProviderAnthropic:
-				defSumProvider, defSumModel = llm.ProviderAnthropic, firstNonEmpty(cfg.LLM.Anthropic.Model, "claude-sonnet-4-6")
-			case llm.ProviderGemini:
-				defSumProvider, defSumModel = llm.ProviderGemini, firstNonEmpty(cfg.LLM.Gemini.Model, "gemini-2.5-pro")
-			case llm.ProviderDeepSeek:
-				defSumProvider, defSumModel = llm.ProviderDeepSeek, firstNonEmpty(cfg.LLM.DeepSeek.Model, "deepseek-v4-flash")
-			case llm.ProviderKimi:
-				defSumProvider, defSumModel = llm.ProviderKimi, firstNonEmpty(cfg.LLM.Kimi.Model, "kimi-k2.6")
-			case llm.ProviderOpenAI, "":
-				// Empty/openai: fall back to the first provider that actually
-				// has a key (mirrors the routing model's fallback) so an
-				// unset default_provider still picks a usable summarizer.
-				switch {
-				case cfg.OpenAI.APIKey != "":
-					// keep openai default
-				case cfg.LLM.Zhipu.APIKey != "":
-					defSumProvider, defSumModel = llm.ProviderZhipu, firstNonEmpty(cfg.LLM.Zhipu.Model, "glm-4.7")
-				case cfg.LLM.Anthropic.APIKey != "":
-					defSumProvider, defSumModel = llm.ProviderAnthropic, firstNonEmpty(cfg.LLM.Anthropic.Model, "claude-sonnet-4-6")
-				case cfg.LLM.Gemini.APIKey != "":
-					defSumProvider, defSumModel = llm.ProviderGemini, firstNonEmpty(cfg.LLM.Gemini.Model, "gemini-2.5-pro")
-				case cfg.LLM.DeepSeek.APIKey != "":
-					defSumProvider, defSumModel = llm.ProviderDeepSeek, firstNonEmpty(cfg.LLM.DeepSeek.Model, "deepseek-v4-flash")
-				case cfg.LLM.Kimi.APIKey != "":
-					defSumProvider, defSumModel = llm.ProviderKimi, firstNonEmpty(cfg.LLM.Kimi.Model, "kimi-k2.6")
-				}
-			}
-			// Prefer the DB-resolved default (default_provider + its model) —
-			// the same source the home-page picker writes and the routing
-			// model's DefaultResolver uses — over the env-only cfg.LLM.Default
-			// switch above, so the summarizer stays consistent with chat / RCA.
-			// Boot-time: a later default change is picked up on restart (the
-			// summarizer is the cheap extraction step; the analysis worker
-			// already tracks the default live via DefaultResolver).
-			if llmSettingsResolver != nil {
-				if provCfgs, resolvedDefault, rerr := llmSettingsResolver.ResolveProviders(rootCtx); rerr == nil && resolvedDefault != "" {
-					defSumProvider = resolvedDefault
-					for _, pc := range provCfgs {
-						if pc.ID == resolvedDefault {
-							if pc.Model != "" {
-								defSumModel = pc.Model
-							}
-							break
-						}
-					}
-				}
-			}
+			// Empty provider/model means the extractor follows the live
+			// llm.MultiClient default — the same default_provider +
+			// <provider>_default_model the home-page picker writes and
+			// invalidateLLMRouter refreshes. Env vars remain an explicit
+			// operator override for rare cases.
+			sumProvider := os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_PROVIDER")
+			sumModel := os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_MODEL")
 			rcaInvConcrete = investigator.NewUsecase(invRepo, concreteRt, llmClient, investigator.Config{
 				Enabled:            true,
 				MinSeverity:        firstNonEmpty(os.Getenv("ONGRID_INVESTIGATOR_MIN_SEVERITY"), "warning"),
 				DedupWindow:        5 * time.Minute,
 				WorkerTimeout:      5 * time.Minute,
 				AgentName:          "incident-investigator",
-				SummarizerModel:    firstNonEmpty(os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_MODEL"), defSumModel),
-				SummarizerProvider: firstNonEmpty(os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_PROVIDER"), defSumProvider),
+				SummarizerModel:    sumModel,
+				SummarizerProvider: sumProvider,
 				SummarizerTimeout:  30 * time.Second,
 				MaxConcurrent:      maxCC,
 				// Fall-back language for auto-fire + backfill (no request
@@ -1535,8 +1483,8 @@ func main() {
 				WithMessageReader(aiopsRepo)
 			rcaInv = rcaInvConcrete
 			log.Info("alert: structured RCA investigator wired",
-				slog.String("summarizer_provider", firstNonEmpty(os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_PROVIDER"), defSumProvider)),
-				slog.String("summarizer_model", firstNonEmpty(os.Getenv("ONGRID_INVESTIGATOR_SUMMARIZER_MODEL"), defSumModel)))
+				slog.String("summarizer_provider", firstNonEmpty(sumProvider, "llm_default")),
+				slog.String("summarizer_model", firstNonEmpty(sumModel, "llm_default")))
 		}
 	}
 

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1410,7 +1410,7 @@ func main() {
 	// investigatorChain so each new-fire fans out to both. Either side
 	// can be nil — the chain skips nil.
 	var legacyInv managerbizalert.Investigator
-	if cfg.OpenAI.APIKey != "" {
+	if hasConfiguredLLMProvider(llmRouter) {
 		legacy := aiopsinvestigator.New(
 			llmClient,
 			toolsReg,
@@ -1423,7 +1423,7 @@ func main() {
 		log.Info("alert: legacy AI initial-diagnosis investigator wired",
 			slog.String("model_source", "llm_default"))
 	} else {
-		log.Info("alert: legacy AI investigator disabled (no LLM)")
+		log.Info("alert: legacy AI investigator disabled (no LLM provider)")
 	}
 
 	var (
@@ -2179,6 +2179,14 @@ func reportLLMReady(resolver *managerbizsetting.LLMSettingsResolver) func(contex
 		}
 		return fmt.Errorf("%w: LLM provider not configured", errs.ErrNotWiredYet)
 	}
+}
+
+type llmProviderCatalog interface {
+	Providers() []llm.ProviderInfo
+}
+
+func hasConfiguredLLMProvider(catalog llmProviderCatalog) bool {
+	return catalog != nil && len(catalog.Providers()) > 0
 }
 
 // pickProviderDefault mirrors llm.MultiClient's catalog default:

--- a/internal/manager/biz/aiops/investigator/investigator.go
+++ b/internal/manager/biz/aiops/investigator/investigator.go
@@ -49,15 +49,14 @@ import (
 // at peak; 3 concurrent LLM round-trips + 100 deep buffer leaves ample
 // headroom while capping spend on a misconfigured rule storm.
 const (
-	defaultWorkers      = 3
-	defaultQueueDepth   = 100
+	defaultWorkers    = 3
+	defaultQueueDepth = 100
 	// Unified with the project-wide LLM timeout floor (see
 	// internal/pkg/llm/client.go::defaultTimeout). The 60 s prior
 	// default false-failed on reasoning-model defaults; 120 s gives a
 	// tool-rich turn room without escaping the human-grade timescale.
 	defaultLLMTimeout = 120 * time.Second
-	defaultUserMsgCap   = 30 * 1024 // ~30KB upper bound for the bundle text
-	defaultModelDefault = "gpt-5.4"
+	defaultUserMsgCap = 30 * 1024 // ~30KB upper bound for the bundle text
 )
 
 // systemPrompt is the fixed system prompt sent on every investigation.
@@ -87,9 +86,9 @@ type ToolInvoker interface {
 
 // Config tunes the investigator. Zero values pick the package defaults.
 type Config struct {
-	// Model is the LLM model slug used in the chat request. Empty falls
-	// back to "gpt-4o" so investigation works even before main.go gets
-	// around to passing cfg.OpenAI.Model through.
+	// Model is the LLM model slug used in the chat request. Empty means
+	// use the router/catalog default so background diagnosis follows the
+	// same default provider+model as the home-page picker.
 	Model string
 	// Workers is the goroutine pool size. Default 3.
 	Workers int
@@ -114,10 +113,10 @@ type Investigator struct {
 	cfg       Config
 	log       *slog.Logger
 
-	jobs    chan job
-	wg      sync.WaitGroup
+	jobs     chan job
+	wg       sync.WaitGroup
 	stopOnce sync.Once
-	stopped chan struct{}
+	stopped  chan struct{}
 }
 
 type job struct {
@@ -130,7 +129,7 @@ type job struct {
 //
 // Any of llmClient / tools / events being nil renders the Investigator a
 // no-op: InvestigateAsync drops the job silently. main.go is expected
-// to gate construction on cfg.OpenAI.APIKey != "" so the no-op shape is
+// to gate construction on an available LLM provider so the no-op shape is
 // only hit in tests.
 func New(llmClient llm.Client, tools ToolInvoker, events EventWriter, cfg Config, log *slog.Logger) *Investigator {
 	if cfg.Workers <= 0 {
@@ -144,9 +143,6 @@ func New(llmClient llm.Client, tools ToolInvoker, events EventWriter, cfg Config
 	}
 	if cfg.UserMsgCap <= 0 {
 		cfg.UserMsgCap = defaultUserMsgCap
-	}
-	if cfg.Model == "" {
-		cfg.Model = defaultModelDefault
 	}
 	if log == nil {
 		log = slog.Default()

--- a/internal/manager/biz/aiops/investigator/investigator_test.go
+++ b/internal/manager/biz/aiops/investigator/investigator_test.go
@@ -177,6 +177,25 @@ func TestInvestigateAsyncWritesEvent(t *testing.T) {
 	}
 }
 
+func TestInvestigateAsyncEmptyModelUsesRouterDefault(t *testing.T) {
+	llmFake := &fakeLLM{content: "initial diagnosis"}
+	toolsFake := &fakeTools{bundle: json.RawMessage(`{"incident":{"id":8}}`)}
+	writer := &fakeWriter{}
+
+	inv := New(llmFake, toolsFake, writer, Config{Workers: 1, QueueDepth: 4}, newQuietLogger())
+	defer inv.Close()
+
+	inv.InvestigateAsync(&model.Incident{ID: 8, Rule: "cpu_high", Severity: "warning"})
+	inv.Close()
+
+	if len(llmFake.gotModels) != 1 {
+		t.Fatalf("llm calls = %d, want 1", len(llmFake.gotModels))
+	}
+	if llmFake.gotModels[0] != "" {
+		t.Fatalf("legacy investigator model = %q, want empty router default", llmFake.gotModels[0])
+	}
+}
+
 // TestInvestigateAsyncDropsOnFullQueue: when the queue is saturated,
 // new jobs are silently dropped (logged warning) rather than blocking.
 func TestInvestigateAsyncDropsOnFullQueue(t *testing.T) {

--- a/internal/manager/biz/alert/investigator/report_extractor.go
+++ b/internal/manager/biz/alert/investigator/report_extractor.go
@@ -56,7 +56,7 @@ func (uc *Usecase) extractStructured(ctx context.Context, incident alertmodel.In
 		ToolCallCount:         toolCallCount,
 	}
 
-	if uc.summarizer == nil || uc.cfg.SummarizerModel == "" {
+	if uc.summarizer == nil {
 		return fallback
 	}
 

--- a/internal/manager/biz/alert/investigator/report_extractor_test.go
+++ b/internal/manager/biz/alert/investigator/report_extractor_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 type fakeSummarizer struct {
-	resp     *llm.ChatResp
-	err      error
-	lastReq  llm.ChatReq
-	calls    int
+	resp    *llm.ChatResp
+	err     error
+	lastReq llm.ChatReq
+	calls   int
 }
 
 func (f *fakeSummarizer) Chat(_ context.Context, req llm.ChatReq) (*llm.ChatResp, error) {
@@ -200,6 +200,27 @@ func TestExtractStructured_ParsesValid(t *testing.T) {
 	}
 	if sum.lastReq.Model != "glm-4-air" {
 		t.Errorf("model = %q, want glm-4-air", sum.lastReq.Model)
+	}
+}
+
+func TestExtractStructured_EmptyModelUsesRouterDefault(t *testing.T) {
+	sum := &fakeSummarizer{resp: &llm.ChatResp{
+		Assistant: llm.Message{Role: "assistant", Content: `{"root_cause":"router default"}`},
+	}}
+	uc := &Usecase{
+		summarizer: sum,
+		cfg:        Config{SummarizerTimeout: time.Second},
+	}
+
+	fields := uc.extractStructured(context.Background(), alertmodel.Incident{ID: 1}, "narrative", 2, "")
+	if fields.RootCause != "router default" {
+		t.Fatalf("root_cause = %q, want router default", fields.RootCause)
+	}
+	if sum.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", sum.calls)
+	}
+	if sum.lastReq.Provider != "" || sum.lastReq.Model != "" {
+		t.Fatalf("summarizer request = provider %q model %q, want empty router defaults", sum.lastReq.Provider, sum.lastReq.Model)
 	}
 }
 

--- a/internal/manager/biz/alert/investigator/usecase.go
+++ b/internal/manager/biz/alert/investigator/usecase.go
@@ -130,13 +130,13 @@ type Config struct {
 	// a different name without recompiling.
 	AgentName string
 
-	// SummarizerModel selects the cheap model used for the structured
-	// extraction (PR-3). Empty → skip the extraction step and fall
-	// back to first-line root_cause + full markdown findings.
+	// SummarizerModel optionally pins the model used for the structured
+	// extraction (PR-3). Empty → use the LLM router default, which tracks
+	// the home-page/default_provider model selection.
 	SummarizerModel string
 
-	// SummarizerProvider routes the extraction call to a specific
-	// provider (e.g. "zhipu" for GLM-4-air). Empty → default provider.
+	// SummarizerProvider optionally routes extraction to a specific
+	// provider (e.g. "zhipu" for GLM-4-air). Empty → router default.
 	SummarizerProvider string
 
 	// SummarizerTimeout bounds the extraction LLM call. Default 30s


### PR DESCRIPTION
## Summary
- Route automatic RCA legacy diagnosis through the default LLM router instead of forcing OpenAI model names.
- Let structured RCA extraction call the summarizer with empty provider/model so it follows the live homepage/default model.
- Add tests covering empty provider/model router default behavior.

## Root Cause
Automatic RCA had two paths that could bypass the homepage model default: the legacy initial diagnosis set cfg.OpenAI.Model on the request, and the structured report extractor skipped or pinned model selection instead of letting the router resolve the default.

## Tests
- go test ./cmd/ongrid ./internal/manager/biz/alert/investigator ./internal/manager/biz/aiops/investigator