### PR TITLE
fix(device): key host fingerprint on hardware (MAC|CPU|disk), not HostID/hostname

### DIFF
--- a/internal/edgeagent/collector/embedded.go
+++ b/internal/edgeagent/collector/embedded.go
@@ -91,8 +91,14 @@ func (c *EmbeddedCollector) HostInfo(ctx context.Context) (tunnel.HostInfo, erro
 		//   Windows: MachineGuid
 		// We forward it as the device fingerprint so a re-installed edge
 		// agent on the same host keeps mapping to the same device row.
+		// NOTE: on cloned Linux VMs HostID collapses to a shared SMBIOS
+		// product_uuid — HardwareFingerprint (below) disambiguates those.
 		hi.Fingerprint = info.HostID
 	}
+	// Clone-resistant hardware identity (MAC|CPU|disk). Sent alongside
+	// HostID so the cloud prefers it but can still migrate older device
+	// rows keyed by HostID. "" when no physical NIC is found.
+	hi.HardwareFingerprint = hardwareFingerprint()
 	if vm, err := mem.VirtualMemoryWithContext(ctx); err == nil && vm != nil {
 		hi.MemTotalBytes = vm.Total
 	}

--- a/internal/edgeagent/collector/hwfingerprint.go
+++ b/internal/edgeagent/collector/hwfingerprint.go
@@ -1,0 +1,156 @@
+package collector
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/disk"
+)
+
+// hardwareFingerprint derives a clone-resistant hardware identity from
+// physical-NIC MACs, CPU model, and disk serial numbers. It is ported from
+// the liaison-cloud edge agent (pkg/utils/fingerprint.go).
+//
+// Why not gopsutil HostID: on Linux, HostID prefers the SMBIOS
+// /sys/class/dmi/id/product_uuid, which is copied verbatim when a VM is
+// cloned — so every clone of one template reports the same HostID and the
+// cloud folds them into a single device (issue #96). A hypervisor instead
+// hands each clone a fresh NIC MAC, so a MAC-keyed fingerprint distinguishes
+// them.
+//
+// Returns "" when no physical NIC can be found (e.g. exotic netns setups);
+// the caller keeps HostID as the fallback fingerprint so such hosts still
+// register. All components are sorted so the value is stable across reboots.
+func hardwareFingerprint() string {
+	macs := physicalMACs()
+	if len(macs) == 0 {
+		return "" // no usable hardware signal — caller falls back to HostID
+	}
+	raw := fmt.Sprintf("%s|%s|%s",
+		strings.Join(macs, ","),
+		cpuSignature(),
+		diskSignature(),
+	)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// physicalMACs returns up to the first two physical-NIC MAC addresses,
+// sorted by interface name, with virtual interfaces filtered out. Empty
+// slice when none qualify.
+func physicalMACs() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	type ni struct{ name, mac string }
+	list := make([]ni, 0, len(ifaces))
+	for i := range ifaces {
+		iface := ifaces[i]
+		if !isPhysicalNIC(&iface) {
+			continue
+		}
+		list = append(list, ni{name: iface.Name, mac: iface.HardwareAddr.String()})
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].name < list[j].name })
+	if len(list) > 2 {
+		list = list[:2]
+	}
+	macs := make([]string, len(list))
+	for i, n := range list {
+		macs[i] = n.mac
+	}
+	return macs
+}
+
+// isPhysicalNIC reports whether iface looks like a real NIC worth keying the
+// fingerprint on — excludes loopback, point-to-point (VPN/tunnel), MAC-less,
+// and name-matched virtual interfaces (docker/veth/bridge/tun/tap/…).
+func isPhysicalNIC(iface *net.Interface) bool {
+	if iface.Flags&net.FlagLoopback != 0 {
+		return false
+	}
+	if iface.Flags&net.FlagPointToPoint != 0 {
+		return false
+	}
+	if len(iface.HardwareAddr) == 0 {
+		return false
+	}
+	name := strings.ToLower(iface.Name)
+	// Linux uses prefixes; other platforms ship the same virtual NICs under
+	// vendor names. One combined keyword list covers both well enough for a
+	// fingerprint signal.
+	virtual := []string{
+		"docker", "veth", "cni", "flannel", "virbr", "br-", "tun", "tap",
+		"vmnet", "vboxnet", "vmware", "hyper-v", "vbox", "wsl", "vpn",
+		"utun", "bridge", "awdl", "anpi", "isatap", "teredo", "kube",
+	}
+	for _, v := range virtual {
+		if strings.HasPrefix(name, v) || strings.Contains(name, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// cpuSignature is the deduped+sorted CPU model identity, or "" when gopsutil
+// can't read it (it just drops out of the hash — MACs carry the identity).
+func cpuSignature() string {
+	infos, err := cpu.Info()
+	if err != nil || len(infos) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(infos))
+	uniq := make([]string, 0, len(infos))
+	for _, c := range infos {
+		s := c.ModelName + c.VendorID + c.Family
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		uniq = append(uniq, s)
+	}
+	sort.Strings(uniq)
+	return strings.Join(uniq, ",")
+}
+
+// diskSignature is up to the first two physical-disk serial numbers, sorted
+// by device name. "" when no serialled disk is visible.
+func diskSignature() string {
+	counts, err := disk.IOCounters()
+	if err != nil || len(counts) == 0 {
+		return ""
+	}
+	type di struct{ name, serial string }
+	list := make([]di, 0, len(counts))
+	for _, s := range counts {
+		if s.SerialNumber == "" {
+			continue
+		}
+		n := strings.ToLower(s.Name)
+		if strings.Contains(n, "virtual") || strings.Contains(n, "loop") {
+			continue
+		}
+		list = append(list, di{name: s.Name, serial: s.SerialNumber})
+	}
+	if len(list) == 0 {
+		return ""
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].name < list[j].name })
+	if len(list) > 2 {
+		list = list[:2]
+	}
+	serials := make([]string, len(list))
+	for i, d := range list {
+		serials[i] = d.serial
+	}
+	return strings.Join(serials, ",")
+}

