### PR TITLE
fix(edge/traces): default insecure_skip_verify on the OTLP trace exporter

### DIFF
--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -60,6 +60,8 @@ processors:
 exporters:
   otlphttp/manager:
     endpoint: {{ .Endpoint }}
+    tls:
+      insecure_skip_verify: {{ .TLSInsecureSkipVerify }}
     {{- if .AuthHeader }}
     headers:
       Authorization: "{{ .AuthHeader }}"
@@ -99,6 +101,7 @@ service:
 //	grpc_endpoint : string (default "127.0.0.1:4317")
 //	http_endpoint : string (default "127.0.0.1:4318")
 //	extra_attrs : map[string]string (extra resource attributes)
+//	tls_insecure_skip_verify : bool (default true; set false with a real cert)
 //
 // The Endpoint must be the manager's public OTLP HTTP write URL (e.g.
 // https://manager.example.com/v1/traces). Auth: when AuthUser is set we
@@ -115,6 +118,19 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 	httpEP := stringOr(cfg.Spec, "http_endpoint", "127.0.0.1:4318")
 	extra := stringMap(cfg.Spec, "extra_attrs")
 
+	// Default to skip-verify because the standard install ships a self-signed
+	// manager cert (deploy/install/upgrade.sh), and the OTLP push goes to the
+	// manager's HTTPS /v1/traces. Without this the exporter fails
+	// "x509: certificate signed by unknown authority" and no edge span ever
+	// lands — mirrors the logs plugin's tls_insecure_skip_verify default.
+	// Operators who plug in a real cert can set spec.tls_insecure_skip_verify=false.
+	tlsInsecure := true
+	if v, ok := cfg.Spec["tls_insecure_skip_verify"]; ok {
+		if b, ok := v.(bool); ok {
+			tlsInsecure = b
+		}
+	}
+
 	authHeader := ""
 	if cfg.AuthPass != "" {
 		if cfg.AuthUser != "" {
@@ -127,12 +143,13 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 	// text/template ranges over maps in key-sorted order (Go 1.12+), so
 	// passing the raw map yields stable rendered output across runs.
 	data := map[string]any{
-		"EdgeID":       cfg.EdgeID,
-		"GRPCEndpoint": grpcEP,
-		"HTTPEndpoint": httpEP,
-		"ExtraAttrs":   extra,
-		"Endpoint":     cfg.Endpoint,
-		"AuthHeader":   authHeader,
+		"EdgeID":                cfg.EdgeID,
+		"GRPCEndpoint":          grpcEP,
+		"HTTPEndpoint":          httpEP,
+		"ExtraAttrs":            extra,
+		"Endpoint":              cfg.Endpoint,
+		"AuthHeader":            authHeader,
+		"TLSInsecureSkipVerify": tlsInsecure,
 	}
 
 	tmpl, err := template.New("otelcol").Parse(otelcolTemplate)

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -57,6 +57,42 @@ func TestRenderHappyPath(t *testing.T) {
 	}
 }
 
+func TestRenderTLSInsecureSkipVerifyDefaultsTrue(t *testing.T) {
+	// The standard install ships a self-signed manager cert, so the OTLP push
+	// to the HTTPS /v1/traces endpoint must skip verification by default —
+	// otherwise the exporter fails x509 and no edge span ever lands.
+	cfg := plugins.PluginConfig{
+		Enabled:  true,
+		EdgeID:   1,
+		Endpoint: "https://manager.example.com/v1/traces",
+	}
+	out, err := render(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "tls:") || !strings.Contains(body, "insecure_skip_verify: true") {
+		t.Errorf("expected tls.insecure_skip_verify: true by default\n--- body ---\n%s", body)
+	}
+}
+
+func TestRenderTLSInsecureSkipVerifyOptOut(t *testing.T) {
+	// Operators with a real cert can turn verification back on.
+	cfg := plugins.PluginConfig{
+		Enabled:  true,
+		EdgeID:   1,
+		Endpoint: "https://manager.example.com/v1/traces",
+		Spec:     map[string]interface{}{"tls_insecure_skip_verify": false},
+	}
+	out, err := render(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if body := string(out); !strings.Contains(body, "insecure_skip_verify: false") {
+		t.Errorf("expected insecure_skip_verify: false when opted out\n--- body ---\n%s", body)
+	}
+}
+
 func TestRenderDefaultEndpoints(t *testing.T) {
 	cfg := plugins.PluginConfig{
 		Enabled:  true,
@@ -126,4 +162,3 @@ func TestRenderRejectsMissingEdgeID(t *testing.T) {
 		t.Errorf("render must reject missing edge_id")
 	}
 }
-


### PR DESCRIPTION
## Summary
The edge **traces plugin** renders an otelcol config whose \`otlphttp/manager\` exporter pushes spans to the manager over HTTPS (\`/v1/traces\`). It had **no \`tls\` block**, so it did full cert verification against the system CA store. The standard install ships a **self-signed** manager cert, so on any such deployment the exporter fails:

\`\`\`
exporting failed. will retry the request after interval, failed to verify certificate: x509: certificate signed by unknown authority
\`\`\`

and **no edge span ever reaches Tempo**.

## Why it went unnoticed
Cloud-internal traces still land (manager → \`tempo:4318\` over plain http via \`WithInsecure()\`), so Tempo always had \`ongrid-manager\` spans — masking that **edge-originated traces have effectively never worked under a self-signed cert**. Verified on the test env: Tempo has only the \`ongrid-manager\` service, zero edge sources; \`edge_plugin_configs\` is empty (the traces plugin had never been enabled). The customer is simply the first to enable it.

metrics + logs already tolerate self-signed (logs has \`tls_insecure_skip_verify\` default true); **traces was the lone holdout**.

## Fix
Render \`tls.insecure_skip_verify\` on the exporter, **default true**, overridable via \`spec.tls_insecure_skip_verify=false\` for operators with a real cert — mirrors the logs plugin exactly.

## Test plan
- [x] \`go build ./internal/edgeagent/...\`
- [x] \`go test ./internal/edgeagent/plugins/traces/\` (added default + opt-out render tests)
- [ ] e2e: enable the traces plugin on a test edge, confirm an edge-sourced span lands in Tempo (not yet run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)