### PR TITLE
fix(install): 兼容旧 Docker 与离线安装证书生成

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -225,9 +225,10 @@ services:
     # Phase-A unblock: let the prometheus.yml `node-exporter-host` job
     # resolve `host.docker.internal` on Linux too. Docker Desktop already
     # provides this name; on Linux the docker-engine resolves the special
-    # value `host-gateway` to the docker0 bridge address.
+    # value `host-gateway` to the docker0 bridge address. Set
+    # ONGRID_HOST_GATEWAY to the docker bridge IP on older engines.
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "host.docker.internal:${ONGRID_HOST_GATEWAY:-host-gateway}"
     ports:
       - "9090:9090"
     volumes:

--- a/deploy/install/.env.example
+++ b/deploy/install/.env.example
@@ -23,6 +23,12 @@ ONGRID_TUNNEL_PORT=40012
 ONGRID_METRICS_PORT=9100
 PROM_PORT=9090
 
+# --- Docker compatibility ---
+# Leave blank on Docker >= 20.10. install.sh / upgrade.sh set this to the
+# docker bridge gateway IP when the daemon rejects the `host-gateway` special
+# value used by Prometheus to reach host.docker.internal.
+ONGRID_HOST_GATEWAY=
+
 # --- MySQL (set passwords; install.sh generates random if left blank) ---
 MYSQL_ROOT_PASSWORD=
 MYSQL_PASSWORD=

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -57,7 +57,7 @@ sudo ./install.sh
 1. 自检 Docker 环境；非 root 自动 `sudo` 重入。
 2. 创建 `/opt/ongrid/`（可通过 `ONGRID_INSTALL_DIR` 覆盖）。
 3. 拷贝 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION` 到安装目录。
-4. **生成自签 TLS 证书**（首次安装且 `certs/tls.crt` 不存在时）：`openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj '/CN=ongrid' -addext 'subjectAltName=DNS:ongrid,DNS:localhost,IP:127.0.0.1'`，落到 `${INSTALL_DIR}/certs/`，私钥 `chmod 600`。脚本不交互，直接生成；末尾 banner 提示替换真证书。
+4. **生成自签 TLS 证书**（首次安装且 `certs/tls.crt` 不存在时）：通过临时 OpenSSL 配置生成 CN=ongrid、SAN 包含 `ongrid` / `localhost` / `127.0.0.1` 的 365 天证书，落到 `${INSTALL_DIR}/certs/`，私钥 `chmod 600`。脚本不交互，直接生成；末尾 banner 提示替换真证书。
 5. `docker load -i images/ongrid.tar`、`images/frontier.tar`、`images/ongrid-web.tar` 加载所有镜像。
 6. 若 `/opt/ongrid/.env` 不存在则从 `.env.example` 创建，并对空字段（`MYSQL_ROOT_PASSWORD`、`MYSQL_PASSWORD`、`ONGRID_JWT_SECRET`、`ONGRID_ADMIN_PASSWORD`）生成随机值，文件权限置 `600`。
 7. `docker compose up -d` 启动 MySQL + ongrid + frontier + nginx + prometheus（ADR-009）。
@@ -351,6 +351,7 @@ sudo ONGRID_CLOUD_ADDR=ongrid.example.com:40012 \
   ssh root@<host> 'docker exec ongrid-prometheus wget -qO- http://localhost:9090/-/ready'
   ```
 - **端口被占用**（`docker compose up` 报 `bind: address already in use`）：编辑 `.env` 里的 `ONGRID_HTTP_PORT`（默认 443）/ `ONGRID_HTTP_REDIRECT_PORT`（默认 80）/ `ONGRID_TUNNEL_PORT` / `ONGRID_METRICS_PORT`，重跑 `docker compose -f /opt/ongrid/docker-compose.yml --env-file /opt/ongrid/.env up -d`。把 `ONGRID_HTTP_REDIRECT_PORT=0` 可以彻底关掉 80→443 跳转监听。
