### PR TITLE
docs(readme): update install commands to v0.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Choose the command for your server architecture:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Integrations

--- a/README_DE.md
+++ b/README_DE.md
@@ -49,15 +49,15 @@ Wählen Sie den Befehl für Ihre Serverarchitektur:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Integrationen

--- a/README_ES.md
+++ b/README_ES.md
@@ -49,15 +49,15 @@ Elige el comando para la arquitectura de tu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Integraciones

--- a/README_FR.md
+++ b/README_FR.md
@@ -49,15 +49,15 @@ Choisissez la commande adaptée à l’architecture de votre serveur :
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Intégrations

--- a/README_JA.md
+++ b/README_JA.md
@@ -49,15 +49,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## インテグレーション

--- a/README_KO.md
+++ b/README_KO.md
@@ -49,15 +49,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## 연동

--- a/README_PT.md
+++ b/README_PT.md
@@ -49,15 +49,15 @@ Escolha o comando para a arquitetura do seu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Integrações

--- a/README_RU.md
+++ b/README_RU.md
@@ -49,15 +49,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## Интеграции

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -49,15 +49,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-amd64.tar.xz
-tar -xf ongrid-v0.8.5-linux-amd64.tar.xz && cd ongrid-v0.8.5-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-amd64.tar.xz
+tar -xf ongrid-v0.8.6-linux-amd64.tar.xz && cd ongrid-v0.8.6-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.8.5/ongrid-v0.8.5-linux-arm64.tar.xz
-tar -xf ongrid-v0.8.5-linux-arm64.tar.xz && cd ongrid-v0.8.5-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.8.6/ongrid-v0.8.6-linux-arm64.tar.xz
+tar -xf ongrid-v0.8.6-linux-arm64.tar.xz && cd ongrid-v0.8.6-linux-arm64
 sudo ./install.sh
 ```
 
@@ -65,10 +65,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.8.5-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.8.6-linux-arm64.tar.xz
 ```
 
 ## 集成


### PR DESCRIPTION
## Summary
- Update top-level multilingual README install commands from v0.8.5 to v0.8.6.
- Update both GitHub Release and ongrid.cloud download examples.

## Validation
- `rg -n "v0\\.8\\.5" README*.md || true`
- `git diff --check`
