### PR TITLE
feat(alerts): add natural language alert rule drafts

### DIFF
--- a/cmd/ongrid/config_tools_adapter.go
+++ b/cmd/ongrid/config_tools_adapter.go
@@ -1,0 +1,1019 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	aiopstools "github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+	managersvcalert "github.com/ongridio/ongrid/internal/manager/service/alert"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+var simpleHostMetricPredicateJoinRE = regexp.MustCompile(`(?i)\s+(and|or)\s+`)
+var simpleHostMetricPredicatePartRE = regexp.MustCompile(`^\(?\s*([a-zA-Z_][a-zA-Z0-9_\-\s]*)\s*(==|!=|>=|<=|>|<)\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*\)?$`)
+var promMetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+
+type chatConfigAdapter struct {
+	alert *managersvcalert.Service
+}
+
+func newChatConfigAdapter(alertSvc *managersvcalert.Service) *chatConfigAdapter {
+	return &chatConfigAdapter{alert: alertSvc}
+}
+
+func (a *chatConfigAdapter) DraftAlertRuleConfig(ctx context.Context, caller aiopstools.ConfigCaller, in aiopstools.AlertRuleConfigArgs) (*aiopstools.ConfigDraft, error) {
+	if a.alert == nil {
+		return nil, errs.ErrNotWiredYet
+	}
+	action, err := normalizeConfigAction(in.Action)
+	if err != nil {
+		return nil, err
+	}
+	rule := normalizeAlertRuleConfigInput(in.Rule)
+	alertCaller := toAlertServiceCaller(caller)
+	ruleInput := toAlertRuleInput(rule)
+	res, err := a.alert.PreviewRule(ctx, alertCaller, ruleInput, in.LookbackSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("preview alert rule: %w", err)
+	}
+	warnings := []string(nil)
+	if res != nil && strings.TrimSpace(res.SkippedReason) != "" {
+		warnings = append(warnings, res.SkippedReason)
+	}
+	preview, err := configRaw(res)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := configRaw(map[string]interface{}{
+		"action": action,
+		"rule":   rule,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &aiopstools.ConfigDraft{
+		Kind:      aiopstools.ConfigResultKindDraft,
+		Domain:    aiopstools.ConfigDomainAlertRule,
+		Action:    action,
+		Summary:   alertRuleDraftSummary(action, rule),
+		Payload:   payload,
+		Preview:   preview,
+		Warnings:  warnings,
+		Rollback:  "可在 Alerts 规则列表中禁用或继续编辑该规则。",
+		ApplyTool: aiopstools.ToolNameApplyConfigChange,
+	}, nil
+}
+
+func (a *chatConfigAdapter) ApplyAlertRuleConfig(ctx context.Context, caller aiopstools.ConfigCaller, in aiopstools.AlertRuleApplyArgs) (*aiopstools.ConfigApplyResult, error) {
+	if a.alert == nil {
+		return nil, errs.ErrNotWiredYet
+	}
+	action, err := normalizeConfigAction(in.Action)
+	if err != nil {
+		return nil, err
+	}
+	alertCaller := toAlertServiceCaller(caller)
+	ruleInput := toAlertRuleInput(in.Rule)
+	if _, err := a.alert.PreviewRule(ctx, alertCaller, ruleInput, 0); err != nil {
+		return nil, fmt.Errorf("preview alert rule before create: %w", err)
+	}
+	rule, err := a.alert.CreateRule(ctx, alertCaller, ruleInput)
+	if err != nil {
+		return nil, fmt.Errorf("create alert rule: %w", err)
+	}
+	return &aiopstools.ConfigApplyResult{
+		Kind:       aiopstools.ConfigResultKindApply,
+		Domain:     aiopstools.ConfigDomainAlertRule,
+		Action:     action,
+		Status:     "applied",
+		ResourceID: rule.ID,
+		Resource: &aiopstools.ConfigTarget{
+			ID:   rule.ID,
+			Name: rule.Name,
+			Type: rule.Kind,
+		},
+		Message:  fmt.Sprintf("alert rule %q created", rule.Name),
+		Rollback: "可在 Alerts 规则列表中禁用或继续编辑该规则。",
+	}, nil
+}
+
+func toAlertRuleInput(in aiopstools.AlertRuleConfigInput) managersvcalert.RuleInput {
+	in = normalizeAlertRuleConfigInput(in)
+	enabled := true
+	if in.Enabled != nil {
+		enabled = *in.Enabled
+	}
+	conds := make([]managersvcalert.RuleCondition, 0, len(in.Conditions))
+	for _, c := range in.Conditions {
+		conds = append(conds, managersvcalert.RuleCondition{
+			Metric:     c.Metric,
+			Operator:   c.Operator,
+			Threshold:  c.Threshold,
+			Window:     c.Window,
+			For:        c.For,
+			Aggregator: c.Aggregator,
+		})
+	}
+	return managersvcalert.RuleInput{
+		RuleKey:             in.RuleKey,
+		Kind:                in.Kind,
+		Name:                in.Name,
+		ScopeType:           in.ScopeType,
+		JoinMode:            in.JoinMode,
+		Severity:            in.Severity,
+		Enabled:             enabled,
+		Conditions:          conds,
+		Spec:                in.Spec,
+		Labels:              in.Labels,
+		RunbookURL:          in.RunbookURL,
+		NotifyChannelIDs:    in.NotifyChannelIDs,
+		NotifyWindowSeconds: in.NotifyWindowSeconds,
+		NotifyMinFires:      in.NotifyMinFires,
+	}
+}
+
+func normalizeAlertRuleConfigInput(in aiopstools.AlertRuleConfigInput) aiopstools.AlertRuleConfigInput {
+	in.Kind = normalizeAlertRuleKind(in.Kind)
+	in = normalizeAlertRuleSpec(in)
+	in = rewriteSimpleHostMetricRawExpr(in)
+	for i := range in.Conditions {
+		in.Conditions[i].Metric = canonicalAlertMetric(in.Conditions[i].Metric)
+		if strings.TrimSpace(in.Conditions[i].Aggregator) == "" {
+			in.Conditions[i].Aggregator = "avg"
+		}
+		if strings.TrimSpace(in.Conditions[i].Window) == "" {
+			in.Conditions[i].Window = "5m"
+		}
+	}
+	if strings.TrimSpace(in.Kind) == "" && len(in.Conditions) > 0 {
+		in.Kind = "metric_threshold"
+	}
+	if strings.TrimSpace(in.Kind) == "" {
+		in.Kind = inferAlertRuleKind(in)
+	}
+	if strings.TrimSpace(in.ScopeType) == "" {
+		in.ScopeType = defaultAlertScope(in.Kind)
+	}
+	if strings.TrimSpace(in.Severity) == "" {
+		in.Severity = "warning"
+	}
+	if strings.TrimSpace(in.RuleKey) == "" {
+		in.RuleKey = suggestedAlertRuleKey(in)
+	}
+	if strings.TrimSpace(in.Name) == "" {
+		in.Name = suggestedAlertRuleName(in)
+	}
+	if strings.TrimSpace(in.RunbookURL) == "" {
+		in.RunbookURL = suggestedAlertRunbookURL(in.RuleKey)
+	}
+	return in
+}
+
+func normalizeAlertRuleKind(kind string) string {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	k = strings.ReplaceAll(k, "-", "_")
+	k = strings.ReplaceAll(k, " ", "_")
+	switch k {
+	case "", "metric_threshold", "metric_raw", "metric_anomaly", "metric_forecast", "metric_burn_rate",
+		"log_match", "log_volume", "trace_latency", "trace_error_rate":
+		return k
+	case "threshold", "host_threshold", "host_metric", "host_metric_threshold":
+		return "metric_threshold"
+	case "promql", "prom_query", "raw_promql", "raw_metric", "database_metric", "db_metric", "custom_metric":
+		return "metric_raw"
+	case "anomaly", "metric_baseline", "baseline":
+		return "metric_anomaly"
+	case "forecast", "predict", "prediction":
+		return "metric_forecast"
+	case "burn_rate", "slo_burn_rate":
+		return "metric_burn_rate"
+	case "log", "log_regex", "log_error", "log_keyword":
+		return "log_match"
+	case "log_rate", "log_count", "log_spike":
+		return "log_volume"
+	case "latency", "trace_p95", "trace_p99":
+		return "trace_latency"
+	case "error_rate", "trace_errors", "trace_error":
+		return "trace_error_rate"
+	default:
+		return k
+	}
+}
+
+func inferAlertRuleKind(in aiopstools.AlertRuleConfigInput) string {
+	if len(in.Conditions) > 0 {
+		return "metric_threshold"
+	}
+	spec := in.Spec
+	if spec == nil {
+		return ""
+	}
+	switch {
+	case hasAnySpecKey(spec, "stream_selector") && hasAnySpecKey(spec, "ratio_op", "ratio_threshold"):
+		return "log_volume"
+	case hasAnySpecKey(spec, "stream_selector", "line_filter", "filter", "regex", "pattern"):
+		return "log_match"
+	case hasAnySpecKey(spec, "threshold_ms", "latency_ms", "quantile", "operation"):
+		return "trace_latency"
+	case hasAnySpecKey(spec, "threshold_pct", "error_rate_pct", "error_rate_threshold"):
+		return "trace_error_rate"
+	case hasAnySpecKey(spec, "sli", "slo", "burns"):
+		return "metric_burn_rate"
+	case hasAnySpecKey(spec, "predict_seconds", "fit_window"):
+		return "metric_forecast"
+	case hasAnySpecKey(spec, "baseline_window", "baseline_step", "deviation", "method"):
+		return "metric_anomaly"
+	case hasAnySpecKey(spec, "expr", "promql", "query", "catalog_metric", "db_metric", "metric_key", "metric", "metric_name"):
+		return "metric_raw"
+	default:
+		return ""
+	}
+}
+
+func normalizeAlertRuleSpec(in aiopstools.AlertRuleConfigInput) aiopstools.AlertRuleConfigInput {
+	if in.Spec == nil {
+		return in
+	}
+	if strings.TrimSpace(in.Kind) == "" {
+		in.Kind = inferAlertRuleKind(in)
+	}
+	switch in.Kind {
+	case "metric_raw":
+		in = normalizeMetricRawSpec(in)
+	case "metric_anomaly":
+		setSpecDefaultString(in.Spec, "method", "zscore")
+		setSpecDefaultString(in.Spec, "baseline_window", "1h")
+		setSpecDefaultString(in.Spec, "baseline_step", "5m")
+		setSpecDefaultNumber(in.Spec, "deviation", 3)
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key"); ok {
+			in.Spec["metric"] = canonicalAlertMetric(metric)
+		}
+	case "metric_forecast":
+		setSpecDefaultString(in.Spec, "fit_window", "1h")
+		setSpecDefaultNumber(in.Spec, "predict_seconds", 21600)
+		setSpecDefaultString(in.Spec, "operator", "<=")
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key"); ok {
+			in.Spec["metric"] = canonicalAlertMetric(metric)
+		}
+	case "metric_burn_rate":
+		setSpecDefaultNumber(in.Spec, "slo", 99.9)
+		if !hasAnySpecKey(in.Spec, "burns") {
+			in.Spec["burns"] = []interface{}{
+				map[string]interface{}{"window": "1h", "multiplier": 14.4},
+				map[string]interface{}{"window": "6h", "multiplier": 6},
+			}
+		}
+	case "log_match":
+		if v, ok := firstSpecString(in.Spec, "filter", "regex", "pattern", "line_regex"); ok && strings.TrimSpace(alertSpecStringValue(in.Spec["line_filter"])) == "" {
+			in.Spec["line_filter"] = v
+		}
+		setSpecDefaultString(in.Spec, "stream_selector", `{ongrid_source=~"journald:.+"}`)
+		setSpecDefaultString(in.Spec, "window", "5m")
+		setSpecDefaultString(in.Spec, "operator", ">=")
+		setSpecDefaultNumber(in.Spec, "threshold", 1)
+	case "log_volume":
+		if op, ok := firstSpecString(in.Spec, "operator", "op"); ok && strings.TrimSpace(alertSpecStringValue(in.Spec["ratio_op"])) == "" {
+			in.Spec["ratio_op"] = op
+		}
+		if threshold, ok := firstSpecNumber(in.Spec, "threshold", "value"); ok && !hasAnySpecKey(in.Spec, "ratio_threshold") {
+			in.Spec["ratio_threshold"] = threshold
+		}
+		setSpecDefaultString(in.Spec, "stream_selector", `{ongrid_source=~".+"}`)
+		setSpecDefaultString(in.Spec, "window", "5m")
+		setSpecDefaultString(in.Spec, "ratio_op", ">=")
+		setSpecDefaultNumber(in.Spec, "ratio_threshold", 2)
+	case "trace_latency":
+		if threshold, ok := firstSpecNumber(in.Spec, "threshold", "latency_ms", "value"); ok && !hasAnySpecKey(in.Spec, "threshold_ms") {
+			in.Spec["threshold_ms"] = threshold
+		}
+		setSpecDefaultString(in.Spec, "quantile", "p95")
+		setSpecDefaultString(in.Spec, "window", "5m")
+		setSpecDefaultNumber(in.Spec, "threshold_ms", 500)
+	case "trace_error_rate":
+		if threshold, ok := firstSpecNumber(in.Spec, "threshold", "error_rate_pct", "error_rate_threshold", "value"); ok && !hasAnySpecKey(in.Spec, "threshold_pct") {
+			in.Spec["threshold_pct"] = threshold
+		}
+		setSpecDefaultString(in.Spec, "window", "5m")
+		setSpecDefaultString(in.Spec, "operator", ">=")
+		setSpecDefaultNumber(in.Spec, "threshold_pct", 1)
+	case "":
+		in = normalizeSpecMetricCondition(in)
+	}
+	return in
+}
+
+func normalizeMetricRawSpec(in aiopstools.AlertRuleConfigInput) aiopstools.AlertRuleConfigInput {
+	if expr, ok := firstSpecString(in.Spec, "expr", "promql", "query"); ok {
+		in.Spec["expr"] = expr
+		return in
+	}
+	if _, hasCatalog := firstSpecString(in.Spec, "catalog_metric", "db_metric", "semantic_metric"); !hasCatalog {
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key", "metric_name"); ok && isClosedSetAlertMetric(canonicalAlertMetric(metric)) {
+			return normalizeSpecMetricCondition(in)
+		}
+	}
+	if expr, ok := buildMetricRawExprFromSpec(in.Spec); ok {
+		in.Spec["expr"] = expr
+		return in
+	}
+	return normalizeSpecMetricCondition(in)
+}
+
+func normalizeSpecMetricCondition(in aiopstools.AlertRuleConfigInput) aiopstools.AlertRuleConfigInput {
+	if len(in.Conditions) > 0 || in.Spec == nil {
+		return in
+	}
+	metric, ok := firstSpecString(in.Spec, "metric", "metric_key", "metric_name")
+	if !ok {
+		return in
+	}
+	operator, opOK := firstSpecString(in.Spec, "operator", "op", "comparison")
+	threshold, thresholdOK := firstSpecNumber(in.Spec, "threshold", "threshold_pct", "threshold_ms", "value")
+	if !opOK || !thresholdOK {
+		return in
+	}
+	if canonical := canonicalAlertMetric(metric); isClosedSetAlertMetric(canonical) {
+		in.Kind = "metric_threshold"
+		in.Conditions = []aiopstools.AlertRuleCondition{{
+			Metric:     canonical,
+			Operator:   normalizeAlertOperator(operator),
+			Threshold:  threshold,
+			Window:     "5m",
+			Aggregator: "avg",
+		}}
+		in.Spec = nil
+		return in
+	}
+	if expr, ok := buildMetricRawExprFromSpec(in.Spec); ok {
+		in.Kind = "metric_raw"
+		in.Spec["expr"] = expr
+	}
+	return in
+}
+
+func buildMetricRawExprFromSpec(spec map[string]interface{}) (string, bool) {
+	if spec == nil {
+		return "", false
+	}
+	selector := alertSpecSelector(spec)
+	var base string
+	if catalogMetric, ok := firstSpecString(spec, "catalog_metric", "db_metric", "semantic_metric"); ok {
+		expr, ok := databaseAlertMetricExpr(catalogMetric, selector)
+		if !ok {
+			return "", false
+		}
+		base = expr
+	} else if metric, ok := firstSpecString(spec, "metric", "metric_key", "metric_name"); ok {
+		if expr, ok := databaseAlertMetricExpr(metric, selector); ok {
+			base = expr
+		} else if promMetricNameRE.MatchString(metric) {
+			base = metricSelector(metric, selector)
+		} else {
+			return "", false
+		}
+	} else {
+		return "", false
+	}
+	operator, ok := firstSpecString(spec, "operator", "op", "comparison")
+	if !ok {
+		return "", false
+	}
+	threshold, ok := firstSpecNumber(spec, "threshold", "threshold_pct", "threshold_ms", "value")
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("(%s) %s %s", base, normalizeAlertOperator(operator), formatAlertFloat(threshold)), true
+}
+
+func databaseAlertMetricExpr(metric string, selector string) (string, bool) {
+	code := normalizeCatalogMetricCode(metric)
+	ms := func(name string) string { return metricSelector(name, selector) }
+	switch code {
+	case "mysql_up", "mysql_liveness", "mysql_alive":
+		return fmt.Sprintf("min(%s)", ms("mysql_up")), true
+	case "mysql_connection_usage_pct", "mysql_connection_pressure", "mysql_connections_pct":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("mysql_global_status_threads_connected"), ms("mysql_global_variables_max_connections")), true
+	case "mysql_threads_running":
+		return fmt.Sprintf("max(%s)", ms("mysql_global_status_threads_running")), true
+	case "mysql_qps", "mysql_query_rate", "mysql_queries_per_second":
+		return fmt.Sprintf("sum(rate(%s[5m]))", ms("mysql_global_status_questions")), true
+	case "mysql_slow_queries_15m", "mysql_slow_queries":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mysql_global_status_slow_queries")), true
+	case "mysql_aborted_connects_15m", "mysql_connection_errors":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mysql_global_status_aborted_connects")), true
+	case "mysql_innodb_buffer_pool_hit_pct", "mysql_buffer_pool_hit_pct":
+		return fmt.Sprintf("100 * (1 - sum(rate(%s[5m])) / clamp_min(sum(rate(%s[5m])), 1))",
+			ms("mysql_global_status_innodb_buffer_pool_reads"), ms("mysql_global_status_innodb_buffer_pool_read_requests")), true
+	case "mysql_row_lock_waits_15m", "mysql_lock_waits":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mysql_global_status_innodb_row_lock_waits")), true
+	case "mysql_open_files_usage_pct":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("mysql_global_status_open_files"), ms("mysql_global_variables_open_files_limit")), true
+	case "mysql_temp_disk_tables_15m", "mysql_tmp_disk_tables":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mysql_global_status_created_tmp_disk_tables")), true
+	case "postgresql_up", "postgres_up", "pg_up":
+		return fmt.Sprintf("min(%s)", ms("pg_up")), true
+	case "postgresql_connection_usage_pct", "postgres_connection_usage_pct", "pg_connection_usage_pct", "postgresql_connection_pressure":
+		return fmt.Sprintf("100 * sum(%s) / clamp_min(max(%s), 1)",
+			ms("pg_stat_activity_count"), ms("pg_settings_max_connections")), true
+	case "postgresql_deadlocks_15m", "postgres_deadlocks_15m", "pg_deadlocks_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("pg_stat_database_deadlocks")), true
+	case "postgresql_cache_hit_ratio_pct", "postgres_cache_hit_ratio_pct", "pg_cache_hit_ratio_pct":
+		return fmt.Sprintf("100 * sum(rate(%s[5m])) / clamp_min(sum(rate(%s[5m])) + sum(rate(%s[5m])), 1)",
+			ms("pg_stat_database_blks_hit"), ms("pg_stat_database_blks_hit"), ms("pg_stat_database_blks_read")), true
+	case "postgresql_temp_bytes_15m", "postgres_temp_bytes_15m", "pg_temp_bytes_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("pg_stat_database_temp_bytes")), true
+	case "postgresql_replication_lag_seconds", "postgres_replication_lag_seconds", "pg_replication_lag_seconds":
+		return fmt.Sprintf("max(%s)", ms("pg_replication_lag_seconds")), true
+	case "postgresql_long_transaction_seconds", "postgres_long_transaction_seconds", "pg_long_transaction_seconds":
+		return fmt.Sprintf("max(%s)", ms("pg_stat_activity_max_tx_duration")), true
+	case "postgresql_locks_count", "postgres_locks_count", "pg_locks_count":
+		return fmt.Sprintf("sum(%s)", ms("pg_locks_count")), true
+	case "postgresql_database_size_bytes", "postgres_database_size_bytes", "pg_database_size_bytes":
+		return fmt.Sprintf("sum(%s)", ms("pg_database_size_bytes")), true
+	case "postgresql_tps", "postgresql_transactions_per_second", "pg_tps":
+		return fmt.Sprintf("sum(rate(%s[5m])) + sum(rate(%s[5m]))",
+			ms("pg_stat_database_xact_commit"), ms("pg_stat_database_xact_rollback")), true
+	case "redis_up", "redis_liveness":
+		return fmt.Sprintf("min(%s)", ms("redis_up")), true
+	case "redis_memory_usage_pct", "redis_memory_pressure":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("redis_memory_used_bytes"), ms("redis_memory_max_bytes")), true
+	case "redis_client_usage_pct", "redis_client_pressure":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("redis_connected_clients"), ms("redis_config_maxclients")), true
+	case "redis_connected_clients":
+		return fmt.Sprintf("max(%s)", ms("redis_connected_clients")), true
+	case "redis_ops_per_second", "redis_qps", "redis_commands_per_second":
+		return fmt.Sprintf("sum(rate(%s[5m]))", ms("redis_commands_processed_total")), true
+	case "redis_keyspace_hit_ratio_pct", "redis_cache_hit_ratio_pct":
+		return fmt.Sprintf("100 * sum(rate(%s[5m])) / clamp_min(sum(rate(%s[5m])) + sum(rate(%s[5m])), 1)",
+			ms("redis_keyspace_hits_total"), ms("redis_keyspace_hits_total"), ms("redis_keyspace_misses_total")), true
+	case "redis_evicted_keys_15m", "redis_evictions":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("redis_evicted_keys_total")), true
+	case "redis_rejected_connections_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("redis_rejected_connections_total")), true
+	case "redis_blocked_clients":
+		return fmt.Sprintf("max(%s)", ms("redis_blocked_clients")), true
+	case "redis_slowlog_length":
+		return fmt.Sprintf("max(%s)", ms("redis_slowlog_length")), true
+	case "redis_latency_usec", "redis_latency_high":
+		return fmt.Sprintf("max(%s)", ms("redis_latency_percentiles_usec")), true
+	case "mongodb_up", "mongo_up", "mongodb_liveness":
+		return fmt.Sprintf("min(%s)", ms("mongodb_up")), true
+	case "mongodb_connections_current", "mongodb_current_connections":
+		return fmt.Sprintf("max(%s)", metricSelector("mongodb_ss_connections", mergeSelector(selector, `conn_type="current"`))), true
+	case "mongodb_operations_per_second", "mongodb_ops_per_second":
+		return fmt.Sprintf("sum(rate(%s[5m]))", ms("mongodb_ss_opcounters")), true
+	case "mongodb_asserts_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mongodb_ss_asserts")), true
+	case "mongodb_page_faults_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mongodb_ss_extra_info_page_faults")), true
+	case "mongodb_resident_memory_bytes":
+		return fmt.Sprintf("max(%s) * 1024 * 1024", ms("mongodb_ss_mem_resident")), true
+	case "mongodb_wiredtiger_cache_usage_pct", "mongodb_cache_usage_pct":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("mongodb_ss_wt_cache_bytes_currently_in_the_cache"), ms("mongodb_ss_wt_cache_maximum_bytes_configured")), true
+	case "mongodb_wiredtiger_dirty_cache_pct":
+		return fmt.Sprintf("100 * max(%s) / clamp_min(max(%s), 1)",
+			ms("mongodb_ss_wt_cache_tracked_dirty_bytes_in_the_cache"), ms("mongodb_ss_wt_cache_maximum_bytes_configured")), true
+	case "mongodb_operation_latency_ms":
+		return fmt.Sprintf("sum(rate(%s[5m])) / clamp_min(sum(rate(%s[5m])), 1) / 1000",
+			ms("mongodb_ss_opLatencies_latency"), ms("mongodb_ss_opLatencies_ops")), true
+	case "mongodb_collection_scans_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mongodb_ss_metrics_queryExecutor_collectionScans_total")), true
+	case "mongodb_sort_spills_15m", "mongodb_query_sort_spills_15m":
+		return fmt.Sprintf("sum(increase(%s[15m]))", ms("mongodb_ss_metrics_query_sort_spillToDisk")), true
+	default:
+		return "", false
+	}
+}
+
+func normalizeCatalogMetricCode(metric string) string {
+	m := strings.ToLower(strings.TrimSpace(metric))
+	m = strings.ReplaceAll(m, "-", "_")
+	m = strings.ReplaceAll(m, " ", "_")
+	m = strings.ReplaceAll(m, ".", "_")
+	return m
+}
+
+func metricSelector(metric, selector string) string {
+	selector = strings.TrimSpace(selector)
+	selector = strings.TrimPrefix(selector, "{")
+	selector = strings.TrimSuffix(selector, "}")
+	if selector == "" {
+		return metric
+	}
+	return fmt.Sprintf("%s{%s}", metric, selector)
+}
+
+func mergeSelector(a, b string) string {
+	a = strings.TrimSpace(strings.Trim(strings.TrimSpace(a), "{}"))
+	b = strings.TrimSpace(strings.Trim(strings.TrimSpace(b), "{}"))
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + "," + b
+	}
+}
+
+func alertSpecSelector(spec map[string]interface{}) string {
+	if selector, ok := firstSpecString(spec, "selector", "label_selector", "matchers"); ok {
+		return selector
+	}
+	for _, key := range []string{"labels", "match_labels"} {
+		if raw, ok := spec[key]; ok {
+			if selector := selectorFromSpecLabels(raw); selector != "" {
+				return selector
+			}
+		}
+	}
+	return ""
+}
+
+func selectorFromSpecLabels(raw interface{}) string {
+	pairs := map[string]string{}
+	switch labels := raw.(type) {
+	case map[string]string:
+		for k, v := range labels {
+			pairs[k] = v
+		}
+	case map[string]interface{}:
+		for k, v := range labels {
+			if s := alertSpecStringValue(v); s != "" {
+				pairs[k] = s
+			}
+		}
+	default:
+		return ""
+	}
+	keys := make([]string, 0, len(pairs))
+	for k := range pairs {
+		if strings.TrimSpace(k) != "" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf(`%s=%s`, k, strconv.Quote(pairs[k])))
+	}
+	return strings.Join(out, ",")
+}
+
+func firstSpecString(spec map[string]interface{}, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if spec == nil {
+			return "", false
+		}
+		if v, ok := spec[key]; ok {
+			if s := strings.TrimSpace(alertSpecStringValue(v)); s != "" {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}
+
+func alertSpecStringValue(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case fmt.Stringer:
+		return x.String()
+	default:
+		return ""
+	}
+}
+
+func firstSpecNumber(spec map[string]interface{}, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		if spec == nil {
+			return 0, false
+		}
+		if v, ok := spec[key]; ok {
+			switch x := v.(type) {
+			case float64:
+				return x, true
+			case float32:
+				return float64(x), true
+			case int:
+				return float64(x), true
+			case int64:
+				return float64(x), true
+			case int32:
+				return float64(x), true
+			case json.Number:
+				if n, err := x.Float64(); err == nil {
+					return n, true
+				}
+			case string:
+				if n, err := strconv.ParseFloat(strings.TrimSpace(x), 64); err == nil {
+					return n, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func hasAnySpecKey(spec map[string]interface{}, keys ...string) bool {
+	if spec == nil {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := spec[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func setSpecDefaultString(spec map[string]interface{}, key, value string) {
+	if strings.TrimSpace(alertSpecStringValue(spec[key])) == "" {
+		spec[key] = value
+	}
+}
+
+func setSpecDefaultNumber(spec map[string]interface{}, key string, value float64) {
+	if _, ok := firstSpecNumber(spec, key); !ok {
+		spec[key] = value
+	}
+}
+
+func normalizeAlertOperator(op string) string {
+	switch strings.TrimSpace(op) {
+	case ">", ">=", "<", "<=", "==", "!=":
+		return strings.TrimSpace(op)
+	case "=", "eq":
+		return "=="
+	case "gte", "=>":
+		return ">="
+	case "gt":
+		return ">"
+	case "lte", "=<":
+		return "<="
+	case "lt":
+		return "<"
+	case "ne", "neq":
+		return "!="
+	default:
+		return ">"
+	}
+}
+
+func formatAlertFloat(n float64) string {
+	return strconv.FormatFloat(n, 'f', -1, 64)
+}
+
+func defaultAlertScope(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "metric_threshold", "metric_anomaly", "metric_forecast", "log_match", "log_volume":
+		return "host"
+	case "metric_raw", "metric_burn_rate", "trace_latency", "trace_error_rate":
+		return "global"
+	default:
+		return ""
+	}
+}
+
+func rewriteSimpleHostMetricRawExpr(in aiopstools.AlertRuleConfigInput) aiopstools.AlertRuleConfigInput {
+	if len(in.Conditions) > 0 {
+		return in
+	}
+	kind := strings.TrimSpace(in.Kind)
+	if kind != "" && kind != "metric_raw" {
+		return in
+	}
+	expr, ok := alertSpecString(in.Spec, "expr")
+	if !ok {
+		return in
+	}
+	conds, joinMode, ok := parseSimpleHostMetricPredicate(expr)
+	if !ok {
+		return in
+	}
+	in.Kind = "metric_threshold"
+	if joinMode != "" && strings.TrimSpace(in.JoinMode) == "" {
+		in.JoinMode = joinMode
+	}
+	in.Conditions = conds
+	in.Spec = nil
+	return in
+}
+
+func alertSpecString(spec map[string]interface{}, key string) (string, bool) {
+	if spec == nil {
+		return "", false
+	}
+	raw, ok := spec[key]
+	if !ok {
+		return "", false
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", false
+	}
+	value = strings.TrimSpace(value)
+	return value, value != ""
+}
+
+func parseSimpleHostMetricPredicate(expr string) ([]aiopstools.AlertRuleCondition, string, bool) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" || strings.ContainsAny(expr, "{}[]") {
+		return nil, "", false
+	}
+	joinMode := ""
+	joins := simpleHostMetricPredicateJoinRE.FindAllStringSubmatch(expr, -1)
+	if len(joins) > 0 {
+		first := strings.ToLower(joins[0][1])
+		for _, j := range joins[1:] {
+			if strings.ToLower(j[1]) != first {
+				return nil, "", false
+			}
+		}
+		if first == "or" {
+			joinMode = "any"
+		} else {
+			joinMode = "all"
+		}
+	}
+
+	parts := simpleHostMetricPredicateJoinRE.Split(expr, -1)
+	conds := make([]aiopstools.AlertRuleCondition, 0, len(parts))
+	for _, part := range parts {
+		matches := simpleHostMetricPredicatePartRE.FindStringSubmatch(strings.TrimSpace(part))
+		if matches == nil {
+			return nil, "", false
+		}
+		metric := canonicalAlertMetric(matches[1])
+		if !isClosedSetAlertMetric(metric) {
+			return nil, "", false
+		}
+		threshold, err := strconv.ParseFloat(matches[3], 64)
+		if err != nil {
+			return nil, "", false
+		}
+		conds = append(conds, aiopstools.AlertRuleCondition{
+			Metric:    metric,
+			Operator:  matches[2],
+			Threshold: threshold,
+		})
+	}
+	if len(conds) == 0 {
+		return nil, "", false
+	}
+	return conds, joinMode, true
+}
+
+func isClosedSetAlertMetric(metric string) bool {
+	switch metric {
+	case "cpu_pct", "mem_pct", "disk_used_pct", "disk_avail_bytes", "load1", "load5", "load15", "net_rx_bps", "net_tx_bps":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalAlertMetric(metric string) string {
+	m := strings.ToLower(strings.TrimSpace(metric))
+	m = strings.ReplaceAll(m, "-", "_")
+	m = strings.ReplaceAll(m, " ", "_")
+	switch m {
+	case "cpu", "cpu_pct", "cpu_percent", "cpu_percentage", "cpu_usage", "cpu_usage_percent", "cpu_used_percent", "cpu_used_pct", "cpu_util", "cpu_utilization":
+		return "cpu_pct"
+	case "mem", "memory", "mem_pct", "memory_pct", "mem_percent", "memory_percent", "mem_usage", "memory_usage", "mem_usage_percent", "memory_usage_percent", "mem_used_percent", "memory_used_percent":
+		return "mem_pct"
+	case "disk", "disk_pct", "disk_percent", "disk_usage", "disk_usage_percent", "disk_used", "disk_used_percent", "disk_used_pct", "filesystem_usage", "filesystem_used_percent":
+		return "disk_used_pct"
+	case "disk_free", "disk_available", "disk_avail", "disk_available_bytes", "disk_avail_bytes", "filesystem_available", "filesystem_avail_bytes":
+		return "disk_avail_bytes"
+	case "load", "load_1", "load1", "loadavg", "load_avg":
+		return "load1"
+	case "load_5", "load5":
+		return "load5"
+	case "load_15", "load15":
+		return "load15"
+	case "net_rx", "rx", "rx_bps", "network_rx", "network_receive", "network_receive_bps", "network_in", "net_in":
+		return "net_rx_bps"
+	case "net_tx", "tx", "tx_bps", "network_tx", "network_transmit", "network_transmit_bps", "network_out", "net_out":
+		return "net_tx_bps"
+	default:
+		return strings.TrimSpace(metric)
+	}
+}
+
+func suggestedAlertRuleKey(in aiopstools.AlertRuleConfigInput) string {
+	if len(in.Conditions) == 0 {
+		if key := suggestedAlertRuleKeyFromSpec(in); key != "" {
+			return key
+		}
+		return "custom_alert_rule"
+	}
+	metric := canonicalAlertMetric(in.Conditions[0].Metric)
+	switch metric {
+	case "cpu_pct":
+		return "cpu_high"
+	case "mem_pct":
+		return "mem_high"
+	case "disk_used_pct":
+		return "disk_high"
+	case "disk_avail_bytes":
+		return "disk_low_available"
+	case "load1", "load5", "load15":
+		return metric + "_high"
+	case "net_rx_bps":
+		return "network_rx_high"
+	case "net_tx_bps":
+		return "network_tx_high"
+	default:
+		return strings.ToLower(strings.NewReplacer("-", "_", " ", "_").Replace(firstNonEmpty(metric, "custom_alert_rule")))
+	}
+}
+
+func suggestedAlertRuleKeyFromSpec(in aiopstools.AlertRuleConfigInput) string {
+	switch strings.TrimSpace(in.Kind) {
+	case "metric_raw":
+		if metric, ok := firstSpecString(in.Spec, "catalog_metric", "db_metric", "semantic_metric", "metric", "metric_key", "metric_name"); ok {
+			return sanitizeRuleKey(metric)
+		}
+		if expr, ok := alertSpecString(in.Spec, "expr"); ok {
+			if metric := firstPromMetricName(expr); metric != "" {
+				return sanitizeRuleKey(metric)
+			}
+		}
+	case "metric_anomaly", "metric_forecast":
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key"); ok {
+			return sanitizeRuleKey(in.Kind + "_" + metric)
+		}
+	case "metric_burn_rate":
+		return "slo_burn_rate"
+	case "log_match":
+		return "log_match"
+	case "log_volume":
+		return "log_volume"
+	case "trace_latency":
+		if service, ok := firstSpecString(in.Spec, "service"); ok {
+			return sanitizeRuleKey("trace_latency_" + service)
+		}
+		return "trace_latency"
+	case "trace_error_rate":
+		if service, ok := firstSpecString(in.Spec, "service"); ok {
+			return sanitizeRuleKey("trace_error_rate_" + service)
+		}
+		return "trace_error_rate"
+	}
+	return ""
+}
+
+func firstPromMetricName(expr string) string {
+	for _, token := range regexp.MustCompile(`[a-zA-Z_:][a-zA-Z0-9_:]*`).FindAllString(expr, -1) {
+		switch token {
+		case "sum", "avg", "max", "min", "rate", "increase", "clamp_min", "histogram_quantile", "by", "without", "and", "or", "on":
+			continue
+		default:
+			return token
+		}
+	}
+	return ""
+}
+
+func sanitizeRuleKey(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteRune('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "custom_alert_rule"
+	}
+	if len(out) > 64 {
+		out = strings.Trim(out[:64], "_")
+	}
+	if out == "" {
+		return "custom_alert_rule"
+	}
+	return out
+}
+
+func suggestedAlertRuleName(in aiopstools.AlertRuleConfigInput) string {
+	if len(in.Conditions) == 0 {
+		return suggestedAlertRuleNameFromSpec(in)
+	}
+	c := in.Conditions[0]
+	metric := canonicalAlertMetric(c.Metric)
+	threshold := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", c.Threshold), "0"), ".")
+	switch metric {
+	case "cpu_pct":
+		return "CPU > " + threshold + "%"
+	case "mem_pct":
+		return "Memory > " + threshold + "%"
+	case "disk_used_pct":
+		return "Disk usage > " + threshold + "%"
+	case "disk_avail_bytes":
+		return "Disk available " + c.Operator + " " + threshold
+	case "load1", "load5", "load15":
+		return strings.ToUpper(metric) + " " + c.Operator + " " + threshold
+	case "net_rx_bps":
+		return "Network RX " + c.Operator + " " + threshold
+	case "net_tx_bps":
+		return "Network TX " + c.Operator + " " + threshold
+	default:
+		return firstNonEmpty(metric, "Custom alert rule") + " " + c.Operator + " " + threshold
+	}
+}
+
+func suggestedAlertRuleNameFromSpec(in aiopstools.AlertRuleConfigInput) string {
+	switch strings.TrimSpace(in.Kind) {
+	case "metric_raw":
+		if metric, ok := firstSpecString(in.Spec, "catalog_metric", "db_metric", "semantic_metric", "metric", "metric_key", "metric_name"); ok {
+			return "Metric alert: " + metric
+		}
+		return "PromQL alert"
+	case "metric_anomaly":
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key"); ok {
+			return "Metric anomaly: " + metric
+		}
+		return "Metric anomaly alert"
+	case "metric_forecast":
+		if metric, ok := firstSpecString(in.Spec, "metric", "metric_key"); ok {
+			return "Metric forecast: " + metric
+		}
+		return "Metric forecast alert"
+	case "metric_burn_rate":
+		return "SLO burn rate alert"
+	case "log_match":
+		return "Log match alert"
+	case "log_volume":
+		return "Log volume alert"
+	case "trace_latency":
+		if service, ok := firstSpecString(in.Spec, "service"); ok {
+			return "Trace latency: " + service
+		}
+		return "Trace latency alert"
+	case "trace_error_rate":
+		if service, ok := firstSpecString(in.Spec, "service"); ok {
+			return "Trace error rate: " + service
+		}
+		return "Trace error rate alert"
+	default:
+		return "Custom alert rule"
+	}
+}
+
+func suggestedAlertRunbookURL(ruleKey string) string {
+	key := strings.TrimSpace(ruleKey)
+	switch key {
+	case "cpu_high", "mem_high", "disk_high", "load1_high", "load5_high", "load15_high":
+		return "https://github.com/ongridio/vault/blob/main/alerts/host-metrics.md#" + key
+	default:
+		return "https://github.com/ongridio/vault/blob/main/concepts/alerting.md"
+	}
+}
+
+func normalizeConfigAction(action string) (string, error) {
+	a := strings.ToLower(strings.TrimSpace(action))
+	switch a {
+	case "", "create":
+		return "create", nil
+	default:
+		return "", fmt.Errorf("%w: action must be create; v1 only supports creating alert rules", errs.ErrInvalid)
+	}
+}
+
+func toAlertServiceCaller(c aiopstools.ConfigCaller) managersvcalert.Caller {
+	return managersvcalert.Caller{UserID: c.UserID, Role: c.Role}
+}
+
+func alertRuleDraftSummary(action string, in aiopstools.AlertRuleConfigInput) string {
+	name := firstNonEmpty(strings.TrimSpace(in.Name), strings.TrimSpace(in.RuleKey), "new alert rule")
+	return fmt.Sprintf("%s alert rule %q", action, name)
+}
+
+func configRaw(v interface{}) (json.RawMessage, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config payload: %w", err)
+	}
+	return b, nil
+}

--- a/cmd/ongrid/config_tools_adapter_test.go
+++ b/cmd/ongrid/config_tools_adapter_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	aiopstools "github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+)
+
+func TestNormalizeAlertRuleConfigInputCanonicalizesHostMetricAliases(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Conditions: []aiopstools.AlertRuleCondition{
+			{Metric: "cpu_usage_percent", Operator: ">", Threshold: 30},
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_threshold" {
+		t.Fatalf("Kind = %q, want metric_threshold", got.Kind)
+	}
+	if got.ScopeType != "host" {
+		t.Fatalf("ScopeType = %q, want host", got.ScopeType)
+	}
+	if got.Severity != "warning" {
+		t.Fatalf("Severity = %q, want warning", got.Severity)
+	}
+	if got.RuleKey != "cpu_high" {
+		t.Fatalf("RuleKey = %q, want cpu_high", got.RuleKey)
+	}
+	if got.Name != "CPU > 30%" {
+		t.Fatalf("Name = %q, want CPU > 30%%", got.Name)
+	}
+	if got.RunbookURL == "" {
+		t.Fatalf("RunbookURL should be defaulted")
+	}
+	if len(got.Conditions) != 1 {
+		t.Fatalf("conditions = %d, want 1", len(got.Conditions))
+	}
+	cond := got.Conditions[0]
+	if cond.Metric != "cpu_pct" {
+		t.Fatalf("condition metric = %q, want cpu_pct", cond.Metric)
+	}
+	if cond.Window != "5m" {
+		t.Fatalf("condition window = %q, want 5m", cond.Window)
+	}
+	if cond.Aggregator != "avg" {
+		t.Fatalf("condition aggregator = %q, want avg", cond.Aggregator)
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputRewritesSimpleMetricRawExpr(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Kind: "metric_raw",
+		Spec: map[string]interface{}{
+			"expr": "cpu_usage_percent > 30 and disk_used_pct > 50 and mem_pct > 50",
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_threshold" {
+		t.Fatalf("Kind = %q, want metric_threshold", got.Kind)
+	}
+	if got.JoinMode != "all" {
+		t.Fatalf("JoinMode = %q, want all", got.JoinMode)
+	}
+	if got.ScopeType != "host" {
+		t.Fatalf("ScopeType = %q, want host", got.ScopeType)
+	}
+	if got.Spec != nil {
+		t.Fatalf("Spec = %#v, want nil after rewrite", got.Spec)
+	}
+	if len(got.Conditions) != 3 {
+		t.Fatalf("conditions = %d, want 3", len(got.Conditions))
+	}
+	wantMetrics := []string{"cpu_pct", "disk_used_pct", "mem_pct"}
+	for i, want := range wantMetrics {
+		if got.Conditions[i].Metric != want {
+			t.Fatalf("condition[%d].Metric = %q, want %q", i, got.Conditions[i].Metric, want)
+		}
+		if got.Conditions[i].Window != "5m" {
+			t.Fatalf("condition[%d].Window = %q, want 5m", i, got.Conditions[i].Window)
+		}
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputKeepsRealMetricRawPromQL(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Kind: "metric_raw",
+		Spec: map[string]interface{}{
+			"expr": `sum by (device_id) (rate(node_cpu_seconds_total{mode!="idle"}[5m])) > 0.8`,
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_raw" {
+		t.Fatalf("Kind = %q, want metric_raw", got.Kind)
+	}
+	if len(got.Conditions) != 0 {
+		t.Fatalf("conditions = %d, want 0", len(got.Conditions))
+	}
+	if got.Spec["expr"] != in.Spec["expr"] {
+		t.Fatalf("Spec expr changed: %#v", got.Spec)
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputHostMetricSpecBecomesThreshold(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Kind: "metric_raw",
+		Spec: map[string]interface{}{
+			"metric":    "cpu",
+			"operator":  ">",
+			"threshold": 90,
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_threshold" {
+		t.Fatalf("Kind = %q, want metric_threshold", got.Kind)
+	}
+	if got.Spec != nil {
+		t.Fatalf("Spec = %#v, want nil", got.Spec)
+	}
+	if len(got.Conditions) != 1 || got.Conditions[0].Metric != "cpu_pct" {
+		t.Fatalf("Conditions = %#v, want cpu_pct threshold condition", got.Conditions)
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputExpandsDatabaseCatalogMetric(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Kind: "metric_raw",
+		Spec: map[string]interface{}{
+			"catalog_metric": "redis_memory_usage_pct",
+			"operator":       ">",
+			"threshold":      80,
+			"labels": map[string]interface{}{
+				"device_id": "7",
+			},
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	expr, _ := got.Spec["expr"].(string)
+	for _, want := range []string{
+		"redis_memory_used_bytes{device_id=\"7\"}",
+		"redis_memory_max_bytes{device_id=\"7\"}",
+		"> 80",
+	} {
+		if !strings.Contains(expr, want) {
+			t.Fatalf("expr = %q, want to contain %q", expr, want)
+		}
+	}
+	if got.Kind != "metric_raw" {
+		t.Fatalf("Kind = %q, want metric_raw", got.Kind)
+	}
+	if got.ScopeType != "global" {
+		t.Fatalf("ScopeType = %q, want global", got.ScopeType)
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputBuildsRawPredicateForCollectedMetricName(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Spec: map[string]interface{}{
+			"metric":    "custom_app_queue_depth",
+			"operator":  ">=",
+			"threshold": "100",
+			"selector":  `job="worker"`,
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_raw" {
+		t.Fatalf("Kind = %q, want metric_raw", got.Kind)
+	}
+	expr, _ := got.Spec["expr"].(string)
+	if expr != `(custom_app_queue_depth{job="worker"}) >= 100` {
+		t.Fatalf("expr = %q, want raw metric predicate", expr)
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputDoesNotInventExprForInvalidMetricName(t *testing.T) {
+	in := aiopstools.AlertRuleConfigInput{
+		Kind: "metric_raw",
+		Spec: map[string]interface{}{
+			"metric":    "not a valid metric()",
+			"operator":  ">",
+			"threshold": 1,
+		},
+	}
+
+	got := normalizeAlertRuleConfigInput(in)
+	if got.Kind != "metric_raw" {
+		t.Fatalf("Kind = %q, want metric_raw", got.Kind)
+	}
+	if expr, ok := got.Spec["expr"].(string); ok && expr != "" {
+		t.Fatalf("expr = %q, want no invented PromQL for invalid metric name", expr)
+	}
+}
+
+func TestDatabaseAlertMetricExprCoversSupportedCatalogMetrics(t *testing.T) {
+	catalogMetrics := []string{
+		"mysql_up",
+		"mysql_connection_usage_pct",
+		"mysql_threads_running",
+		"mysql_qps",
+		"mysql_slow_queries_15m",
+		"mysql_aborted_connects_15m",
+		"mysql_innodb_buffer_pool_hit_pct",
+		"mysql_row_lock_waits_15m",
+		"mysql_open_files_usage_pct",
+		"mysql_temp_disk_tables_15m",
+		"postgresql_up",
+		"postgresql_connection_usage_pct",
+		"postgresql_deadlocks_15m",
+		"postgresql_cache_hit_ratio_pct",
+		"postgresql_temp_bytes_15m",
+		"postgresql_replication_lag_seconds",
+		"postgresql_long_transaction_seconds",
+		"postgresql_locks_count",
+		"postgresql_database_size_bytes",
+		"postgresql_tps",
+		"redis_up",
+		"redis_memory_usage_pct",
+		"redis_client_usage_pct",
+		"redis_connected_clients",
+		"redis_ops_per_second",
+		"redis_keyspace_hit_ratio_pct",
+		"redis_evicted_keys_15m",
+		"redis_rejected_connections_15m",
+		"redis_blocked_clients",
+		"redis_slowlog_length",
+		"redis_latency_usec",
+		"mongodb_up",
+		"mongodb_connections_current",
+		"mongodb_operations_per_second",
+		"mongodb_asserts_15m",
+		"mongodb_page_faults_15m",
+		"mongodb_resident_memory_bytes",
+		"mongodb_wiredtiger_cache_usage_pct",
+		"mongodb_wiredtiger_dirty_cache_pct",
+		"mongodb_operation_latency_ms",
+		"mongodb_collection_scans_15m",
+		"mongodb_sort_spills_15m",
+	}
+
+	for _, metric := range catalogMetrics {
+		t.Run(metric, func(t *testing.T) {
+			expr, ok := databaseAlertMetricExpr(metric, `device_id="db-1"`)
+			if !ok {
+				t.Fatalf("databaseAlertMetricExpr(%q) ok = false, want true", metric)
+			}
+			if !strings.Contains(expr, `device_id="db-1"`) {
+				t.Fatalf("expr = %q, want selector propagated", expr)
+			}
+		})
+	}
+}
+
+func TestNormalizeAlertRuleConfigInputDefaultsAllSupportedKinds(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     aiopstools.AlertRuleConfigInput
+		assert func(t *testing.T, got aiopstools.AlertRuleConfigInput)
+	}{
+		{
+			name: "metric_anomaly",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "anomaly",
+				Spec: map[string]interface{}{"metric": "memory"},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Kind != "metric_anomaly" || got.Spec["metric"] != "mem_pct" || got.Spec["method"] != "zscore" || got.Spec["baseline_window"] != "1h" {
+					t.Fatalf("got = %#v, want canonical metric_anomaly defaults", got)
+				}
+			},
+		},
+		{
+			name: "metric_forecast",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "forecast",
+				Spec: map[string]interface{}{"metric": "disk_available"},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Kind != "metric_forecast" || got.Spec["metric"] != "disk_avail_bytes" || got.Spec["fit_window"] != "1h" || got.Spec["operator"] != "<=" {
+					t.Fatalf("got = %#v, want metric_forecast defaults", got)
+				}
+				if got.Spec["predict_seconds"] != float64(21600) {
+					t.Fatalf("predict_seconds = %#v, want 21600", got.Spec["predict_seconds"])
+				}
+			},
+		},
+		{
+			name: "metric_burn_rate",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "burn_rate",
+				Spec: map[string]interface{}{"sli": `sum(rate(http_requests_total{code!~"5.."}[$window])) / sum(rate(http_requests_total[$window]))`},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				burns, ok := got.Spec["burns"].([]interface{})
+				if got.Kind != "metric_burn_rate" || got.Spec["slo"] != float64(99.9) || !ok || len(burns) != 2 {
+					t.Fatalf("got = %#v, want metric_burn_rate defaults", got)
+				}
+			},
+		},
+		{
+			name: "log_match",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "log",
+				Spec: map[string]interface{}{"pattern": "(?i)error|panic"},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Kind != "log_match" || got.Spec["line_filter"] != "(?i)error|panic" || got.Spec["operator"] != ">=" || got.Spec["threshold"] != float64(1) {
+					t.Fatalf("got = %#v, want log_match defaults", got)
+				}
+			},
+		},
+		{
+			name: "log_volume",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "log_volume",
+				Spec: map[string]interface{}{"operator": ">", "threshold": 3},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Spec["ratio_op"] != ">" || got.Spec["ratio_threshold"] != float64(3) {
+					t.Fatalf("got = %#v, want log_volume ratio aliases", got)
+				}
+			},
+		},
+		{
+			name: "trace_latency",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "latency",
+				Spec: map[string]interface{}{"service": "checkout", "threshold": 750},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Kind != "trace_latency" || got.Spec["threshold_ms"] != float64(750) || got.Spec["quantile"] != "p95" {
+					t.Fatalf("got = %#v, want trace_latency defaults", got)
+				}
+			},
+		},
+		{
+			name: "trace_error_rate",
+			in: aiopstools.AlertRuleConfigInput{
+				Kind: "error_rate",
+				Spec: map[string]interface{}{"service": "checkout", "threshold": 2.5},
+			},
+			assert: func(t *testing.T, got aiopstools.AlertRuleConfigInput) {
+				if got.Kind != "trace_error_rate" || got.Spec["threshold_pct"] != 2.5 || got.Spec["operator"] != ">=" {
+					t.Fatalf("got = %#v, want trace_error_rate defaults", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeAlertRuleConfigInput(tt.in)
+			tt.assert(t, got)
+			if got.RuleKey == "" {
+				t.Fatalf("RuleKey should be defaulted")
+			}
+			if got.Name == "" {
+				t.Fatalf("Name should be defaulted")
+			}
+			if got.RunbookURL == "" {
+				t.Fatalf("RunbookURL should be defaulted")
+			}
+		})
+	}
+}

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1046,6 +1046,31 @@ func main() {
 	)
 	webshellHandler.SetAuthz(authzMW)
 
+	alertSvc := managersvcalert.New(alertUC, alertRepo, notifyRouter, log.With(slog.String("comp", "alert-svc")))
+	// Wire the read-only preview clients (Prom range + Loki range). Each
+	// is optional — when nil, the corresponding kind returns skipped_reason
+	// instead of a hard error. Built before the AIOps runtime so
+	// conversational draft tools can reuse the same service path.
+	{
+		previewDeps := managerbizalert.PreviewDeps{}
+		if promQueryClient != nil {
+			previewDeps.Prom = promQueryClient
+		}
+		if cfg.Logs.URL != "" {
+			previewDeps.Log = pkglogquery.New(cfg.Logs.URL, log.With(slog.String("comp", "alert-preview-log")))
+		}
+		alertSvc.SetPreviewDeps(previewDeps)
+	}
+
+	// IM bridge admin repo/UC is needed by Settings -> Channels HTTP handlers.
+	// The runtime-facing Bridge service still wires later, after aiopsSvc
+	// exists.
+	if err := managerimbridgedata.Migrate(db); err != nil {
+		log.Error("imbridge: migrate failed", slog.Any("err", err))
+	}
+	imbridgeRepo := managerimbridgedata.New(db)
+	imbridgeUC := managerbizimbridge.NewUC(imbridgeRepo)
+
 	// manager/aiops biz + service + server.
 	//
 	// BudgetChecker wiring: cfg.LLM.DailyTokenLimit (ONGRID_LLM_DAILY_TOKEN_LIMIT,
@@ -1073,6 +1098,7 @@ func main() {
 	}
 	toolsReg := aiopstools.NewRegistry(fbClient, edgeUC, deviceUC, promQuerier, logQuerier, traceQuerier, alertUC, log)
 	toolsReg.SetPluginConfigLister(pluginConfigUC)
+	toolsReg.SetConfigManager(newChatConfigAdapter(alertSvc))
 	// query_change_events (HLD-013 Phase 2) — RCA "what changed near T".
 	// *audit.Usecase satisfies aiopstools.AuditLister via ListChanges.
 	toolsReg.SetAuditLister(auditUC)
@@ -1315,16 +1341,11 @@ func main() {
 	// group; signature verification is enforced inside the handler.
 	// Threads map to ongrid chat_sessions owned by a service-account
 	// user — S3 will replace that with per-IM-user binding.
-	if err := managerimbridgedata.Migrate(db); err != nil {
-		log.Error("imbridge: migrate failed", slog.Any("err", err))
-	}
-	imbridgeRepo := managerimbridgedata.New(db)
 	// Service-account user_id: superuser admin (id=1 on every install
 	// thanks to bootstrap). Future: take from cfg.
 	const imBridgeServiceUserID uint64 = 1
 	imbridgeAgentAdapter := managerbizimbridge.NewAiopsAdapter(aiopsSvc, imBridgeServiceUserID, llmSettingsResolver, log)
 	imbridgeSvc := managerbizimbridge.NewBridge(imbridgeRepo, imbridgeAgentAdapter, imBridgeServiceUserID, log)
-	imbridgeUC := managerbizimbridge.NewUC(imbridgeRepo)
 	imbridgeHandler := managerserverimbridge.NewHandler(imbridgeSvc, imbridgeRepo, imbridgeUC, log)
 
 	// Stream supervisor: long-connection mode. Runs one
@@ -1572,20 +1593,6 @@ func main() {
 		}()
 	}
 
-	alertSvc := managersvcalert.New(alertUC, alertRepo, notifyRouter, log.With(slog.String("comp", "alert-svc")))
-	// Wire the read-only preview clients (Prom range + Loki range). Each
-	// is optional — when nil, the corresponding kind returns
-	// skipped_reason instead of a hard error.
-	{
-		previewDeps := managerbizalert.PreviewDeps{}
-		if promQueryClient != nil {
-			previewDeps.Prom = promQueryClient
-		}
-		if cfg.Logs.URL != "" {
-			previewDeps.Log = pkglogquery.New(cfg.Logs.URL, log.With(slog.String("comp", "alert-preview-log")))
-		}
-		alertSvc.SetPreviewDeps(previewDeps)
-	}
 	alertHandler := managerserveralert.NewHandler(alertSvc, alertSvc, alertSvc).
 		WithInvestigations(manageralertdata.NewInvestigationRepo(db)).
 		WithRuntime(cfg.Alert.EvaluatorInterval, cfg.Alert.Cooldown)
@@ -2546,6 +2553,8 @@ var coordinatorToolNames = []string{
 	"list_repo_sources",
 	"read_source",
 	"grep_source",
+	"draft_config_change",
+	"apply_config_change",
 }
 
 // Heavy on parameters because every dep flows through this site
@@ -2753,9 +2762,12 @@ func buildAIOpsRuntime(
 		SystemPrompt: strings.TrimSpace(`
 你是 ongrid 的 AIOps 协调员。你的本职是**判断派给谁 / 直接知识答 / 直接拒绝**，不亲自做深度数据查询。
 
-你手上能用的工具就是当前 toolBag 里显式注册的那几个（query_devices / query_incidents / get_topology / list_database_sources / analyze_database_status / query_knowledge / search_web 这类轻量定位 + 知识工具，list_repo_sources / read_source / grep_source 这三个只读读码工具，加上 AgentTool 这个派活工具）。**不要尝试调用任何没有在 schema 中提供的工具名**——深度的实时集群数据查询（promql / logql / host_*）被设计成只在 specialist 手上；数据库状态、明确类型的库/表/集合/key 数量、集群/复制、可选高级 collector、指标覆盖和性能总览，只要 MySQL / PostgreSQL / Redis / MongoDB exporter 可能覆盖，统一先用 analyze_database_status；纯配置/资产问题，比如"我有多少数据库 / 配置了哪些采集源 / 采集源在哪个设备 / 我的数据库在哪台设备 / 来源插件关系 / 采集源数量"，用 list_database_sources。
+你手上能用的工具就是当前 toolBag 里显式注册的那几个（query_devices / query_incidents / get_topology / list_database_sources / analyze_database_status / query_knowledge / search_web 这类轻量定位 + 知识工具，list_repo_sources / read_source / grep_source 这三个只读读码工具，draft_config_change / apply_config_change 配置工具，加上 AgentTool 这个派活工具）。**不要尝试调用任何没有在 schema 中提供的工具名**——深度的实时集群数据查询（promql / logql / host_*）被设计成只在 specialist 手上；数据库状态、明确类型的库/表/集合/key 数量、集群/复制、可选高级 collector、指标覆盖和性能总览，只要 MySQL / PostgreSQL / Redis / MongoDB exporter 可能覆盖，统一先用 analyze_database_status；纯配置/资产问题，比如"我有多少数据库 / 配置了哪些采集源 / 采集源在哪个设备 / 我的数据库在哪台设备 / 来源插件关系 / 采集源数量"，用 list_database_sources。
+
+最高优先级例外：用户要求"配置 / 创建 / 新增"告警规则时，这是**对话式配置**，不是知识问答、不是源码问题、不是排障。只允许调用 draft_config_change 或 apply_config_change；domain 必须是 alert_rule，action 必须是 create。不要 query_knowledge，不要 list_repo_sources/read_source/grep_source，不要 AgentTool。draft_config_change 一旦成功返回 config_draft，立刻停止工具调用，用最终回答概括草案并等待用户点确认/取消；同一轮绝不第二次调用 draft_config_change。创建告警规则支持现有所有 rule kind：metric_threshold / metric_raw / metric_anomaly / metric_forecast / metric_burn_rate / log_match / log_volume / trace_latency / trace_error_rate。host 简单阈值用 metric_threshold 的 closed-set 指标；数据库、自定义采集和其它真实 Prometheus 指标用 metric_raw，必须把完整 PromQL predicate 或 catalog_metric/metric+operator+threshold 交给工具 preview。缺少可自动默认的字段时用合理默认值，不要反复查资料。用户要求更新/启用/禁用/删除告警规则，或配置通知渠道、IM bot、LLM 模型集成时，直接说明 v1 暂只支持自然语言创建告警规则。
 
 工作流程：
+  0. 对话式配置（自然语言创建告警规则）→ 直接调用 draft_config_change，并设置 domain=alert_rule、action=create；draft 成功后马上最终回答，不再调用任何工具。用户确认后才调用 apply_config_change，并传 confirmed=true、domain=alert_rule、action=create 和草案 payload。自然语言创建规则支持当前所有创建方式；数据库 / custommetrics / 任意已采集 Prometheus 指标用 metric_raw，不要塞进 metric_threshold。通知渠道、IM bot、LLM 模型集成，以及更新/启用/禁用/删除告警规则不属于 v1，直接说明暂不支持。
   1. 用户问运维 / 排查 / 性能 / 资源 / 告警 / 健康 类问题 → 用 AgentTool 派给对应 specialist（**你的本职就是这一步**）
   2. 用户问"X 怎么做 / Y 怎么排查"类知识题 → query_knowledge 一次拉 KB，然后基于 playbook 回答
   2b. 用户问源码 / 某文件某行 / 函数或类型定义 / 把告警·日志里的 file:line·栈关联到代码 → 直接用 grep_source（搜函数名·报错串）/ read_source（读文件或行区间）/ list_repo_sources（看仓库结构）回答。这是只读查询，和 query_knowledge 一样是你自己能做的，**不要为读代码去派 specialist**。repo 参数用仓库名子串（如 "geminio"）。**做逻辑探查**：定位到一段代码后，顺着它调用的函数 / 引用的类型 / 报错分支继续 grep + read 逐层跟读，理清「输入怎么流到这、为什么走到这个分支」再下结论，别只读一处。
@@ -2889,7 +2901,7 @@ func ongridBasePrompt() string {
 
 1. **专家派活是第一选择**（看用户问题前先想这一步）。Ongrid 有 5 个 specialist worker，每个 toolBag 都比你裁剪过、推理更聚焦。**只要用户的问题落入任一专家域——不管单域还是跨域——必须用 ` + bt + `AgentTool` + bt + ` 派给 specialist，而不是自己一路 query_***。"单域问题我自己也能搞定"是错觉，是被监控的反模式。
 
-   **触发条件**（命中即派，不要犹豫；不要先自己跑工具"探探"再决定）：
+   **触发条件**（命中即派，不要犹豫；不要先自己跑工具"探探"再决定）。但"配置/创建/新增告警规则"是对话式配置例外，即使句子里出现 CPU / 内存 / 数据库 / 日志 / 链路 / 告警 / 配置，也不要派 specialist，直接走 draft_config_change。创建规则支持现有全部 rule kind；host closed-set 用 metric_threshold，数据库 / custommetrics / 其它已采集 Prometheus 指标用 metric_raw。更新/启用/禁用/删除告警规则，或配置通知渠道、IM bot、LLM 模型集成不属于 v1，直接说明暂不支持：
 
    | 用户话里出现 | 派给 |
    |---|---|
@@ -2920,6 +2932,7 @@ func ongridBasePrompt() string {
    prompt 必须自包含（worker 看不到你的对话）。description 是给人看的一句话摘要。
 
    **不要派 AgentTool 的边界**——仅限以下场景：
+   - 对话式配置（自然语言创建告警规则）→ 直接 draft_config_change，不派专家、不查 KB、不读代码；数据库 / custommetrics / 任意已采集 Prometheus 指标用 metric_raw；其他配置类需求说明 v1 暂不支持
    - 单一已知数据点的事实查询（"device 3 现在 CPU 多少" / "ongrid 集群有几台 device"）→ 直接调对应工具
    - 知识库 / 文档查询（"OOM 怎么排查"）→ 直接 query_knowledge
    - 不存在的设备 / 模糊澄清 → 先 query_devices 或问用户
@@ -2962,6 +2975,8 @@ func ongridBasePrompt() string {
     - 未命中再走通用诊断或调实时数据工具
     - query 用自然语言整句即可（不必拆词，向量检索喜欢完整语义）
     - 同一会话同一主题只查一次 KB；KB 已答过的话题不要重复查
+
+    **RAG-first 例外**：用户是在要求创建告警规则时，不要 query_knowledge；直接按对话式配置规则调用 ` + bt + `draft_config_change` + bt + `，成功后停止工具调用并等待确认。创建规则支持现有全部 rule kind；host closed-set 用 metric_threshold，数据库 / custommetrics / 其它已采集 Prometheus 指标用 metric_raw。更新/启用/禁用/删除告警规则，或配置通知渠道、IM bot、LLM 模型集成时，直接说明 v1 暂不支持。
 `)
 }
 

--- a/internal/manager/biz/aiops/tools/config_tools.go
+++ b/internal/manager/biz/aiops/tools/config_tools.go
@@ -1,0 +1,454 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+const (
+	ToolNameDraftConfigChange = "draft_config_change"
+	ToolNameApplyConfigChange = "apply_config_change"
+)
+
+const (
+	ConfigDomainAlertRule = "alert_rule"
+	ConfigResultKindDraft = "config_draft"
+	ConfigResultKindApply = "config_apply_result"
+)
+
+// ConfigCaller is the caller identity the config tools hand to the cmd-layer
+// adapter. The adapter enforces admin-only writes using the same role model as
+// the Alerts HTTP handlers.
+type ConfigCaller struct {
+	UserID      uint64
+	Role        string
+	IsSuperuser bool
+}
+
+// ConfigManager is the consumer-owned seam for conversational alert rule
+// creation. The tools package owns JSON schema + tool gating; cmd/ongrid owns
+// mapping to the existing alert service.
+type ConfigManager interface {
+	DraftAlertRuleConfig(ctx context.Context, caller ConfigCaller, in AlertRuleConfigArgs) (*ConfigDraft, error)
+	ApplyAlertRuleConfig(ctx context.Context, caller ConfigCaller, in AlertRuleApplyArgs) (*ConfigApplyResult, error)
+}
+
+type ConfigChangeDraftArgs struct {
+	Domain          string               `json:"domain"`
+	Action          string               `json:"action"`
+	LookbackSeconds int                  `json:"lookback_seconds,omitempty"`
+	Rule            AlertRuleConfigInput `json:"rule,omitempty"`
+}
+
+type ConfigChangeApplyArgs struct {
+	Domain           string               `json:"domain"`
+	Action           string               `json:"action"`
+	Rule             AlertRuleConfigInput `json:"rule,omitempty"`
+	Payload          json.RawMessage      `json:"payload,omitempty"`
+	Confirmed        bool                 `json:"confirmed"`
+	ConfirmationText string               `json:"confirmation_text,omitempty"`
+}
+
+type ConfigTarget struct {
+	ID       uint64 `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Existing bool   `json:"existing,omitempty"`
+}
+
+type ConfigDraft struct {
+	Kind      string          `json:"kind"`
+	Domain    string          `json:"domain"`
+	Action    string          `json:"action"`
+	Summary   string          `json:"summary"`
+	Target    *ConfigTarget   `json:"target,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Preview   json.RawMessage `json:"preview,omitempty"`
+	Diff      json.RawMessage `json:"diff,omitempty"`
+	Warnings  []string        `json:"warnings,omitempty"`
+	Rollback  string          `json:"rollback,omitempty"`
+	ApplyTool string          `json:"apply_tool"`
+}
+
+type ConfigApplyResult struct {
+	Kind       string        `json:"kind"`
+	Domain     string        `json:"domain"`
+	Action     string        `json:"action"`
+	Status     string        `json:"status"`
+	ResourceID uint64        `json:"resource_id,omitempty"`
+	Resource   *ConfigTarget `json:"resource,omitempty"`
+	Message    string        `json:"message,omitempty"`
+	Rollback   string        `json:"rollback,omitempty"`
+}
+
+type AlertRuleConfigArgs struct {
+	Action          string               `json:"action"`
+	LookbackSeconds int                  `json:"lookback_seconds,omitempty"`
+	Rule            AlertRuleConfigInput `json:"rule,omitempty"`
+}
+
+type AlertRuleApplyArgs struct {
+	Action           string               `json:"action"`
+	Rule             AlertRuleConfigInput `json:"rule,omitempty"`
+	Confirmed        bool                 `json:"confirmed"`
+	ConfirmationText string               `json:"confirmation_text,omitempty"`
+}
+
+type AlertRuleConfigInput struct {
+	RuleKey             string                 `json:"rule_key,omitempty"`
+	Kind                string                 `json:"kind,omitempty"`
+	Name                string                 `json:"name,omitempty"`
+	ScopeType           string                 `json:"scope_type,omitempty"`
+	JoinMode            string                 `json:"join_mode,omitempty"`
+	Severity            string                 `json:"severity,omitempty"`
+	Enabled             *bool                  `json:"enabled,omitempty"`
+	Conditions          []AlertRuleCondition   `json:"conditions,omitempty"`
+	Spec                map[string]interface{} `json:"spec,omitempty"`
+	Labels              map[string]string      `json:"labels,omitempty"`
+	RunbookURL          string                 `json:"runbook_url,omitempty"`
+	NotifyChannelIDs    []uint64               `json:"notify_channel_ids,omitempty"`
+	NotifyWindowSeconds int                    `json:"notify_window_seconds,omitempty"`
+	NotifyMinFires      int                    `json:"notify_min_fires,omitempty"`
+}
+
+type AlertRuleCondition struct {
+	Metric     string  `json:"metric"`
+	Operator   string  `json:"operator"`
+	Threshold  float64 `json:"threshold"`
+	Window     string  `json:"window,omitempty"`
+	For        string  `json:"for,omitempty"`
+	Aggregator string  `json:"aggregator,omitempty"`
+}
+
+type configToolKind string
+
+const (
+	configToolDraftChange configToolKind = "draft_change"
+	configToolApplyChange configToolKind = "apply_change"
+)
+
+type ConfigTool struct {
+	kind    configToolKind
+	manager ConfigManager
+	log     *slog.Logger
+}
+
+func NewDraftConfigChangeTool(manager ConfigManager, log *slog.Logger) *ConfigTool {
+	return newConfigTool(configToolDraftChange, manager, log)
+}
+
+func NewApplyConfigChangeTool(manager ConfigManager, log *slog.Logger) *ConfigTool {
+	return newConfigTool(configToolApplyChange, manager, log)
+}
+
+func newConfigTool(kind configToolKind, manager ConfigManager, log *slog.Logger) *ConfigTool {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ConfigTool{kind: kind, manager: manager, log: log}
+}
+
+func (t *ConfigTool) Info(_ context.Context) (*basetool.ToolInfo, error) {
+	switch t.kind {
+	case configToolDraftChange:
+		return &basetool.ToolInfo{
+			Name:        ToolNameDraftConfigChange,
+			Description: "Create a read-only configuration draft for a new alert rule across all supported alert rule kinds. It never persists business config.",
+			WhenToUse:   "Use directly when the user asks to configure, create, or add an alert rule from natural language. Only domain=alert_rule and action=create are supported. Supports metric_threshold, metric_raw, metric_anomaly, metric_forecast, metric_burn_rate, log_match, log_volume, trace_latency, and trace_error_rate. Use metric_threshold only for the host closed-set metrics; use metric_raw for database, custom, or arbitrary collected Prometheus metrics. Do not call query_knowledge, code tools, or AgentTool first for alert-rule creation requests. After one successful config_draft, stop tool calls and ask the user to confirm or cancel; do not call this tool again in the same turn.",
+			Parameters:  draftConfigChangeSchema,
+			Class:       "read",
+		}, nil
+	case configToolApplyChange:
+		return &basetool.ToolInfo{
+			Name:        ToolNameApplyConfigChange,
+			Description: "Apply a previously confirmed new alert-rule configuration draft.",
+			WhenToUse:   "MUTATING. Use only after the user explicitly confirms an alert-rule config_draft. Requires confirmed=true, an admin caller, domain=alert_rule, action=create, and the payload from the draft.",
+			Parameters:  applyConfigChangeSchema,
+			Class:       "write",
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown config tool kind %q", t.kind)
+	}
+}
+
+func (t *ConfigTool) InvokableRun(ctx context.Context, argsJSON string, opts ...basetool.InvokeOption) (string, error) {
+	if t.manager == nil {
+		return "", fmt.Errorf("config tool: manager not configured")
+	}
+	caller := configCallerFromContext(ctx, opts)
+	switch t.kind {
+	case configToolDraftChange:
+		var in ConfigChangeDraftArgs
+		if err := json.Unmarshal([]byte(argsJSON), &in); err != nil {
+			return "", fmt.Errorf("%s: bad args: %w", ToolNameDraftConfigChange, err)
+		}
+		out, err := t.draftConfigChange(ctx, caller, in)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", ToolNameDraftConfigChange, err)
+		}
+		return marshalConfigToolResult(out)
+	case configToolApplyChange:
+		var in ConfigChangeApplyArgs
+		if err := json.Unmarshal([]byte(argsJSON), &in); err != nil {
+			return "", fmt.Errorf("%s: bad args: %w", ToolNameApplyConfigChange, err)
+		}
+		if err := validateApplyGate(caller, in.Confirmed); err != nil {
+			return "", fmt.Errorf("%s: %w", ToolNameApplyConfigChange, err)
+		}
+		if err := in.applyPayloadDefaults(); err != nil {
+			return "", fmt.Errorf("%s: %w", ToolNameApplyConfigChange, err)
+		}
+		out, err := t.applyConfigChange(ctx, caller, in)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", ToolNameApplyConfigChange, err)
+		}
+		return marshalConfigToolResult(out)
+	default:
+		return "", fmt.Errorf("unknown config tool kind %q", t.kind)
+	}
+}
+
+func (t *ConfigTool) draftConfigChange(ctx context.Context, caller ConfigCaller, in ConfigChangeDraftArgs) (*ConfigDraft, error) {
+	if _, err := normalizeConfigDomain(in.Domain); err != nil {
+		return nil, err
+	}
+	action, err := normalizeConfigCreateAction(in.Action)
+	if err != nil {
+		return nil, err
+	}
+	return t.manager.DraftAlertRuleConfig(ctx, caller, AlertRuleConfigArgs{
+		Action:          action,
+		LookbackSeconds: in.LookbackSeconds,
+		Rule:            in.Rule,
+	})
+}
+
+func (t *ConfigTool) applyConfigChange(ctx context.Context, caller ConfigCaller, in ConfigChangeApplyArgs) (*ConfigApplyResult, error) {
+	if _, err := normalizeConfigDomain(in.Domain); err != nil {
+		return nil, err
+	}
+	action, err := normalizeConfigCreateAction(in.Action)
+	if err != nil {
+		return nil, err
+	}
+	return t.manager.ApplyAlertRuleConfig(ctx, caller, AlertRuleApplyArgs{
+		Action:           action,
+		Rule:             in.Rule,
+		Confirmed:        in.Confirmed,
+		ConfirmationText: in.ConfirmationText,
+	})
+}
+
+func configCallerFromContext(ctx context.Context, opts []basetool.InvokeOption) ConfigCaller {
+	resolved := basetool.ResolveOptions(opts)
+	caller := ConfigCaller{UserID: resolved.UserID}
+	if t, ok := tenantctx.From(ctx); ok {
+		caller.UserID = t.UserID
+		caller.Role = t.Role
+		caller.IsSuperuser = t.IsSuperuser
+	}
+	return caller
+}
+
+func validateApplyGate(caller ConfigCaller, confirmed bool) error {
+	if !confirmed {
+		return fmt.Errorf("%w: confirmed=true required before applying a configuration draft", errs.ErrInvalid)
+	}
+	if caller.Role != "admin" && !caller.IsSuperuser {
+		return fmt.Errorf("%w: admin role required to apply configuration", errs.ErrForbidden)
+	}
+	return nil
+}
+
+func normalizeConfigDomain(domain string) (string, error) {
+	d := strings.ToLower(strings.TrimSpace(domain))
+	switch d {
+	case ConfigDomainAlertRule, "alert", "alert_rule_config":
+		return ConfigDomainAlertRule, nil
+	default:
+		return "", fmt.Errorf("%w: domain must be alert_rule; v1 only supports creating alert rules", errs.ErrInvalid)
+	}
+}
+
+func normalizeConfigCreateAction(action string) (string, error) {
+	a := strings.ToLower(strings.TrimSpace(action))
+	switch a {
+	case "", "create":
+		return "create", nil
+	default:
+		return "", fmt.Errorf("%w: action must be create; v1 only supports creating alert rules", errs.ErrInvalid)
+	}
+}
+
+func (in *ConfigChangeApplyArgs) applyPayloadDefaults() error {
+	if len(in.Payload) == 0 {
+		return nil
+	}
+	var payload struct {
+		Action string               `json:"action"`
+		Rule   AlertRuleConfigInput `json:"rule,omitempty"`
+	}
+	if err := json.Unmarshal(in.Payload, &payload); err != nil {
+		return fmt.Errorf("bad draft payload: %w", err)
+	}
+	if in.Action == "" {
+		in.Action = payload.Action
+	}
+	if isZeroAlertRuleInput(in.Rule) {
+		in.Rule = payload.Rule
+	}
+	return nil
+}
+
+func isZeroAlertRuleInput(in AlertRuleConfigInput) bool {
+	return in.RuleKey == "" &&
+		in.Kind == "" &&
+		in.Name == "" &&
+		in.ScopeType == "" &&
+		in.JoinMode == "" &&
+		in.Severity == "" &&
+		in.Enabled == nil &&
+		len(in.Conditions) == 0 &&
+		len(in.Spec) == 0 &&
+		len(in.Labels) == 0 &&
+		in.RunbookURL == "" &&
+		len(in.NotifyChannelIDs) == 0 &&
+		in.NotifyWindowSeconds == 0 &&
+		in.NotifyMinFires == 0
+}
+
+func marshalConfigToolResult(v interface{}) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal config result: %w", err)
+	}
+	var decoded interface{}
+	if err := json.Unmarshal(b, &decoded); err == nil {
+		scrubConfigSecrets(decoded)
+		b, err = json.Marshal(decoded)
+		if err != nil {
+			return "", fmt.Errorf("marshal scrubbed config result: %w", err)
+		}
+	}
+	return string(b), nil
+}
+
+func scrubConfigSecrets(v interface{}) {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		for k, value := range x {
+			if isSensitiveConfigKey(k) {
+				if s, ok := value.(string); ok && s != "" {
+					x[k] = "******"
+					continue
+				}
+			}
+			scrubConfigSecrets(value)
+		}
+	case []interface{}:
+		for _, item := range x {
+			scrubConfigSecrets(item)
+		}
+	}
+}
+
+func isSensitiveConfigKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	switch k {
+	case "secret", "app_secret", "verify_token", "encrypt_key", "token", "password", "api_key", "apikey":
+		return true
+	default:
+		return false
+	}
+}
+
+var draftConfigChangeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["domain", "action", "rule"],
+  "properties": {
+    "domain": {
+      "type": "string",
+      "enum": ["alert_rule"],
+      "description": "Only alert_rule is supported in v1."
+    },
+    "action": {"type": "string", "enum": ["create"]},
+    "lookback_seconds": {
+      "type": "integer",
+      "minimum": 60,
+      "maximum": 604800,
+      "description": "alert_rule preview lookback window; default 86400."
+    },
+    "rule": {"$ref": "#/$defs/rule", "description": "Required for creating an alert rule."}
+  },
+  "$defs": {
+    "rule": {
+      "type": "object",
+      "properties": {
+        "rule_key": {"type": "string", "description": "Required for create. Lower snake case."},
+        "kind": {
+          "type": "string",
+          "enum": ["metric_threshold", "metric_raw", "metric_anomaly", "metric_forecast", "metric_burn_rate", "log_match", "log_volume", "trace_latency", "trace_error_rate"],
+          "description": "Choose the existing alert creation mode. metric_threshold is only for host closed-set metrics. metric_raw is for arbitrary PromQL predicates, database metrics, custommetrics, and any exact collected metric name."
+        },
+        "name": {"type": "string"},
+        "scope_type": {"type": "string"},
+        "join_mode": {"type": "string", "enum": ["all", "any"]},
+        "severity": {"type": "string", "enum": ["info", "warning", "critical"]},
+        "enabled": {"type": "boolean"},
+        "conditions": {
+          "type": "array",
+          "description": "Only for kind=metric_threshold host rules. Canonical host metrics: cpu_pct, mem_pct, disk_used_pct, disk_avail_bytes, load1, load5, load15, net_rx_bps, net_tx_bps. Do not put MySQL/PostgreSQL/Redis/MongoDB/custom metrics here; use metric_raw instead.",
+          "items": {"$ref": "#/$defs/condition"}
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Kind-specific spec. metric_raw: either expr/promql/query with the full PromQL predicate, or catalog_metric/db_metric/metric plus operator and threshold. For exact collected metrics, set metric to the Prometheus metric name and operator/threshold, e.g. redis_connected_clients > 100. Database catalog_metric examples: mysql_connection_usage_pct, mysql_slow_queries_15m, postgresql_connection_usage_pct, postgresql_deadlocks_15m, redis_memory_usage_pct, redis_keyspace_hit_ratio_pct, mongodb_connections_current, mongodb_wiredtiger_cache_usage_pct. Optional selector/label_selector/matchers or labels can scope the metric. metric_anomaly: metric, method(zscore|mad), baseline_window, baseline_step, deviation. metric_forecast: metric, fit_window, predict_seconds, operator, threshold. metric_burn_rate: sli using $window, slo, burns[{window,multiplier}]. log_match: stream_selector, line_filter, window, operator, threshold. log_volume: stream_selector, window, ratio_op, ratio_threshold. trace_latency: service, operation(optional), quantile(p50|p95|p99), window, threshold_ms. trace_error_rate: service, window, operator, threshold_pct."
+        },
+        "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+        "runbook_url": {"type": "string"},
+        "notify_channel_ids": {"type": "array", "items": {"type": "integer"}},
+        "notify_window_seconds": {"type": "integer", "minimum": 0},
+        "notify_min_fires": {"type": "integer", "minimum": 0}
+      }
+    },
+    "condition": {
+      "type": "object",
+      "properties": {
+        "metric": {"type": "string"},
+        "operator": {"type": "string"},
+        "threshold": {"type": "number"},
+        "window": {"type": "string"},
+        "for": {"type": "string"},
+        "aggregator": {"type": "string"}
+      }
+    }
+  }
+}`)
+
+var applyConfigChangeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["domain", "action", "confirmed"],
+  "properties": {
+    "domain": {
+      "type": "string",
+      "enum": ["alert_rule"],
+      "description": "Configuration domain from the config_draft."
+    },
+    "action": {"type": "string", "enum": ["create"]},
+    "confirmed": {"type": "boolean", "description": "Must be true after explicit user confirmation."},
+    "confirmation_text": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "description": "Optional payload object returned by draft_config_change; used as defaults for action/rule."
+    },
+    "rule": {"type": "object", "additionalProperties": true}
+  }
+}`)

--- a/internal/manager/biz/aiops/tools/config_tools_test.go
+++ b/internal/manager/biz/aiops/tools/config_tools_test.go
@@ -1,0 +1,153 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+)
+
+type fakeConfigManager struct {
+	draftAlertCalls int
+	applyAlertCalls int
+	lastDraft       AlertRuleConfigArgs
+	lastApply       AlertRuleApplyArgs
+}
+
+func (f *fakeConfigManager) DraftAlertRuleConfig(_ context.Context, _ ConfigCaller, in AlertRuleConfigArgs) (*ConfigDraft, error) {
+	f.draftAlertCalls++
+	f.lastDraft = in
+	return &ConfigDraft{
+		Kind:      ConfigResultKindDraft,
+		Domain:    ConfigDomainAlertRule,
+		Action:    "create",
+		Summary:   "draft",
+		ApplyTool: ToolNameApplyConfigChange,
+	}, nil
+}
+
+func (f *fakeConfigManager) ApplyAlertRuleConfig(_ context.Context, _ ConfigCaller, in AlertRuleApplyArgs) (*ConfigApplyResult, error) {
+	f.applyAlertCalls++
+	f.lastApply = in
+	return &ConfigApplyResult{
+		Kind:       ConfigResultKindApply,
+		Domain:     ConfigDomainAlertRule,
+		Action:     "create",
+		Status:     "applied",
+		ResourceID: 7,
+	}, nil
+}
+
+func TestConfigDraftToolCallsAlertRuleManager(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewDraftConfigChangeTool(fake, nil)
+	got, err := tool.InvokableRun(context.Background(), `{"domain":"alert_rule","action":"create","lookback_seconds":3600,"rule":{"rule_key":"cpu_high","name":"CPU High"}}`)
+	if err != nil {
+		t.Fatalf("InvokableRun() error = %v", err)
+	}
+	if fake.draftAlertCalls != 1 {
+		t.Fatalf("draft calls = %d, want 1", fake.draftAlertCalls)
+	}
+	if fake.lastDraft.Action != "create" || fake.lastDraft.LookbackSeconds != 3600 || fake.lastDraft.Rule.RuleKey != "cpu_high" {
+		t.Fatalf("draft args = %+v, want create/cpu_high", fake.lastDraft)
+	}
+	if !strings.Contains(got, `"kind":"config_draft"`) {
+		t.Fatalf("unexpected result: %s", got)
+	}
+}
+
+func TestConfigDraftToolRejectsUnsupportedDomain(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewDraftConfigChangeTool(fake, nil)
+	_, err := tool.InvokableRun(context.Background(), `{"domain":"notification_channel","action":"create"}`)
+	if err == nil {
+		t.Fatalf("expected unsupported domain error")
+	}
+	if fake.draftAlertCalls != 0 {
+		t.Fatalf("draft called for unsupported domain")
+	}
+}
+
+func TestConfigDraftToolRejectsNonCreateAction(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewDraftConfigChangeTool(fake, nil)
+	_, err := tool.InvokableRun(context.Background(), `{"domain":"alert_rule","action":"update"}`)
+	if err == nil {
+		t.Fatalf("expected unsupported action error")
+	}
+	if fake.draftAlertCalls != 0 {
+		t.Fatalf("draft called for unsupported action")
+	}
+}
+
+func TestConfigApplyToolRequiresConfirmation(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewApplyConfigChangeTool(fake, nil)
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 1, Role: "admin"})
+	_, err := tool.InvokableRun(ctx, `{"domain":"alert_rule","action":"create","confirmed":false}`)
+	if err == nil {
+		t.Fatalf("expected confirmation error")
+	}
+	if fake.applyAlertCalls != 0 {
+		t.Fatalf("apply called without confirmation")
+	}
+}
+
+func TestConfigApplyToolRequiresAdmin(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewApplyConfigChangeTool(fake, nil)
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 2, Role: "viewer"})
+	_, err := tool.InvokableRun(ctx, `{"domain":"alert_rule","action":"create","confirmed":true}`)
+	if err == nil {
+		t.Fatalf("expected forbidden error")
+	}
+	if fake.applyAlertCalls != 0 {
+		t.Fatalf("apply called for non-admin")
+	}
+}
+
+func TestConfigApplyToolAdminCallsManager(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewApplyConfigChangeTool(fake, nil)
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 1, Role: "admin"})
+	got, err := tool.InvokableRun(ctx, `{"domain":"alert_rule","action":"create","confirmed":true}`)
+	if err != nil {
+		t.Fatalf("InvokableRun() error = %v", err)
+	}
+	if fake.applyAlertCalls != 1 {
+		t.Fatalf("apply calls = %d, want 1", fake.applyAlertCalls)
+	}
+	if !strings.Contains(got, `"status":"applied"`) {
+		t.Fatalf("unexpected result: %s", got)
+	}
+}
+
+func TestConfigApplyToolUsesPayloadDefaults(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewApplyConfigChangeTool(fake, nil)
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 1, Role: "admin"})
+	args := `{"domain":"alert_rule","confirmed":true,"payload":{"action":"create","rule":{"rule_key":"cpu_high","name":"CPU High"}}}`
+	if _, err := tool.InvokableRun(ctx, args); err != nil {
+		t.Fatalf("InvokableRun() error = %v", err)
+	}
+	if fake.applyAlertCalls != 1 {
+		t.Fatalf("apply calls = %d, want 1", fake.applyAlertCalls)
+	}
+	if fake.lastApply.Action != "create" || fake.lastApply.Rule.RuleKey != "cpu_high" {
+		t.Fatalf("apply args = %+v, want payload defaults", fake.lastApply)
+	}
+}
+
+func TestConfigApplyToolRejectsNonCreateAction(t *testing.T) {
+	fake := &fakeConfigManager{}
+	tool := NewApplyConfigChangeTool(fake, nil)
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 1, Role: "admin"})
+	_, err := tool.InvokableRun(ctx, `{"domain":"alert_rule","action":"disable","confirmed":true}`)
+	if err == nil {
+		t.Fatalf("expected unsupported action error")
+	}
+	if fake.applyAlertCalls != 0 {
+		t.Fatalf("apply called for unsupported action")
+	}
+}