+- **`invalid IP address in add-host: "host-gateway"`**：目标机 Docker daemon 太旧，不支持 Docker 20.10 引入的 `host-gateway` 特殊值。新版 `install.sh` / `upgrade.sh` 会自动把 `.env` 里的 `ONGRID_HOST_GATEWAY` 写成 Docker bridge 网关 IP；已经遇到该错误的机器可直接重跑 `sudo ./install.sh`。如仍失败，手动执行 `ip -4 addr show docker0` 查网关（通常是 `172.17.0.1`），写入 `/opt/ongrid/.env`：`ONGRID_HOST_GATEWAY=<网关IP>` 后再 `cd /opt/ongrid && sudo docker compose --env-file .env up -d`。
 - **MySQL healthcheck 超时**：首次拉起冷启动慢，observe `docker logs ongrid-mysql`。安装脚本最多等 60 秒，ongrid 容器会一直等到 mysql healthy；如 60s 内没进入 healthy，手动看 MySQL 日志。
 - **`/healthz` 不通**：`docker logs ongrid -n 200`，常见是 `.env` 里 `ONGRID_JWT_SECRET` 为空或 `ONGRID_DB_DSN` 错误。
 - **AI Chat 接口 500**：`OPENAI_API_KEY` 没填。要么填 key，要么不调用 chat 接口。

--- a/deploy/install/docker-compose.yml
+++ b/deploy/install/docker-compose.yml
@@ -295,13 +295,14 @@ services:
       - --web.route-prefix=/prometheus/
     # Phase-A unblock for missing host metrics: let prometheus.yml's
     # node-exporter-host job reach the host's node_exporter on Linux too.
