### PR TITLE
feat(edge): collect and display primary IPv4 address

### DIFF
--- a/internal/edgeagent/collector/embedded.go
+++ b/internal/edgeagent/collector/embedded.go
@@ -99,6 +99,9 @@ func (c *EmbeddedCollector) HostInfo(ctx context.Context) (tunnel.HostInfo, erro
 	// HostID so the cloud prefers it but can still migrate older device
 	// rows keyed by HostID. "" when no physical NIC is found.
 	hi.HardwareFingerprint = hardwareFingerprint()
+	// Primary IPv4 address. Best-effort: "" when no suitable address
+	// can be determined (no non-loopback interface with an IPv4 addr).
+	hi.IPAddress = primaryIPv4()
 	if vm, err := mem.VirtualMemoryWithContext(ctx); err == nil && vm != nil {
 		hi.MemTotalBytes = vm.Total
 	}

--- a/internal/edgeagent/collector/hwfingerprint.go
+++ b/internal/edgeagent/collector/hwfingerprint.go
@@ -154,3 +154,55 @@ func diskSignature() string {
 	}
 	return strings.Join(serials, ",")
 }
+
+// primaryIPv4 returns the first non-loopback IPv4 address found on the
+// host. It prefers addresses on physical NICs (same filter as
+// hardwareFingerprint) but falls back to any non-loopback address so
+// cloud-only / containerised hosts still get an IP. Returns "" when no
+// suitable address is found.
+func primaryIPv4() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	// First pass: look for an address on a physical NIC.
+	for i := range ifaces {
+		if !isPhysicalNIC(&ifaces[i]) {
+			continue
+		}
+		addrs, err := ifaces[i].Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ip, _, err := net.ParseCIDR(a.String())
+			if err != nil || ip == nil {
+				continue
+			}
+			if ip4 := ip.To4(); ip4 != nil && !ip4.IsLoopback() {
+				return ip4.String()
+			}
+		}
+	}
+	// Second pass: any non-loopback interface (fallback for cloud VMs
+	// where the primary NIC may not match isPhysicalNIC heuristics).
+	for i := range ifaces {
+		if ifaces[i].Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := ifaces[i].Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ip, _, err := net.ParseCIDR(a.String())
+			if err != nil || ip == nil {
+				continue
+			}
+			if ip4 := ip.To4(); ip4 != nil && !ip4.IsLoopback() {
+				return ip4.String()
+			}
+		}
+	}
+	return ""
+}

--- a/internal/edgeagent/collector/scrape.go
+++ b/internal/edgeagent/collector/scrape.go
@@ -246,6 +246,9 @@ func (s *Scraper) HostInfo(ctx context.Context) (tunnel.HostInfo, error) {
 	}
 	// Clone-resistant hardware identity — see embedded.go.
 	hi.HardwareFingerprint = hardwareFingerprint()
+	// Primary IPv4 address. Best-effort: "" when no suitable address
+	// can be determined.
+	hi.IPAddress = primaryIPv4()
 	if vm, err := mem.VirtualMemoryWithContext(ctx); err == nil && vm != nil {
 		hi.MemTotalBytes = vm.Total
 	}

--- a/internal/manager/biz/device/repo.go
+++ b/internal/manager/biz/device/repo.go
@@ -101,6 +101,7 @@ type HostFacts struct {
 	CPUCount       int
 	MemTotalBytes  uint64
 	DiskTotalBytes uint64
+	IPAddress      string
 }
 
 // Usage is the live percentage gauges for one device.

--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -147,10 +147,10 @@ func (u *Usecase) Create(ctx context.Context, name string, createdBy *uint64) (*
 // Spec JSON shape mirrors what each plugin's defaults expect:
 //   - logs:        promtail tails /var/log/*. job=node-syslog by default.
 //   - traces:      otelcol-contrib OTLP receiver on :4318, exporter
-//                  points at the manager's /v1/traces (resolved by the
-//                  PluginConfigUC's EndpointResolver, so spec stays empty).
+//     points at the manager's /v1/traces (resolved by the
+//     PluginConfigUC's EndpointResolver, so spec stays empty).
 //   - metrics:     in-process scraper polling 127.0.0.1:9100 (the
-//                  hostmetrics plugin's node_exporter listen addr).
+//     hostmetrics plugin's node_exporter listen addr).
 //   - hostmetrics: subprocess node_exporter on :9102.
 //   - procmetrics: subprocess process-exporter on :9256.
 //
@@ -283,6 +283,7 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 		KernelVersion: info.KernelVersion,
 		CPUCount:      info.CPUCount,
 		MemTotalBytes: info.MemTotalBytes,
+		IPAddress:     info.IPAddress,
 		Online:        true,
 	}
 	dev, err := u.devices.FindOrCreateByFingerprint(ctx, seed)
