### PR TITLE
fix(edge): create /var/lib/ongrid-edge explicitly in installers

### DIFF
--- a/deploy/install/edge/install-edge.sh
+++ b/deploy/install/edge/install-edge.sh
@@ -26,7 +26,8 @@ SERVICE_USER=ongrid-edge
 SERVICE_GROUP=ongrid-edge
 BIN_DEST=/usr/local/bin/ongrid-edge
 PLUGIN_BIN_DIR=/usr/local/lib/ongrid-edge   # bundled plugin binaries (promtail, etc.)
-PLUGIN_WORK_DIR=/var/lib/ongrid-edge/plugins # rendered plugin configs + subprocess logs
+STATE_DIR=/var/lib/ongrid-edge               # agent state root (StateDirectory=)
+PLUGIN_WORK_DIR="${STATE_DIR}/plugins"       # rendered plugin configs + subprocess logs
 CONFIG_DIR=/etc/ongrid-edge
 ENV_FILE="${CONFIG_DIR}/ongrid-edge.env"
 UNIT_FILE=/etc/systemd/system/ongrid-edge.service
@@ -148,6 +149,17 @@ install -m 0755 -o root -g root "$BIN_SRC" "$BIN_DEST"
 # Per-platform variant lives under SCRIPT_DIR with the same -OS-ARCH suffix
 # as the main edge binary.
 mkdir -p "$PLUGIN_BIN_DIR"
+# Base state dir. The subdirs below (plugins/, .upgrade/) get created and
+# chowned individually, but the agent also needs to own the base
+# /var/lib/ongrid-edge itself so it can create further state dirs at runtime.
+# The unit's StateDirectory= only guarantees that on systemd >= 235; it is
+# silently ignored on older releases (CentOS/RHEL 7 = systemd 219), which
+# otherwise leaves the base root-owned and unwritable by the service user —
+# every collector plugin then fails `configure` and the edge ships no data.
+# Create it explicitly so this holds regardless of systemd version.
+mkdir -p "$STATE_DIR"
+chown "$SERVICE_USER":"$SERVICE_GROUP" "$STATE_DIR" 2>/dev/null || true
+chmod 0755 "$STATE_DIR"
 mkdir -p "$PLUGIN_WORK_DIR"
 chown "$SERVICE_USER":"$SERVICE_GROUP" "$PLUGIN_WORK_DIR" 2>/dev/null || true
 chmod 750 "$PLUGIN_WORK_DIR"
@@ -293,6 +305,23 @@ for tool in promtail otelcol-contrib node_exporter process_exporter mysqld_expor
         SELFCHECK_FAIL=1
     fi
 done
+
+# 1b) state dir writable by the service user. On systemd < 235 (CentOS/RHEL 7)
+# the unit's StateDirectory= is silently ignored, so this probe catches the
+# "online but no data" failure: without a writable /var/lib/ongrid-edge every
+# collector plugin fails `configure` with EACCES.
+if command -v runuser >/dev/null 2>&1; then
+    SVC_W=(runuser -u "$SERVICE_USER" -- test -w "$STATE_DIR")
+else
+    SVC_W=(sudo -u "$SERVICE_USER" test -w "$STATE_DIR")
+fi
+if [[ -d "$STATE_DIR" ]] && "${SVC_W[@]}" 2>/dev/null; then
+    log_info "state dir writable by $SERVICE_USER: $STATE_DIR"
+else
+    log_error "$SERVICE_USER cannot write $STATE_DIR — every collector plugin will fail; edge will be online with no data"
+    log_error "  fix: mkdir -p $STATE_DIR; chown $SERVICE_USER:$SERVICE_GROUP $STATE_DIR; chmod 0755 $STATE_DIR; systemctl restart ongrid-edge"
+    SELFCHECK_FAIL=1
+fi
 
 # 2) service user can read the journal (logs plugin journald source).
 # Group membership added above is visible to a fresh runuser/sudo session.

--- a/deploy/install/edge/install.sh
+++ b/deploy/install/edge/install.sh
@@ -306,9 +306,15 @@ PrivateTmp=true
 # User=) at start and implicitly adds it to ReadWritePaths. Without
 # this, ProtectSystem=strict makes /var/lib read-only and the agent's
 # runtime mkdir of /var/lib/ongrid-edge/.upgrade fails EROFS.
+#
+# StateDirectory= needs systemd >= 235. On 233/234 ProtectSystem=strict and
+# ReadWritePaths= are honored but StateDirectory= is not, so its implicit
+# writable path is lost and the sandboxed agent still can't write the state
+# dir even after the installer pre-created it. List it in ReadWritePaths=
+# explicitly so writability never depends on StateDirectory= taking effect.
 StateDirectory=ongrid-edge
 StateDirectoryMode=0755
-ReadWritePaths=/var/log/ongrid-edge
+ReadWritePaths=/var/lib/ongrid-edge /var/log/ongrid-edge
 StandardOutput=journal
 StandardError=journal
 

--- a/deploy/install/edge/install.sh
+++ b/deploy/install/edge/install.sh
@@ -33,6 +33,7 @@ ENV_DIR="/etc/ongrid-edge"
 ENV_FILE="${ENV_DIR}/ongrid-edge.env"
 SERVICE_FILE="/etc/systemd/system/ongrid-edge.service"
 LOG_DIR="/var/log/ongrid-edge"
+STATE_DIR="/var/lib/ongrid-edge"
 SERVICE_USER="ongrid-edge"
 SERVICE_GROUP="ongrid-edge"
 
@@ -259,6 +260,22 @@ EOF
 chmod 640 "$ENV_FILE"
 chown "root:${SERVICE_GROUP}" "$ENV_FILE"
 