--- a/internal/manager/biz/aiops/tools/query_knowledge_basetool.go
+++ b/internal/manager/biz/aiops/tools/query_knowledge_basetool.go
@@ -32,6 +32,7 @@ const queryKnowledgeWhenToUse = "**回答任何运维 / 故障排查 / 部署 / 
 	"先用 GET /v1/knowledge/paths 看现有目录，再用 path_prefix 收窄（例 '网络/' 拿所有网络类，'网络/DNS' 拿 DNS 一支）。" +
 	"或带 tags 数组进一步过滤（例 ['dns','tls']，any-match 命中即可）。" +
 	"NOT for: 实时指标 / 告警 / 设备状态——那些用 query_promql / query_logql / get_edge_summary。" +
+	"NOT for conversational config requests that create alert rules; use draft_config_change/apply_config_change directly. Other config write requests are not supported in v1." +
 	"query 用自然语言整句（不必拆词）；同一主题同一会话只查一次。"
 
 const queryKnowledgeSchema = `{

--- a/internal/manager/biz/aiops/tools/registry.go
+++ b/internal/manager/biz/aiops/tools/registry.go
@@ -107,6 +107,9 @@ type Registry struct {
 	// post-construction from cmd/main.go because PluginConfigUC is built
 	// before chat runtime but after the registry's constructor deps.
 	pluginConfigs PluginConfigLister
+	// configManager feeds conversational configuration draft/apply tools.
+	// Wired from cmd/main.go after the alert service exists.
+	configManager ConfigManager
 
 	log   *slog.Logger
 	tools map[string]Tool
@@ -138,6 +141,11 @@ func (r *Registry) SetPluginConfigLister(p PluginConfigLister) {
 		}
 	}
 }
+
+// SetConfigManager wires the conversational configuration tools consumed by
+// the graph BaseTool registry. The legacy closure-style registry does not
+// expose these mutating flows.
+func (r *Registry) SetConfigManager(m ConfigManager) { r.configManager = m }
 
 // NewRegistry builds a Registry and auto-registers the two MVP tools
 // (get_host_load, get_process_list). When promQuery / logQuery /

--- a/internal/manager/biz/aiops/tools/registry_basetool.go
+++ b/internal/manager/biz/aiops/tools/registry_basetool.go
@@ -154,6 +154,16 @@ func (r *Registry) BuildBaseTools() *ToolBag {
 		))
 	}
 
+	// Conversational configuration: draft_config_change is read-only and
+	// apply_config_change is Class="write" so viewer sessions cannot see it.
+	// The apply implementation also requires confirmed=true and an admin caller.
+	if r.configManager != nil {
+		out = append(out,
+			NewDraftConfigChangeTool(r.configManager, r.log),
+			NewApplyConfigChangeTool(r.configManager, r.log),
+		)
+	}
+
 	// 14-16: Coordinator-only sub-agent control tools.
 	// Gated on r.spawner — set via SetWorkerSpawner after the
 	// chatruntime.Runtime is constructed in main.go. When the spawner is

--- a/internal/manager/biz/aiops/tools/toolbag.go
+++ b/internal/manager/biz/aiops/tools/toolbag.go
@@ -14,7 +14,7 @@
 //
 //   - core = always exposes a full schema (host/cluster reads,
 //     query_*, database inventory/status helpers, coordinator-only
-//     AgentTool / SendMessage / TaskStop). 15 entries today.
+//     AgentTool / SendMessage / TaskStop, conversational config tools).
 //   - specialty = redacted-by-default when toolBag size > threshold;
 //     schema fetched on demand via ToolSearch (host_files
 //     trio, host_restart_service, alert detail, ranking helpers).
@@ -52,7 +52,7 @@ import (
 // call ToolSearch). Below threshold the bag never partitions, so
 // ToolSearch sits in the same flat slice as everything else.
 var tierByName = map[string]string{
-	// core (always full schema) — 15 entries.
+	// core (always full schema).
 	"get_host_load":           "core",
 	"get_host_processes":      "core",
 	"query_promql":            "core",
@@ -68,6 +68,8 @@ var tierByName = map[string]string{
 	"AgentTool":               "core",
 	"SendMessage":             "core",
 	"TaskStop":                "core",
+	"draft_config_change":     "core",
+	"apply_config_change":     "core",
 
 	// specialty (deferred when over threshold) — host-files trio,
 	// alert detail tools, ranking helpers, mutating restart, generic

--- a/internal/manager/service/alert/service.go
+++ b/internal/manager/service/alert/service.go
@@ -119,15 +119,15 @@ type RuleCondition struct {
 
 // Rule is the DTO returned by rule endpoints.
 type Rule struct {
-	ID         uint64            `json:"id"`
-	RuleKey    string            `json:"rule_key"`
-	Kind       string            `json:"kind"`
-	Name       string            `json:"name"`
-	SourceType string            `json:"source_type"`
-	ScopeType  string            `json:"scope_type"`
-	JoinMode   string            `json:"join_mode"`
-	Severity   string            `json:"severity"`
-	Enabled    bool              `json:"enabled"`
+	ID         uint64 `json:"id"`
+	RuleKey    string `json:"rule_key"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	SourceType string `json:"source_type"`
+	ScopeType  string `json:"scope_type"`
+	JoinMode   string `json:"join_mode"`
+	Severity   string `json:"severity"`
+	Enabled    bool   `json:"enabled"`
 	// Conditions is populated for kind=metric_threshold; empty for other kinds.
 	Conditions []RuleCondition `json:"conditions,omitempty"`
 	// Spec is populated for non-metric_threshold kinds (decoded from
