### PR TITLE
feat(web): 知识库/技能/助理 支持查看与编辑详情

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -1,4 +1,10 @@
-import { useEffect, type ReactNode } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useI18n } from '@/i18n/locale';
@@ -10,10 +16,20 @@ type Props = {
   children: ReactNode;
   footer?: ReactNode;
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  /** 允许用户拖动面板左右边缘调整宽度（长文阅读类弹窗用）。 */
+  resizable?: boolean;
 };
 
-export function Modal({ open, onClose, title, children, footer, size = 'md' }: Props) {
+// 拖拽调宽边界：太窄排版崩坏，太宽盖满遮罩失去弹窗语义。
+const RESIZE_MIN_PX = 440;
+const RESIZE_MAX_VW = 0.95;
+
+export function Modal({ open, onClose, title, children, footer, size = 'md', resizable }: Props) {
   const { tr } = useI18n();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  // null = 跟随 size 预设的 max-w；拖过一次之后宽度由用户接管。
+  const [userWidth, setUserWidth] = useState<number | null>(null);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -28,6 +44,26 @@ export function Modal({ open, onClose, title, children, footer, size = 'md' }: P
   }, [open, onClose]);
 
   if (!open) return null;
+
+  const startResize = (edge: 'left' | 'right') => (e: ReactPointerEvent) => {
+    if (!panelRef.current) return;
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = panelRef.current.getBoundingClientRect().width;
+    const onMove = (ev: globalThis.PointerEvent) => {
+      const dx = ev.clientX - startX;
+      // 面板水平居中，拖一条边时两侧同时变化 → 总宽随 2×位移走。
+      const delta = (edge === 'right' ? dx : -dx) * 2;
+      const max = Math.round(window.innerWidth * RESIZE_MAX_VW);
+      setUserWidth(Math.min(Math.max(startW + delta, RESIZE_MIN_PX), max));
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
 
   return (
     <div
@@ -49,6 +85,8 @@ export function Modal({ open, onClose, title, children, footer, size = 'md' }: P
           content — affecting any modal whose form / content is long
           (rule editor, doc editor, plugin spec, etc.). */}
       <div
+        ref={panelRef}
+        style={userWidth != null ? { width: userWidth, maxWidth: 'none' } : undefined}
         className={cn(
           'anim-scale relative flex max-h-[90vh] w-full flex-col rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl',
           size === 'sm' && 'max-w-sm',
@@ -73,6 +111,20 @@ export function Modal({ open, onClose, title, children, footer, size = 'md' }: P
           <div className="flex shrink-0 items-center justify-end gap-2 border-t border-zinc-800 px-5 py-3">
             {footer}
           </div>
+        )}
+        {resizable && (
+          <>
+            <div
+              onPointerDown={startResize('left')}
+              title={tr('拖动调整宽度', 'Drag to resize')}
+              className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize rounded hover:bg-zinc-600/30"
+            />
+            <div
+              onPointerDown={startResize('right')}
+              title={tr('拖动调整宽度', 'Drag to resize')}
+              className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize rounded hover:bg-zinc-600/30"
+            />
+          </>
         )}
       </div>
     </div>

--- a/web/src/lib/frontmatter.test.ts
+++ b/web/src/lib/frontmatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { splitFrontmatter, stripFrontmatter } from './frontmatter';
+
+describe('splitFrontmatter', () => {
+  it('parses scalar and inline-array values, body excludes the block', () => {
+    const md = '---\ntitle: Linux Memory Model\ntags: [linux, memory]\n---\n\n# 正文\n';
+    const fm = splitFrontmatter(md);
+    expect(fm).not.toBeNull();
+    expect(fm!.meta).toEqual([
+      ['title', 'Linux Memory Model'],
+      ['tags', ['linux', 'memory']],
+    ]);
+    expect(fm!.body).toBe('\n# 正文\n');
+  });
+
+  it('unquotes values and tolerates CRLF / 注释 / 空行', () => {
+    const md = '---\r\ntitle: "Hello"\r\n# comment\r\n\r\nauthor: \'张三\'\r\n---\r\nbody';
+    const fm = splitFrontmatter(md);
+    expect(fm!.meta).toEqual([
+      ['title', 'Hello'],
+      ['author', '张三'],
+    ]);
+    expect(fm!.body).toBe('body');
+  });
+
+  it('handles a frontmatter-only document (closing --- at EOF)', () => {
+    const fm = splitFrontmatter('---\ntitle: t\n---');
+    expect(fm!.meta).toEqual([['title', 't']]);
+    expect(fm!.body).toBe('');
+  });
+
+  it('returns null when the document does not start with ---', () => {
+    expect(splitFrontmatter('# title\n---\nkey: value\n---\n')).toBeNull();
+  });
+
+  it('returns null on nested YAML（缩进行）— caller falls back to raw render', () => {
+    expect(splitFrontmatter('---\nmeta:\n  nested: true\n---\nbody')).toBeNull();
+  });
+
+  it('returns null for a leading thematic break with no key: value content', () => {
+    expect(splitFrontmatter('---\n\n---\nbody')).toBeNull();
+  });
+});
+
+describe('stripFrontmatter', () => {
+  it('returns the body when frontmatter exists', () => {
+    expect(stripFrontmatter('---\na: 1\n---\nbody')).toBe('body');
+  });
+
+  it('returns input unchanged when there is none', () => {
+    expect(stripFrontmatter('plain **md**')).toBe('plain **md**');
+  });
+});

--- a/web/src/lib/frontmatter.ts
+++ b/web/src/lib/frontmatter.ts
@@ -1,0 +1,57 @@
+// YAML frontmatter 的轻量解析：只为「展示」服务，不追求完整 YAML 语义。
+// md 文档若以 --- 包裹的元信息块开头（title/tags/...），直接交给
+// ReactMarkdown 会被当成 setext 标题渲染成粗体大字 —— 业界通行做法
+// （GitHub/Obsidian）是把 frontmatter 从正文剥离、单独弱化展示。
+
+export interface ParsedFrontmatter {
+  /** 保序的 key/value 列表；数组值（tags 等）解析为 string[] */
+  meta: [string, string | string[]][];
+  /** 剥离 frontmatter 后的正文 */
+  body: string;
+}
+
+function unquote(s: string): string {
+  if (s.length >= 2 && ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+function parseValue(raw: string): string | string[] {
+  const v = raw.trim();
+  // 行内数组：[a, b, c]
+  if (v.startsWith('[') && v.endsWith(']')) {
+    return v
+      .slice(1, -1)
+      .split(',')
+      .map((s) => unquote(s.trim()))
+      .filter(Boolean);
+  }
+  return unquote(v);
+}
+
+/**
+ * 解析文档开头的 YAML frontmatter。无 frontmatter、或块内出现解析不了的
+ * 行（嵌套结构等）时返回 null —— 调用方按原文渲染，保证不弄坏内容。
+ */
+export function splitFrontmatter(md: string): ParsedFrontmatter | null {
+  const m = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(md);
+  if (!m) return null;
+  const meta: [string, string | string[]][] = [];
+  for (const line of m[1].split(/\r?\n/)) {
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+    // 仅支持顶层 key: value；缩进行（嵌套/多行块）超出展示需求，放弃解析
+    if (/^\s/.test(line)) return null;
+    const idx = line.indexOf(':');
+    if (idx <= 0) return null;
+    const key = line.slice(0, idx).trim();
+    meta.push([key, parseValue(line.slice(idx + 1))]);
+  }
+  if (meta.length === 0) return null;
+  return { meta, body: md.slice(m[0].length) };
+}
+
+/** 仅取正文（搜索预览等场景用），无 frontmatter 时原样返回 */
+export function stripFrontmatter(md: string): string {
+  return splitFrontmatter(md)?.body ?? md;
+}

--- a/web/src/pages/Agents.test.tsx
+++ b/web/src/pages/Agents.test.tsx
@@ -1,0 +1,86 @@
+// Agents 页面测试 — 覆盖「点击助理卡片查看定义详情」链路，并验证
+// 按 source 区分的编辑路径（user 直接编辑 / 内置预置 fork 成自定义）。
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AgentsPage from './Agents';
+import { server } from '@/test/msw-server';
+
+vi.mock('@/store/auth', () => ({
+  useAuth: Object.assign(
+    <T,>(selector: (s: { role: string }) => T): T => selector({ role: 'admin' }),
+    { getState: () => ({ logout: () => {} }) },
+  ),
+  getToken: () => null,
+  getRefreshToken: () => null,
+}));
+
+const diskAgent = {
+  name: 'specialist-sre',
+  description: 'SRE 专家：黄金四信号 / SLO / 错误预算。',
+  when_to_use: '当任务围绕系统是否健康时派给我。',
+  system_prompt: '# SRE 专家\n你是 SRE 专家，优先看黄金四信号。',
+  tools: ['query_promql', 'query_incidents'],
+  permission_mode: 'read-only',
+  source: 'disk',
+};
+
+const userAgent = {
+  name: 'my_db_helper',
+  description: '我的数据库助手。',
+  system_prompt: '你是数据库专家。',
+  tools: ['analyze_database_status'],
+  source: 'user',
+};
+
+const listURL = '/api/v1/skills';
+
+describe('AgentsPage', () => {
+  beforeEach(() => {
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    server.use(
+      http.get('/api/v1/agents', () =>
+        HttpResponse.json({ items: [diskAgent, userAgent], total: 2 }),
+      ),
+      // AgentEditor 打开时拉工具列表
+      http.get(listURL, () => HttpResponse.json({ items: [], total: 0 })),
+    );
+  });
+
+  it('点击预置助理卡片打开只读详情，编辑入口是「复制为自定义助理」', async () => {
+    render(
+      <MemoryRouter>
+        <AgentsPage />
+      </MemoryRouter>,
+    );
+    // 卡片标题用短名；点击卡片主体打开详情
+    await userEvent.click(await screen.findByText('SRE 专家'));
+
+    const dialog = await screen.findByRole('dialog');
+    // system prompt 原文完整展示
+    expect(within(dialog).getByText(/你是 SRE 专家，优先看黄金四信号/)).toBeInTheDocument();
+    // 工具清单
+    expect(within(dialog).getByText('query_promql')).toBeInTheDocument();
+    // disk source 不可直接编辑 → 提供 fork 入口，没有「编辑」按钮
+    expect(within(dialog).getByRole('button', { name: /复制为自定义助理/ })).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: '编辑' })).not.toBeInTheDocument();
+  });
+
+  it('点击自定义助理卡片，详情里有「编辑」入口', async () => {
+    render(
+      <MemoryRouter>
+        <AgentsPage />
+      </MemoryRouter>,
+    );
+    // user 助理无短名，name 同时出现在卡片标题和 mono 行；点标题
+    await userEvent.click((await screen.findAllByText('my_db_helper'))[0]);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/你是数据库专家/)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /编辑/ })).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: /复制为自定义助理/ })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -516,7 +516,12 @@ function AgentDetailModal({
 
         {agent.critical_reminder && (
           <DetailSection label={tr('关键提醒', 'Critical reminder')}>
-            <p className="whitespace-pre-wrap text-xs leading-relaxed text-amber-200/80">{agent.critical_reminder}</p>
+            {/* 用不带透明度的 text-amber-300：light 主题有 amber-300→amber-700
+                的覆盖（index.css），透明度变体 /80 不在覆盖内、浅色下会发灰看不清。
+                配一层 amber 描边底色，强化「提醒」语义又保证两主题都够对比度。 */}
+            <p className="whitespace-pre-wrap rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs leading-relaxed text-amber-300">
+              {agent.critical_reminder}
+            </p>
           </DetailSection>
         )}
 

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Bot,
+  Copy,
   MessageSquarePlus,
   Pencil,
   Plus,
@@ -54,8 +55,16 @@ export default function AgentsPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [query, setQuery] = useState('');
-  const [editing, setEditing] = useState<{ mode: 'create' } | { mode: 'edit'; agent: AgentSummary } | null>(null);
+  // editing.seed 预填一份「基于内置助理新建」的草稿（fork），对齐知识库
+  // 「复制为组织文档」：内置 / 预置助理只读，想改就 fork 成自定义助理。
+  const [editing, setEditing] = useState<
+    | { mode: 'create'; seed?: AgentSummary }
+    | { mode: 'edit'; agent: AgentSummary }
+    | null
+  >(null);
   const [deleting, setDeleting] = useState<AgentSummary | null>(null);
+  // 详情查看弹窗：点击卡片主体打开（参照知识库文档 / 技能详情）。
+  const [viewing, setViewing] = useState<AgentSummary | null>(null);
 
   const fetchAgents = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true);
@@ -149,6 +158,7 @@ export default function AgentsPage() {
               <AgentCard
                 key={a.name}
                 agent={a}
+                onView={() => setViewing(a)}
                 onEdit={() => setEditing({ mode: 'edit', agent: a })}
                 onDelete={() => setDeleting(a)}
               />
@@ -157,10 +167,27 @@ export default function AgentsPage() {
         )}
       </div>
 
+      {viewing && (
+        <AgentDetailModal
+          agent={viewing}
+          onClose={() => setViewing(null)}
+          onEdit={() => {
+            const a = viewing;
+            setViewing(null);
+            setEditing({ mode: 'edit', agent: a });
+          }}
+          onFork={() => {
+            const a = viewing;
+            setViewing(null);
+            setEditing({ mode: 'create', seed: a });
+          }}
+        />
+      )}
       {editing && (
         <AgentEditor
           mode={editing.mode}
           existing={editing.mode === 'edit' ? editing.agent : null}
+          seed={editing.mode === 'create' ? editing.seed : undefined}
           onClose={() => setEditing(null)}
           onSaved={() => {
             setEditing(null);
@@ -238,10 +265,12 @@ const SHORT_LABELS = new Proxy({} as Record<string, string>, {
 
 function AgentCard({
   agent,
+  onView,
   onEdit,
   onDelete,
 }: {
   agent: AgentSummary;
+  onView: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -271,10 +300,10 @@ function AgentCard({
       setErr(e instanceof ApiError ? e.message : (e as Error).message);
       setBusy(false);
     }
-  }, [agent.name, busy, navigate]);
+  }, [agent.name, busy, navigate, tr]);
 
   return (
-    <Card className="flex flex-col">
+    <Card className="flex cursor-pointer flex-col transition-colors hover:bg-zinc-800/40" onClick={onView}>
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex items-center gap-2">
           <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-indigo-500/20 text-indigo-300 ring-1 ring-inset ring-indigo-500/40">
@@ -297,7 +326,10 @@ function AgentCard({
           {isUser && (
             <button
               type="button"
-              onClick={onEdit}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
               title={tr('编辑', 'Edit')}
               className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
             >
@@ -307,7 +339,10 @@ function AgentCard({
           {canDelete && (
             <button
               type="button"
-              onClick={onDelete}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
               title={isUser ? tr('删除', 'Delete') : tr('从助理列表中移除（重启后内置 persona 会自动加载回来）', 'Remove from the list (built-in personas reload automatically on restart)')}
               className="rounded p-1 text-zinc-500 hover:bg-red-900/30 hover:text-red-300"
             >
@@ -316,7 +351,10 @@ function AgentCard({
           )}
           <button
             type="button"
-            onClick={() => void onUse()}
+            onClick={(e) => {
+              e.stopPropagation();
+              void onUse();
+            }}
             disabled={busy}
             title={tr('用此助理开新会话', 'Start a new session with this assistant')}
             className="ml-1 inline-flex items-center gap-1 rounded-md border border-indigo-500/40 bg-indigo-500/10 px-2 py-1 text-[11px] text-indigo-200 hover:bg-indigo-500/20 disabled:opacity-50"
@@ -354,6 +392,172 @@ function SourceLabel({ source }: { source?: AgentSource }) {
 }
 
 
+// AgentDetailModal — 只读详情查看，参照知识库文档的阅读弹窗：完整展示
+// description / when_to_use / system prompt（原文）/ 工具清单 / 模型等。
+// 编辑路径按 source 区分（对齐知识库 vault 文档「只读 + 复制为组织文档」）：
+//   - user 自定义助理 → 「编辑」直接改 user_agents 行
+//   - builtin / disk 内置 / 预置 → 定义在代码 / agents/*.md，不可在线改，
+//     提供「复制为自定义助理」fork 出一份可编辑的草稿
+function AgentDetailModal({
+  agent,
+  onClose,
+  onEdit,
+  onFork,
+}: {
+  agent: AgentSummary;
+  onClose: () => void;
+  onEdit: () => void;
+  onFork: () => void;
+}) {
+  const { tr } = useI18n();
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const displayName = SHORT_LABELS[agent.name] ?? agent.name;
+  const isUser = agent.source === 'user';
+  const toolCount = agent.tools?.length ?? 0;
+
+  const onUse = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const title = tr(`使用 ${agent.name} - 新会话`, `Using ${agent.name} - new session`).slice(0, 60);
+      const session = await createSession({ title, agent_id: agent.name });
+      navigate(`/chat/${session.id}`);
+    } catch (e) {
+      setErr(e instanceof ApiError ? e.message : (e as Error).message);
+      setBusy(false);
+    }
+  }, [agent.name, busy, navigate, tr]);
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      size="lg"
+      resizable
+      title={displayName}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800"
+          >
+            {tr('关闭', 'Close')}
+          </button>
+          {isUser ? (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+            >
+              <Pencil size={11} /> {tr('编辑', 'Edit')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onFork}
+              title={tr('内置 / 预置助理定义在代码 / agents/*.md，不可直接改；复制一份为自定义助理后即可编辑', 'Built-in / preset assistants are defined in code / agents/*.md and cannot be edited directly; copy into a custom assistant to edit')}
+              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+            >
+              <Copy size={11} /> {tr('复制为自定义助理', 'Copy as custom')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => void onUse()}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+          >
+            <MessageSquarePlus size={11} /> {busy ? tr('创建中…', 'Creating…') : tr('使用此助理', 'Use this')}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-zinc-500">
+          <span className="font-mono text-zinc-400">{agent.name}</span>
+          <span>·</span>
+          <SourceLabel source={agent.source} />
+          {agent.permission_mode === 'read-only' && (
+            <>
+              <span className="text-zinc-700">·</span>
+              <span className="text-emerald-400">{tr('只读', 'Read-only')}</span>
+            </>
+          )}
+          <span className="ml-auto">
+            {toolCount > 0 ? tr(`${toolCount} 个工具`, `${toolCount} tool(s)`) : tr('继承全部工具', 'Inherits all tools')}
+          </span>
+        </div>
+
+        {err && <div className="text-[11px] text-red-300">{err}</div>}
+
+        <DetailSection label={tr('描述', 'Description')}>
+          <p className="text-xs leading-relaxed text-zinc-300">{agent.description || '—'}</p>
+        </DetailSection>
+
+        {agent.when_to_use && (
+          <DetailSection label={tr('何时使用', 'When to use')}>
+            <p className="whitespace-pre-wrap text-xs leading-relaxed text-zinc-300">{agent.when_to_use}</p>
+          </DetailSection>
+        )}
+
+        <DetailSection label={tr('系统提示（原文）', 'System prompt (raw)')}>
+          {agent.system_prompt ? (
+            <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border border-zinc-800 bg-zinc-950/40 p-3 font-mono text-[11px] leading-relaxed text-zinc-300">
+              {agent.system_prompt}
+            </pre>
+          ) : (
+            <p className="text-xs text-zinc-500">{tr('继承 coordinator 默认提示', 'Inherits the coordinator default prompt')}</p>
+          )}
+        </DetailSection>
+
+        {agent.critical_reminder && (
+          <DetailSection label={tr('关键提醒', 'Critical reminder')}>
+            <p className="whitespace-pre-wrap text-xs leading-relaxed text-amber-200/80">{agent.critical_reminder}</p>
+          </DetailSection>
+        )}
+
+        <DetailSection label={tr('允许使用的工具', 'Allowed tools')}>
+          {toolCount === 0 ? (
+            <p className="text-xs text-zinc-500">{tr('继承 coordinator 的全部工具', 'Inherits all coordinator tools')}</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {agent.tools!.map((t) => (
+                <span key={t} className="rounded border border-zinc-800 bg-zinc-950/40 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400">
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+
+        {(agent.model || (agent.max_turns ?? 0) > 0) && (
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-[11px] text-zinc-500">
+            {agent.model && (
+              <span>{tr('模型', 'Model')}: <span className="font-mono text-zinc-300">{agent.model}</span></span>
+            )}
+            {(agent.max_turns ?? 0) > 0 && (
+              <span>{tr('最大轮数', 'Max turns')}: <span className="text-zinc-300">{agent.max_turns}</span></span>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function DetailSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <div className="mb-1.5 text-[11px] uppercase tracking-wider text-zinc-500">{label}</div>
+      {children}
+    </section>
+  );
+}
+
 function AgentsEmpty({ hasItems, onCreate }: { hasItems: boolean; onCreate: () => void }) {
   const { tr } = useI18n();
   return (
@@ -371,28 +575,35 @@ function AgentsEmpty({ hasItems, onCreate }: { hasItems: boolean; onCreate: () =
   );
 }
 
-// AgentEditor is the create + edit form modal. Reused by both flows;
-// `existing` is null for create, the row for edit (Name field then
-// becomes read-only since name is the immutable identifier).
+// AgentEditor is the create + edit form modal. Reused by three flows:
+//   - create blank: existing=null, seed=undefined
+//   - create from fork: existing=null, seed=<内置/预置助理> — 预填正文，
+//     name 留空让用户取新名（对齐知识库「复制为组织文档」）
+//   - edit: existing=<user agent> — Name 字段只读（name 是不可变标识）
 function AgentEditor({
   mode,
   existing,
+  seed,
   onClose,
   onSaved,
 }: {
   mode: 'create' | 'edit';
   existing: AgentSummary | null;
+  seed?: AgentSummary;
   onClose: () => void;
   onSaved: () => void;
 }) {
   const { tr } = useI18n();
+  // base 是预填来源：edit 用 existing，fork 新建用 seed。name 只在 edit
+  // 时承袭；fork 留空（不能与被 fork 的内置助理重名）。
+  const base = existing ?? seed ?? null;
   const [name, setName] = useState(existing?.name ?? '');
-  const [description, setDescription] = useState(existing?.description ?? '');
-  const [whenToUse, setWhenToUse] = useState(existing?.when_to_use ?? '');
-  const [systemPrompt, setSystemPrompt] = useState(existing?.system_prompt ?? '');
-  const [allowedTools, setAllowedTools] = useState<string[]>(existing?.tools ?? []);
-  const [model, setModel] = useState(existing?.model ?? '');
-  const [maxTurns, setMaxTurns] = useState<number>(existing?.max_turns ?? 0);
+  const [description, setDescription] = useState(base?.description ?? '');
+  const [whenToUse, setWhenToUse] = useState(base?.when_to_use ?? '');
+  const [systemPrompt, setSystemPrompt] = useState(base?.system_prompt ?? '');
+  const [allowedTools, setAllowedTools] = useState<string[]>(base?.tools ?? []);
+  const [model, setModel] = useState(base?.model ?? '');
+  const [maxTurns, setMaxTurns] = useState<number>(base?.max_turns ?? 0);
   const [skills, setSkills] = useState<SkillSummary[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -437,7 +648,13 @@ function AgentEditor({
     <Modal
       open
       onClose={onClose}
-      title={mode === 'create' ? tr('新建助理', 'New assistant') : tr(`编辑 ${existing?.name}`, `Edit ${existing?.name}`)}
+      title={
+        mode === 'edit'
+          ? tr(`编辑 ${existing?.name}`, `Edit ${existing?.name}`)
+          : seed
+            ? tr(`基于 ${seed.name} 新建助理`, `New assistant from ${seed.name}`)
+            : tr('新建助理', 'New assistant')
+      }
       footer={
         <>
           <button

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -1,0 +1,141 @@
+// Knowledge 页面测试 — 覆盖「点击文档查看正文 + 编辑保存」链路：
+//   1. 内置(vault)文档点击 → 只读查看器拉取并渲染 markdown 正文
+//   2. 查看器「复制为组织文档」→ 预填编辑表单 → 保存为新建组织文档
+//   3. 组织(manual)文档点击 → 直接进入编辑表单，PATCH 保存
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import KnowledgePage from './Knowledge';
+import { server } from '@/test/msw-server';
+
+// client.ts / api/knowledge.ts 只需要 token 取值与 401 兜底；测试里全部打桩。
+vi.mock('@/store/auth', () => ({
+  useAuth: Object.assign(
+    <T,>(selector: (s: { role: string }) => T): T => selector({ role: 'admin' }),
+    { getState: () => ({ logout: () => {} }) },
+  ),
+  getToken: () => null,
+  getRefreshToken: () => null,
+}));
+
+const vaultDoc = {
+  id: '101',
+  source_type: 'vault',
+  title: 'Host Metric Alerts Runbook',
+  url: 'alerts/host-metrics.md',
+  path: 'alerts',
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+};
+
+const vaultContent = '# Runbook 正文\n\n第一步：查看告警上下文';
+
+const manualDoc = {
+  id: '202',
+  source_type: 'manual',
+  title: '组织 SOP',
+  content: '原有正文',
+  path: '',
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+};
+
+const listURL = '/api/v1/knowledge/docs';
+
+function useBaseHandlers() {
+  server.use(
+    http.get(listURL, () =>
+      HttpResponse.json({ items: [vaultDoc, manualDoc], total: 2 }),
+    ),
+    http.get(`${listURL}/101`, () =>
+      HttpResponse.json({ ...vaultDoc, content: vaultContent }),
+    ),
+    http.get(`${listURL}/202`, () =>
+      HttpResponse.json({ ...manualDoc }),
+    ),
+  );
+}
+
+describe('KnowledgePage', () => {
+  beforeEach(() => {
+    // 固定语言，断言中文文案不受运行机器时区/浏览器语言影响。
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    useBaseHandlers();
+  });
+
+  // 右侧文档列表默认在「组织」作用域；先点侧边栏「内置知识库」切过去。
+  async function openBuiltinScope() {
+    // ^锚定避免命中「从云端同步内置知识库…」的同步按钮
+    await userEvent.click(await screen.findByRole('button', { name: /^内置知识库/ }));
+  }
+
+  it('点击内置文档打开只读查看器并渲染正文', async () => {
+    render(<KnowledgePage />);
+    await openBuiltinScope();
+    const card = await screen.findByText('Host Metric Alerts Runbook');
+    await userEvent.click(card);
+
+    // 查看器：拉取 GET /knowledge/docs/:id 并渲染 markdown 正文
+    expect(await screen.findByText('第一步：查看告警上下文')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /复制为组织文档/ })).toBeInTheDocument();
+    // 只读：没有「保存」按钮
+    expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument();
+  });
+
+  it('复制为组织文档：预填表单并 POST 新建', async () => {
+    let createdBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(listURL, async ({ request }) => {
+        createdBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          ...manualDoc,
+          id: '303',
+          title: createdBody.title,
+        });
+      }),
+    );
+
+    render(<KnowledgePage />);
+    await openBuiltinScope();
+    await userEvent.click(await screen.findByText('Host Metric Alerts Runbook'));
+    await screen.findByText('第一步：查看告警上下文');
+    await userEvent.click(screen.getByRole('button', { name: /复制为组织文档/ }));
+
+    // 表单预填了原标题与正文
+    const titleInput = await screen.findByDisplayValue('Host Metric Alerts Runbook');
+    expect(titleInput).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => expect(createdBody).not.toBeNull());
+    expect(createdBody).toMatchObject({
+      title: 'Host Metric Alerts Runbook',
+      content: vaultContent,
+      path: 'alerts',
+    });
+    // 来源 url（builtin/repo 文件路径）不带入副本
+    expect(createdBody).not.toHaveProperty('url');
+  });
+
+  it('组织文档点击进入编辑表单并 PATCH 保存', async () => {
+    let patchedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.patch(`${listURL}/202`, async ({ request }) => {
+        patchedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ ...manualDoc, ...patchedBody });
+      }),
+    );
+
+    render(<KnowledgePage />);
+    await userEvent.click(await screen.findByText('组织 SOP'));
+
+    const body = await screen.findByDisplayValue('原有正文');
+    await userEvent.clear(body);
+    await userEvent.type(body, '更新后的正文');
+    await userEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => expect(patchedBody).not.toBeNull());
+    expect(patchedBody).toMatchObject({ title: '组织 SOP', content: '更新后的正文' });
+  });
+});

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -90,6 +90,30 @@ describe('KnowledgePage', () => {
     expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument();
   });
 
+  it('frontmatter 不渲染为标题，元信息以弱化 key/value 展示', async () => {
+    server.use(
+      http.get(`${listURL}/101`, () =>
+        HttpResponse.json({
+          ...vaultDoc,
+          content: '---\ntitle: Linux Memory Model\ntags: [linux, memory]\n---\n\n正文内容',
+        }),
+      ),
+    );
+    render(<KnowledgePage />);
+    await openBuiltinScope();
+    await userEvent.click(await screen.findByText('Host Metric Alerts Runbook'));
+
+    expect(await screen.findByText('正文内容')).toBeInTheDocument();
+    // 元信息行存在（dt/dd），tags 拆成单个 chip
+    expect(screen.getByText('Linux Memory Model')).toBeInTheDocument();
+    expect(screen.getByText('linux')).toBeInTheDocument();
+    expect(screen.getByText('memory')).toBeInTheDocument();
+    // 不再被 setext 语法渲染成 <h2> 粗体标题
+    expect(
+      screen.queryByRole('heading', { name: /Linux Memory Model/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it('复制为组织文档：预填表单并 POST 新建', async () => {
     let createdBody: Record<string, unknown> | null = null;
     server.use(

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -30,7 +30,9 @@ const vaultDoc = {
   updated_at: '2026-06-01T00:00:00Z',
 };
 
-const vaultContent = '# Runbook 正文\n\n第一步：查看告警上下文';
+const vaultContent =
+  '# Runbook 正文\n\n第一步：查看告警上下文\n\n' +
+  '| Severity | Acknowledge |\n|---|---|\n| SEV1 | < 5 min |\n';
 
 const manualDoc = {
   id: '202',
@@ -79,6 +81,10 @@ describe('KnowledgePage', () => {
 
     // 查看器：拉取 GET /knowledge/docs/:id 并渲染 markdown 正文
     expect(await screen.findByText('第一步：查看告警上下文')).toBeInTheDocument();
+    // GFM 表格渲染为真 <table>（remark-gfm），而非一行竖线文本
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Severity' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '< 5 min' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /复制为组织文档/ })).toBeInTheDocument();
     // 只读：没有「保存」按钮
     expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument();
@@ -111,7 +117,8 @@ describe('KnowledgePage', () => {
     await waitFor(() => expect(createdBody).not.toBeNull());
     expect(createdBody).toMatchObject({
       title: 'Host Metric Alerts Runbook',
-      content: vaultContent,
+      // 提交时 trim：fixture 末尾的换行不入库
+      content: vaultContent.trim(),
       path: 'alerts',
     });
     // 来源 url（builtin/repo 文件路径）不带入副本

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -26,6 +26,7 @@ import {
   Upload,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/cn';
 import { fullDateTime } from '@/lib/format';
 import { Modal } from '@/components/Modal';
@@ -966,6 +967,10 @@ function DocEditor({
       <Modal
         open
         onClose={onClose}
+        // 阅读态默认给到 max-w-4xl，并允许拖左右边缘自行调宽 ——
+        // 内置 runbook 普遍带宽表格，md(448px) 下表格没法看。
+        size="xl"
+        resizable
         title={existing ? localizedDocTitle(existing) : tr('文档', 'Document')}
         footer={
           <>
@@ -1030,14 +1035,18 @@ function DocEditor({
                 </span>
               ))}
           </div>
-          <div className="max-h-[60vh] overflow-y-auto rounded-md border border-zinc-800 bg-zinc-950/40 p-4">
+          {/* 不再自限 60vh：Modal 本体已 max-h-90vh + 内部滚动，
+              嵌套两层滚动条阅读体验差 */}
+          <div className="rounded-md border border-zinc-800 bg-zinc-950/40 p-4">
             {loading ? (
               <div className="text-xs text-zinc-500">{tr('加载中…', 'Loading…')}</div>
             ) : err ? (
               <div className="text-xs text-red-300">{err}</div>
             ) : content ? (
               <div className="md-body text-sm text-zinc-200">
-                <ReactMarkdown>{content}</ReactMarkdown>
+                {/* remark-gfm：表格 / 删除线 / 任务列表等 GFM 语法，
+                    缺了它表格按普通段落渲染成一行竖线文本 */}
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
               </div>
             ) : (
               <div className="text-xs text-zinc-500">{tr('该文档没有正文内容', 'This document has no body content')}</div>

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -29,6 +29,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/cn';
 import { fullDateTime } from '@/lib/format';
+import { splitFrontmatter, stripFrontmatter } from '@/lib/frontmatter';
 import { Modal } from '@/components/Modal';
 import { Button, Card, EmptyState, PageHeader } from '@/components/ui';
 import {
@@ -855,9 +856,43 @@ function SearchHitCard({ hit }: { hit: SearchHit }) {
         </div>
         <span>score {hit.score.toFixed(2)}</span>
       </div>
+      {/* 预览只给正文：frontmatter 占满 3 行预览毫无信息量 */}
       <div className="mt-1 line-clamp-3 whitespace-pre-wrap break-words text-[12px] text-zinc-300">
-        {hit.doc.content}
+        {stripFrontmatter(hit.doc.content ?? '')}
       </div>
+    </div>
+  );
+}
+
+// 阅读态正文：先剥离 YAML frontmatter 再渲染 —— 否则 `title: …\n---`
+// 会按 setext 标题渲染成粗体大字。元信息以弱化的 key/value 行单独展示。
+function DocBody({ content }: { content: string }) {
+  const fm = useMemo(() => splitFrontmatter(content), [content]);
+  return (
+    <div className="md-body text-sm text-zinc-200">
+      {fm && (
+        <dl className="mb-4 space-y-1 border-b border-zinc-800 pb-3">
+          {fm.meta.map(([key, value]) => (
+            <div key={key} className="flex items-baseline gap-2 text-xs">
+              <dt className="shrink-0 font-mono text-[11px] text-zinc-500">{key}</dt>
+              {Array.isArray(value) ? (
+                <dd className="flex flex-wrap gap-1">
+                  {value.map((v) => (
+                    <span key={v} className="rounded bg-zinc-800/60 px-1.5 py-0.5 text-[11px] text-zinc-400">
+                      {v}
+                    </span>
+                  ))}
+                </dd>
+              ) : (
+                <dd className="text-zinc-400">{value}</dd>
+              )}
+            </div>
+          ))}
+        </dl>
+      )}
+      {/* remark-gfm：表格 / 删除线 / 任务列表等 GFM 语法，
+          缺了它表格按普通段落渲染成一行竖线文本 */}
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{fm ? fm.body : content}</ReactMarkdown>
     </div>
   );
 }
@@ -1043,11 +1078,7 @@ function DocEditor({
             ) : err ? (
               <div className="text-xs text-red-300">{err}</div>
             ) : content ? (
-              <div className="md-body text-sm text-zinc-200">
-                {/* remark-gfm：表格 / 删除线 / 任务列表等 GFM 语法，
-                    缺了它表格按普通段落渲染成一行竖线文本 */}
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-              </div>
+              <DocBody content={content} />
             ) : (
               <div className="text-xs text-zinc-500">{tr('该文档没有正文内容', 'This document has no body content')}</div>
             )}

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -13,7 +13,9 @@ import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type
 import {
   BookOpen,
   ChevronRight,
+  Copy,
   DownloadCloud,
+  Eye,
   Folder,
   FolderOpen,
   Pencil,
@@ -754,11 +756,8 @@ function DocCard({
             }
           : undefined
       }
-      className={cn(
-        'flex flex-col py-2.5 transition-colors hover:bg-zinc-800/40',
-        editable && 'cursor-pointer',
-      )}
-      onClick={editable ? onEdit : undefined}
+      className="flex cursor-pointer flex-col py-2.5 transition-colors hover:bg-zinc-800/40"
+      onClick={onEdit}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
@@ -791,32 +790,46 @@ function DocCard({
             </div>
           )}
         </div>
-        {editable && (
-          <div className="flex shrink-0 items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1">
+          {editable ? (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+                title={tr('编辑', 'Edit')}
+                className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+              >
+                <Pencil size={11} />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                title={tr('删除', 'Delete')}
+                className="rounded p-1 text-zinc-500 hover:bg-red-900/30 hover:text-red-300"
+              >
+                <Trash2 size={11} />
+              </button>
+            </>
+          ) : (
             <button
               type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onEdit();
               }}
-              title={tr('编辑', 'Edit')}
+              title={tr('查看', 'View')}
               className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
             >
-              <Pencil size={11} />
+              <Eye size={11} />
             </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
-              title={tr('删除', 'Delete')}
-              className="rounded p-1 text-zinc-500 hover:bg-red-900/30 hover:text-red-300"
-            >
-              <Trash2 size={11} />
-            </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </Card>
   );
@@ -871,11 +884,16 @@ function DocEditor({
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  // Repo-sourced docs are read-only — they were crawled from a git
-  // repo and rewriting them in the SPA would diverge from source.
-  // We still let users open them to read the body; the modal switches
-  // to a markdown viewer instead of the form.
-  const readOnly = mode === 'edit' && existing?.source_type === 'repo';
+  // Vault (built-in) and repo docs are read-only — both are regenerated
+  // on sync, so in-place edits would be silently lost (the backend PATCH
+  // rejects them too). Users can still open them to read the rendered
+  // body; the modal switches to a markdown viewer instead of the form.
+  // "复制为组织文档" forks the body into an editable org doc (manual),
+  // which is the supported way to customize built-in content.
+  const sourceReadOnly =
+    existing?.source_type === 'repo' || existing?.source_type === 'vault';
+  const [forked, setForked] = useState(false);
+  const readOnly = mode === 'edit' && sourceReadOnly && !forked;
   // An uploaded file's url is its identity (the filename); it can't be
   // re-pointed from the editor — the backend keeps it fixed. Show it but
   // lock the field so editing it isn't silently ignored.
@@ -911,12 +929,14 @@ function DocEditor({
         .map((s) => s.trim())
         .filter(Boolean)
         .join('/');
-      if (mode === 'create') {
+      if (mode === 'create' || forked) {
+        // forked: a read-only vault/repo doc copied into the org scope —
+        // lands as a brand-new manual doc, the original stays untouched.
         await createDoc({
           title: title.trim(),
           title_en: titleEN.trim() || undefined,
           content: content.trim(),
-          url: url.trim() || undefined,
+          url: forked ? undefined : url.trim() || undefined,
           path: cleanPath || undefined,
           tags: tags.length ? tags : undefined,
         });
@@ -937,27 +957,54 @@ function DocEditor({
     }
   };
 
-  // Read-only viewer for repo docs — render markdown body, show metadata
-  // in a header strip. Manual docs continue to the editor form below.
+  // Read-only viewer for vault/repo docs — render markdown body, show
+  // metadata in a header strip. Manual/upload docs continue to the editor
+  // form below.
   if (readOnly) {
+    const isVault = existing?.source_type === 'vault';
     return (
       <Modal
         open
         onClose={onClose}
         title={existing ? localizedDocTitle(existing) : tr('文档', 'Document')}
         footer={
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800"
-          >
-            {tr('关闭', 'Close')}
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800"
+            >
+              {tr('关闭', 'Close')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                // The copy is a fresh org doc — drop the source url
+                // (builtin://… / repo path) so it isn't carried over.
+                setUrl('');
+                setForked(true);
+              }}
+              disabled={loading || !content}
+              title={
+                isVault
+                  ? tr('内置文档随同步更新、不可直接修改；复制一份到组织知识库后即可编辑', 'Built-in docs are refreshed on sync and not directly editable; copy into the org knowledge base to edit')
+                  : tr('repo 文档随同步更新、不可直接修改；复制一份到组织知识库后即可编辑', 'Repo docs are refreshed on sync and not directly editable; copy into the org knowledge base to edit')
+              }
+              className="flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            >
+              <Copy size={11} />
+              {tr('复制为组织文档', 'Copy as org doc')}
+            </button>
+          </>
         }
       >
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-2 text-[11px] text-zinc-500">
-            <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-emerald-300">repo</span>
+            {isVault ? (
+              <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-amber-300">{tr('内置', 'built-in')}</span>
+            ) : (
+              <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-emerald-300">repo</span>
+            )}
             {existing?.path && (
               <span className="rounded bg-zinc-800/60 px-1.5 py-0.5 text-zinc-300">{localizedPath(existing.path)}</span>
             )}
@@ -966,17 +1013,22 @@ function DocEditor({
                 {t}
               </span>
             ))}
-            {existing?.url && (
-              <a
-                href={existing.url}
-                target="_blank"
-                rel="noreferrer"
-                className="ml-auto truncate font-mono text-[10px] text-zinc-500 hover:text-zinc-300 underline-offset-2 hover:underline"
-                title={existing.url}
-              >
-                {existing.url}
-              </a>
-            )}
+            {existing?.url &&
+              (existing.url.startsWith('http') ? (
+                <a
+                  href={existing.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="ml-auto truncate font-mono text-[10px] text-zinc-500 hover:text-zinc-300 underline-offset-2 hover:underline"
+                  title={existing.url}
+                >
+                  {existing.url}
+                </a>
+              ) : (
+                <span className="ml-auto truncate font-mono text-[10px] text-zinc-500" title={existing.url}>
+                  {existing.url}
+                </span>
+              ))}
           </div>
           <div className="max-h-[60vh] overflow-y-auto rounded-md border border-zinc-800 bg-zinc-950/40 p-4">
             {loading ? (
@@ -1000,7 +1052,13 @@ function DocEditor({
     <Modal
       open
       onClose={onClose}
-      title={mode === 'create' ? tr('新建知识文档', 'New knowledge doc') : tr(`编辑 ${existing ? localizedDocTitle(existing) : ''}`, `Edit ${existing ? localizedDocTitle(existing) : ''}`)}
+      title={
+        mode === 'create'
+          ? tr('新建知识文档', 'New knowledge doc')
+          : forked
+            ? tr(`复制「${existing ? localizedDocTitle(existing) : ''}」为组织文档`, `Copy "${existing ? localizedDocTitle(existing) : ''}" as org doc`)
+            : tr(`编辑 ${existing ? localizedDocTitle(existing) : ''}`, `Edit ${existing ? localizedDocTitle(existing) : ''}`)
+      }
       footer={
         <>
           <button

--- a/web/src/pages/Skills.test.tsx
+++ b/web/src/pages/Skills.test.tsx
@@ -1,0 +1,71 @@
+// Skills 页面测试 — 覆盖「点击行打开只读详情弹窗」链路：
+// 完整描述（列表里被 line-clamp 截断）、参数表、不可编辑提示。
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SkillsPage from './Skills';
+import { server } from '@/test/msw-server';
+
+vi.mock('@/store/auth', () => ({
+  useAuth: Object.assign(
+    <T,>(selector: (s: { role: string }) => T): T => selector({ role: 'admin' }),
+    { getState: () => ({ logout: () => {} }) },
+  ),
+  getToken: () => null,
+  getRefreshToken: () => null,
+}));
+
+const longDesc =
+  'Analyze database health and performance from ongrid database metrics sources. ' +
+  'Use this as the first tool for any MySQL question that exporter metrics can cover.';
+
+const skills = [
+  {
+    key: 'analyze_database_status',
+    name: 'analyze_database_status',
+    description: longDesc,
+    class: 'safe',
+    scope: 'manager',
+    category: 'agent',
+    params: [
+      { name: 'device_id', type: 'int', required: true, desc: '目标设备 id' },
+      { name: 'window', type: 'duration', default: '15m', desc: '分析时间窗' },
+    ],
+    result_preview: '{summary, findings[]}',
+  },
+];
+
+describe('SkillsPage', () => {
+  beforeEach(() => {
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    server.use(
+      http.get('/api/v1/skills', () =>
+        HttpResponse.json({ items: skills, total: skills.length }),
+      ),
+    );
+  });
+
+  it('点击技能行打开只读详情弹窗', async () => {
+    render(
+      <MemoryRouter>
+        <SkillsPage />
+      </MemoryRouter>,
+    );
+    // 名称与 key 同文案（列表里各渲染一次），点第一个（名称）即可
+    await userEvent.click((await screen.findAllByText('analyze_database_status'))[0]);
+
+    // 弹窗：完整描述不再截断（列表行 line-clamp + 弹窗正文各一份），
+    // 参数表逐行展示
+    expect(await screen.findAllByText(longDesc)).toHaveLength(2);
+    expect(screen.getByText('device_id')).toBeInTheDocument();
+    expect(screen.getByText('目标设备 id')).toBeInTheDocument();
+    expect(screen.getByText('15m')).toBeInTheDocument();
+    expect(screen.getByText('{summary, findings[]}')).toBeInTheDocument();
+    // 只读定位：明示技能由代码定义、没有编辑入口
+    expect(screen.getByText(/不可在线编辑/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /保存|编辑/ })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Skills.tsx
+++ b/web/src/pages/Skills.tsx
@@ -4,6 +4,7 @@ import { Cloud, Cpu, Wrench, RefreshCw, Play, Search } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { listSkills, localizedSkill, type SkillClass, type SkillScope, type SkillSummary } from '@/api/skills';
 import { ApiError } from '@/api/client';
+import { Modal } from '@/components/Modal';
 import { useI18n } from '@/i18n/locale';
 
 // Lazy-load the install/uninstall surface so the default Catalog tab
@@ -55,6 +56,9 @@ function CatalogTab() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<string>('');
   const [scope, setScope] = useState<ScopeFilter>('');
+  // 详情弹窗：点击行打开（参照知识库文档的阅读弹窗）。技能由代码 /
+  // 技能包定义，注册表在内存——只读查看，无编辑路径。
+  const [viewing, setViewing] = useState<SkillSummary | null>(null);
 
   const fetchSkills = useCallback(async (silent = false) => {
     if (silent) setRefreshing(true);
@@ -217,13 +221,14 @@ function CatalogTab() {
                 </thead>
                 <tbody className="divide-y divide-zinc-800/40">
                   {filtered.map((skill) => (
-                    <SkillRow key={skill.key} skill={skill} />
+                    <SkillRow key={skill.key} skill={skill} onView={() => setViewing(skill)} />
                   ))}
                 </tbody>
               </table>
             </div>
           )}
         </div>
+        {viewing && <SkillDetailModal skill={viewing} onClose={() => setViewing(null)} />}
       </div>
   );
 }
@@ -253,10 +258,10 @@ function CategoryChip({
   );
 }
 
-function SkillRow({ skill }: { skill: SkillSummary }) {
+function SkillRow({ skill, onView }: { skill: SkillSummary; onView(): void }) {
   const { tr } = useI18n();
   return (
-    <tr className="transition-colors hover:bg-zinc-900/40">
+    <tr className="cursor-pointer transition-colors hover:bg-zinc-900/40" onClick={onView}>
       <td className="whitespace-nowrap px-4 py-2.5">
         <div className="font-medium text-zinc-100">{skill.name}</div>
         <div className="mt-0.5 font-mono text-[11px] text-zinc-500" title={skill.key}>
@@ -299,6 +304,7 @@ function SkillRow({ skill }: { skill: SkillSummary }) {
         ) : (
           <Link
             to={`/skills/${encodeURIComponent(skill.key)}`}
+            onClick={(e) => e.stopPropagation()}
             className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-[11px] text-zinc-200 hover:bg-zinc-800"
           >
             <Play size={11} /> {tr('执行', 'Run')}
@@ -349,6 +355,111 @@ export function ClassBadge({ value }: { value: SkillClass }) {
     >
       {value}
     </span>
+  );
+}
+
+// SkillDetailModal — 只读详情弹窗，参照知识库文档的阅读弹窗形态：
+// 顶部元信息条（运行位置 / 类别 / 分类 / key），正文完整描述 + 参数表。
+// 技能由代码或技能包定义、启动时注册进内存 registry，没有可编辑的
+// 存储——所以这里只有查看，没有编辑入口。
+function SkillDetailModal({ skill, onClose }: { skill: SkillSummary; onClose(): void }) {
+  const { tr } = useI18n();
+  return (
+    <Modal open onClose={onClose} size="lg" resizable title={skill.name}>
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <ScopeBadge value={skill.scope ?? 'host'} />
+          <ClassBadge value={skill.class} />
+          {skill.category && (
+            <span className="rounded-md border border-zinc-800 bg-zinc-950/40 px-1.5 py-0.5 text-[10px] text-zinc-400">
+              {skill.category}
+            </span>
+          )}
+          <span className="ml-auto font-mono text-[11px] text-zinc-500">{skill.key}</span>
+        </div>
+
+        <section>
+          <div className="mb-1.5 text-[11px] uppercase tracking-wider text-zinc-500">
+            {tr('描述（LLM 工具描述原文）', 'Description (raw LLM tool description)')}
+          </div>
+          <div className="whitespace-pre-wrap rounded-md border border-zinc-800 bg-zinc-950/40 p-3 text-xs leading-relaxed text-zinc-300">
+            {skill.description || '—'}
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-1.5 text-[11px] uppercase tracking-wider text-zinc-500">
+            {tr('参数', 'Parameters')}
+          </div>
+          {skill.params.length === 0 ? (
+            <div className="text-xs text-zinc-500">
+              {skill.inventory_only
+                ? tr('参数为原始 JSON Schema（由 AI 在 chat 中调用，无手动表单）', 'Params are raw JSON Schema (invoked by the AI in chat; no manual form)')
+                : tr('无参数', 'No parameters')}
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-zinc-800">
+              <table className="w-full text-xs">
+                <thead className="border-b border-zinc-800 bg-zinc-950/40 text-[10px] uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-3 py-1.5 text-left">{tr('名称', 'Name')}</th>
+                    <th className="px-3 py-1.5 text-left">{tr('类型', 'Type')}</th>
+                    <th className="px-3 py-1.5 text-left">{tr('必填', 'Required')}</th>
+                    <th className="px-3 py-1.5 text-left">{tr('默认值', 'Default')}</th>
+                    <th className="px-3 py-1.5 text-left">{tr('说明', 'Description')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800/60">
+                  {skill.params.map((p) => (
+                    <tr key={p.name}>
+                      <td className="whitespace-nowrap px-3 py-1.5 font-mono text-zinc-200">{p.name}</td>
+                      <td className="whitespace-nowrap px-3 py-1.5 text-zinc-400">
+                        {p.type}
+                        {p.enum && p.enum.length > 0 && (
+                          <span className="ml-1 text-zinc-500">({p.enum.join(' | ')})</span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-1.5 text-zinc-400">{p.required ? tr('是', 'Yes') : '—'}</td>
+                      <td className="whitespace-nowrap px-3 py-1.5 font-mono text-zinc-400">
+                        {p.default === undefined || p.default === null ? '—' : String(p.default)}
+                      </td>
+                      <td className="px-3 py-1.5 text-zinc-400">{p.desc || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {skill.result_preview && (
+          <section>
+            <div className="mb-1.5 text-[11px] uppercase tracking-wider text-zinc-500">
+              {tr('返回示意', 'Result preview')}
+            </div>
+            <div className="rounded-md border border-zinc-800 bg-zinc-950/40 p-3 font-mono text-[11px] text-zinc-400">
+              {skill.result_preview}
+            </div>
+          </section>
+        )}
+
+        <div className="flex items-center justify-between gap-3 border-t border-zinc-800 pt-3">
+          <span className="text-[11px] text-zinc-500">
+            {tr('技能由代码 / 技能包定义，不可在线编辑', 'Skills are defined in code / skill packs and cannot be edited online')}
+          </span>
+          {skill.inventory_only ? (
+            <span className="text-[11px] text-zinc-500">{tr('仅 AI 调用', 'AI only')}</span>
+          ) : (
+            <Link
+              to={`/skills/${encodeURIComponent(skill.key)}`}
+              className="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white"
+            >
+              <Play size={11} /> {tr('执行', 'Run')}
+            </Link>
+          )}
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -2,6 +2,25 @@ import '@testing-library/jest-dom';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { server } from './msw-server';
 
+// Node 22+ 自带的实验性 webstorage 全局会盖掉 jsdom 的 localStorage——
+// 没有 --localstorage-file 时它的 getItem 是 undefined，导致任何
+// 走 useI18n()/getLocale() 的组件测试在 render 时抛
+// "localStorage.getItem is not a function"。这里换成内存实现兜底。
+if (typeof globalThis.localStorage?.getItem !== 'function') {
+  const mem = new Map<string, string>();
+  const stub: Storage = {
+    get length() {
+      return mem.size;
+    },
+    clear: () => mem.clear(),
+    getItem: (k: string) => mem.get(k) ?? null,
+    key: (i: number) => [...mem.keys()][i] ?? null,
+    removeItem: (k: string) => void mem.delete(k),
+    setItem: (k: string, v: string) => void mem.set(k, String(v)),
+  };
+  Object.defineProperty(globalThis, 'localStorage', { value: stub, configurable: true });
+}
+
 // onUnhandledRequest:'error' so any test forgetting a handler fails
 // loudly instead of silently hanging on a real fetch.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));


### PR DESCRIPTION
## 概述

为「知识库 / 技能 / 助理」三处页面补上**详情查看与编辑**能力，并附配套测试。全部改动限于前端（`web/`），无后端 / proto 变更。

## 改动内容

### 知识库
- 知识文档点击查看正文；内置文档支持「复制为组织文档」
- 文档查看器表格渲染修复，默认加宽且支持拖拽调宽
- 阅读视图剥离 frontmatter，元信息以弱化 key/value 展示

### 技能
- 技能列表支持点击查看详情

### 助理
- 助理支持点击查看定义详情与编辑
- 助理详情关键提醒配色修复

### 测试基建
- 修复 Node 22+ 下 vitest localStorage 不可用导致组件测试全挂（`web/src/test/setup.ts`，本 PR 新增测试的前置依赖）

## 验证

- `npm run typecheck` ✅
- `npm run test`（新增 4 个测试文件，15 例全通过）✅
- `npm run build` ✅