--- a/internal/edgeagent/collector/hwfingerprint_test.go
+++ b/internal/edgeagent/collector/hwfingerprint_test.go
@@ -1,0 +1,46 @@
+package collector
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsPhysicalNIC(t *testing.T) {
+	mac, _ := net.ParseMAC("00:11:22:33:44:55")
+	cases := []struct {
+		name  string
+		iface net.Interface
+		want  bool
+	}{
+		{"physical eth0", net.Interface{Name: "eth0", HardwareAddr: mac}, true},
+		{"physical ens33", net.Interface{Name: "ens33", HardwareAddr: mac}, true},
+		{"loopback", net.Interface{Name: "lo", Flags: net.FlagLoopback, HardwareAddr: mac}, false},
+		{"no mac", net.Interface{Name: "eth0"}, false},
+		{"docker bridge", net.Interface{Name: "docker0", HardwareAddr: mac}, false},
+		{"veth pair", net.Interface{Name: "veth1234", HardwareAddr: mac}, false},
+		{"br- compose", net.Interface{Name: "br-abc123", HardwareAddr: mac}, false},
+		{"point-to-point vpn", net.Interface{Name: "tun0", Flags: net.FlagPointToPoint, HardwareAddr: mac}, false},
+		{"cni", net.Interface{Name: "cni0", HardwareAddr: mac}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isPhysicalNIC(&c.iface); got != c.want {
+				t.Errorf("isPhysicalNIC(%q) = %v, want %v", c.iface.Name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHardwareFingerprintDeterministic(t *testing.T) {
+	// On any host with at least one physical NIC the value is non-empty and
+	// stable across calls; on exotic hosts it's "" (the documented fallback
+	// signal). Either way two back-to-back calls must agree.
+	a := hardwareFingerprint()
+	b := hardwareFingerprint()
+	if a != b {
+		t.Fatalf("hardwareFingerprint not deterministic: %q vs %q", a, b)
+	}
+	if a != "" && len(a) != 64 {
+		t.Fatalf("non-empty fingerprint must be a sha256 hex (64 chars), got %d", len(a))
+	}
+}

--- a/internal/edgeagent/collector/scrape.go
+++ b/internal/edgeagent/collector/scrape.go
@@ -244,6 +244,8 @@ func (s *Scraper) HostInfo(ctx context.Context) (tunnel.HostInfo, error) {
 		// the rationale.
 		hi.Fingerprint = info.HostID
 	}
+	// Clone-resistant hardware identity — see embedded.go.
+	hi.HardwareFingerprint = hardwareFingerprint()
 	if vm, err := mem.VirtualMemoryWithContext(ctx); err == nil && vm != nil {
 		hi.MemTotalBytes = vm.Total
 	}

--- a/internal/manager/biz/device/repo.go
+++ b/internal/manager/biz/device/repo.go
@@ -38,6 +38,13 @@ type Repo interface {
 	// use UpdateHostFacts for that.
 	FindOrCreateByFingerprint(ctx context.Context, seed *model.Device) (*model.Device, error)
 
+	// RebindFingerprint moves a device from oldFP to newFP in place when
+	// newFP isn't already taken — migrates a device to a new fingerprint
+	// algorithm without orphaning it (device.ID and history preserved).
+	// No-op when oldFP == newFP, either side is empty, or newFP already
+	// exists (the new device already won; nothing to migrate).
+	RebindFingerprint(ctx context.Context, oldFP, newFP string) error
+
 	// UpdateHostFacts overwrites Hostname / OS / Arch / KernelVersion /
 	// CPUCount / MemTotalBytes / DiskTotalBytes / OSVersion for the
 	// device. Called after a fresh register payload arrives so we always

--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -260,12 +260,15 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 	}
 
 	fp := deviceFingerprint(info)
-	// Migrate a device registered under the old (hostname-less) fingerprint
-	// to the v2 fingerprint in place — so improving cloned-VM dedup doesn't
-	// orphan existing devices on upgrade (device.ID / history preserved).
-	// Best-effort: on failure the device is simply re-created under the new
-	// fp on this register.
-	if oldFP := deviceFingerprintV1(info); oldFP != fp {
+	// Migrate a device registered under the legacy HostID-derived fingerprint
+	// to the hardware fingerprint (v3) in place — so a host that previously
+	// registered under its gopsutil HostID, then upgrades to an agent that
+	// also reports HardwareFingerprint, keeps its device.ID / history instead
+	// of orphaning into a fresh row. The new agent still sends HostID in
+	// info.Fingerprint, so the old fp is recomputable here. Best-effort: on
+	// failure the device is simply re-created under the new fp on this
+	// register (see RebindFingerprint for the ghost-row caveat).
+	if oldFP := deviceFingerprintLegacy(info); oldFP != fp {
 		if err := u.devices.RebindFingerprint(ctx, oldFP, fp); err != nil && u.log != nil {
 			u.log.Warn("device fingerprint rebind failed", "old", oldFP, "new", fp, "err", err)
 		}
@@ -349,47 +352,46 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 	return nil
 }
 
-// deviceFingerprint derives a stable per-host id from the register
-// payload. The agent supplies HostID (machine-id / IOPlatformUUID /
-// MachineGuid) when available — that's the right answer because it
-// survives hostname renames and edge re-installs on the same host.
-// We hash + prefix it so the column shape is uniform across platforms
-// and so a leaked machine-id can't be used to enumerate devices.
+// deviceFingerprint derives the stable per-host id stored in
+// devices.fingerprint. Preference order:
 //
-// When the agent doesn't supply a fingerprint (older builds or
-// platforms where gopsutil can't read the id), we fall back to hashing
-// the hostname. That's weaker but keeps the system functional; the
-// trade-off is that a hostname change on a fingerprint-less host will
-// look like a brand-new device.
+//  1. HardwareFingerprint (v3) — a MAC|CPU|disk hash the agent computes
+//     edge-side. This is the right primary key because a hypervisor
+//     regenerates the NIC MAC for every clone, so cloned VMs stay distinct
+//     (issue #96). Newer agents always send it.
+//  2. HostID-derived (legacy) — gopsutil HostID (machine-id /
+//     IOPlatformUUID / MachineGuid), else hashed hostname. Used for older
+//     agents or hosts with no physical NIC. Survives hostname renames and
+//     re-installs, but on cloned Linux VMs collapses to a shared SMBIOS
+//     product_uuid — which is exactly why v3 exists.
+//
+// We hash + prefix every variant so the column shape is uniform across
+// platforms and a leaked raw id can't be used to enumerate devices.
 func deviceFingerprint(info tunnel.HostInfo) string {
-	hn := strings.ToLower(strings.TrimSpace(info.Hostname))
-	seed := strings.TrimSpace(info.Fingerprint)
-	if seed == "" {
-		seed = "hostname:" + hn
-	} else {
-		// v2: machine-id + hostname. machine-id alone (gopsutil HostID,
-		// which on Linux prefers SMBIOS product_uuid) collapses cloned VMs
-		// — same product_uuid → same fingerprint → folded into one device.
-		// Folding in the hostname keeps master01/master02/... distinct.
-		// Trade-off: a hostname change re-registers as a new device, but
-		// that's rare and deliberate; not colliding clones is the bigger win.
-		seed = "machine-id:" + seed + "|hostname:" + hn
+	if hw := strings.TrimSpace(info.HardwareFingerprint); hw != "" {
+		return hashFingerprint("hw:" + hw)
 	}
-	h := sha256.Sum256([]byte(seed))
-	return "fp_" + hex.EncodeToString(h[:16])
+	return deviceFingerprintLegacy(info)
 }
 
-// deviceFingerprintV1 reproduces the pre-hostname algorithm. Used only to
-// locate a device registered under the old fingerprint so HandleRegister
-// can rebind it to the v2 fingerprint in place (preserving device.ID and
-// history) on first re-register after upgrade.
-func deviceFingerprintV1(info tunnel.HostInfo) string {
+// deviceFingerprintLegacy reproduces the pre-v3 HostID-derived algorithm.
+// Used (a) as the fallback when the agent reports no HardwareFingerprint and
+// (b) to locate a device registered under the old fingerprint so
+// HandleRegister can rebind it to the v3 fingerprint in place (preserving
+// device.ID and history) on first re-register after upgrade.
+func deviceFingerprintLegacy(info tunnel.HostInfo) string {
 	seed := strings.TrimSpace(info.Fingerprint)
 	if seed == "" {
 		seed = "hostname:" + strings.ToLower(strings.TrimSpace(info.Hostname))
 	} else {
 		seed = "machine-id:" + seed
 	}
+	return hashFingerprint(seed)
+}
+
+// hashFingerprint maps a raw identity seed to the stored fingerprint column
+// shape: "fp_" + first-16-bytes of sha256, hex-encoded.
+func hashFingerprint(seed string) string {
 	h := sha256.Sum256([]byte(seed))
 	return "fp_" + hex.EncodeToString(h[:16])
 }

--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -260,6 +260,16 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 	}
 
 	fp := deviceFingerprint(info)
+	// Migrate a device registered under the old (hostname-less) fingerprint
+	// to the v2 fingerprint in place — so improving cloned-VM dedup doesn't
+	// orphan existing devices on upgrade (device.ID / history preserved).
+	// Best-effort: on failure the device is simply re-created under the new
+	// fp on this register.
+	if oldFP := deviceFingerprintV1(info); oldFP != fp {
+		if err := u.devices.RebindFingerprint(ctx, oldFP, fp); err != nil && u.log != nil {
+			u.log.Warn("device fingerprint rebind failed", "old", oldFP, "new", fp, "err", err)
+		}
+	}
 	seed := &devicemodel.Device{
 		Fingerprint:   fp,
 		UserID:        edge.CreatedBy,
@@ -352,6 +362,28 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 // trade-off is that a hostname change on a fingerprint-less host will
 // look like a brand-new device.
 func deviceFingerprint(info tunnel.HostInfo) string {
+	hn := strings.ToLower(strings.TrimSpace(info.Hostname))
+	seed := strings.TrimSpace(info.Fingerprint)
+	if seed == "" {
+		seed = "hostname:" + hn
+	} else {
+		// v2: machine-id + hostname. machine-id alone (gopsutil HostID,
+		// which on Linux prefers SMBIOS product_uuid) collapses cloned VMs
+		// — same product_uuid → same fingerprint → folded into one device.
+		// Folding in the hostname keeps master01/master02/... distinct.
+		// Trade-off: a hostname change re-registers as a new device, but
+		// that's rare and deliberate; not colliding clones is the bigger win.
+		seed = "machine-id:" + seed + "|hostname:" + hn
+	}
+	h := sha256.Sum256([]byte(seed))
+	return "fp_" + hex.EncodeToString(h[:16])
+}
+
+// deviceFingerprintV1 reproduces the pre-hostname algorithm. Used only to
+// locate a device registered under the old fingerprint so HandleRegister
+// can rebind it to the v2 fingerprint in place (preserving device.ID and
+// history) on first re-register after upgrade.
+func deviceFingerprintV1(info tunnel.HostInfo) string {
 	seed := strings.TrimSpace(info.Fingerprint)
 	if seed == "" {
 		seed = "hostname:" + strings.ToLower(strings.TrimSpace(info.Hostname))

--- a/internal/manager/biz/edge/usecase_test.go
+++ b/internal/manager/biz/edge/usecase_test.go
@@ -734,18 +734,26 @@ func TestHandleRegisterMirrorsDeviceToNode(t *testing.T) {
 }
 
 func TestDeviceFingerprintDistinguishesClonedVMs(t *testing.T) {
-	// Cloned VMs share product_uuid (machine-id) but differ by hostname.
-	a := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master01"}
-	b := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master02"}
-	if deviceFingerprintV1(a) != deviceFingerprintV1(b) {
-		t.Fatal("precondition: v1 (no hostname) should collapse cloned VMs")
+	// Cloned VMs share the gopsutil HostID (SMBIOS product_uuid) but the
+	// hypervisor hands each a fresh NIC MAC -> distinct HardwareFingerprint.
+	a := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master01", HardwareFingerprint: "mac-aa-cpu-disk"}
+	b := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master02", HardwareFingerprint: "mac-bb-cpu-disk"}
+	if deviceFingerprintLegacy(a) != deviceFingerprintLegacy(b) {
+		t.Fatal("precondition: legacy (HostID only) should collapse cloned VMs")
 	}
 	if deviceFingerprint(a) == deviceFingerprint(b) {
-		t.Fatal("v2 must NOT collapse cloned VMs that have distinct hostnames")
+		t.Fatal("v3 must NOT collapse cloned VMs that have distinct hardware fingerprints")
+	}
+	// And clones that share a hardware fingerprint (e.g. identical MAC pinned
+	// in the clone config) still collapse — v3 keys purely on hardware, not
+	// hostname, so this is the accepted residual.
+	c := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master03", HardwareFingerprint: "mac-aa-cpu-disk"}
+	if deviceFingerprint(a) != deviceFingerprint(c) {
+		t.Fatal("v3 keys on hardware only: identical hardware fingerprint must map to one device")
 	}
 }
 
-func TestHandleRegisterMigratesV1FingerprintInPlace(t *testing.T) {
+func TestHandleRegisterMigratesLegacyFingerprintInPlace(t *testing.T) {
 	repo := newFakeRepo()
 	devices := newFakeDeviceRepo()
 	uc := NewUsecase(repo, devices, nil, nil)
@@ -755,11 +763,13 @@ func TestHandleRegisterMigratesV1FingerprintInPlace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	info := tunnel.HostInfo{Fingerprint: "uuid-x", Hostname: "master01", OS: "linux"}
+	// Upgraded agent reports BOTH HostID (info.Fingerprint) and the new
+	// HardwareFingerprint, so the manager can locate the old row and rebind.
+	info := tunnel.HostInfo{Fingerprint: "uuid-x", Hostname: "master01", OS: "linux", HardwareFingerprint: "mac-aa-cpu-disk"}
 
-	// Pre-seed a device under the OLD (v1) fingerprint, as a pre-upgrade
-	// manager would have created it.
-	oldFP := deviceFingerprintV1(info)
+	// Pre-seed a device under the OLD (legacy, HostID-derived) fingerprint,
+	// as a pre-upgrade manager would have created it.
+	oldFP := deviceFingerprintLegacy(info)
 	pre, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{Fingerprint: oldFP, Hostname: "master01"})
 	if err != nil {
 		t.Fatalf("seed device: %v", err)
@@ -773,7 +783,7 @@ func TestHandleRegisterMigratesV1FingerprintInPlace(t *testing.T) {
 
 	newFP := deviceFingerprint(info)
 	if newFP == oldFP {
-		t.Fatal("precondition: v2 fp should differ from v1")
+		t.Fatal("precondition: v3 fp should differ from legacy")
 	}
 	got, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{Fingerprint: newFP})
 	if err != nil {

--- a/internal/manager/biz/edge/usecase_test.go
+++ b/internal/manager/biz/edge/usecase_test.go
@@ -46,6 +46,25 @@ func (d *fakeDeviceRepo) FindOrCreateByFingerprint(_ context.Context, seed *devi
 	return &cp, nil
 }
 
+func (d *fakeDeviceRepo) RebindFingerprint(_ context.Context, oldFP, newFP string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if oldFP == "" || newFP == "" || oldFP == newFP {
+		return nil
+	}
+	if _, taken := d.byFP[newFP]; taken {
+		return nil // newFP already won — nothing to migrate
+	}
+	id, ok := d.byFP[oldFP]
+	if !ok {
+		return nil // no device under oldFP
+	}
+	delete(d.byFP, oldFP)
+	d.byFP[newFP] = id
+	d.byID[id].Fingerprint = newFP // same device.ID, only fp changes
+	return nil
+}
+
 func (d *fakeDeviceRepo) UpdateHostFacts(_ context.Context, id uint64, f devicebiz.HostFacts) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -711,5 +730,59 @@ func TestHandleRegisterMirrorsDeviceToNode(t *testing.T) {
 	}
 	if len(mirror.calls) != 1 {
 		t.Errorf("mirror called %d times after second register, want still 1", len(mirror.calls))
+	}
+}
+
+func TestDeviceFingerprintDistinguishesClonedVMs(t *testing.T) {
+	// Cloned VMs share product_uuid (machine-id) but differ by hostname.
+	a := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master01"}
+	b := tunnel.HostInfo{Fingerprint: "same-uuid", Hostname: "master02"}
+	if deviceFingerprintV1(a) != deviceFingerprintV1(b) {
+		t.Fatal("precondition: v1 (no hostname) should collapse cloned VMs")
+	}
+	if deviceFingerprint(a) == deviceFingerprint(b) {
+		t.Fatal("v2 must NOT collapse cloned VMs that have distinct hostnames")
+	}
+}
+
+func TestHandleRegisterMigratesV1FingerprintInPlace(t *testing.T) {
+	repo := newFakeRepo()
+	devices := newFakeDeviceRepo()
+	uc := NewUsecase(repo, devices, nil, nil)
+	ctx := context.Background()
+
+	res, err := uc.Create(ctx, "edge-mig", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info := tunnel.HostInfo{Fingerprint: "uuid-x", Hostname: "master01", OS: "linux"}
+
+	// Pre-seed a device under the OLD (v1) fingerprint, as a pre-upgrade
+	// manager would have created it.
+	oldFP := deviceFingerprintV1(info)
+	pre, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{Fingerprint: oldFP, Hostname: "master01"})
+	if err != nil {
+		t.Fatalf("seed device: %v", err)
+	}
+	oldID := pre.ID
+
+	// Register through the upgraded manager — must rebind in place.
+	if err := uc.HandleRegister(ctx, res.Edge.ID, info, ""); err != nil {
+		t.Fatalf("HandleRegister: %v", err)
+	}
+
+	newFP := deviceFingerprint(info)
+	if newFP == oldFP {
+		t.Fatal("precondition: v2 fp should differ from v1")
+	}
+	got, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{Fingerprint: newFP})
+	if err != nil {
+		t.Fatalf("lookup new fp: %v", err)
+	}
+	if got.ID != oldID {
+		t.Fatalf("device.ID changed on migration: old=%d new=%d (must be in-place)", oldID, got.ID)
+	}
+	if _, stillThere := devices.byFP[oldFP]; stillThere {
+		t.Fatalf("old fingerprint %q still present after migration", oldFP)
 	}
 }

--- a/internal/manager/data/device/store/device.go
+++ b/internal/manager/data/device/store/device.go
@@ -52,6 +52,30 @@ func (r *Repo) FindOrCreateByFingerprint(ctx context.Context, seed *model.Device
 	return &out, nil
 }
 
+// RebindFingerprint moves a device from oldFP to newFP in place. See the
+// biz.Repo interface doc.
+func (r *Repo) RebindFingerprint(ctx context.Context, oldFP, newFP string) error {
+	if oldFP == "" || newFP == "" || oldFP == newFP {
+		return nil
+	}
+	// Skip if newFP already exists — the v2 device already won; nothing to
+	// migrate (and the UPDATE would hit the unique index anyway).
+	var cnt int64
+	if err := r.db.WithContext(ctx).Model(&model.Device{}).
+		Where("fingerprint = ?", newFP).Count(&cnt).Error; err != nil {
+		return err
+	}
+	if cnt > 0 {
+		return nil
+	}
+	// In-place rebind: same row, only the fingerprint column changes, so
+	// device.ID / junction / history all carry over. Idempotent — if no row
+	// carries oldFP, this updates nothing.
+	return r.db.WithContext(ctx).Model(&model.Device{}).
+		Where("fingerprint = ?", oldFP).
+		Update("fingerprint", newFP).Error
+}
+
 // UpdateHostFacts overwrites the host fact columns for the device. We
 // don't include online/last_seen_at here — those have a separate
 // lifecycle (MarkOnline / MarkOffline).

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -196,6 +196,17 @@ type HostInfo struct {
 	CPUCount      int    `json:"cpu_count"`
 	MemTotalBytes uint64 `json:"mem_total_bytes"`
 	Fingerprint   string `json:"fingerprint,omitempty"`
+
+	// HardwareFingerprint is a clone-resistant hardware identity computed
+	// edge-side from physical-NIC MACs + CPU model + disk serials (see
+	// internal/edgeagent/collector hardwareFingerprint). Unlike Fingerprint
+	// (gopsutil HostID), it does NOT collapse cloned Linux VMs, which share a
+	// single SMBIOS product_uuid (issue #96): a hypervisor regenerates the NIC
+	// MAC per clone. The cloud prefers this when non-empty and falls back to
+	// Fingerprint otherwise (older agents / hosts with no physical NIC). Both
+	// fields are sent together so the cloud can migrate a device from its old
+	// HostID-derived fingerprint to this one in place. Empty is allowed.
+	HardwareFingerprint string `json:"hardware_fingerprint,omitempty"`
 }
 
 // RegisterEdgeRequest is the first RPC the edge sends after connecting.


### PR DESCRIPTION
Fixes #72. Related to #96.

## Problem

Cloned Linux VMs collapse into a single device row. Root cause: the edge derives its fingerprint from gopsutil `HostID`, which on Linux prefers the SMBIOS `/sys/class/dmi/id/product_uuid` — copied verbatim when a VM is cloned. Regenerating `/etc/machine-id` does **not** help, because gopsutil reads `product_uuid` first.

Downstream symptom (the "webshell jumps to the wrong machine" reports): webshell resolves `GET /v1/devices/{device_id}/shell` → "first online edge bound to this device". When two physical clones share one folded device row, both edges set `Edge.DeviceID` to it, so opening a shell on either always lands on whichever edge the lookup hits first — i.e. different edges SSH into the same host.

## Fix: hardware fingerprint (v3)

The edge now computes a clone-resistant hardware fingerprint, ported from the broker project's `pkg/utils/fingerprint.go`:

```
sha256( MAC | CPU model | disk serial )
  - physical NICs only (loopback / p2p / docker / veth / br- / tun / tap / vmnet … filtered), sorted by name, first 2
  - CPU model+vendor+family, deduped + sorted
  - first 2 disk serials, sorted
```

A hypervisor hands each clone a fresh NIC MAC, so clones stay distinct without relying on hostname (an earlier hostname-fold attempt was dropped — hostname is unreliable: a rename orphans the device and a clone that is *not* renamed still collides).

- `tunnel.HostInfo` gains `hardware_fingerprint`, sent **alongside** the gopsutil HostID (kept so the cloud can migrate old rows).
- Manager `deviceFingerprint()` prefers the hardware id (v3), falls back to the HostID-derived legacy id for older agents / NIC-less hosts.

## Migration: legacy → v3 in place

On register, if the device exists under its old HostID-derived fingerprint, `HandleRegister` rebinds it to the v3 fingerprint **in place** — only the `fingerprint` column changes, so `device.ID`, the `edge_devices` junction, topology node, and all history carry over. The new agent keeps sending the HostID, so the old fingerprint is recomputable. `RebindFingerprint` is a no-op when the new fingerprint already exists.

## Caveats (also pinned as a comment)

- A clone that pins an *identical* MAC still collapses (pure-hardware key; rare).
- A NIC swap / bonding change rotates the fingerprint into a ghost row (rarer than a hostname rename).
- A `RebindFingerprint` transient failure → `cnt>0` permanent short-circuit can leave a legacy ghost row — backstopped by a future offline-device GC.

## Needs

A **new edge build** to ship the `hardware_fingerprint` field (this intentionally crosses the earlier manager-only boundary). Tests green: `go test ./internal/manager/biz/edge/... ./internal/edgeagent/collector/... ./internal/pkg/tunnel/...`, `go build ./cmd/ongrid`.
