### PR TITLE
fix databasemetrics secret lifecycle

### DIFF
--- a/internal/edgeagent/plugins/databasemetrics/secrets.go
+++ b/internal/edgeagent/plugins/databasemetrics/secrets.go
@@ -38,7 +38,11 @@ func RegisterSecretHandler(client tunnel.Client, log *slog.Logger) {
 			return nil, err
 		}
 		for _, req := range reqs {
-			log.Info("databasemetrics secret written",
+			action := "written"
+			if req.Delete {
+				action = "deleted"
+			}
+			log.Info("databasemetrics secret "+action,
 				slog.String("source", req.SourceID),
 				slog.String("path", req.Path))
 		}
@@ -412,6 +416,7 @@ func writeManagedSecretsInBase(ctx context.Context, baseDir string, reqs []tunne
 type managedSecretWritePlan struct {
 	path    string
 	content string
+	delete  bool
 }
 
 type stagedManagedSecretWrite struct {
@@ -420,6 +425,7 @@ type stagedManagedSecretWrite struct {
 	backupPath  string
 	hadOriginal bool
 	installed   bool
+	deleteOnly  bool
 }
 
 func planManagedSecretWrites(ctx context.Context, baseDir string, reqs []tunnel.WriteDatabaseMetricsSecretRequest) ([]managedSecretWritePlan, error) {
@@ -437,6 +443,16 @@ func planManagedSecretWrites(ctx context.Context, baseDir string, reqs []tunnel.
 			return nil, fmt.Errorf("write database metrics secret: duplicate path %q for sources %q and %q", cleanPath, prevSourceID, req.SourceID)
 		}
 		seenPaths[cleanPath] = req.SourceID
+		if req.Delete {
+			if strings.TrimSpace(req.Content) != "" || req.PreservePassword {
+				return nil, fmt.Errorf("write database metrics secret: delete request must not include content or preserve_password")
+			}
+			plans = append(plans, managedSecretWritePlan{
+				path:   cleanPath,
+				delete: true,
+			})
+			continue
+		}
 		content := req.Content
 		if strings.TrimSpace(content) == "" && req.PreservePassword {
 			nextContent, err := buildManagedSecretPreservingPasswordInBase(baseDir, req)
@@ -495,6 +511,9 @@ func stageManagedSecretWrites(ctx context.Context, plans []managedSecretWritePla
 }
 
 func stageManagedSecretWrite(plan managedSecretWritePlan) (stagedManagedSecretWrite, error) {
+	if plan.delete {
+		return stagedManagedSecretWrite{path: plan.path, deleteOnly: true}, nil
+	}
 	dir := filepath.Dir(plan.path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return stagedManagedSecretWrite{}, fmt.Errorf("write database metrics secret: mkdir: %w", err)
@@ -545,6 +564,37 @@ func commitManagedSecretWrites(ctx context.Context, staged []stagedManagedSecret
 			return err
 		}
 		st := &staged[i]
+		if st.deleteOnly {
+			if info, err := os.Lstat(st.path); err == nil {
+				if info.Mode()&os.ModeSymlink != 0 {
+					if rollbackErr := rollbackManagedSecretWrites(staged); rollbackErr != nil {
+						return errors.Join(fmt.Errorf("write database metrics secret: refusing symlink path"), rollbackErr)
+					}
+					return fmt.Errorf("write database metrics secret: refusing symlink path")
+				}
+				backupPath, err := reserveManagedSecretBackupPath(filepath.Dir(st.path))
+				if err != nil {
+					if rollbackErr := rollbackManagedSecretWrites(staged); rollbackErr != nil {
+						return errors.Join(err, rollbackErr)
+					}
+					return err
+				}
+				if err := os.Rename(st.path, backupPath); err != nil {
+					if rollbackErr := rollbackManagedSecretWrites(staged); rollbackErr != nil {
+						return errors.Join(fmt.Errorf("write database metrics secret: backup existing before delete: %w", err), rollbackErr)
+					}
+					return fmt.Errorf("write database metrics secret: backup existing before delete: %w", err)
+				}
+				st.backupPath = backupPath
+				st.hadOriginal = true
+			} else if !os.IsNotExist(err) {
+				if rollbackErr := rollbackManagedSecretWrites(staged); rollbackErr != nil {
+					return errors.Join(fmt.Errorf("write database metrics secret: stat target: %w", err), rollbackErr)
+				}
+				return fmt.Errorf("write database metrics secret: stat target: %w", err)
+			}
+			continue
+		}
 		if info, err := os.Lstat(st.path); err == nil {
 			if info.Mode()&os.ModeSymlink != 0 {
 				if rollbackErr := rollbackManagedSecretWrites(staged); rollbackErr != nil {

--- a/internal/edgeagent/plugins/databasemetrics/secrets_test.go
+++ b/internal/edgeagent/plugins/databasemetrics/secrets_test.go
@@ -100,6 +100,28 @@ func TestWriteManagedSecretsInBase_WhenLaterRequestInvalid_LeavesEarlierSecretUn
 	}
 }
 
+func TestWriteManagedSecretsInBaseDeletesSecret(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "redis-prod.dsn")
+	if err := os.WriteFile(path, []byte("redis://:old-secret@127.0.0.1:6379/0\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := writeManagedSecretsInBase(context.Background(), base, []tunnel.WriteDatabaseMetricsSecretRequest{
+		{
+			SourceID: "redis-prod",
+			Path:     path,
+			Delete:   true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("writeManagedSecretsInBase() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("Stat() error = %v, want not exist", err)
+	}
+}
+
 func TestBuildManagedSecretPreservingPasswordForPostgresSkipVerify(t *testing.T) {
 	base := t.TempDir()
 	path := filepath.Join(base, "pg-prod.dsn")

--- a/internal/manager/biz/edge/plugin_config.go
+++ b/internal/manager/biz/edge/plugin_config.go
@@ -197,11 +197,14 @@ func (uc *PluginConfigUC) Set(ctx context.Context, edgeID uint64, plugin string,
 		}
 		in.Spec = spec
 		databaseSecretReqs = secretReqs
-		if len(databaseSecretReqs) > 0 {
-			previous, err = uc.repo.Get(ctx, edgeID, plugin)
-			if err != nil {
-				return nil, fmt.Errorf("load previous %s config: %w", plugin, err)
-			}
+		previous, err = uc.repo.Get(ctx, edgeID, plugin)
+		if errors.Is(err, errs.ErrNotFound) {
+			previous = nil
+		} else if err != nil {
+			return nil, fmt.Errorf("load previous %s config: %w", plugin, err)
+		}
+		if previous != nil {
+			databaseSecretReqs = append(databaseSecretReqs, databaseMetricsSecretDeleteRequests(decodeSpec(previous.SpecJSON), in.Spec)...)
 		}
 	}
 	specJSON := "{}"

--- a/internal/manager/biz/edge/plugin_config_databasemetrics.go
+++ b/internal/manager/biz/edge/plugin_config_databasemetrics.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -95,6 +96,65 @@ func (uc *PluginConfigUC) writeDatabaseMetricsSecrets(ctx context.Context, edgeI
 		return fmt.Errorf("write databasemetrics secrets: %w", err)
 	}
 	return nil
+}
+
+func databaseMetricsSecretDeleteRequests(previousSpec, nextSpec map[string]interface{}) []tunnel.WriteDatabaseMetricsSecretRequest {
+	previousPaths := databaseMetricsManagedSecretPaths(previousSpec)
+	if len(previousPaths) == 0 {
+		return nil
+	}
+	nextPaths := databaseMetricsManagedSecretPaths(nextSpec)
+	paths := make([]string, 0, len(previousPaths))
+	for path := range previousPaths {
+		if _, stillUsed := nextPaths[path]; !stillUsed {
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	out := make([]tunnel.WriteDatabaseMetricsSecretRequest, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, tunnel.WriteDatabaseMetricsSecretRequest{
+			SourceID: previousPaths[path],
+			Path:     path,
+			Delete:   true,
+		})
+	}
+	return out
+}
+
+func databaseMetricsManagedSecretPaths(spec map[string]interface{}) map[string]string {
+	out := map[string]string{}
+	rawSources, ok := spec["sources"].([]interface{})
+	if !ok {
+		return out
+	}
+	for _, raw := range rawSources {
+		source, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(mapString(source, "id"))
+		dbType := strings.ToLower(strings.TrimSpace(mapString(source, "db_type")))
+		path := ""
+		if connection, ok := mapValue(source["connection"]); ok {
+			connType := mapString(connection, "type")
+			if connType != "" && connType != "managed" {
+				continue
+			}
+			path = mapString(connection, "path")
+		}
+		if path == "" && id != "" && databaseMetricsDBTypeSupported(dbType) {
+			path = databaseMetricsSecretPath(id, dbType)
+		}
+		if path == "" {
+			continue
+		}
+		if id == "" {
+			id = filepath.Base(path)
+		}
+		out[path] = id
+	}
+	return out
 }
 
 func sanitizeDatabaseMetricsSource(i int, source map[string]interface{}) (map[string]interface{}, *tunnel.WriteDatabaseMetricsSecretRequest, error) {

--- a/internal/manager/biz/edge/plugin_config_databasemetrics_test.go
+++ b/internal/manager/biz/edge/plugin_config_databasemetrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/edge"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
@@ -35,7 +36,7 @@ func (r *fakePluginConfigRepo) ListByEdge(_ context.Context, edgeID uint64) ([]*
 func (r *fakePluginConfigRepo) Get(_ context.Context, edgeID uint64, plugin string) (*model.PluginConfig, error) {
 	row := r.rows[plugin]
 	if row == nil || row.EdgeID != edgeID {
-		return nil, nil
+		return nil, errs.ErrNotFound
 	}
 	cp := *row
 	return &cp, nil
@@ -250,8 +251,12 @@ func TestSetDatabaseMetrics_WhenSecretWriteFails_RollsBackConfig(t *testing.T) {
 	if writer.calls != 1 {
 		t.Fatalf("secret writer calls = %d, want 1", writer.calls)
 	}
-	if len(writer.reqs) != 2 {
-		t.Fatalf("secret writes = %d, want 2", len(writer.reqs))
+	if len(writer.reqs) != 3 {
+		t.Fatalf("secret writes = %d, want 3", len(writer.reqs))
+	}
+	deleteReq := writer.reqs[2]
+	if !deleteReq.Delete || deleteReq.Path != "/var/lib/ongrid-edge/secrets/old-redis.dsn" {
+		t.Fatalf("delete req = %#v, want old-redis delete", deleteReq)
 	}
 	got := repo.rows[model.PluginNameDatabaseMetrics]
 	if got == nil {
@@ -259,6 +264,54 @@ func TestSetDatabaseMetrics_WhenSecretWriteFails_RollsBackConfig(t *testing.T) {
 	}
 	if got.ID != 23 || got.Enabled != false || got.SpecJSON != oldSpec {
 		t.Fatalf("rolled back row = %#v, want old spec/enabled/id", got)
+	}
+}
+
+func TestSetDatabaseMetricsDeletesRemovedSecret(t *testing.T) {
+	oldSpec := `{"sources":[{"id":"pg-prod","db_type":"postgresql","enabled":true,"connection":{"type":"managed","path":"/var/lib/ongrid-edge/secrets/pg-prod.dsn","secret_set":true}},{"id":"redis-prod","db_type":"redis","enabled":true,"connection":{"type":"managed","path":"/var/lib/ongrid-edge/secrets/redis-prod.dsn","secret_set":true}}]}`
+	repo := newFakePluginConfigRepo()
+	repo.rows[model.PluginNameDatabaseMetrics] = &model.PluginConfig{
+		ID:         23,
+		EdgeID:     7,
+		PluginName: model.PluginNameDatabaseMetrics,
+		Enabled:    true,
+		SpecJSON:   oldSpec,
+	}
+	writer := &fakeDatabaseSecretWriter{}
+	uc := NewPluginConfigUC(repo, nil, fakeEndpointResolver{}, nil)
+	uc.SetDatabaseMetricsSecretWriter(writer)
+
+	_, err := uc.Set(context.Background(), 7, model.PluginNameDatabaseMetrics, SetInput{
+		Enabled: true,
+		Spec: map[string]interface{}{
+			"sources": []interface{}{
+				map[string]interface{}{
+					"id":             "pg-prod",
+					"db_type":        "postgresql",
+					"listen_address": "127.0.0.1:19187",
+					"connection": map[string]interface{}{
+						"type":       "managed",
+						"secret_set": true,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if writer.calls != 1 {
+		t.Fatalf("secret writer calls = %d, want 1", writer.calls)
+	}
+	if len(writer.reqs) != 1 {
+		t.Fatalf("secret requests = %d, want 1", len(writer.reqs))
+	}
+	req := writer.reqs[0]
+	if !req.Delete {
+		t.Fatalf("Delete = false, want true: %#v", req)
+	}
+	if req.SourceID != "redis-prod" || req.Path != "/var/lib/ongrid-edge/secrets/redis-prod.dsn" {
+		t.Fatalf("delete req = %#v", req)
 	}
 }
 

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -176,6 +176,7 @@ type WriteDatabaseMetricsSecretRequest struct {
 	DBType           string                 `json:"db_type,omitempty"`
 	Credentials      map[string]interface{} `json:"credentials,omitempty"`
 	PreservePassword bool                   `json:"preserve_password,omitempty"`
+	Delete           bool                   `json:"delete,omitempty"`
 }
 
 // WriteDatabaseMetricsSecretsRequest batches edge-local credential writes so


### PR DESCRIPTION
## Summary

- allow first-time `databasemetrics` saves when no previous plugin config row exists
- add manager-side diffing for removed database metric secret paths
- extend the edge secret RPC to delete stale managed secret files with backup/rollback semantics

## Root Cause

First-time saves with credentials prepared secret writes, then tried to load a previous `databasemetrics` row for rollback. The real repo returns `ErrNotFound` on the first save, so the save failed before the config could be persisted or secrets could be written.

Separately, removing a database source stopped the source but left its edge-local credential file under `/var/lib/ongrid-edge/secrets` because the secret RPC only supported writes.

## Validation

```bash
ASDF_GOLANG_VERSION=1.23.9 go test ./internal/manager/biz/edge ./internal/edgeagent/plugins/databasemetrics ./internal/edgeagent/plugins/custommetrics ./internal/manager/data/edge/store ./internal/pkg/tunnel ./internal/manager/service/frontierbound
git diff --check
```