@@ -137,7 +137,7 @@ type Rule struct {
 	RunbookURL string            `json:"runbook_url,omitempty"`
 	// NotifyChannelIDs lists channels this rule pins notifications to.
 	// Empty / nil → router falls back to global channel filters.
-	NotifyChannelIDs []uint64  `json:"notify_channel_ids,omitempty"`
+	NotifyChannelIDs []uint64 `json:"notify_channel_ids,omitempty"`
 	// NotifyWindowSeconds + NotifyMinFires expose the per-rule
 	// 「发送策略」 dampening config. Both zero = disabled (UI hides
 	// the "已启用" badge); both > 0 = enabled.
@@ -149,13 +149,13 @@ type Rule struct {
 
 // RuleInput is the transport-side rule create/update payload.
 type RuleInput struct {
-	RuleKey    string
-	Kind       string
-	Name       string
-	ScopeType  string
-	JoinMode   string
-	Severity   string
-	Enabled    bool
+	RuleKey   string
+	Kind      string
+	Name      string
+	ScopeType string
+	JoinMode  string
+	Severity  string
+	Enabled   bool
 	// Conditions populates kind=metric_threshold rules.
 	Conditions []RuleCondition
 	// Spec is the kind-specific opaque payload for non-metric_threshold

--- a/web/src/components/MessageBubble.test.tsx
+++ b/web/src/components/MessageBubble.test.tsx
@@ -1,0 +1,163 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MessageBubble, type ConfigDraftResult } from './MessageBubble';
+import type { ChatMessage } from '@/api/chat';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const supportedKinds = [
+  'metric_threshold',
+  'metric_raw',
+  'metric_anomaly',
+  'metric_forecast',
+  'metric_burn_rate',
+  'log_match',
+  'log_volume',
+  'trace_latency',
+  'trace_error_rate',
+];
+
+function draftFor(kind: string): ConfigDraftResult {
+  return {
+    kind: 'config_draft',
+    domain: 'alert_rule',
+    action: 'create',
+    summary: `Create ${kind} rule`,
+    payload: {
+      action: 'create',
+      rule: {
+        rule_key: `${kind}_natural_language`,
+        kind,
+        name: `${kind} from natural language`,
+        severity: 'warning',
+        spec: specFor(kind),
+      },
+    },
+    preview: {
+      fire_count: 2,
+      samples: [{ summary: `${kind} sample` }],
+    },
+    warnings: [`${kind} preview warning`],
+    rollback: 'Disable or edit the rule from Alerts.',
+    apply_tool: 'apply_config_change',
+  };
+}
+
+function specFor(kind: string): Record<string, unknown> {
+  switch (kind) {
+    case 'metric_raw':
+      return {
+        expr: '(100 * max(redis_memory_used_bytes) / clamp_min(max(redis_memory_max_bytes), 1)) > 80',
+      };
+    case 'metric_anomaly':
+      return { metric: 'cpu_pct', method: 'zscore', baseline_window: '1h', deviation: 3 };
+    case 'metric_forecast':
+      return { metric: 'disk_avail_bytes', predict_seconds: 21600, operator: '<=', threshold: 0 };
+    case 'metric_burn_rate':
+      return {
+        sli: 'sum(rate(http_requests_total{code!~"5.."}[$window])) / sum(rate(http_requests_total[$window]))',
+        slo: 99.9,
+        burns: [{ window: '1h', multiplier: 14.4 }],
+      };
+    case 'log_match':
+      return { stream_selector: '{ongrid_source=~"journald:.+"}', line_filter: '(?i)error|panic' };
+    case 'log_volume':
+      return { stream_selector: '{ongrid_source=~".+"}', ratio_op: '>=', ratio_threshold: 2 };
+    case 'trace_latency':
+      return { service: 'checkout', quantile: 'p95', threshold_ms: 500 };
+    case 'trace_error_rate':
+      return { service: 'checkout', operator: '>=', threshold_pct: 1 };
+    default:
+      return {};
+  }
+}
+
+function toolCardMessage(draft: ConfigDraftResult): ChatMessage {
+  return {
+    id: `tool-card-${draft.summary}`,
+    role: 'tool',
+    kind: 'tool_card',
+    tool_call: {
+      id: `call-${draft.summary}`,
+      name: 'draft_config_change',
+      status: 'success',
+      result: draft,
+    },
+  };
+}
+
+describe('MessageBubble config draft card', () => {
+  it.each(supportedKinds)('renders and confirms %s drafts', async (kind) => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const draft = draftFor(kind);
+
+    render(<MessageBubble message={toolCardMessage(draft)} onConfirmConfigDraft={onConfirm} />);
+
+    expect(screen.getByText(`Create ${kind} rule`)).toBeInTheDocument();
+    expect(screen.getByText(
+      `action: create · rule_key: ${kind}_natural_language · kind: ${kind} · name: ${kind} from natural language · severity: warning`,
+    )).toBeInTheDocument();
+    expect(screen.getByText('Preview fire_count=2')).toBeInTheDocument();
+    expect(screen.getByText(`${kind} preview warning`)).toBeInTheDocument();
+    expect(screen.getByText('Disable or edit the rule from Alerts.')).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /确认应用|Apply/ }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(draft);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /已确认|Confirmed/ })).toBeDisabled();
+    });
+  });
+
+  it('cancels without calling confirm', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(<MessageBubble message={toolCardMessage(draftFor('metric_raw'))} onConfirmConfigDraft={onConfirm} />);
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /取消|Cancel/ }));
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /已取消|Cancelled/ })).toBeDisabled();
+    });
+  });
+
+  it('does not render a config draft card for unsupported config domains', () => {
+    const draft = {
+      ...draftFor('metric_raw'),
+      domain: 'notification_channel',
+      summary: 'Create notification channel',
+    } as ConfigDraftResult;
+
+    render(<MessageBubble message={toolCardMessage(draft)} onConfirmConfigDraft={vi.fn()} />);
+
+    expect(screen.queryByText('Create notification channel')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /确认应用|Apply/ })).not.toBeInTheDocument();
+  });
+
+  it('renders a persisted tool result string as a draft card', () => {
+    const draft = draftFor('metric_raw');
+    const message: ChatMessage = {
+      id: 'persisted-tool-result',
+      role: 'tool',
+      tool_name: 'draft_config_change',
+      content: JSON.stringify(draft),
+    };
+
+    render(<MessageBubble message={message} onConfirmConfigDraft={vi.fn()} />);
+
+    expect(screen.getByText('Create metric_raw rule')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /确认应用|Apply/ })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -1,20 +1,36 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Wrench, ChevronDown, ChevronRight, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Wrench, ChevronDown, ChevronRight, Loader2, AlertCircle, CheckCircle2, XCircle } from 'lucide-react';
 import type { ChatMessage, ToolCallSummary } from '@/api/chat';
 import { cn } from '@/lib/cn';
 import { useI18n } from '@/i18n/locale';
