### PR TITLE
fix(aiops): scope ToolSearch to persona whitelist via ctx

### DIFF
--- a/internal/manager/biz/aiops/chatruntime/runtime.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime.go
@@ -614,6 +614,11 @@ func (rt *Runtime) Handle(ctx context.Context, req *Request) (*Reply, error) {
 	invokeOpts = append(invokeOpts, compose.WithToolsNodeOption(
 		compose.WithToolOption(graph.WithInvokeOpts(basetool.WithUserText(req.UserText))),
 	))
+	// Thread the persona-filtered tool view onto ctx so ToolSearch
+	// (which runs inside the graph) only returns tools the current
+	// persona is allowed to see. Must happen BEFORE the coordinator-
+	// stub append so stubs don't leak into the filtered view.
+	ctx = basetool.WithFilteredTools(ctx, sessionToolBag)
 	// Thread the UI locale onto ctx so AgentTool can pick it up and
 	// forward it into the sub-agent's SpawnRequest. Without this, a
 	// coordinator that handles an English question hands off to a

--- a/internal/manager/biz/aiops/chatruntime/worker.go
+++ b/internal/manager/biz/aiops/chatruntime/worker.go
@@ -540,6 +540,12 @@ func (rt *Runtime) GetWorker(workerID string) (*Worker, bool) {
 func (rt *Runtime) runWorker(ctx context.Context, agentDef *Agent, sessID, userText, locale string) (string, error) {
 	workerTools := filterToolsForAgent(rt.cfg.ToolBag, agentDef, false)
 
+	// Thread the persona-filtered tool view onto ctx so ToolSearch
+	// (which runs inside the worker graph) only returns tools the
+	// worker persona is allowed to see. ctx is per-request (each
+	// worker has its own), so concurrent workers don't race.
+	ctx = basetool.WithFilteredTools(ctx, workerTools)
+
 	systemPrompt := ComposeSystemPrompt(rt.cfg.BasePrompt, nil, agentDef)
 
 	// KB-first prologue. Weak coordinator models (GLM-4 etc) don't

--- a/internal/manager/biz/aiops/tools/basetool/filtered_tools.go
+++ b/internal/manager/biz/aiops/tools/basetool/filtered_tools.go
@@ -1,0 +1,33 @@
+// filtered_tools.go implements ctx-propagation of the persona-whitelist-
+// filtered tool view. ToolSearch reads from ctx so it only returns tools
+// the current persona (coordinator or worker) is allowed to see, without
+// shared mutable state on the ToolBag that would race across concurrent
+// workers.
+package basetool
+
+import (
+	"context"
+)
+
+type filteredToolsCtxKeyT struct{}
+
+var filteredToolsCtxKey = filteredToolsCtxKeyT{}
+
+// WithFilteredTools returns ctx augmented with the persona-filtered tool
+// slice. The runtime calls this before graph.Invoke so ToolSearch (which
+// runs inside the graph) can scope its search to only whitelist-surviving
+// tools. nil/empty is a no-op.
+func WithFilteredTools(ctx context.Context, tools []BaseTool) context.Context {
+	if len(tools) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, filteredToolsCtxKey, tools)
+}
+
+// FilteredToolsFromContext retrieves the persona-filtered tool slice from
+// ctx, if any. Returns nil when no filtering was applied (caller should
+// fall back to the full tool universe).
+func FilteredToolsFromContext(ctx context.Context) []BaseTool {
+	v, _ := ctx.Value(filteredToolsCtxKey).([]BaseTool)
+	return v
+}

--- a/internal/manager/biz/aiops/tools/tool_search_tool.go
+++ b/internal/manager/biz/aiops/tools/tool_search_tool.go
@@ -147,8 +147,16 @@ func (t *ToolSearchTool) InvokableRun(ctx context.Context, argsJSON string, _ ..
 		maxResults = 20
 	}
 
-	all := t.bag.AllTools()
-	matches := matchTools(ctx, all, args.Query, maxResults)
+	// Use the persona-filtered view from ctx when available (set by
+	// chatruntime before graph.Invoke), so ToolSearch only returns tools
+	// the current persona (coordinator or worker) is allowed to see.
+	// Falls back to AllTools() when no filtering has been applied (e.g.
+	// legacy agent path, or a persona with no whitelist).
+	searchSet := basetool.FilteredToolsFromContext(ctx)
+	if searchSet == nil {
+		searchSet = t.bag.AllTools()
+	}
+	matches := matchTools(ctx, searchSet, args.Query, maxResults)
 
 	resp := toolSearchResponse{Query: args.Query, Tools: matches}
 	out, err := json.Marshal(resp)


### PR DESCRIPTION
ToolSearch 之前搜索的是全量工具（AllTools()），会泄漏 persona 不应看到的工具 schema。三个改动：

1. alwaysLoadedTools（worker.go）：ToolSearch 绕过 coordinator 和 worker 的 persona whitelist——它是 LLM 需要的基础设施工具，不受 persona 限制。

2. ctx 传递（basetool/filtered_tools.go）：filterToolsForAgentRole 产出过滤后的工具列表后，通过 WithFilteredTools 写入 ctx。ToolSearch 通过 FilteredToolsFromContext 读取，无过滤时回退到 AllTools()（兼容 legacy 路径）。

3. wiring（runtime.go Handle + worker.go runWorker）：各自在 g.Invoke 前将过滤后的工具列表写入 ctx，使图内的 ToolSearch 只返回当前 persona 可见的工具。ctx 是 per-request 的，并发 worker 无竞态。

具体验证：
1，白名单工具query_devices，可搜索
<img width="1738" height="888" alt="image" src="https://github.com/user-attachments/assets/1cc61666-0f54-4a0e-a477-82827f5128a6" />
2，非白名单工具query_promql，已过滤
<img width="1596" height="1080" alt="image" src="https://github.com/user-attachments/assets/9ebc18e5-ee8a-4819-8f13-79d1675a42e5" />
3，Tool Search始终可用
