### PR TITLE
feat(system): add web upgrade check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,33 @@ jobs:
             (cd dist/out && sha256sum -c "ongrid-${tag}-linux-${arch}.tar.xz.sha256")
           done
 
+      - name: Write release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          published_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > dist/out/latest.json <<EOF
+          {
+            "version": "${tag}",
+            "tag_name": "${tag}",
+            "release_url": "https://github.com/ongridio/ongrid/releases/tag/${tag}",
+            "published_at": "${published_at}",
+            "download_base": "https://ongrid.cloud/dl",
+            "assets": {
+              "linux-amd64": {
+                "package": "ongrid-${tag}-linux-amd64.tar.xz",
+                "sha256": "ongrid-${tag}-linux-amd64.tar.xz.sha256"
+              },
+              "linux-arm64": {
+                "package": "ongrid-${tag}-linux-arm64.tar.xz",
+                "sha256": "ongrid-${tag}-linux-arm64.tar.xz.sha256"
+              }
+            }
+          }
+          EOF
+          test -s dist/out/latest.json
+
       - name: Write release install notes
         shell: bash
         run: |
@@ -198,6 +225,7 @@ jobs:
             "dist/out/ongrid-${tag}-linux-amd64.tar.xz.sha256" \
             "dist/out/ongrid-${tag}-linux-arm64.tar.xz" \
             "dist/out/ongrid-${tag}-linux-arm64.tar.xz.sha256" \
+            "dist/out/latest.json" \
             --verify-tag \
             --title "Ongrid ${tag}" \
             --generate-notes \

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -137,6 +137,7 @@ import (
 	managerserversetting "github.com/ongridio/ongrid/internal/manager/server/setting"
 	managerserverskill "github.com/ongridio/ongrid/internal/manager/server/skill"
 	managerserversystemhealth "github.com/ongridio/ongrid/internal/manager/server/systemhealth"
+	managerserversystemupgrade "github.com/ongridio/ongrid/internal/manager/server/systemupgrade"
 	managerservertopology "github.com/ongridio/ongrid/internal/manager/server/topology"
 	managerservertraces "github.com/ongridio/ongrid/internal/manager/server/traces"
 
@@ -147,6 +148,7 @@ import (
 	managersvcmetric "github.com/ongridio/ongrid/internal/manager/service/metric"
 	managersvcprom "github.com/ongridio/ongrid/internal/manager/service/prometheus"
 	managersvcsystemhealth "github.com/ongridio/ongrid/internal/manager/service/systemhealth"
+	managersvcsystemupgrade "github.com/ongridio/ongrid/internal/manager/service/systemupgrade"
 
 	// Builtin skill init() blocks register Executors with the shared
 	// internal/skill registry. Both manager (metadata) and edge
@@ -1613,6 +1615,10 @@ func main() {
 		LLM:       llmSettingsResolver,
 	})
 	systemHealthHandler := managerserversystemhealth.NewHandler(systemHealthSvc)
+	systemUpgradeSvc := managersvcsystemupgrade.New(managersvcsystemupgrade.Config{
+		CurrentVersion: version,
+	}, nil)
+	systemUpgradeHandler := managerserversystemupgrade.NewHandler(systemUpgradeSvc)
 
 	// HTTP handler for the knowledge base — built here, wired to routes
 	// below. The biz Usecase + tool registry SetKnowledgeSearcher were
@@ -1824,6 +1830,7 @@ func main() {
 			aiopsHandler.Register(protected)
 			alertHandler.Register(protected)
 			systemHealthHandler.Register(protected)
+			systemUpgradeHandler.Register(protected)
 			imbridgeHandler.RegisterProtected(protected)
 			skillHandler.Register(protected)
 			if knowledgeHandler != nil {

--- a/internal/manager/server/systemupgrade/http.go
+++ b/internal/manager/server/systemupgrade/http.go
@@ -1,0 +1,100 @@
+// Package systemupgrade exposes the platform upgrade-check API.
+package systemupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	upgradesvc "github.com/ongridio/ongrid/internal/manager/service/systemupgrade"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+type UpgradeService interface {
+	Check(ctx context.Context) (*upgradesvc.Info, error)
+}
+
+type Info = upgradesvc.Info
+
+type Handler struct {
+	svc UpgradeService
+}
+
+func NewHandler(svc UpgradeService) *Handler {
+	return &Handler{svc: svc}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Get("/v1/system/upgrade", h.check)
+	r.Post("/v1/system/upgrade/check", h.check)
+}
+
+// check godoc
+// @Summary Check platform upgrade
+// @Router /v1/system/upgrade [get]
+// @Router /v1/system/upgrade/check [post]
+// @Success 200 {object} systemupgrade.Info
+func (h *Handler) check(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if h.svc == nil {
+		writeErr(w, errs.ErrNotWiredYet)
+		return
+	}
+	info, err := h.svc.Check(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, info)
+}
+
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	t, ok := tenantctx.From(r.Context())
+	if !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return false
+	}
+	if t.Role != "admin" {
+		writeErr(w, errs.ErrForbidden)
+		return false
+	}
+	return true
+}
+
+type errorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if body == nil {
+		return
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	slug := "internal"
+	switch {
+	case errors.Is(err, errs.ErrUnauthorized):
+		status, slug = http.StatusUnauthorized, "unauthorized"
+	case errors.Is(err, errs.ErrForbidden):
+		status, slug = http.StatusForbidden, "forbidden"
+	case errors.Is(err, errs.ErrInvalid):
+		status, slug = http.StatusBadRequest, "invalid"
+	case errors.Is(err, errs.ErrNotFound):
+		status, slug = http.StatusNotFound, "not-found"
+	default:
+		status, slug = http.StatusBadGateway, "upstream"
+	}
+	writeJSON(w, status, errorBody{Error: err.Error(), Code: slug})
+}

--- a/internal/manager/server/systemupgrade/http_test.go
+++ b/internal/manager/server/systemupgrade/http_test.go
@@ -1,0 +1,92 @@
+package systemupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	upgradesvc "github.com/ongridio/ongrid/internal/manager/service/systemupgrade"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+type stubUpgrade struct {
+	called bool
+	info   *upgradesvc.Info
+	err    error
+}
+
+func (s *stubUpgrade) Check(context.Context) (*upgradesvc.Info, error) {
+	s.called = true
+	if s.info != nil || s.err != nil {
+		return s.info, s.err
+	}
+	return &upgradesvc.Info{
+		CurrentVersion:      "v0.8.4",
+		LatestVersion:       "v0.8.5",
+		UpdateAvailable:     true,
+		ComparisonSupported: true,
+		CheckedAt:           time.Now().UTC(),
+		Commands: []upgradesvc.UpgradeCommand{
+			{ID: "auto", Label: "Auto", Arch: "linux", Command: "sudo ./upgrade.sh"},
+		},
+	}, nil
+}
+
+func TestCheckRequiresAdmin(t *testing.T) {
+	t.Parallel()
+	svc := &stubUpgrade{}
+	router := newRouter(NewHandler(svc))
+
+	userReq := httptest.NewRequest(http.MethodPost, "/v1/system/upgrade/check", nil)
+	userReq = userReq.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 2, Role: "user"}))
+	userRec := httptest.NewRecorder()
+	router.ServeHTTP(userRec, userReq)
+	if userRec.Code != http.StatusForbidden {
+		t.Fatalf("user status = %d body=%s", userRec.Code, userRec.Body.String())
+	}
+	if svc.called {
+		t.Fatalf("service should not be called for non-admin")
+	}
+
+	anonReq := httptest.NewRequest(http.MethodPost, "/v1/system/upgrade/check", nil)
+	anonRec := httptest.NewRecorder()
+	router.ServeHTTP(anonRec, anonReq)
+	if anonRec.Code != http.StatusUnauthorized {
+		t.Fatalf("anon status = %d body=%s", anonRec.Code, anonRec.Body.String())
+	}
+}
+
+func TestCheckReturnsUpgradeInfo(t *testing.T) {
+	t.Parallel()
+	svc := &stubUpgrade{}
+	router := newRouter(NewHandler(svc))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/system/upgrade/check", nil)
+	req = req.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 1, Role: "admin"}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !svc.called {
+		t.Fatalf("service was not called")
+	}
+	var info upgradesvc.Info
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatalf("response is not upgrade info: %v", err)
+	}
+	if !info.UpdateAvailable || info.LatestVersion != "v0.8.5" {
+		t.Fatalf("info = %+v", info)
+	}
+}
+
+func newRouter(h *Handler) http.Handler {
+	r := chi.NewRouter()
+	h.Register(r)
+	return r
+}