+import { Button } from '@/components/ui';
+
+export type ConfigDraftResult = {
+  kind: 'config_draft';
+  domain?: string;
+  action?: string;
+  summary?: string;
+  target?: { id?: number; name?: string; type?: string; existing?: boolean };
+  payload?: unknown;
+  preview?: unknown;
+  diff?: unknown;
+  warnings?: string[];
+  rollback?: string;
+  apply_tool?: string;
+};
 
 type Props = {
   message: ChatMessage;
+  onConfirmConfigDraft?: (draft: ConfigDraftResult) => void;
 };
 
-export function MessageBubble({ message }: Props) {
+export function MessageBubble({ message, onConfirmConfigDraft }: Props) {
   if (message.kind === 'tool_card' && message.tool_call) {
-    return <ToolCallSummaryBlock call={fromSummary(message.tool_call)} />;
+    return <ToolCallSummaryBlock call={fromSummary(message.tool_call)} onConfirmConfigDraft={onConfirmConfigDraft} />;
   }
-  if (message.role === 'tool') return <ToolBubble message={message} />;
+  if (message.role === 'tool') return <ToolBubble message={message} onConfirmConfigDraft={onConfirmConfigDraft} />;
   if (message.role === 'user') return <UserBubble message={message} />;
   // Tool-only assistant rows (empty content + has tool_calls) shouldn't
   // appear during streaming; on history reload they would, so suppress.
@@ -25,7 +41,7 @@ export function MessageBubble({ message }: Props) {
   ) {
     return null;
   }
-  return <AssistantBubble message={message} />;
+  return <AssistantBubble message={message} onConfirmConfigDraft={onConfirmConfigDraft} />;
 }
 
 // fromSummary maps the wire-level ToolCallSummary (server SSE shape) to
@@ -64,7 +80,7 @@ function UserBubble({ message }: Props) {
   );
 }
 
