### PR TITLE
fix(alert): persist send-policy fields on rule update

### DIFF
--- a/internal/manager/data/alert/store/repo.go
+++ b/internal/manager/data/alert/store/repo.go
@@ -585,6 +585,12 @@ func (r *Repo) UpdateRule(ctx context.Context, id uint64, in *model.Rule) error 
 		"labels_json":      in.LabelsJSON,
 		"annotations_json": in.AnnotationsJSON,
 		"runbook_url":      in.RunbookURL,
+		// 发送策略 (send-policy): a map-based Updates only writes the keys
+		// listed here — omitting these three silently dropped every edit to
+		// the rule's dampening window / threshold / pinned channels.
+		"notify_window_seconds":   in.NotifyWindowSeconds,
+		"notify_min_fires":        in.NotifyMinFires,
+		"notify_channel_ids_json": in.NotifyChannelIDsJSON,
 	}
 	res := r.db.WithContext(ctx).Model(&model.Rule{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {


### PR DESCRIPTION
## Summary
- `UpdateRule` (alert store repo) used a map-based gorm `Updates` that listed only a subset of columns, so edits to the rule's **send-policy** (`notify_window_seconds`, `notify_min_fires`, `notify_channel_ids_json`) were silently dropped.
- Symptom: the UI's 发送策略 changes were accepted and round-tripped through `buildRuleRow`, then never written to the DB — reopening the rule showed the old values.
- Fix adds the three columns to the `updates` map. Using a map (not a struct) means zero values still write, so disabling the policy (both fields back to 0) and clearing pinned channels now persist correctly.

## Test plan
- [x] `go build ./internal/manager/data/alert/store/`
- [x] `go test ./internal/manager/data/alert/store/ ./internal/manager/biz/alert/`
- [ ] Manual: edit a rule's 发送策略 in the UI, save, reopen — values persist; set both back to 0 — policy clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
