### PR TITLE
fix(alert): refresh incident summary/value/threshold on re-fire and reopen

### DIFF
--- a/internal/manager/biz/alert/refire_refresh_test.go
+++ b/internal/manager/biz/alert/refire_refresh_test.go
@@ -1,0 +1,119 @@
+package alert
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/alert"
+)
+
+// TestRecordFiringRefreshesContentOnRefire verifies that a second firing for
+// the same dedupe_key refreshes the incident's summary/value/threshold from the
+// latest firing rather than freezing the values captured at first creation.
+// This covers both the already-open "bump" path and the resolved "reopen" path.
+func TestRecordFiringRefreshesContentOnRefire(t *testing.T) {
+	ptr := func(f float64) *float64 { return &f }
+
+	t.Run("open_bump_refreshes_content", func(t *testing.T) {
+		repo := newFakeRepo()
+		uc := NewUsecase(repo, nil)
+		now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+		first, err := uc.RecordFiring(context.Background(), FiringInput{
+			ScopeType:  model.RuleScopeGlobal,
+			Rule:       "device_offline",
+			Severity:   "warning",
+			Summary:    "device offline (> 90)",
+			Value:      ptr(120),
+			Threshold:  ptr(90),
+			DedupeKey:  "global:device_offline",
+			OccurredAt: now,
+		})
+		if err != nil {
+			t.Fatalf("RecordFiring first: %v", err)
+		}
+		if !first.IsNew {
+			t.Fatalf("first firing should create a new incident")
+		}
+
+		second, err := uc.RecordFiring(context.Background(), FiringInput{
+			ScopeType:  model.RuleScopeGlobal,
+			Rule:       "device_offline",
+			Severity:   "warning",
+			Summary:    "device offline (> 300)",
+			Value:      ptr(400),
+			Threshold:  ptr(300),
+			DedupeKey:  "global:device_offline",
+			OccurredAt: now.Add(time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("RecordFiring second: %v", err)
+		}
+		if second.IsNew || second.IsReopen {
+			t.Fatalf("second firing should bump existing incident, got IsNew=%v IsReopen=%v", second.IsNew, second.IsReopen)
+		}
+
+		got := repo.incidents[second.Incident.ID]
+		if got.Summary != "device offline (> 300)" {
+			t.Fatalf("summary = %q, want refreshed to second firing", got.Summary)
+		}
+		if got.Value == nil || *got.Value != 400 {
+			t.Fatalf("value = %v, want 400", got.Value)
+		}
+		if got.Threshold == nil || *got.Threshold != 300 {
+			t.Fatalf("threshold = %v, want 300", got.Threshold)
+		}
+	})
+
+	t.Run("resolved_reopen_refreshes_content", func(t *testing.T) {
+		repo := newFakeRepo()
+		uc := NewUsecase(repo, nil)
+		now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+		first, err := uc.RecordFiring(context.Background(), FiringInput{
+			ScopeType:  model.RuleScopeGlobal,
+			Rule:       "device_offline",
+			Severity:   "warning",
+			Summary:    "device offline (> 90)",
+			Value:      ptr(120),
+			Threshold:  ptr(90),
+			DedupeKey:  "global:device_offline",
+			OccurredAt: now,
+		})
+		if err != nil {
+			t.Fatalf("RecordFiring first: %v", err)
+		}
+
+		// Mark the incident resolved so the next firing takes the reopen path.
+		repo.incidents[first.Incident.ID].Status = model.IncidentStatusResolved
+
+		second, err := uc.RecordFiring(context.Background(), FiringInput{
+			ScopeType:  model.RuleScopeGlobal,
+			Rule:       "device_offline",
+			Severity:   "warning",
+			Summary:    "device offline (> 300)",
+			Value:      ptr(400),
+			Threshold:  ptr(300),
+			DedupeKey:  "global:device_offline",
+			OccurredAt: now.Add(time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("RecordFiring second: %v", err)
+		}
+		if !second.IsReopen {
+			t.Fatalf("second firing should reopen resolved incident")
+		}
+
+		got := repo.incidents[second.Incident.ID]
+		if got.Summary != "device offline (> 300)" {
+			t.Fatalf("summary = %q, want refreshed to second firing", got.Summary)
+		}
+		if got.Value == nil || *got.Value != 400 {
+			t.Fatalf("value = %v, want 400", got.Value)
+		}
+		if got.Threshold == nil || *got.Threshold != 300 {
+			t.Fatalf("threshold = %v, want 300", got.Threshold)
+		}
+	})
+}

--- a/internal/manager/biz/alert/repo.go
+++ b/internal/manager/biz/alert/repo.go
@@ -57,8 +57,8 @@ type Repo interface {
 	// Firing path.
 	GetIncidentByDedupeKey(ctx context.Context, dedupeKey string) (*model.Incident, error)
 	CreateIncident(ctx context.Context, in *model.Incident) error
-	BumpIncidentFiring(ctx context.Context, id uint64, firedAt time.Time) error
-	ReopenIncident(ctx context.Context, id uint64, firedAt time.Time) error
+	BumpIncidentFiring(ctx context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error
+	ReopenIncident(ctx context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error
 	MarkIncidentNotified(ctx context.Context, id uint64, at time.Time) error
 
 	// Silence matching for the firing path.

--- a/internal/manager/biz/alert/testutil_test.go
+++ b/internal/manager/biz/alert/testutil_test.go
@@ -295,7 +295,7 @@ func (r *fakeRepo) CreateIncident(_ context.Context, in *model.Incident) error {
 	return nil
 }
 
-func (r *fakeRepo) BumpIncidentFiring(_ context.Context, id uint64, firedAt time.Time) error {
+func (r *fakeRepo) BumpIncidentFiring(_ context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error {
 	r.bumpCalls++
 	i, ok := r.incidents[id]
 	if !ok {
@@ -303,10 +303,13 @@ func (r *fakeRepo) BumpIncidentFiring(_ context.Context, id uint64, firedAt time
 	}
 	i.LastFiredAt = firedAt
 	i.EventCount++
+	i.Summary = summary
+	i.Value = value
+	i.Threshold = threshold
 	return nil
 }
 
-func (r *fakeRepo) ReopenIncident(_ context.Context, id uint64, firedAt time.Time) error {
+func (r *fakeRepo) ReopenIncident(_ context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error {
 	r.reopenCalls++
 	i, ok := r.incidents[id]
 	if !ok {
@@ -318,6 +321,9 @@ func (r *fakeRepo) ReopenIncident(_ context.Context, id uint64, firedAt time.Tim
 	i.ResolvedAt = nil
 	i.ResolvedBy = nil
 	i.EventCount++
+	i.Summary = summary
+	i.Value = value
+	i.Threshold = threshold
 	return nil
 }
 

--- a/internal/manager/biz/alert/usecase.go
+++ b/internal/manager/biz/alert/usecase.go
@@ -371,16 +371,19 @@ func (u *Usecase) RecordFiring(ctx context.Context, in FiringInput) (*FiringResu
 		// Existing incident path (cold or race-recovery).
 		switch existing.Status {
 		case model.IncidentStatusResolved:
-			if err := u.repo.ReopenIncident(ctx, existing.ID, occurredAt); err != nil {
+			if err := u.repo.ReopenIncident(ctx, existing.ID, occurredAt, in.Summary, in.Value, in.Threshold); err != nil {
 				return nil, fmt.Errorf("reopen incident: %w", err)
 			}
 			existing.Status = model.IncidentStatusOpen
 			existing.SilencedUntil = nil
 			existing.ResolvedAt = nil
 			existing.ResolvedBy = nil
+			existing.Summary = in.Summary
+			existing.Value = in.Value
+			existing.Threshold = in.Threshold
 			isReopen = true
 		default:
-			if err := u.repo.BumpIncidentFiring(ctx, existing.ID, occurredAt); err != nil {
+			if err := u.repo.BumpIncidentFiring(ctx, existing.ID, occurredAt, in.Summary, in.Value, in.Threshold); err != nil {
 				return nil, fmt.Errorf("bump incident: %w", err)
 			}
 		}

--- a/internal/manager/data/alert/store/repo.go
+++ b/internal/manager/data/alert/store/repo.go
@@ -173,16 +173,22 @@ func (r *Repo) UpdateIncidentStatus(ctx context.Context, id uint64, status strin
 }
 
 // BumpIncidentFiring increments event_count and refreshes last_fired_at on a
-// re-firing incident. Status is intentionally left untouched: an Ack or
-// Silence sticks across subsequent firings (rules 3 and 4).
+// re-firing incident. It also refreshes summary/value/threshold from the
+// latest firing so edits to the rule (e.g. a changed threshold) are reflected
+// in the open incident rather than frozen at first creation. Status is
+// intentionally left untouched: an Ack or Silence sticks across subsequent
+// firings (rules 3 and 4).
 // Use ReopenIncident for the resolved -> open transition.
-func (r *Repo) BumpIncidentFiring(ctx context.Context, id uint64, firedAt time.Time) error {
+func (r *Repo) BumpIncidentFiring(ctx context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error {
 	if firedAt.IsZero() {
 		firedAt = time.Now().UTC()
 	}
 	res := r.db.WithContext(ctx).Model(&model.Incident{}).Where("id = ?", id).Updates(map[string]any{
 		"last_fired_at": firedAt,
 		"event_count":   gorm.Expr("event_count + ?", 1),
+		"summary":       summary,
+		"value":         value,
+		"threshold":     threshold,
 	})
 	if res.Error != nil {
 		return res.Error
@@ -195,8 +201,10 @@ func (r *Repo) BumpIncidentFiring(ctx context.Context, id uint64, firedAt time.T
 
 // ReopenIncident transitions a resolved incident back to open and clears the
 // resolved_at / resolved_by columns. Used when a re-firing arrives for a
-// previously resolved incident with the same dedupe_key.
-func (r *Repo) ReopenIncident(ctx context.Context, id uint64, firedAt time.Time) error {
+// previously resolved incident with the same dedupe_key. It also refreshes
+// summary/value/threshold from the latest firing so the reopened incident
+// reflects the current rule rather than the content frozen at first creation.
+func (r *Repo) ReopenIncident(ctx context.Context, id uint64, firedAt time.Time, summary string, value, threshold *float64) error {
 	if firedAt.IsZero() {
 		firedAt = time.Now().UTC()
 	}
@@ -207,6 +215,9 @@ func (r *Repo) ReopenIncident(ctx context.Context, id uint64, firedAt time.Time)
 		"silenced_until": nil,
 		"resolved_at":    nil,
 		"resolved_by":    nil,
+		"summary":        summary,
+		"value":          value,
+		"threshold":      threshold,
 	})
 	if res.Error != nil {
 		return res.Error

--- a/internal/manager/data/alert/store/store_test.go
+++ b/internal/manager/data/alert/store/store_test.go
@@ -77,7 +77,8 @@ func TestIncidentEventRoundTrip(t *testing.T) {
 	if err := repo.CreateEvent(ctx, ev); err != nil {
 		t.Fatalf("CreateEvent: %v", err)
 	}
-	if err := repo.BumpIncidentFiring(ctx, got.ID, incident.FirstFiredAt.Add(5*time.Minute)); err != nil {
+	bumpedValue, bumpedThreshold := 42.0, 300.0
+	if err := repo.BumpIncidentFiring(ctx, got.ID, incident.FirstFiredAt.Add(5*time.Minute), "edge 2 cpu high (> 300)", &bumpedValue, &bumpedThreshold); err != nil {
 		t.Fatalf("BumpIncidentFiring: %v", err)
 	}
 	if err := repo.UpdateIncidentStatus(ctx, got.ID, model.IncidentStatusAcknowledged, ptrUint64(99), incident.FirstFiredAt.Add(6*time.Minute)); err != nil {
@@ -96,6 +97,15 @@ func TestIncidentEventRoundTrip(t *testing.T) {
 	}
 	if gotAfter.EventCount != 2 {
 		t.Fatalf("event_count = %d", gotAfter.EventCount)
+	}
+	if gotAfter.Summary != "edge 2 cpu high (> 300)" {
+		t.Fatalf("summary = %q, want refreshed", gotAfter.Summary)
+	}
+	if gotAfter.Value == nil || *gotAfter.Value != bumpedValue {
+		t.Fatalf("value = %v, want %v", gotAfter.Value, bumpedValue)
+	}
+	if gotAfter.Threshold == nil || *gotAfter.Threshold != bumpedThreshold {
+		t.Fatalf("threshold = %v, want %v", gotAfter.Threshold, bumpedThreshold)
 	}
 
 	list, err := repo.ListEventsByIncident(ctx, got.ID, 10)


### PR DESCRIPTION
## Summary

Alert incidents stored their `summary`, `value`, and `threshold` once, at first creation, and never refreshed them. Re-firings reuse the same row by `dedupe_key` and only bumped counters, so once a rule's threshold was edited (e.g. `device_offline` changed from `> 90` to `> 300`), already-open incidents kept showing the stale `> 90` text forever.

## What / Why

- `RecordFiring`'s existing-incident path called `BumpIncidentFiring` (open) or `ReopenIncident` (resolved -> open); neither refreshed incident content.
- Both repo methods now also update `summary`, `value`, and `threshold` from the latest firing, so open/reopened incidents reflect the current rule.
- Interface, GORM impl, callers, and the in-memory result mirror were updated to thread `summary, value, threshold` through.

## Test plan

- [x] `go build ./...`
- [x] New `TestRecordFiringRefreshesContentOnRefire` covering both the open->bump and resolved->reopen paths asserts the stored incident reflects the SECOND firing.
- [x] `store_test.go` round-trip now asserts the columns are refreshed after a bump.
- [x] `go test ./internal/manager/biz/alert/... ./internal/manager/data/alert/...` passes.

Note: a pre-existing, unrelated build failure exists in `internal/manager/biz/edge` test (`e.DeletedAt.Valid` on `*time.Time`) on `upstream/main`; it is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)