-function AssistantBubble({ message }: Props) {
+function AssistantBubble({ message, onConfirmConfigDraft }: Props) {
   // Codex-style: no rounded card around assistant prose. Render markdown
   // flush against the column so headings/lists/code blocks read like a
   // document. Tool calls (when attached) appear as their own rows inside
@@ -81,19 +97,20 @@ function AssistantBubble({ message }: Props) {
         </div>
       )}
       {message.tool_calls?.map((tc, i) => (
-        <ToolCallSummaryBlock key={`${tc.name}-${i}`} call={tc} />
+        <ToolCallSummaryBlock key={`${tc.name}-${i}`} call={tc} onConfirmConfigDraft={onConfirmConfigDraft} />
       ))}
     </div>
   );
 }
 
-function ToolBubble({ message }: Props) {
+function ToolBubble({ message, onConfirmConfigDraft }: Props) {
   // History-reload path: the message persisted by the agent loop only
   // carries the tool name + JSON result string. We don't have args for
   // these (would need to join chat_tool_calls); show what we have.
   const result = message.content ? safeParse(message.content) : undefined;
   return (
     <ToolCallSummaryBlock
+      onConfirmConfigDraft={onConfirmConfigDraft}
       call={{
         name: message.tool_name ?? 'tool',
         status: 'success',
@@ -105,6 +122,7 @@ function ToolBubble({ message }: Props) {
 
 function ToolCallSummaryBlock({
   call,
+  onConfirmConfigDraft,
 }: {
   call: {
     name: string;
@@ -115,6 +133,7 @@ function ToolCallSummaryBlock({
     duration_ms?: number;
     error?: string;
   };
+  onConfirmConfigDraft?: (draft: ConfigDraftResult) => void;
 }) {
   const { tr } = useI18n();
   const [open, setOpen] = useState(false);
@@ -122,6 +141,7 @@ function ToolCallSummaryBlock({
   const isPending = status === 'pending';
   const isError = status === 'error' || status === 'timeout' || !!call.error;
   const hint = argSummary(call.arguments);
+  const configDraft = !isError ? asConfigDraft(call.result) : null;
   return (
     <div
       className={cn(
@@ -161,6 +181,9 @@ function ToolCallSummaryBlock({
           )}
         </span>
       </button>
+      {configDraft && (
+        <ConfigDraftCard draft={configDraft} onConfirm={onConfirmConfigDraft} />
+      )}
       {open && (
         <div className="border-t border-zinc-800/80 bg-zinc-950/40 px-3 py-2">
           {call.arguments !== undefined && (
@@ -193,6 +216,128 @@ function ToolCallSummaryBlock({
       )}
     </div>
   );
+}
+
+function ConfigDraftCard({
+  draft,
+  onConfirm,
+}: {
+  draft: ConfigDraftResult;
+  onConfirm?: (draft: ConfigDraftResult) => void;
+}) {
+  const { tr } = useI18n();
+  const [state, setState] = useState<'idle' | 'confirmed' | 'cancelled'>('idle');
+  const preview = previewSummary(draft.preview);
+  const warnings = Array.isArray(draft.warnings) ? draft.warnings.filter(Boolean) : [];
+  const payload = payloadSummary(draft.payload);
+  const disabled = state !== 'idle' || !onConfirm;
+
+  return (
+    <div className="border-t border-zinc-800/80 bg-zinc-950/30 px-3 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-300">
+              {domainLabel(draft.domain, tr)}
+            </span>
+            {draft.action && (
+              <span className="text-[11px] uppercase text-zinc-500">{draft.action}</span>
+            )}
+            {draft.target?.name && (
+              <span className="truncate text-[11px] text-zinc-500">{draft.target.name}</span>
+            )}
+          </div>
+          <div className="text-sm font-medium text-zinc-100">
+            {draft.summary || tr('配置草案', 'Configuration draft')}
+          </div>
+          {payload && <div className="text-[11px] leading-5 text-zinc-400">{payload}</div>}
+          {preview && <div className="text-[11px] leading-5 text-zinc-400">{preview}</div>}
+          {warnings.length > 0 && (
+            <div className="space-y-1 text-[11px] leading-5 text-amber-300">
+              {warnings.slice(0, 3).map((w, i) => (
+                <div key={`${w}-${i}`}>{w}</div>
+              ))}
+            </div>
+          )}
+          {draft.rollback && (
+            <div className="text-[11px] leading-5 text-zinc-500">{draft.rollback}</div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="primary"
+            disabled={disabled}
+            onClick={() => {
+              setState('confirmed');
+              onConfirm?.(draft);
+            }}
+          >
+            <CheckCircle2 size={13} />
+            {state === 'confirmed' ? tr('已确认', 'Confirmed') : tr('确认应用', 'Apply')}
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={state !== 'idle'}
+            onClick={() => setState('cancelled')}
+          >
+            <XCircle size={13} />
+            {state === 'cancelled' ? tr('已取消', 'Cancelled') : tr('取消', 'Cancel')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function asConfigDraft(result: unknown): ConfigDraftResult | null {
+  const value = typeof result === 'string' ? safeParse(result) : result;
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+  if (obj.kind !== 'config_draft') return null;
+  if (obj.domain !== 'alert_rule') return null;
+  return obj as ConfigDraftResult;
+}
+
+function domainLabel(domain: string | undefined, tr: (zh: string, en: string) => string): string {
+  switch (domain) {
+    case 'alert_rule':
+      return tr('告警规则', 'Alert rule');
+    default:
+      return tr('配置', 'Config');
+  }
+}
+
+function previewSummary(preview: unknown): string {
+  if (!preview || typeof preview !== 'object') return '';
+  const p = preview as Record<string, unknown>;
+  if (typeof p.skipped_reason === 'string' && p.skipped_reason) return p.skipped_reason;
+  if (typeof p.fire_count === 'number') {
+    const unit = typeof p.unit === 'string' && p.unit ? ` ${p.unit}` : '';
+    return `Preview fire_count=${p.fire_count}${unit}`;
+  }
+  return '';
+}
+
+function payloadSummary(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return '';
+  const obj = payload as Record<string, unknown>;
+  const rows: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (rows.length >= 4) break;
+    if (value === null || value === undefined || value === '') continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      rows.push(`${key}: ${String(value)}`);
+      continue;
+    }
+    if (typeof value === 'object') {
+      const nested = Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== null && v !== undefined && v !== '')
+        .slice(0, 4)
+        .map(([k, v]) => `${k}: ${String(v)}`);
+      if (nested.length > 0) rows.push(nested.join(' · '));
+    }
+  }
+  return rows.join(' · ');
 }
 
 function StatusIcon({ status }: { status?: string }) {

--- a/web/src/pages/ChatThread.tsx
+++ b/web/src/pages/ChatThread.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { ChatInput, type ModelSelection, type SubmitPayload } from '@/components/ChatInput';
-import { MessageBubble } from '@/components/MessageBubble';
+import { MessageBubble, type ConfigDraftResult } from '@/components/MessageBubble';
 import { AgentBadge } from '@/components/AgentBadge';
 import { PageHeader } from '@/components/ui';
 import {
@@ -312,6 +312,27 @@ export default function ChatThreadPage() {
     }
   }
 
+  function confirmConfigDraft(draft: ConfigDraftResult) {
+    if (submitting) return;
+    const applyTool = draft.apply_tool || 'apply_config_change';
+    const payload = JSON.stringify(draft.payload ?? {}, null, 2);
+    const content = [
+      tr('确认应用这个配置草案。', 'Confirm applying this configuration draft.'),
+      `domain: ${draft.domain || 'config'}`,
+      `action: ${draft.action || 'apply'}`,
+      applyTool ? `apply_tool: ${applyTool}` : '',
+      tr(
+        '请调用 apply_config_change，传 confirmed=true、domain=alert_rule、action=create 和下方 payload，创建这条告警规则。',
+        'Call apply_config_change with confirmed=true, domain=alert_rule, action=create, and the payload below to create this alert rule.',
+      ),
+      'payload:',
+      '```json',
+      payload,
+      '```',
+    ].filter(Boolean).join('\n');
+    void send(content, []);
+  }
+
   function ThinkingIndicator() {
     return (
       <div className="flex items-center gap-2 text-[11px] text-zinc-600">
@@ -352,7 +373,13 @@ export default function ChatThreadPage() {
             ) : messages.length === 0 ? (
               <div className="text-center text-sm text-zinc-500">{tr('这是一个新的会话，发条消息试试。', "This is a new session — try sending a message.")}</div>
             ) : (
-              messages.map((m) => <MessageBubble key={m.id} message={m} />)
+              messages.map((m) => (
+                <MessageBubble
+                  key={m.id}
+                  message={m}
+                  onConfirmConfigDraft={isViewer ? undefined : confirmConfigDraft}
+                />
+              ))
             )}
             {submitting && <ThinkingIndicator />}
             {error && (

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -12,7 +12,6 @@ import {
   History,
   ListTree,
   Network,
-  PlugZap,
   Search,
   ShieldAlert,
   TrendingUp,
@@ -70,7 +69,7 @@ const PROMPT_POOL: PromptPreset[] = [
   { titleZh: '列出离线超过 24 小时的设备', titleEn: 'List devices offline > 24h',
     descZh: '找掉线节点', descEn: 'Find disconnected nodes',
     promptZh: '列出离线超过 24 小时的设备，按最后在线时间倒序展示。',
-    promptEn: 'List devices offline for over 24h, sorted by last-seen descending.', icon: PlugZap },
+    promptEn: 'List devices offline for over 24h, sorted by last-seen descending.', icon: AlertTriangle },
   { titleZh: '对比本周和上周的整体负载', titleEn: 'Compare load: this week vs. last',
     descZh: '看趋势变化', descEn: 'See the trend',
     promptZh: '对比本周和上周所有设备的整体 CPU、内存、负载趋势，指出变化最大的节点。',
@@ -127,6 +126,10 @@ const PROMPT_POOL: PromptPreset[] = [
     descZh: 'MySQL / PostgreSQL / Redis / MongoDB', descEn: 'MySQL / PostgreSQL / Redis / MongoDB',
     promptZh: '分析当前数据库状态，覆盖 MySQL、PostgreSQL、Redis、MongoDB；按异常优先输出总体结论、每个数据库的关键指标、风险和证据。',
     promptEn: 'Analyze current database status across MySQL, PostgreSQL, Redis, and MongoDB. Prioritize anomalies and include the overall conclusion, key metrics, risks, and evidence for each database.', icon: Database },
+  { titleZh: '配置一条 CPU 告警', titleEn: 'Configure a CPU alert',
+    descZh: '先草案试算，确认后应用', descEn: 'Draft and preview before applying',
+    promptZh: '配置一条 CPU 超过 90% 且持续 5 分钟的 warning 告警，先生成草案并试算，不要直接应用。',
+    promptEn: 'Configure a warning alert for CPU over 90% for 5 minutes. Generate a draft with preview first; do not apply it yet.', icon: Bell },
 ];
 
 function samplePrompts(n: number): typeof PROMPT_POOL {


### PR DESCRIPTION
## Summary
- Add `draft_config_change` and `apply_config_change` AIOps tools for create-only natural language alert rule configuration.
- Wire the config tools into the tool registry, toolbag, and chat coordinator prompts so rule creation uses a read-only draft first.
- Map natural language alert inputs to the existing alert service preview/create flow, including all current rule kinds plus database/custom Prometheus metrics through `metric_raw`.
- Add the chat draft card with Apply/Cancel confirmation and a Home prompt for CPU alert creation.

## Impact
- Alert rules are only persisted after explicit user confirmation and an admin caller.
- Viewer chats can see drafts but cannot apply them.
- v1 intentionally supports only `alert_rule` + `create`; other config domains/actions are rejected.
- Existing Alerts APIs are reused instead of introducing a separate persistence path.

## Verification
- `go test -race ./cmd/ongrid ./internal/manager/biz/aiops/tools`
- `npm test -- MessageBubble.test.tsx`
- `npm run typecheck`
- `npm run build` (passes; Vite still reports the existing large chunk warning)
- In-app browser: created a Redis memory usage alert draft from natural language, saw the draft card, cancelled it, and verified no alert rule was created.
