### PR TITLE
fix(frontierbound): stop device_id label falling back to edge_id

### DIFF
--- a/internal/manager/service/frontierbound/handlers.go
+++ b/internal/manager/service/frontierbound/handlers.go
@@ -193,6 +193,18 @@ func Install(ctx context.Context, c *Client, w Wiring) error {
 			return nil, fmt.Errorf("register_edge: decode: %w", err)
 		}
 		canonicalEdgeID := c.canonicalizeEdgeID(edgeID)
+		if canonicalEdgeID == 0 {
+			// Transport→canonical binding not established yet (EdgeOnline's
+			// resolveEdgeID must land first). Registering with 0 makes
+			// HandleRegister(0) fail AND leaves the edge_devices host
+			// junction uncreated — after which every metric falls back to
+			// edge_id (issue #96 root cause). Fail loudly so the edge
+			// retries once the binding is ready, instead of silently
+			// mis-registering and poisoning the device_id labels.
+			log.Error("frontierbound: register_edge — no canonical edge id (transport binding not ready, retry)",
+				slog.Uint64("transport_edge_id", edgeID))
+			return nil, fmt.Errorf("register_edge: edge binding not ready")
+		}
 		if err := w.EdgeUC.HandleRegister(rpcCtx, canonicalEdgeID, in.HostInfo, in.AgentVersion); err != nil {
 			log.Error("frontierbound: HandleRegister",
 				slog.Uint64("edge_id", canonicalEdgeID),
@@ -276,6 +288,17 @@ func Install(ctx context.Context, c *Client, w Wiring) error {
 			return json.Marshal(tunnel.PushHostMetricsResponse{Accepted: 0})
 		}
 		deviceID := resolveDeviceID(rpcCtx, w.DeviceResolver, canonicalEdgeID)
+		if deviceID == 0 {
+			// Host junction missing — drop rather than write edge_id as a
+			// bogus device_id label (issue #96). Accepted=0 lets the edge
+			// retry; the link is created by register_edge.
+			log.Warn("frontierbound: push_host_metrics dropped — device_id unresolved (edge_devices host junction missing; edge needs to (re)register)",
+				slog.Uint64("edge_id", canonicalEdgeID),
+				slog.Uint64("transport_edge_id", edgeID),
+				slog.Int("n", len(in.Points)),
+			)
+			return json.Marshal(tunnel.PushHostMetricsResponse{Accepted: 0})
+		}
 		if err := w.MetricIngester.Push(rpcCtx, deviceID, in.Points); err != nil {
 			log.Warn("frontierbound: ingest push",
 				slog.Uint64("edge_id", canonicalEdgeID),
@@ -323,6 +346,18 @@ func Install(ctx context.Context, c *Client, w Wiring) error {
 			return json.Marshal(tunnel.PushPromSamplesResponse{Accepted: n})
 		}
 		deviceID := resolveDeviceID(rpcCtx, w.DeviceResolver, canonicalEdgeID)
+		if deviceID == 0 {
+			// Host junction missing — drop rather than pollute the TSDB
+			// with edge_id-as-device_id (issue #96). Accepted=n so the
+			// edge does not spin-retry; the link lands on register_edge.
+			log.Warn("frontierbound: push_prom_samples dropped — device_id unresolved (edge_devices host junction missing; edge needs to (re)register)",
+				slog.Uint64("edge_id", canonicalEdgeID),
+				slog.Uint64("transport_edge_id", edgeID),
+				slog.String("source", in.Source),
+				slog.Int("n", n),
+			)
+			return json.Marshal(tunnel.PushPromSamplesResponse{Accepted: n})
+		}
 		if err := w.PromIngester.Push(rpcCtx, deviceID, in.Source, in.Samples); err != nil {
 			log.Warn("frontierbound: prom ingest push",
 				slog.Uint64("edge_id", canonicalEdgeID),
@@ -424,20 +459,25 @@ func safeAddr(a net.Addr) string {
 }
 
 // resolveDeviceID maps a tunnel-side edge_id to the host device_id
-// labelled into the push pipeline. When DeviceResolver is wired and
-// returns a positive id, that's authoritative. Otherwise we fall back
-// to edge_id (which numerically equals device_id for pre-launch data
-// thanks to the backfill that reuses the integer).
+// labelled into the push pipeline. Returns the resolved device_id, or 0
+// when it cannot be resolved.
+//
+// It MUST NOT fall back to edge_id. After the edge/device entity split
+// (May 2026) edge_id and device.ID are independent auto-increment
+// sequences, so a fallback writes a WRONG device_id label into the
+// immutable Prometheus TSDB (issue #96 — Monitor showed edge_ids like
+// 10/11/12 that don't exist on the Devices page). Callers MUST drop the
+// batch when this returns 0 rather than persist a bogus label.
 func resolveDeviceID(ctx context.Context, dr DeviceResolver, edgeID uint64) uint64 {
 	if dr == nil || edgeID == 0 {
-		return edgeID
+		return 0
 	}
 	id, err := dr.LookupHostDevice(ctx, edgeID)
 	if err != nil || id == 0 {
-		// Junction missing (race during register) — fall back to the
-		// numerically-equal edge id. The backfill keeps these in sync
-		// for any edge that has ever connected.
-		return edgeID
+		// Host junction not resolvable (edge not yet linked to a device).
+		// Return 0 so the caller drops this batch instead of polluting
+		// history with edge_id-as-device_id.
+		return 0
 	}
 	return id
 }

--- a/internal/manager/service/frontierbound/handlers_test.go
+++ b/internal/manager/service/frontierbound/handlers_test.go
@@ -42,6 +42,25 @@ func (f *fakeMetricIngester) Push(_ context.Context, _ uint64, _ []tunnel.HostMe
 	return nil
 }
 
+// fakeDeviceResolver resolves edge_id -> device_id. By default it returns
+// the edge_id itself (1:1, simulating a present host junction) so push
+// tests reach the ingester. Set err (or id) to exercise the
+// "junction missing -> drop" path (issue #96).
+type fakeDeviceResolver struct {
+	id  uint64 // when non-zero, always return this device_id
+	err error  // when non-nil, simulate an unresolvable junction
+}
+
+func (f *fakeDeviceResolver) LookupHostDevice(_ context.Context, edgeID uint64) (uint64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	if f.id != 0 {
+		return f.id, nil
+	}
+	return edgeID, nil
+}
+
 // installAndDispatch runs Install on a fakeService-backed Client, then
 // returns the registered RPC for `method`. Tests call it like a function.
 func installAndDispatch(t *testing.T, w Wiring) (*fakeService, geminio.RPC) {
@@ -60,6 +79,10 @@ func installAndDispatch(t *testing.T, w Wiring) (*fakeService, geminio.RPC) {
 	}
 	if w.MetricIngester == nil {
 		w.MetricIngester = &fakeMetricIngester{}
+	}
+	if w.DeviceResolver == nil {
+		// Default: a present 1:1 junction so push tests reach the ingester.
+		w.DeviceResolver = &fakeDeviceResolver{}
 	}
 	if err := Install(context.Background(), c, w); err != nil {
 		t.Fatalf("Install: %v", err)
@@ -156,6 +179,31 @@ func TestInstall_PushPromSamples_IngesterError(t *testing.T) {
 	rpc(context.Background(), &fakeReq{data: body, clientID: 1}, rsp)
 	if rsp.err == nil {
 		t.Errorf("expected rsp.err on ingester failure")
+	}
+}
+
+// Issue #96: when the host junction can't be resolved, resolveDeviceID
+// returns 0 and the handler MUST drop the batch (never write edge_id as
+// the device_id label). The ingester must not be called.
+func TestInstall_PushPromSamples_DropsWhenDeviceUnresolved(t *testing.T) {
+	pi := &fakePromIngester{}
+	_, rpc := installAndDispatch(t, Wiring{
+		PromIngester:   pi,
+		DeviceResolver: &fakeDeviceResolver{err: errors.New("no host junction")},
+		Log:            slog.Default(),
+	})
+	body, _ := json.Marshal(tunnel.PushPromSamplesRequest{
+		EdgeID:  5,
+		Source:  "embedded",
+		Samples: []tunnel.PromSample{{Name: "x", Value: 1, TsMs: 1}},
+	})
+	rsp := &fakeResp{}
+	rpc(context.Background(), &fakeReq{data: body, clientID: 1}, rsp)
+	if rsp.err != nil {
+		t.Fatalf("drop must not error: %v", rsp.err)
+	}
+	if pi.pushCnt != 0 {
+		t.Fatalf("ingester called %d times, want 0 — must drop, never write edge_id as device_id", pi.pushCnt)
 	}
 }
 


### PR DESCRIPTION
Refs #96 (do **not** auto-close — historical-data cleanup is tracked there).

## What

`resolveDeviceID` fell back to `edge_id` when `LookupHostDevice` failed. After the edge/device entity split, `edge_id != device.ID`, so this wrote **wrong `device_id` labels** into the immutable Prometheus TSDB — Monitor showed `device_id` 10/11/12 that don't exist on the Devices page (max id 9), because re-installed edges inflate `edge_id` while `devices` dedup by fingerprint.

## Changes

1. **Stop the bleeding** — `resolveDeviceID` returns `0` (not `edge_id`) on failure. The host-metric and prom-sample push handlers now **drop the batch + WARN** instead of persisting a bogus label.
2. **Root-cause guard** — `register_edge` now fails loudly when `canonicalEdgeID == 0` (transport binding not ready) instead of calling `HandleRegister(0)`, which silently left the `edge_devices` host junction uncreated — the reason every later `LookupHostDevice` failed and fell back forever.
3. **Tests** — `fakeDeviceResolver` + a `DropsWhenDeviceUnresolved` case asserting the ingester is never called when the junction is missing.

## Note on completeness

Change 2 prevents the *mis-registration* that creates the missing junction. The deeper question of **why the transport→canonical binding wasn't established in the first place** (EdgeOnline's `resolveEdgeID`) may need runtime confirmation — the new WARN logs (`device_id unresolved … junction missing`) will surface exactly which edges hit it. Verified: `go build ./cmd/ongrid`, `go test ./internal/manager/service/frontierbound/...` green.

## Historical data

Per the decision in #96: **option A** — leave the polluted `device_id={10,11,12}` series to age out with TSDB retention; this PR only stops new pollution and fixes forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)