@@ -296,6 +297,7 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 		KernelVersion: info.KernelVersion,
 		CPUCount:      info.CPUCount,
 		MemTotalBytes: info.MemTotalBytes,
+		IPAddress:     info.IPAddress,
 	}); err != nil {
 		return fmt.Errorf("update device host facts: %w", err)
 	}

--- a/internal/manager/data/device/store/device.go
+++ b/internal/manager/data/device/store/device.go
@@ -89,6 +89,7 @@ func (r *Repo) UpdateHostFacts(ctx context.Context, id uint64, f biz.HostFacts) 
 		"cpu_count":        f.CPUCount,
 		"mem_total_bytes":  f.MemTotalBytes,
 		"disk_total_bytes": f.DiskTotalBytes,
+		"ip_address":       f.IPAddress,
 	})
 	if res.Error != nil {
 		return res.Error

--- a/internal/manager/model/device/model.go
+++ b/internal/manager/model/device/model.go
@@ -50,6 +50,12 @@ type Device struct {
 	Arch          string `gorm:"size:32;not null"`
 	KernelVersion string `gorm:"size:128;not null;column:kernel_version"`
 
+	// IPAddress is the primary IPv4 address reported by the edge agent
+	// on its most recent register_edge handshake. Empty string when the
+	// agent hasn't reported one yet (pre-IP-collection binary) or when
+	// no suitable address was found on the host.
+	IPAddress string `gorm:"size:45;not null;default:'';column:ip_address"`
+
 	// Capacity facts. CPUCount is core count; MemTotalBytes / DiskTotalBytes
 	// are total capacity. liaison-cloud uses int for CPU/Memory/Disk; we
 	// keep CPUCount as int (matches the wire shape) and use uint64 for the

--- a/internal/manager/server/device/http.go
+++ b/internal/manager/server/device/http.go
@@ -81,6 +81,7 @@ type deviceItem struct {
 	OSVersion      string     `json:"os_version,omitempty"`
 	Arch           string     `json:"arch,omitempty"`
 	KernelVersion  string     `json:"kernel_version,omitempty"`
+	IPAddress      string     `json:"ip_address,omitempty"`
 	CPUCount       int        `json:"cpu_count,omitempty"`
 	MemTotalBytes  uint64     `json:"mem_total_bytes,omitempty"`
 	DiskTotalBytes uint64     `json:"disk_total_bytes,omitempty"`
@@ -113,9 +114,9 @@ type updateRolesReq struct {
 }
 
 type edgeLinkRow struct {
-	EdgeID    uint64 `json:"edge_id"`
-	DeviceID  uint64 `json:"device_id"`
-	Type      string `json:"type"` // host | discovered
+	EdgeID    uint64    `json:"edge_id"`
+	DeviceID  uint64    `json:"device_id"`
+	Type      string    `json:"type"` // host | discovered
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -313,6 +314,7 @@ func devToItem(d *devicemodel.Device) deviceItem {
 		OSVersion:      d.OSVersion,
 		Arch:           d.Arch,
 		KernelVersion:  d.KernelVersion,
+		IPAddress:      d.IPAddress,
 		CPUCount:       d.CPUCount,
 		MemTotalBytes:  d.MemTotalBytes,
 		DiskTotalBytes: d.DiskTotalBytes,

--- a/internal/manager/server/edge/http.go
+++ b/internal/manager/server/edge/http.go
@@ -342,6 +342,7 @@ type hostInfoDTO struct {
 	KernelVersion string `json:"kernel_version,omitempty"`
 	CPUCount      int    `json:"cpu_count,omitempty"`
 	MemTotalBytes uint64 `json:"mem_total_bytes,omitempty"`
+	IPAddress     string `json:"ip_address,omitempty"`
 }
 
 type listItem struct {
@@ -791,6 +792,7 @@ func deviceToHostInfo(d *devicemodel.Device) *hostInfoDTO {
 		KernelVersion: d.KernelVersion,
 		CPUCount:      d.CPUCount,
 		MemTotalBytes: d.MemTotalBytes,
+		IPAddress:     d.IPAddress,
 	}
 }
 

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -237,6 +237,14 @@ type HostInfo struct {
 	// fields are sent together so the cloud can migrate a device from its old
 	// HostID-derived fingerprint to this one in place. Empty is allowed.
 	HardwareFingerprint string `json:"hardware_fingerprint,omitempty"`
+
+	// IPAddress is the primary IPv4 address of the host, collected
+	// edge-side during register_edge. Used for display in the device
+	// list/detail so operators can identify hosts by IP without
+	// cross-referencing external tools. Empty string when the agent
+	// cannot determine a suitable address (e.g. no non-loopback
+	// interface found).
+	IPAddress string `json:"ip_address,omitempty"`
 }
 
 // RegisterEdgeRequest is the first RPC the edge sends after connecting.

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -231,6 +231,7 @@ export default function EdgesPage() {
                   <th className="px-4 py-2.5 text-left">ID</th>
                   <th className="px-4 py-2.5 text-left">{tr('名称', 'Name')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('主机名', 'Hostname')}</th>
+                  <th className="px-4 py-2.5 text-left">IP</th>
                   <th className="px-4 py-2.5 text-left">{tr('角色', 'Roles')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('状态', 'Status')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('最后心跳', 'Last heartbeat')}</th>
@@ -242,13 +243,13 @@ export default function EdgesPage() {
               <tbody className="divide-y divide-zinc-800/40">
                 {loading && edges.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={10} className="px-4 py-10 text-center text-zinc-500">
                       {tr('加载中…', 'Loading…')}
                     </td>
                   </tr>
                 ) : edges.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={10} className="px-4 py-10 text-center text-zinc-500">
                       {rolesFilter
                         ? tr(
                             `没有 ${ROLE_FILTER_TITLES[rolesFilter]?.[0] ?? rolesFilter} 设备。点设备名打开详情后可在右上角分配角色。`,
@@ -283,6 +284,9 @@ export default function EdgesPage() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">
                         {extractHostname(e.host_info) ?? '—'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
+                        {extractIP(e.host_info) ?? '—'}
                       </td>
                       <td
                         className="cursor-pointer whitespace-nowrap px-4 py-2.5"
@@ -758,6 +762,25 @@ function pickHostname(value: Record<string, unknown>): string | null {
     if (!normalized) continue;
     return normalized.includes(':') ? normalized.split(':')[0] || normalized : normalized;
   }
+  return null;
+}
+
+function extractIP(hostInfo: Edge['host_info']): string | null {
+  if (!hostInfo) return null;
+  if (typeof hostInfo === 'string') {
+    const parsed = safeParseHostInfo(hostInfo);
+    if (!parsed) return null;
+    return extractIPFromObj(parsed);
+  }
+  if (typeof hostInfo === 'object') {
+    return extractIPFromObj(hostInfo);
+  }
+  return null;
+}
+
+function extractIPFromObj(obj: Record<string, unknown>): string | null {
+  const v = obj.ip_address;
+  if (typeof v === 'string' && v.trim()) return v.trim();
   return null;
 }
 


### PR DESCRIPTION
该PR目标：在边缘设备收集IP地址，并在Web端显示IP，用以区分与识别，通常主机名默认是重复的

- 当前仅支持IP v4，IP v6显示为-
- 兼容未采集IP的设备

设备页：
<img width="2578" height="564" alt="image" src="https://github.com/user-attachments/assets/3f7f1f65-3572-4acd-831a-54f81dc07e72" />
主机信息：
<img width="904" height="658" alt="image" src="https://github.com/user-attachments/assets/d8cf66ad-46bc-414e-a78e-47817fa5e5f4" />
