### PR TITLE
security: harden JWT boot check, auth cache, goroutine leak, and timing attacks

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -241,6 +241,11 @@ func main() {
 	}
 
 	// iam wiring.
+	const insecureJWTSecret = "dev-insecure-secret-change-me"
+	if cfg.JWT.Secret == insecureJWTSecret {
+		log.Error("FATAL: ONGRID_JWT_SECRET is still the built-in default — refusing to start. Set a strong random secret (e.g. openssl rand -base64 32) in your environment.")
+		os.Exit(1)
+	}
 	userRepo := iamdatauser.NewRepo(db)
 	signer := auth.NewSigner(cfg.JWT.Secret, cfg.JWT.AccessTTL, cfg.JWT.RefreshTTL)
 	userUC := iambizuser.NewUsecase(userRepo, signer, log)
@@ -2626,14 +2631,15 @@ func buildAIOpsRuntime(
 		defProv = llm.ProviderOpenAI
 	}
 	if _, ok := innerModels[defProv]; !ok {
-		// Default provider not configured — pick any configured
-		// provider deterministically so the routing model can still
-		// dispatch. Without this fallback the build errors and the
-		// graph kernel never wires.
+		// Default provider not configured — pick the first configured
+		// provider alphabetically so the result is deterministic across
+		// restarts (Go map iteration order is randomized).
+		keys := make([]string, 0, len(innerModels))
 		for k := range innerModels {
-			defProv = k
-			break
+			keys = append(keys, k)
 		}
+		sort.Strings(keys)
+		defProv = keys[0]
 	}
 	// DefaultResolver lets calls that omit a provider (the RCA investigator
 	// worker, query_translate) track the LIVE configured default — the model