+# --- state dir ---------------------------------------------------------------
+#
+# The unit below sets StateDirectory=ongrid-edge so systemd creates
+# /var/lib/ongrid-edge (owned by the service user) at start. But
+# StateDirectory= requires systemd >= 235 and is SILENTLY IGNORED on older
+# releases — CentOS/RHEL 7 ships systemd 219. When ignored, the base dir is
+# never created, /var/lib stays root:root 0755, and the agent — running
+# unprivileged as ${SERVICE_USER} — cannot mkdir its plugin work dirs beneath
+# it. Every collector plugin then fails `configure` with EACCES, no exporter
+# starts, and the edge shows up "online but with no data". Create the dir
+# explicitly so the installer is correct regardless of systemd version. This
+# is idempotent and a harmless no-op where StateDirectory= already made it.
+mkdir -p "$STATE_DIR"
+chown "$SERVICE_USER":"$SERVICE_GROUP" "$STATE_DIR"
+chmod 0755 "$STATE_DIR"
+
 # --- systemd unit ------------------------------------------------------------
 
 cat > "$SERVICE_FILE" <<'EOF'
@@ -378,6 +395,22 @@ for tool in promtail otelcol-contrib node_exporter process_exporter mysqld_expor
         SELFCHECK_FAIL=1
     fi
 done
+# State dir must exist and be writable by the service user. On systemd < 235
+# (CentOS/RHEL 7) the unit's StateDirectory= is silently ignored, so this is
+# the probe that catches the "online but no data" failure: without a writable
+# /var/lib/ongrid-edge every collector plugin fails `configure` with EACCES.
+if command -v runuser >/dev/null 2>&1; then
+    SVC_W=(runuser -u "$SERVICE_USER" -- test -w "$STATE_DIR")
+else
+    SVC_W=(sudo -u "$SERVICE_USER" test -w "$STATE_DIR")
+fi
+if [[ -d "$STATE_DIR" ]] && "${SVC_W[@]}" 2>/dev/null; then
+    log_ok "state dir writable by ${SERVICE_USER}: ${STATE_DIR}"
+else
+    log_error "${SERVICE_USER} cannot write ${STATE_DIR} — every collector plugin will fail; edge will be online with no data"
+    log_error "  fix: mkdir -p ${STATE_DIR}; chown ${SERVICE_USER}:${SERVICE_GROUP} ${STATE_DIR}; chmod 0755 ${STATE_DIR}; systemctl restart ongrid-edge"
+    SELFCHECK_FAIL=1
+fi
 if command -v runuser >/dev/null 2>&1; then
     JREAD=(runuser -u "$SERVICE_USER" -- journalctl -n 1 --no-pager)
 else

--- a/deploy/install/edge/ongrid-edge.service
+++ b/deploy/install/edge/ongrid-edge.service
@@ -33,11 +33,18 @@ PrivateTmp=true
 # ReadWritePaths whitelist. Without this, ProtectSystem=strict makes the
 # parent /var/lib read-only and the agent's runtime mkdir of
 # /var/lib/ongrid-edge/.upgrade fails EROFS — discovered on VM-0-3
-# during ADR-024 E2E. /var/log/ongrid-edge stays explicit because the
-# installer creates and chowns it differently.
+# during ADR-024 E2E.
+#
+# But StateDirectory= needs systemd >= 235. On 233/234 ProtectSystem=strict
+# and ReadWritePaths= are honored while StateDirectory= is not, so its
+# *implicit* writable path is lost and the sandboxed agent still can't write
+# /var/lib/ongrid-edge even when the installer pre-created it on disk. List
+# the state dir in ReadWritePaths= explicitly so writability never depends on
+# StateDirectory= taking effect. Redundant (harmless) on systemd >= 235; a
+# no-op on < 232 where the sandbox itself is off.
 StateDirectory=ongrid-edge
 StateDirectoryMode=0755
-ReadWritePaths=/var/log/ongrid-edge
+ReadWritePaths=/var/lib/ongrid-edge /var/log/ongrid-edge
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Problem
The edge installers relied **solely** on the systemd unit's
`StateDirectory=ongrid-edge` to create the agent's state dir.
`StateDirectory=` requires **systemd ≥ 235** and is *silently ignored* on
older releases — CentOS/RHEL 7 ship systemd 219.

On those hosts the base dir is never created, `/var/lib` stays `root:root 0755`,
and the agent (running unprivileged as `ongrid-edge`) cannot `mkdir` its plugin
work dirs beneath it:

```
plugin configure failed  hostmetrics  err: mkdir /var/lib/ongrid-edge: permission denied
plugin configure failed  procmetrics  ...permission denied
plugin configure failed  logs / traces ...permission denied
```

Every collector plugin fails `configure` with EACCES -> no exporter starts ->
the edge registers as **online but ships no data**. The existing self-check
only validated plugin binaries, journald readability, and data-plane
reachability, so installs reported success while telemetry was dead.

## Fix
- **install.sh** (curl-pipe / UI one-liner): explicit, idempotent
  `mkdir -p /var/lib/ongrid-edge` + chown + `chmod 0755` before the unit starts.
- **install-edge.sh** (tarball): chown/chmod the **base** dir too, not just the
  `plugins/` and `.upgrade/` subdirs, so the service user owns the state root.
- **both**: a self-check probe that fails loudly when the service user can't
  write the state dir.

Belt-and-suspenders with `StateDirectory=` (a harmless no-op on systemd >= 235);
makes the installers correct regardless of systemd version.

## Test
- `bash -n` passes on both scripts.
- Verified the remediation (`mkdir + chown + restart`) on affected hosts:
  collectors come up and data flows within 1-2 min.