--- a/internal/manager/service/systemupgrade/service.go
+++ b/internal/manager/service/systemupgrade/service.go
@@ -1,0 +1,323 @@
+// Package systemupgrade checks the upstream ongrid release and prepares
+// operator-run upgrade commands for the Web UI.
+package systemupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultReleaseMetadataURL = "https://ongrid.cloud/dl/latest.json"
+	defaultGitHubReleaseURL   = "https://api.github.com/repos/ongridio/ongrid/releases/latest"
+	defaultDownloadBase       = "https://ongrid.cloud/dl"
+	maxReleaseMetadataBytes   = 1 << 20
+)
+
+type Config struct {
+	CurrentVersion string
+	ReleaseAPIURL  string
+	ReleaseAPIURLs []string
+	DownloadBase   string
+	Timeout        time.Duration
+}
+
+type Service struct {
+	cfg  Config
+	http *http.Client
+}
+
+type Info struct {
+	CurrentVersion      string           `json:"current_version"`
+	LatestVersion       string           `json:"latest_version"`
+	UpdateAvailable     bool             `json:"update_available"`
+	ComparisonSupported bool             `json:"comparison_supported"`
+	ReleaseURL          string           `json:"release_url,omitempty"`
+	PublishedAt         *time.Time       `json:"published_at,omitempty"`
+	CheckedAt           time.Time        `json:"checked_at"`
+	Commands            []UpgradeCommand `json:"commands"`
+}
+
+type UpgradeCommand struct {
+	ID      string `json:"id"`
+	Label   string `json:"label"`
+	Arch    string `json:"arch"`
+	Command string `json:"command"`
+}
+
+type releasePayload struct {
+	TagName       string `json:"tag_name"`
+	Version       string `json:"version"`
+	LatestVersion string `json:"latest_version"`
+	HTMLURL       string `json:"html_url"`
+	ReleaseURL    string `json:"release_url"`
+	PublishedAt   string `json:"published_at"`
+	DownloadBase  string `json:"download_base"`
+}
+
+type releaseInfo struct {
+	latestVersion string
+	releaseURL    string
+	publishedAt   *time.Time
+	downloadBase  string
+}
+
+func New(cfg Config, client *http.Client) *Service {
+	cfg.ReleaseAPIURLs = normalizeReleaseURLs(cfg)
+	if cfg.DownloadBase == "" {
+		cfg.DownloadBase = defaultDownloadBase
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+	return &Service{cfg: cfg, http: client}
+}
+
+func (s *Service) Check(ctx context.Context) (*Info, error) {
+	var fetchErrs []error
+	for _, sourceURL := range s.cfg.ReleaseAPIURLs {
+		rel, err := s.fetchLatest(ctx, sourceURL)
+		if err != nil {
+			fetchErrs = append(fetchErrs, fmt.Errorf("%s: %w", sourceURL, err))
+			continue
+		}
+		return s.buildInfo(rel), nil
+	}
+	return nil, fmt.Errorf("fetch latest release: %w", errors.Join(fetchErrs...))
+}
+
+func (s *Service) buildInfo(rel *releaseInfo) *Info {
+	latest := strings.TrimSpace(rel.latestVersion)
+	cmp, comparable := compareVersions(s.cfg.CurrentVersion, latest)
+	updateAvailable := comparable && cmp < 0
+	downloadBase := strings.TrimSpace(rel.downloadBase)
+	if downloadBase == "" {
+		downloadBase = s.cfg.DownloadBase
+	}
+	return &Info{
+		CurrentVersion:      strings.TrimSpace(s.cfg.CurrentVersion),
+		LatestVersion:       latest,
+		UpdateAvailable:     updateAvailable,
+		ComparisonSupported: comparable,
+		ReleaseURL:          rel.releaseURL,
+		PublishedAt:         rel.publishedAt,
+		CheckedAt:           time.Now().UTC(),
+		Commands:            buildCommands(latest, downloadBase),
+	}
+}
+
+func (s *Service) fetchLatest(ctx context.Context, sourceURL string) (*releaseInfo, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json, text/plain;q=0.9, */*;q=0.8")
+	req.Header.Set("User-Agent", "ongrid/"+strings.TrimSpace(s.cfg.CurrentVersion))
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxReleaseMetadataBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read latest release: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		msg := strings.TrimSpace(string(raw))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg)
+	}
+
+	return parseReleaseMetadata(raw)
+}
+
+func parseReleaseMetadata(raw []byte) (*releaseInfo, error) {
+	body := strings.TrimSpace(string(raw))
+	if body == "" {
+		return nil, errors.New("release metadata is empty")
+	}
+	if strings.HasPrefix(body, "{") {
+		var rel releasePayload
+		if err := json.Unmarshal(raw, &rel); err != nil {
+			return nil, fmt.Errorf("decode latest release: %w", err)
+		}
+		latest := firstNonEmpty(rel.TagName, rel.LatestVersion, rel.Version)
+		if latest == "" {
+			return nil, errors.New("decode latest release: version is empty")
+		}
+		publishedAt, err := parseOptionalTime(rel.PublishedAt)
+		if err != nil {
+			return nil, fmt.Errorf("decode latest release: %w", err)
+		}
+		return &releaseInfo{
+			latestVersion: latest,
+			releaseURL:    firstNonEmpty(rel.HTMLURL, rel.ReleaseURL),
+			publishedAt:   publishedAt,
+			downloadBase:  strings.TrimSpace(rel.DownloadBase),
+		}, nil
+	}
+
+	fields := strings.Fields(body)
+	if len(fields) == 0 {
+		return nil, errors.New("release metadata is empty")
+	}
+	return &releaseInfo{latestVersion: fields[0]}, nil
+}
+
+func parseOptionalTime(value string) (*time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid published_at: %w", err)
+	}
+	return &parsed, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeReleaseURLs(cfg Config) []string {
+	urls := cfg.ReleaseAPIURLs
+	if len(urls) == 0 && strings.TrimSpace(cfg.ReleaseAPIURL) != "" {
+		urls = []string{cfg.ReleaseAPIURL}
+	}
+	if len(urls) == 0 {
+		urls = []string{defaultReleaseMetadataURL, defaultGitHubReleaseURL}
+	}
+	out := make([]string, 0, len(urls))
+	for _, sourceURL := range urls {
+		sourceURL = strings.TrimSpace(sourceURL)
+		if sourceURL != "" {
+			out = append(out, sourceURL)
+		}
+	}
+	if len(out) == 0 {
+		return []string{defaultReleaseMetadataURL, defaultGitHubReleaseURL}
+	}
+	return out
+}
+
+func buildCommands(version, downloadBase string) []UpgradeCommand {
+	base := strings.TrimRight(downloadBase, "/")
+	return []UpgradeCommand{
+		{
+			ID:      "linux-amd64",
+			Label:   "Linux amd64",
+			Arch:    "linux-amd64",
+			Command: buildArchCommand(version, base, "amd64"),
+		},
+		{
+			ID:      "linux-arm64",
+			Label:   "Linux arm64",
+			Arch:    "linux-arm64",
+			Command: buildArchCommand(version, base, "arm64"),
+		},
+		{
+			ID:      "auto",
+			Label:   "Auto-detect Linux arch",
+			Arch:    "linux",
+			Command: buildAutoCommand(version, base),
+		},
+	}
+}
+
+func buildAutoCommand(version, base string) string {
+	return fmt.Sprintf(
+		`ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "unsupported arch: $ARCH"; exit 1 ;;
+esac
+PKG="ongrid-%s-linux-${ARCH}"
+curl -fL -O %s/${PKG}.tar.xz || wget %s/${PKG}.tar.xz
+tar xf ${PKG}.tar.xz && cd ${PKG}
+sudo ./upgrade.sh`,
+		version,
+		base,
+		base,
+	)
+}
+
+func buildArchCommand(version, base, arch string) string {
+	pkg := fmt.Sprintf("ongrid-%s-linux-%s", version, arch)
+	return fmt.Sprintf(
+		`curl -fL -O %s/%s.tar.xz || wget %s/%s.tar.xz
+tar xf %s.tar.xz && cd %s
+sudo ./upgrade.sh`,
+		base,
+		pkg,
+		base,
+		pkg,
+		pkg,
+		pkg,
+	)
+}
+
+func compareVersions(current, latest string) (int, bool) {
+	cur, ok := parseVersion(current)
+	if !ok {
+		return 0, false
+	}
+	next, ok := parseVersion(latest)
+	if !ok {
+		return 0, false
+	}
+	for i := range cur {
+		if cur[i] < next[i] {
+			return -1, true
+		}
+		if cur[i] > next[i] {
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+func parseVersion(v string) ([3]int, bool) {
+	var out [3]int
+	s := strings.TrimSpace(v)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(s, "+-"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
+}

--- a/internal/manager/service/systemupgrade/service_test.go
+++ b/internal/manager/service/systemupgrade/service_test.go
@@ -1,0 +1,227 @@
+package systemupgrade
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCheckDetectsNewerRelease(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest" {
+			t.Fatalf("path = %q, want /latest", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{
+			"tag_name":"v0.8.10",
+			"html_url":"https://github.com/ongridio/ongrid/releases/tag/v0.8.10",
+			"published_at":"2026-06-10T00:00:00Z"
+		}`)); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{
+		CurrentVersion: "v0.8.4",
+		ReleaseAPIURL:  srv.URL + "/latest",
+		DownloadBase:   "https://ongrid.cloud/dl",
+	}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !info.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true")
+	}
+	if !info.ComparisonSupported {
+		t.Fatalf("ComparisonSupported = false, want true")
+	}
+	if info.LatestVersion != "v0.8.10" {
+		t.Fatalf("LatestVersion = %q", info.LatestVersion)
+	}
+	if len(info.Commands) != 3 {
+		t.Fatalf("commands = %d, want 3", len(info.Commands))
+	}
+	if !strings.Contains(info.Commands[2].Command, "PKG=\"ongrid-v0.8.10-linux-${ARCH}\"") {
+		t.Fatalf("auto command does not auto-detect arch: %s", info.Commands[2].Command)
+	}
+	if !strings.Contains(info.Commands[2].Command, "\ncurl -fL -O https://ongrid.cloud/dl/${PKG}.tar.xz || wget https://ongrid.cloud/dl/${PKG}.tar.xz\n") {
+		t.Fatalf("auto command does not use multiline curl/wget format: %s", info.Commands[2].Command)
+	}
+	wantAmd64Command := strings.Join([]string{
+		"curl -fL -O https://ongrid.cloud/dl/ongrid-v0.8.10-linux-amd64.tar.xz || wget https://ongrid.cloud/dl/ongrid-v0.8.10-linux-amd64.tar.xz",
+		"tar xf ongrid-v0.8.10-linux-amd64.tar.xz && cd ongrid-v0.8.10-linux-amd64",
+		"sudo ./upgrade.sh",
+	}, "\n")
+	if info.Commands[0].Command != wantAmd64Command {
+		t.Fatalf("amd64 command = %q, want %q", info.Commands[0].Command, wantAmd64Command)
+	}
+}
+
+func TestCheckReportsNoUpdateWhenCurrentMatchesLatest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"tag_name":"v0.8.4"}`)); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{CurrentVersion: "v0.8.4", ReleaseAPIURL: srv.URL}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if info.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = true, want false")
+	}
+	if !info.ComparisonSupported {
+		t.Fatalf("ComparisonSupported = false, want true")
+	}
+}
+
+func TestCheckKeepsDevVersionNonComparable(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"tag_name":"v0.8.4"}`)); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{CurrentVersion: "dev", ReleaseAPIURL: srv.URL}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if info.ComparisonSupported {
+		t.Fatalf("ComparisonSupported = true, want false")
+	}
+	if info.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = true, want false for non-comparable current")
+	}
+}
+
+func TestCheckReturnsErrorOnBadReleaseResponse(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{CurrentVersion: "v0.8.4", ReleaseAPIURL: srv.URL}, srv.Client())
+	_, err := svc.Check(context.Background())
+	if err == nil {
+		t.Fatalf("Check returned nil error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 429") {
+		t.Fatalf("error = %v, want HTTP 429", err)
+	}
+}
+
+func TestCheckUsesOfficialMetadataBeforeGitHubFallback(t *testing.T) {
+	t.Parallel()
+	var githubCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dl/latest.json":
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{
+				"version":"v0.8.10",
+				"release_url":"https://github.com/ongridio/ongrid/releases/tag/v0.8.10",
+				"download_base":"https://mirror.example.test/dl"
+			}`)); err != nil {
+				t.Fatalf("write response: %v", err)
+			}
+		case "/github/latest":
+			githubCalled = true
+			http.Error(w, "github should not be called", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{
+		CurrentVersion: "v0.8.4",
+		ReleaseAPIURLs: []string{
+			srv.URL + "/dl/latest.json",
+			srv.URL + "/github/latest",
+		},
+	}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if githubCalled {
+		t.Fatalf("GitHub fallback was called despite official metadata success")
+	}
+	if !info.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true")
+	}
+	if !strings.Contains(info.Commands[0].Command, "https://mirror.example.test/dl") {
+		t.Fatalf("command does not use metadata download_base: %s", info.Commands[0].Command)
+	}
+}
+
+func TestCheckFallsBackToGitHubMetadata(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dl/latest.json":
+			http.Error(w, "metadata not synced yet", http.StatusNotFound)
+		case "/github/latest":
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"tag_name":"v0.8.5"}`)); err != nil {
+				t.Fatalf("write response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{
+		CurrentVersion: "v0.8.4",
+		ReleaseAPIURLs: []string{
+			srv.URL + "/dl/latest.json",
+			srv.URL + "/github/latest",
+		},
+	}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if info.LatestVersion != "v0.8.5" {
+		t.Fatalf("LatestVersion = %q, want v0.8.5", info.LatestVersion)
+	}
+	if !info.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true")
+	}
+}
+
+func TestCheckAcceptsPlainTextVersionMetadata(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if _, err := w.Write([]byte("v0.8.6\n")); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := New(Config{CurrentVersion: "v0.8.4", ReleaseAPIURL: srv.URL}, srv.Client())
+	info, err := svc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if info.LatestVersion != "v0.8.6" {
+		t.Fatalf("LatestVersion = %q, want v0.8.6", info.LatestVersion)
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,9 +35,9 @@ const SettingsLLM = lazy(() => import('@/pages/settings/LLM'));
 const SettingsNotifications = lazy(() => import('@/pages/settings/Notifications'));
 const SettingsChannels = lazy(() => import('@/pages/settings/Channels'));
 const SettingsIntegrations = lazy(() => import('@/pages/settings/Integrations'));
-const SettingsMarketplace = lazy(() => import('@/pages/settings/Marketplace'));
 const SettingsPreferences = lazy(() => import('@/pages/settings/Preferences'));
 const SettingsHealth = lazy(() => import('@/pages/settings/Health'));
+const SettingsUpgrade = lazy(() => import('@/pages/settings/Upgrade'));
 // Admin section (top-level "管理" tab) — platform governance pages.
 // Lifted out of /settings so adding RBAC editor / audit log doesn't
 // keep cluttering the settings rail. /settings now answers "how the
@@ -143,6 +143,7 @@ export default function App() {
           <Route path="channels" element={<SettingsChannels />} />
           <Route path="integrations" element={<SettingsIntegrations />} />
           <Route path="health" element={<SettingsHealth />} />
+          <Route path="upgrade" element={<SettingsUpgrade />} />
           {/* /settings/marketplace retired (2026-05-19). Install surface
               is currently hidden from visible nav (no AIOps skill
               ecosystem yet); reachable via /skills?tab=install URL only.

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -5,7 +5,9 @@ export type LoginResponse = {
   refresh_token?: string;
   token_type?: string;
   expires_in?: number;
-  user: { email: string; role: string; id?: string };
+  role?: string;
+  email?: string;
+  user?: { email?: string; role?: string; id?: string };
 };
 
 export type SelfResponse = {

--- a/web/src/api/systemUpgrade.ts
+++ b/web/src/api/systemUpgrade.ts
@@ -1,0 +1,23 @@
+import { request } from '@/api/client';
+
+export type UpgradeCommand = {
+  id: string;
+  label: string;
+  arch: string;
+  command: string;
+};
+
+export type UpgradeInfo = {
+  current_version: string;
+  latest_version: string;
+  update_available: boolean;
+  comparison_supported: boolean;
+  release_url?: string;
+  published_at?: string;
+  checked_at: string;
+  commands: UpgradeCommand[];
+};
+
+export function checkSystemUpgrade() {
+  return request<UpgradeInfo>('POST', '/system/upgrade/check');
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
   Pencil,
   Trash2,
   Share2,
+  ArrowUpCircle,
 } from 'lucide-react';
 import { Avatar } from './Avatar';
 import { AgentBadge } from './AgentBadge';
@@ -46,6 +47,7 @@ import { useChatSessions, invalidateChatSessions } from '@/store/chatSessions';
 import { deleteSession, renameSession, type ChatSession } from '@/api/chat';
 import { listEdges, type EdgeRole } from '@/api/edges';
 import { getManagerVersion } from '@/api/version';
+import { checkSystemUpgrade } from '@/api/systemUpgrade';
 import { onDevicesChanged } from '@/lib/events';
 
 export function Sidebar() {
@@ -71,6 +73,8 @@ export function Sidebar() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [managerVersion, setManagerVersion] = useState('');
   const managerVersionLabel = managerVersion.trim();
+  const [upgradeAvailable, setUpgradeAvailable] = useState<{ latestVersion: string } | null>(null);
+  const canCheckUpgrade = role === 'admin' || isAdmin;
 
   useEffect(() => {
     let cancelled = false;
@@ -85,6 +89,29 @@ export function Sidebar() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!canCheckUpgrade || !managerVersionLabel) {
+      setUpgradeAvailable(null);
+      return;
+    }
+    let cancelled = false;
+    void checkSystemUpgrade()
+      .then((info) => {
+        if (cancelled) return;
+        if (info.comparison_supported && info.update_available) {
+          setUpgradeAvailable({ latestVersion: info.latest_version });
+          return;
+        }
+        setUpgradeAvailable(null);
+      })
+      .catch(() => {
+        if (!cancelled) setUpgradeAvailable(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canCheckUpgrade, managerVersionLabel]);
 
   // Roles actually present in the user's fleet — drives which 设备 sub-
   // items appear. We don't render a role link for a role with 0 devices,
@@ -352,23 +379,42 @@ export function Sidebar() {
       {/* Brand row — keeps the product identity visible while the user
           row below still owns the avatar + menu. Clicking the wordmark
           goes home. */}
-      <Link
-        to="/"
-        aria-label={tr('Ongrid 首页', 'Ongrid home')}
-        className="flex items-center gap-1.5 border-b border-zinc-800/60 px-3 py-3 hover:bg-zinc-800/40"
-      >
-        <OngridLogo size={32} className="-mr-0.5" />
-        <span className="text-[16px] font-semibold tracking-tight text-zinc-100">Ongrid</span>
-        {managerVersionLabel ? (
-          <span
-            className="ml-1 max-w-[78px] truncate rounded-full border border-zinc-700/70 bg-zinc-800/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-zinc-400"
-            title={tr(`当前版本：${managerVersionLabel}`, `Current version: ${managerVersionLabel}`)}
-            aria-label={tr(`当前版本：${managerVersionLabel}`, `Current version: ${managerVersionLabel}`)}
+      <div className="flex items-center gap-1.5 border-b border-zinc-800/60 px-3 py-3">
+        <Link
+          to="/"
+          aria-label={tr('Ongrid 首页', 'Ongrid home')}
+          className="flex min-w-0 items-center gap-1.5 rounded-lg px-1 py-1 -ml-1 hover:bg-zinc-800/40"
+        >
+          <OngridLogo size={32} className="-mr-0.5 shrink-0" />
+          <span className="text-[16px] font-semibold tracking-tight text-zinc-100">Ongrid</span>
+          {managerVersionLabel ? (
+            <span
+              className="ml-1 max-w-[78px] shrink-0 truncate rounded-full border border-zinc-700/70 bg-zinc-800/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-zinc-400"
+              title={tr(`当前版本：${managerVersionLabel}`, `Current version: ${managerVersionLabel}`)}
+              aria-label={tr(`当前版本：${managerVersionLabel}`, `Current version: ${managerVersionLabel}`)}
+            >
+              {managerVersionLabel}
+            </span>
+          ) : null}
+        </Link>
+        {upgradeAvailable ? (
+          <Link
+            to="/settings/upgrade"
+            className="inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/45 bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium leading-none text-emerald-700 transition hover:border-emerald-500/70 hover:bg-emerald-100 hover:text-emerald-800 focus:outline-none focus:ring-1 focus:ring-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-300 dark:hover:bg-emerald-500/15 dark:hover:text-emerald-200"
+            title={tr(
+              `发现新版本 ${upgradeAvailable.latestVersion}，点击查看升级命令`,
+              `New version ${upgradeAvailable.latestVersion} available. View upgrade commands`,
+            )}
+            aria-label={tr(
+              `发现新版本 ${upgradeAvailable.latestVersion}，打开升级页面`,
+              `New version ${upgradeAvailable.latestVersion} available. Open upgrade page`,
+            )}
           >
-            {managerVersionLabel}
-          </span>
+            <ArrowUpCircle size={11} />
+            <span>{tr('升级', 'Update')}</span>
+          </Link>
         ) : null}
-      </Link>
+      </div>
 
       {/* user / collapse / bell */}
       <div ref={userMenuRef} className="relative flex items-center gap-2 px-3 py-3">

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -25,8 +25,8 @@ export default function LoginPage() {
       setSession({
         access_token: res.access_token,
         refresh_token: res.refresh_token,
-        role: res.user?.role ?? 'user',
-        email: res.user?.email ?? email.trim(),
+        role: res.user?.role ?? res.role ?? 'user',
+        email: res.user?.email ?? res.email ?? email.trim(),
       });
       navigate('/', { replace: true });
     } catch (err) {

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -9,6 +9,7 @@ import {
   HeartPulse,
   Plug,
   Shield,
+  UploadCloud,
 } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import type { IconType } from '@/lib/icon';
@@ -30,6 +31,7 @@ type RailItem = {
 
 const RAIL_ITEMS: RailItem[] = [
   { to: 'health', icon: HeartPulse, labelZh: '健康', labelEn: 'Health', hintZh: '平台自检 / 依赖状态', hintEn: 'Platform self-check / dependency status' },
+  { to: 'upgrade', icon: UploadCloud, labelZh: '升级', labelEn: 'Upgrade', hintZh: '检测版本 / 复制命令', hintEn: 'Check version / copy command' },
   { to: 'integrations', icon: Plug, labelZh: '集成', labelEn: 'Integrations', hintZh: 'Prometheus / Grafana 等外部系统', hintEn: 'External systems — Prometheus / Grafana / etc.' },
   // marketplace entry retired 2026-05-19 — install/uninstall moved to
   // /skills?tab=install so the whole skill story (loaded + installed)

--- a/web/src/pages/settings/Upgrade.tsx
+++ b/web/src/pages/settings/Upgrade.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Copy,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  TerminalSquare,
+} from 'lucide-react';
+import { ApiError } from '@/api/client';
+import { checkSystemUpgrade, type UpgradeCommand, type UpgradeInfo } from '@/api/systemUpgrade';
+import { Button, Card } from '@/components/ui';
+import { cn } from '@/lib/cn';
+import type { IconType } from '@/lib/icon';
+import { useI18n } from '@/i18n/locale';
+
+const MIN_MANUAL_REFRESH_MS = 650;
+
+export default function SettingsUpgrade() {
+  const { tr, locale } = useI18n();
+  const [info, setInfo] = useState<UpgradeInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const run = useCallback(async (manual = false) => {
+    setLoading(true);
+    setErr(null);
+    const started = Date.now();
+    try {
+      const next = await checkSystemUpgrade();
+      setInfo(next);
+    } catch (e) {
+      setErr(e instanceof ApiError ? e.message : (e as Error).message);
+    } finally {
+      if (manual) {
+        const elapsed = Date.now() - started;
+        if (elapsed < MIN_MANUAL_REFRESH_MS) {
+          await wait(MIN_MANUAL_REFRESH_MS - elapsed);
+        }
+      }
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  const checkedAt = info?.checked_at
+    ? new Date(info.checked_at).toLocaleString(locale === 'zh-CN' ? 'zh-CN' : 'en-US')
+    : tr('尚未检测', 'Not checked');
+  const publishedAt = info?.published_at
+    ? new Date(info.published_at).toLocaleDateString(locale === 'zh-CN' ? 'zh-CN' : 'en-US')
+    : null;
+  const status = getStatus(info);
+  const StatusIcon = status.icon;
+
+  const onCopy = async (command: UpgradeCommand) => {
+    await copyText(command.command);
+    setCopied(command.id);
+    window.setTimeout(() => setCopied((current) => (current === command.id ? null : current)), 1600);
+  };
+
+  return (
+    <div className="space-y-4" aria-busy={loading}>
+      <Card className="p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <StatusIcon size={15} className={status.iconClass} />
+              <h2 className="text-sm font-medium text-zinc-100">{tr('版本升级', 'Version upgrade')}</h2>
+              {info && (
+                <span className={cn('rounded-full px-2 py-0.5 text-[11px] ring-1', status.badgeClass)}>
+                  {tr(status.labelZh, status.labelEn)}
+                </span>
+              )}
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[11px] text-zinc-500">
+              <Clock3 size={12} className="text-zinc-600" />
+              <span>{checkedAt}</span>
+            </div>
+          </div>
+          <Button
+            variant="primary"
+            onClick={() => void run(true)}
+            disabled={loading}
+            className="w-full justify-center sm:w-auto"
+          >
+            {loading ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
+            {loading ? tr('检测中', 'Checking') : tr('检测更新', 'Check updates')}
+          </Button>
+        </div>
+        {err && (
+          <div className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+            {err}
+          </div>
+        )}
+      </Card>
+
+      {loading && !info ? (
+        <Card className="flex h-32 items-center justify-center text-sm text-zinc-500">
+          <Loader2 size={15} className="mr-2 animate-spin" /> {tr('正在检测最新版本…', 'Checking latest version…')}
+        </Card>
+      ) : info ? (
+        <>
+          <VersionSummary info={info} publishedAt={publishedAt} />
+          <UpgradeState info={info} />
+          <CommandList
+            commands={info.commands}
+            copied={copied}
+            onCopy={(command) => void onCopy(command)}
+          />
+        </>
+      ) : (
+        <Card className="p-5 text-sm text-zinc-500">{tr('暂无检测结果', 'No check result yet')}</Card>
+      )}
+    </div>
+  );
+}
+
+function VersionSummary({ info, publishedAt }: { info: UpgradeInfo; publishedAt: string | null }) {
+  const { tr } = useI18n();
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <Card compact>
+        <div className="text-xs text-zinc-500">{tr('当前版本', 'Current version')}</div>
+        <div className="mt-1 font-mono text-lg font-semibold text-zinc-100">
+          {info.current_version || tr('开发构建', 'Development build')}
+        </div>
+      </Card>
+      <Card compact>
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs text-zinc-500">{tr('最新版本', 'Latest version')}</div>
+          {info.release_url && (
+            <a
+              href={info.release_url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-accent hover:text-accent/80"
+            >
+              {tr('Release', 'Release')}
+              <ExternalLink size={11} />
+            </a>
+          )}
+        </div>
+        <div className="mt-1 font-mono text-lg font-semibold text-zinc-100">{info.latest_version}</div>
+        {publishedAt && <div className="mt-1 text-[11px] text-zinc-500">{publishedAt}</div>}
+      </Card>
+    </div>
+  );
+}
+
+function UpgradeState({ info }: { info: UpgradeInfo }) {
+  const { tr } = useI18n();
+  if (!info.comparison_supported) {
+    return (
+      <StatePanel
+        tone="warning"
+        icon={AlertTriangle}
+        title={tr('当前构建版本无法比较', 'Current build cannot be compared')}
+        text={tr('开发构建或非标准版本号不会自动判断是否需要升级。', 'Development or non-standard versions cannot be compared automatically.')}
+      />
+    );
+  }
+  if (info.update_available) {
+    return (
+      <StatePanel
+        tone="accent"
+        icon={TerminalSquare}
+        title={tr('发现新版本', 'New version available')}
+        text={tr('复制下面的升级命令，在目标服务器终端执行。', 'Copy an upgrade command below and run it on the target server terminal.')}
+      />
+    );
+  }
+  return (
+    <StatePanel
+      tone="success"
+      icon={CheckCircle2}
+      title={tr('当前已是最新版本', 'Already up to date')}
+      text={tr('仍可复制命令用于重新安装当前版本。', 'You can still copy a command to reinstall the current version.')}
+    />
+  );
+}
+
+function StatePanel({
+  tone,
+  icon: Icon,
+  title,
+  text,
+}: {
+  tone: 'success' | 'warning' | 'accent';
+  icon: IconType;
+  title: string;
+  text: string;
+}) {
+  const toneClass = {
+    success: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-200',
+    warning: 'border-amber-500/25 bg-amber-500/10 text-amber-200',
+    accent: 'border-accent/30 bg-accent/10 text-accent',
+  }[tone];
+  return (
+    <div className={cn('rounded-xl border px-4 py-3', toneClass)}>
+      <div className="flex items-start gap-2">
+        <Icon size={15} className="mt-0.5 shrink-0" />
+        <div className="min-w-0">
+          <div className="text-sm font-medium">{title}</div>
+          <div className="mt-1 text-xs opacity-80">{text}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CommandList({
+  commands,
+  copied,
+  onCopy,
+}: {
+  commands: UpgradeCommand[];
+  copied: string | null;
+  onCopy: (command: UpgradeCommand) => void;
+}) {
+  const { tr } = useI18n();
+  const ordered = useMemo(() => {
+    const auto = commands.find((item) => item.id === 'auto');
+    const rest = commands.filter((item) => item.id !== 'auto');
+    return auto ? [...rest, auto] : commands;
+  }, [commands]);
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-2 px-1 text-xs font-medium text-zinc-400">
+        <TerminalSquare size={13} />
+        <span>{tr('升级命令', 'Upgrade commands')}</span>
+      </div>
+      <div className="space-y-2">
+        {ordered.map((item) => (
+          <Card key={item.id} compact className="p-0">
+            <div className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-zinc-100">{commandLabel(item, tr)}</span>
+                </div>
+                <div className="mt-1 font-mono text-[11px] text-zinc-500">{item.arch}</div>
+              </div>
+              <Button
+                variant={copied === item.id ? 'subtle' : 'ghost'}
+                onClick={() => onCopy(item)}
+                className="w-full justify-center sm:w-auto"
+              >
+                <Copy size={12} />
+                {copied === item.id ? tr('已复制', 'Copied') : tr('复制命令', 'Copy command')}
+              </Button>
+            </div>
+            <pre className="whitespace-pre-wrap break-words border-t border-zinc-200 bg-zinc-50 px-3 py-2 text-[12px] leading-6 text-zinc-800 dark:border-zinc-800/60 dark:bg-zinc-950/60 dark:text-zinc-200">
+              <code>{item.command}</code>
+            </pre>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function getStatus(info: UpgradeInfo | null) {
+  if (!info) {
+    return {
+      icon: ShieldCheck,
+      iconClass: 'text-zinc-400',
+      labelZh: '未检测',
+      labelEn: 'Not checked',
+      badgeClass: 'bg-zinc-500/10 text-zinc-300 ring-zinc-500/25',
+    };
+  }
+  if (!info.comparison_supported) {
+    return {
+      icon: AlertTriangle,
+      iconClass: 'text-amber-400',
+      labelZh: '需人工确认',
+      labelEn: 'Manual check',
+      badgeClass: 'bg-amber-500/10 text-amber-300 ring-amber-500/25',
+    };
+  }
+  if (info.update_available) {
+    return {
+      icon: TerminalSquare,
+      iconClass: 'text-accent',
+      labelZh: '可升级',
+      labelEn: 'Update available',
+      badgeClass: 'bg-accent/10 text-accent ring-accent/30',
+    };
+  }
+  return {
+    icon: CheckCircle2,
+    iconClass: 'text-emerald-400',
+    labelZh: '最新',
+    labelEn: 'Up to date',
+    badgeClass: 'bg-emerald-500/10 text-emerald-300 ring-emerald-500/25',
+  };
+}
+
+function commandLabel(item: UpgradeCommand, tr: (zh: string, en: string) => string) {
+  switch (item.id) {
+    case 'auto':
+      return tr('自动识别 Linux 架构', 'Auto-detect Linux arch');
+    case 'linux-amd64':
+      return tr('Linux amd64 服务器', 'Linux amd64 server');
+    case 'linux-arm64':
+      return tr('Linux arm64 服务器', 'Linux arm64 server');
+    default:
+      return item.label;
+  }
+}
+
+async function copyText(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const el = document.createElement('textarea');
+  el.value = text;
+  el.setAttribute('readonly', 'true');
+  el.style.position = 'fixed';
+  el.style.opacity = '0';
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}

--- a/web/src/pages/settings/Upgrade.tsx
+++ b/web/src/pages/settings/Upgrade.tsx
@@ -88,7 +88,7 @@ export default function SettingsUpgrade() {
             variant="primary"
             onClick={() => void run(true)}
             disabled={loading}
-            className="w-full justify-center sm:w-auto"
+            className="w-full justify-center bg-indigo-600 text-white hover:bg-indigo-500 sm:w-auto"
           >
             {loading ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
             {loading ? tr('检测中', 'Checking') : tr('检测更新', 'Check updates')}
@@ -169,7 +169,7 @@ function UpgradeState({ info }: { info: UpgradeInfo }) {
   if (info.update_available) {
     return (
       <StatePanel
-        tone="accent"
+        tone="info"
         icon={TerminalSquare}
         title={tr('发现新版本', 'New version available')}
         text={tr('复制下面的升级命令，在目标服务器终端执行。', 'Copy an upgrade command below and run it on the target server terminal.')}
@@ -192,7 +192,7 @@ function StatePanel({
   title,
   text,
 }: {
-  tone: 'success' | 'warning' | 'accent';
+  tone: 'success' | 'warning' | 'info';
   icon: IconType;
   title: string;
   text: string;
@@ -200,7 +200,7 @@ function StatePanel({
   const toneClass = {
     success: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-200',
     warning: 'border-amber-500/25 bg-amber-500/10 text-amber-200',
-    accent: 'border-accent/30 bg-accent/10 text-accent',
+    info: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
   }[tone];
   return (
     <div className={cn('rounded-xl border px-4 py-3', toneClass)}>
@@ -236,9 +236,9 @@ function CommandList({
         <TerminalSquare size={13} />
         <span>{tr('升级命令', 'Upgrade commands')}</span>
       </div>
-      <div className="space-y-2">
+      <Card compact className="divide-y divide-zinc-800/60 p-0">
         {ordered.map((item) => (
-          <Card key={item.id} compact className="p-0">
+          <div key={item.id}>
             <div className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
@@ -258,9 +258,9 @@ function CommandList({
             <pre className="whitespace-pre-wrap break-words border-t border-zinc-200 bg-zinc-50 px-3 py-2 text-[12px] leading-6 text-zinc-800 dark:border-zinc-800/60 dark:bg-zinc-950/60 dark:text-zinc-200">
               <code>{item.command}</code>
             </pre>
-          </Card>
+          </div>
         ))}
-      </div>
+      </Card>
     </section>
   );
 }
@@ -269,7 +269,7 @@ function getStatus(info: UpgradeInfo | null) {
   if (!info) {
     return {
       icon: ShieldCheck,
-      iconClass: 'text-zinc-400',
+      iconClass: 'text-zinc-500',
       labelZh: '未检测',
       labelEn: 'Not checked',
       badgeClass: 'bg-zinc-500/10 text-zinc-300 ring-zinc-500/25',
@@ -278,7 +278,7 @@ function getStatus(info: UpgradeInfo | null) {
   if (!info.comparison_supported) {
     return {
       icon: AlertTriangle,
-      iconClass: 'text-amber-400',
+      iconClass: 'text-amber-500',
       labelZh: '需人工确认',
       labelEn: 'Manual check',
       badgeClass: 'bg-amber-500/10 text-amber-300 ring-amber-500/25',
@@ -287,15 +287,15 @@ function getStatus(info: UpgradeInfo | null) {
   if (info.update_available) {
     return {
       icon: TerminalSquare,
-      iconClass: 'text-accent',
+      iconClass: 'text-sky-500',
       labelZh: '可升级',
       labelEn: 'Update available',
-      badgeClass: 'bg-accent/10 text-accent ring-accent/30',
+      badgeClass: 'bg-sky-500/10 text-sky-300 ring-sky-500/25',
     };
   }
   return {
     icon: CheckCircle2,
-    iconClass: 'text-emerald-400',
+    iconClass: 'text-emerald-500',
     labelZh: '最新',
     labelEn: 'Up to date',
     badgeClass: 'bg-emerald-500/10 text-emerald-300 ring-emerald-500/25',


### PR DESCRIPTION
## Summary
- add an admin-only platform upgrade check API with ongrid.cloud metadata first and GitHub release fallback
- surface update availability beside the sidebar version badge and add a Settings > Upgrade page
- publish latest.json in release assets for the upgrade checker
- align upgrade commands with the UI rules: one Card with divided rows, semantic status colors, and i18n copy

## Verification
- go test ./cmd/ongrid ./internal/manager/service/systemupgrade ./internal/manager/server/systemupgrade
- npm run build
- npx eslint src/pages/settings/Upgrade.tsx src/components/Sidebar.tsx src/App.tsx --max-warnings 0
- git diff --check origin/main...HEAD
- verified in local OrbStack Ubuntu VM: v0.8.3 backend shows the green upgrade entry and /settings/upgrade renders v0.8.4 commands
- captured and reviewed light + dark theme screenshots for the upgrade page

## Notes
- Draft PR for review while we confirm release metadata hosting/sync behavior.