--- a/internal/manager/biz/edge/authcache.go
+++ b/internal/manager/biz/edge/authcache.go
@@ -1,0 +1,56 @@
+package edge
+
+import (
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+// authCacheTTL is how long a successful credential verification is cached.
+// 60 seconds covers typical high-frequency push bursts while ensuring
+// revoked keys stop working within a bounded window.
+const authCacheTTL = 60 * time.Second
+
+// authCache caches successful argon2id verifications to avoid the 64 MiB
+// per-call cost on every data-plane auth_request. Keys are the SHA-256 of
+// accessKey + ":" + secretKey so plaintext credentials are never stored.
+type authCache struct {
+	mu      sync.Mutex
+	entries map[[32]byte]authCacheEntry
+}
+
+type authCacheEntry struct {
+	edgeID    uint64
+	expiresAt time.Time
+}
+
+func newAuthCache() *authCache {
+	return &authCache{entries: make(map[[32]byte]authCacheEntry)}
+}
+
+func (c *authCache) key(accessKey, secretKey string) [32]byte {
+	return sha256.Sum256([]byte(accessKey + ":" + secretKey))
+}
+
+// lookup returns (edgeID, true) if the credential pair has a valid cache hit.
+func (c *authCache) lookup(accessKey, secretKey string) (uint64, bool) {
+	k := c.key(accessKey, secretKey)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[k]
+	if !ok || time.Now().After(e.expiresAt) {
+		if ok {
+			delete(c.entries, k)
+		}
+		return 0, false
+	}
+	return e.edgeID, true
+}
+
+// store records a successful verification result.
+func (c *authCache) store(accessKey, secretKey string, edgeID uint64) {
+	k := c.key(accessKey, secretKey)
+	c.mu.Lock()
+	c.entries[k] = authCacheEntry{edgeID: edgeID, expiresAt: time.Now().Add(authCacheTTL)}
+	c.mu.Unlock()
+}

--- a/internal/manager/biz/edge/authn.go
+++ b/internal/manager/biz/edge/authn.go
@@ -14,13 +14,14 @@ import (
 // AccessKeyAuthenticator implements tunnel.AuthFunc for edge handshakes.
 // Injected into internal/pkg/tunnel at wiring time by cmd/ongrid.
 type AccessKeyAuthenticator struct {
-	repo Repo
-	log  *slog.Logger
+	repo  Repo
+	log   *slog.Logger
+	cache *authCache
 }
 
 // NewAccessKeyAuthenticator builds the authenticator. log may be nil.
 func NewAccessKeyAuthenticator(repo Repo, log *slog.Logger) *AccessKeyAuthenticator {
-	return &AccessKeyAuthenticator{repo: repo, log: log}
+	return &AccessKeyAuthenticator{repo: repo, log: log, cache: newAuthCache()}
 }
 
 // Authenticate looks up the edge by AccessKeyID, verifies the argon2id
@@ -28,15 +29,23 @@ func NewAccessKeyAuthenticator(repo Repo, log *slog.Logger) *AccessKeyAuthentica
 // returns the Session on success. All failure paths collapse to
 // errs.ErrUnauthorized so the tunnel layer never leaks enumeration signals.
 //
+// Successful verifications are cached for authCacheTTL (60s) to avoid the
+// expensive argon2id computation on every high-frequency data-plane push.
+//
 // On success it fires a goroutine that bumps status='online' + last_seen_at
 // via repo.UpdateStatus; errors are logged and swallowed so a flaky DB does
-// not block the handshake. The goroutine uses context.Background() rather
-// than ctx because the calling handshake ctx may be canceled the moment
-// Authenticate returns.
+// not block the handshake. The goroutine uses a 5-second timeout so it
+// cannot leak indefinitely if the database is stalled.
 func (a *AccessKeyAuthenticator) Authenticate(ctx context.Context, accessKey, secretKey string) (tunnel.Session, error) {
 	if a.repo == nil {
 		return tunnel.Session{}, errs.ErrNotWiredYet
 	}
+
+	// Fast path: check the credential cache before hitting argon2id.
+	if edgeID, ok := a.cache.lookup(accessKey, secretKey); ok {
+		return tunnel.Session{EdgeID: edgeID}, nil
+	}
+
 	e, err := a.repo.GetByAccessKey(ctx, accessKey)
 	if err != nil || e == nil {
 		return tunnel.Session{}, errs.ErrUnauthorized
@@ -46,9 +55,12 @@ func (a *AccessKeyAuthenticator) Authenticate(ctx context.Context, accessKey, se
 	}
 
 	edgeID := e.ID
+	a.cache.store(accessKey, secretKey, edgeID)
+
 	go func() {
-		bg := context.Background()
-		if err := a.repo.UpdateStatus(bg, edgeID, model.StatusOnline, time.Now().UTC()); err != nil && a.log != nil {
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.repo.UpdateStatus(bgCtx, edgeID, model.StatusOnline, time.Now().UTC()); err != nil && a.log != nil {
 			a.log.Warn("authn: UpdateStatus(online) failed", "edge_id", edgeID, "err", err)
 		}
 	}()

--- a/internal/manager/biz/marketplace/signature.go
+++ b/internal/manager/biz/marketplace/signature.go
@@ -3,6 +3,7 @@ package marketplace
 import (
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -231,18 +232,11 @@ func computePackHash(packPath string) ([32]byte, error) {
 	return out, nil
 }
 
-// bytesEqual is a tiny constant-time-ish equality check for the
-// pinned-key DER comparison. ECDSA pubkey DER is short (<100 B) and
-// we don't need real timing-attack resistance here — equal-length
-// prefix equality is enough.
+// bytesEqual is a constant-time equality check for the pinned-key DER
+// comparison. Uses crypto/subtle to prevent timing side-channels.
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return subtle.ConstantTimeCompare(a, b) == 1
 }


### PR DESCRIPTION
## Summary

- **Refuse startup on default JWT secret** — if `ONGRID_JWT_SECRET` is still `dev-insecure-secret-change-me`, the manager now fatally exits with a clear error message, preventing production deployments with a predictable signing key.
- **Add argon2id verification cache** — successful credential checks in the data-plane `auth_request` path are cached for 60s (key = SHA-256 of credential pair). Avoids the 64 MiB / ~60ms argon2id cost on every high-frequency edge push, mitigating potential DoS amplification.
- **Fix goroutine leak** — the background `UpdateStatus(online)` goroutine in `AccessKeyAuthenticator.Authenticate` now uses a 5-second timeout context instead of unbounded `context.Background()`, preventing indefinite goroutine accumulation when the database is stalled.
- **Deterministic LLM provider fallback** — the `buildAIOpsRuntime` fallback that picks a default provider from the `innerModels` map now sorts keys alphabetically instead of relying on Go's randomized map iteration order.
- **Constant-time key comparison** — marketplace signature verification's `bytesEqual` (used for ECDSA public key DER pinning) now uses `crypto/subtle.ConstantTimeCompare` instead of a hand-rolled byte loop.

## Test plan

- [x] `go build ./cmd/ongrid` and `go build ./cmd/ongrid-edge` pass
- [x] `go test ./internal/manager/biz/edge/...` passes
- [x] `go test ./internal/manager/biz/marketplace/...` passes
- [x] `go test ./internal/pkg/passwd/...` passes
- [ ] Manual: start manager without `ONGRID_JWT_SECRET` set → verify fatal exit with descriptive error
- [ ] Manual: verify edge data-plane push frequency no longer causes argon2id CPU spikes under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)