-    # `host-gateway` is a docker-engine special value that resolves to the
-    # docker0 bridge IP. Phase-B (edge metrics plugin tunnel-RPC push)
+    # `${ONGRID_HOST_GATEWAY:-host-gateway}` uses Docker's special value on
+    # modern engines; install.sh / upgrade.sh backfill a bridge IP on older
+    # engines that reject the special value. Phase-B (edge metrics plugin tunnel-RPC push)
     # will eventually obviate this static job, but the entry stays
     # harmless when no node_exporter is listening (Prom marks the target
     # DOWN and continues).
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "host.docker.internal:${ONGRID_HOST_GATEWAY:-host-gateway}"
     volumes:
       # Bind-mount TSDB to host. Prometheus runs as nobody (uid 65534) so
       # install.sh chowns this dir accordingly. Move to a fast SSD or

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -23,6 +23,105 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+generate_self_signed_tls_cert() {
+    local cert_dir="$1"
+    local cert_file="$cert_dir/tls.crt"
+    local key_file="$cert_dir/tls.key"
+    local openssl_conf openssl_output
+
+    command -v openssl >/dev/null 2>&1 || {
+        log_error "openssl not found; cannot generate self-signed cert"
+        log_error "install openssl, or drop tls.crt + tls.key into $cert_dir/ and re-run"
+        return 1
+    }
+
+    openssl_conf=$(mktemp "${TMPDIR:-/tmp}/ongrid-openssl.XXXXXX.cnf") || {
+        log_error "failed to create temporary OpenSSL config"
+        return 1
+    }
+    cat >"$openssl_conf" <<'EOF'
+[req]
+distinguished_name = dn
+prompt = no
+x509_extensions = v3_req
+
+[dn]
+CN = ongrid
+
+[v3_req]
+subjectAltName = DNS:ongrid,DNS:localhost,IP:127.0.0.1
+EOF
+
+    if ! openssl_output=$(openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$key_file" \
+        -out "$cert_file" \
+        -config "$openssl_conf" \
+        -extensions v3_req 2>&1); then
+        log_error "failed to generate self-signed TLS cert using $(openssl version 2>/dev/null || printf 'openssl')"
+        [[ -z "$openssl_output" ]] || printf '%s\n' "$openssl_output" >&2
+        rm -f "$openssl_conf" "$cert_file" "$key_file"
+        return 1
+    fi
+
+    rm -f "$openssl_conf"
+    chmod 600 "$key_file"
+    chmod 644 "$cert_file"
+}
+
+docker_supports_host_gateway() {
+    local version major minor
+    version=$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)
+    version=${version%%-*}
+    version=${version%%+*}
+    IFS=. read -r major minor _ <<<"$version"
+
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    (( major > 20 || (major == 20 && minor >= 10) ))
+}
+
+detect_docker_bridge_gateway() {
+    local gateway
+    gateway=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null | head -n 1 || true)
+    if [[ -z "$gateway" ]] && command -v ip >/dev/null 2>&1; then
+        gateway=$(ip -4 addr show docker0 2>/dev/null | sed -n -E 's/.*inet ([0-9.]+)\/.*/\1/p' | head -n 1 || true)
+    fi
+    printf '%s' "$gateway"
+}
+
+set_env_value() {
+    local key="$1" value="$2" esc
+    esc=$(printf '%s' "$value" | sed -e 's/[\\|&]/\\&/g')
+    if grep -qE "^${key}=" "$ENV_FILE"; then
+        sed -i.bak -E "s|^${key}=.*|${key}=${esc}|" "$ENV_FILE"
+        rm -f "${ENV_FILE}.bak"
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+    fi
+}
+
+ensure_host_gateway_env() {
+    local configured gateway
+    configured=$(grep -E '^ONGRID_HOST_GATEWAY=' "$ENV_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)
+    if [[ -n "$configured" && "$configured" != "host-gateway" ]]; then
+        log_info "ONGRID_HOST_GATEWAY=${configured} (from .env)"
+        return
+    fi
+
+    if docker_supports_host_gateway; then
+        return
+    fi
+
+    gateway=$(detect_docker_bridge_gateway)
+    if [[ -z "$gateway" ]]; then
+        log_error "docker daemon does not support host-gateway and docker bridge gateway could not be detected"
+        log_error "set ONGRID_HOST_GATEWAY=<docker0 gateway IP> in ${ENV_FILE}, then re-run sudo ./install.sh"
+        return 1
+    fi
+
+    set_env_value ONGRID_HOST_GATEWAY "$gateway"
+    log_warn "docker daemon does not support host-gateway; using ONGRID_HOST_GATEWAY=${gateway}"
+}
+
 on_error() {
     local exit_code=$?
     log_error "install failed at line $1 (exit $exit_code)"
@@ -445,19 +544,7 @@ mkdir -p "$INSTALL_DIR/certs"
 chmod 700 "$INSTALL_DIR/certs"
 if [[ ! -f "$INSTALL_DIR/certs/tls.crt" || ! -f "$INSTALL_DIR/certs/tls.key" ]]; then
     log_info "generating self-signed TLS cert (valid 365d, CN=ongrid)"
-    command -v openssl >/dev/null 2>&1 || {
-        log_error "openssl not found; cannot generate self-signed cert"
-        log_error "install openssl, or drop tls.crt + tls.key into $INSTALL_DIR/certs/ and re-run"
-        exit 1
-    }
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-        -subj "/CN=ongrid" \
-        -keyout "$INSTALL_DIR/certs/tls.key" \
-        -out    "$INSTALL_DIR/certs/tls.crt" \
-        -addext "subjectAltName = DNS:ongrid,DNS:localhost,IP:127.0.0.1" \
-        2>/dev/null
-    chmod 600 "$INSTALL_DIR/certs/tls.key"
-    chmod 644 "$INSTALL_DIR/certs/tls.crt"
+    generate_self_signed_tls_cert "$INSTALL_DIR/certs"
     log_warn "self-signed cert: browsers will warn — replace with a real cert in $INSTALL_DIR/certs/ later"
 fi
 
@@ -663,6 +750,8 @@ fi
 sed -i.bak -E "s|^ONGRID_VERSION=.*|ONGRID_VERSION=${VERSION_FROM_FILE}|" "$ENV_FILE"
 rm -f "${ENV_FILE}.bak"
 chmod 600 "$ENV_FILE"
+
+ensure_host_gateway_env
 
 # Load env for later banner use (read-only subset; don't export secrets).
 ONGRID_HTTP_PORT=$(grep -E '^ONGRID_HTTP_PORT=' "$ENV_FILE" | cut -d= -f2- || true)

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -18,6 +18,105 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+generate_self_signed_tls_cert() {
+    local cert_dir="$1"
+    local cert_file="$cert_dir/tls.crt"
+    local key_file="$cert_dir/tls.key"
+    local openssl_conf openssl_output
+
+    command -v openssl >/dev/null 2>&1 || {
+        log_error "openssl not found; cannot generate self-signed cert"
+        log_error "install openssl, or drop tls.crt + tls.key into $cert_dir/ and re-run"
+        return 1
+    }
+
+    openssl_conf=$(mktemp "${TMPDIR:-/tmp}/ongrid-openssl.XXXXXX.cnf") || {
+        log_error "failed to create temporary OpenSSL config"
+        return 1
+    }
+    cat >"$openssl_conf" <<'EOF'
+[req]
+distinguished_name = dn
+prompt = no
+x509_extensions = v3_req
+
+[dn]
+CN = ongrid
+
+[v3_req]
+subjectAltName = DNS:ongrid,DNS:localhost,IP:127.0.0.1
+EOF
+
+    if ! openssl_output=$(openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$key_file" \
+        -out "$cert_file" \
+        -config "$openssl_conf" \
+        -extensions v3_req 2>&1); then
+        log_error "failed to generate self-signed TLS cert using $(openssl version 2>/dev/null || printf 'openssl')"
+        [[ -z "$openssl_output" ]] || printf '%s\n' "$openssl_output" >&2
+        rm -f "$openssl_conf" "$cert_file" "$key_file"
+        return 1
+    fi
+
+    rm -f "$openssl_conf"
+    chmod 600 "$key_file"
+    chmod 644 "$cert_file"
+}
+
+docker_supports_host_gateway() {
+    local version major minor
+    version=$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)
+    version=${version%%-*}
+    version=${version%%+*}
+    IFS=. read -r major minor _ <<<"$version"
+
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    (( major > 20 || (major == 20 && minor >= 10) ))
+}
+
+detect_docker_bridge_gateway() {
+    local gateway
+    gateway=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null | head -n 1 || true)
+    if [[ -z "$gateway" ]] && command -v ip >/dev/null 2>&1; then
+        gateway=$(ip -4 addr show docker0 2>/dev/null | sed -n -E 's/.*inet ([0-9.]+)\/.*/\1/p' | head -n 1 || true)
+    fi
+    printf '%s' "$gateway"
+}
+
+set_env_value() {
+    local key="$1" value="$2" esc
+    esc=$(printf '%s' "$value" | sed -e 's/[\\|&]/\\&/g')
+    if grep -qE "^${key}=" "$ENV_FILE"; then
+        sed -i.bak -E "s|^${key}=.*|${key}=${esc}|" "$ENV_FILE"
+        rm -f "${ENV_FILE}.bak"
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+    fi
+}
+
+ensure_host_gateway_env() {
+    local configured gateway
+    configured=$(grep -E '^ONGRID_HOST_GATEWAY=' "$ENV_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)
+    if [[ -n "$configured" && "$configured" != "host-gateway" ]]; then
+        log_info "ONGRID_HOST_GATEWAY=${configured} (from .env)"
+        return
+    fi
+
+    if docker_supports_host_gateway; then
+        return
+    fi
+
+    gateway=$(detect_docker_bridge_gateway)
+    if [[ -z "$gateway" ]]; then
+        log_error "docker daemon does not support host-gateway and docker bridge gateway could not be detected"
+        log_error "set ONGRID_HOST_GATEWAY=<docker0 gateway IP> in ${ENV_FILE}, then re-run sudo ./upgrade.sh"
+        return 1
+    fi
+
+    set_env_value ONGRID_HOST_GATEWAY "$gateway"
+    log_warn "docker daemon does not support host-gateway; using ONGRID_HOST_GATEWAY=${gateway}"
+}
+
 trap 'log_error "upgrade failed at line $LINENO"' ERR
 
 if [[ $EUID -ne 0 ]]; then
@@ -222,13 +321,7 @@ mkdir -p "$INSTALL_DIR/certs"
 chmod 700 "$INSTALL_DIR/certs"
 if [[ ! -f "$INSTALL_DIR/certs/tls.crt" || ! -f "$INSTALL_DIR/certs/tls.key" ]]; then
     log_info "no TLS cert under $INSTALL_DIR/certs; generating self-signed (365d, CN=ongrid)"
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-        -subj "/CN=ongrid" \
-        -keyout "$INSTALL_DIR/certs/tls.key" \
-        -out    "$INSTALL_DIR/certs/tls.crt" \
-        -addext "subjectAltName = DNS:ongrid,DNS:localhost,IP:127.0.0.1" \
-        2>/dev/null
-    chmod 600 "$INSTALL_DIR/certs/tls.key"
+    generate_self_signed_tls_cert "$INSTALL_DIR/certs"
     log_warn "self-signed cert: replace with real one in $INSTALL_DIR/certs/ later"
 fi
 if [[ -f "$SCRIPT_DIR/VERSION" ]]; then
@@ -336,6 +429,7 @@ backfill_plain() {
 # v0.7.20+: Grafana admin pin needed for SA token bootstrap.
 backfill_plain  GRAFANA_ADMIN_USER     admin
 backfill_secret GRAFANA_ADMIN_PASSWORD 20
+ensure_host_gateway_env
 
 chmod 600 "$ENV_FILE"
 


### PR DESCRIPTION
- 将安装/升级脚本的自签 TLS 证书生成改为临时 OpenSSL config 方式，避免旧版 OpenSSL 不支持 -addext 导致安装失败
- 保留 OpenSSL 失败输出，安装报错时能看到真实原因
- 将 prometheus extra_hosts 的 host-gateway 改为 ONGRID_HOST_GATEWAY 可配置
- install.sh / upgrade.sh 在 Docker 不支持 host-gateway 时自动探测 docker bridge 网关并写入 .env
- 在 .env.example 和安装排障文档中补充 ONGRID_HOST_GATEWAY 说明
- 同步开发 compose 的 host-gateway 配置方式