### PR TITLE
fix(edge): sync device presence with edge heartbeat + delete (#145)

### DIFF
--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -205,10 +205,22 @@ func (u *Usecase) List(ctx context.Context, f ListFilter) ([]*model.Edge, error)
 	return u.repo.List(ctx, f)
 }
 
-// Delete soft-deletes an edge.
+// Delete soft-deletes an edge. The linked Device is marked offline first
+// so deleting an edge doesn't leave its host stuck "online" in the device
+// list / query_devices forever (the device row outlives the edge row; only
+// HandleOffline on a tunnel close used to flip it, so a hard delete left an
+// orphan that read as perpetually online).
 func (u *Usecase) Delete(ctx context.Context, id uint64) error {
 	if u.repo == nil {
 		return errs.ErrNotWiredYet
+	}
+	if u.devices != nil {
+		edge, err := u.repo.GetByID(ctx, id)
+		if err == nil && edge.DeviceID != nil {
+			if derr := u.devices.MarkOffline(ctx, *edge.DeviceID); derr != nil && u.log != nil {
+				u.log.Warn("delete edge: device mark-offline failed", "edge_id", id, "device_id", *edge.DeviceID, "err", derr)
+			}
+		}
 	}
 	return u.repo.Delete(ctx, id)
 }
@@ -402,11 +414,32 @@ func hashFingerprint(seed string) string {
 // pinned to online because a heartbeat arriving at all implies a live
 // session; the authenticator already set online on handshake but subsequent
 // heartbeats also refresh the timestamp.
+//
+// The linked Device's denormalised last_seen_at is refreshed too. Without
+// this it was only bumped on register (MarkOnline in HandleRegister), so a
+// continuously-connected edge left its Device.LastSeenAt frozen at the last
+// reconnect time — the device list / query_devices then showed a host as
+// "last seen hours ago" while its edge heartbeat was seconds fresh, and any
+// last_seen freshness filter ("offline > N hours") was unusable.
 func (u *Usecase) HandleHeartbeat(ctx context.Context, edgeID uint64, ts time.Time) error {
 	if u.repo == nil {
 		return errs.ErrNotWiredYet
 	}
-	return u.repo.UpdateStatus(ctx, edgeID, model.StatusOnline, ts)
+	if err := u.repo.UpdateStatus(ctx, edgeID, model.StatusOnline, ts); err != nil {
+		return err
+	}
+	// Best-effort device mirror: a stale device last_seen must not fail the
+	// heartbeat. MarkOnline sets online=true + bumps last_seen_at, which is
+	// exactly the right semantics for a live heartbeat.
+	if u.devices != nil {
+		edge, err := u.repo.GetByID(ctx, edgeID)
+		if err == nil && edge.DeviceID != nil {
+			if derr := u.devices.MarkOnline(ctx, *edge.DeviceID); derr != nil && u.log != nil {
+				u.log.Warn("heartbeat: device last_seen bump failed", "edge_id", edgeID, "device_id", *edge.DeviceID, "err", derr)
+			}
+		}
+	}
+	return nil
 }
 
 // HandleOffline flips an edge's status to offline. Called from the

--- a/internal/manager/biz/edge/usecase_test.go
+++ b/internal/manager/biz/edge/usecase_test.go
@@ -223,7 +223,7 @@ func (r *fakeRepo) GetByID(_ context.Context, id uint64) (*model.Edge, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return nil, errs.ErrNotFound
 	}
 	cp := *e
@@ -234,7 +234,7 @@ func (r *fakeRepo) GetByAccessKey(_ context.Context, ak string) (*model.Edge, er
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, e := range r.byID {
-		if e.AccessKeyID == ak && !e.DeletedAt.Valid {
+		if e.AccessKeyID == ak && e.DeletedAt == nil {
 			cp := *e
 			return &cp, nil
 		}
@@ -246,7 +246,7 @@ func (r *fakeRepo) GetByName(_ context.Context, name string) (*model.Edge, error
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, e := range r.byID {
-		if e.Name == name && !e.DeletedAt.Valid {
+		if e.Name == name && e.DeletedAt == nil {
 			cp := *e
 			return &cp, nil
 		}
@@ -259,7 +259,7 @@ func (r *fakeRepo) List(_ context.Context, f ListFilter) ([]*model.Edge, error) 
 	defer r.mu.Unlock()
 	var out []*model.Edge
 	for _, e := range r.byID {
-		if e.DeletedAt.Valid {
+		if e.DeletedAt != nil {
 			continue
 		}
 		if f.Status != "" && e.Status != f.Status {
@@ -278,7 +278,7 @@ func (r *fakeRepo) UpdateSecretHash(_ context.Context, id uint64, hash string) e
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
 	e.SecretKeyHash = hash
@@ -290,7 +290,7 @@ func (r *fakeRepo) UpdateStatus(_ context.Context, id uint64, status string, las
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
 	e.Status = status
@@ -303,7 +303,7 @@ func (r *fakeRepo) UpdateName(_ context.Context, id uint64, name string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
 	e.Name = name
@@ -314,7 +314,7 @@ func (r *fakeRepo) SetDeviceID(_ context.Context, id, deviceID uint64) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
 	d := deviceID
@@ -326,7 +326,7 @@ func (r *fakeRepo) SetAgentVersion(_ context.Context, id uint64, v string) error
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
 	e.AgentVersion = v
@@ -337,11 +337,11 @@ func (r *fakeRepo) Delete(_ context.Context, id uint64) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.byID[id]
-	if !ok || e.DeletedAt.Valid {
+	if !ok || e.DeletedAt != nil {
 		return errs.ErrNotFound
 	}
-	e.DeletedAt.Valid = true
-	e.DeletedAt.Time = time.Now()
+	now := time.Now()
+	e.DeletedAt = &now
 	return nil
 }
 
@@ -350,7 +350,7 @@ func (r *fakeRepo) Count(_ context.Context) (int64, error) {
 	defer r.mu.Unlock()
 	var n int64
 	for _, e := range r.byID {
-		if !e.DeletedAt.Valid {
+		if e.DeletedAt == nil {
 			n++
 		}
 	}
@@ -586,6 +586,84 @@ func TestHandleRegisterIsIdempotentForSameHost(t *testing.T) {
 	}
 	if got := len(devices.byID); got != 1 {
 		t.Errorf("device rows = %d, want 1 (fingerprint dedupe)", got)
+	}
+}
+
+func TestHandleHeartbeatBumpsLinkedDeviceLastSeen(t *testing.T) {
+	repo := newFakeRepo()
+	devices := newFakeDeviceRepo()
+	uc := NewUsecase(repo, devices, nil, nil)
+	ctx := context.Background()
+
+	res, err := uc.Create(ctx, "edge-hb", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info := tunnel.HostInfo{Hostname: "hb-host", OS: "linux"}
+	if err := uc.HandleRegister(ctx, res.Edge.ID, info, ""); err != nil {
+		t.Fatalf("HandleRegister: %v", err)
+	}
+	// Register marks the device online once.
+	if devices.onlineCalls != 1 {
+		t.Fatalf("precondition: onlineCalls after register = %d, want 1", devices.onlineCalls)
+	}
+
+	// A heartbeat must refresh the DEVICE last_seen too, not just the edge —
+	// otherwise a continuously-connected edge leaves Device.LastSeenAt frozen
+	// at the register time.
+	if err := uc.HandleHeartbeat(ctx, res.Edge.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("HandleHeartbeat: %v", err)
+	}
+	if devices.onlineCalls != 2 {
+		t.Errorf("onlineCalls after heartbeat = %d, want 2 (device last_seen not bumped on heartbeat)", devices.onlineCalls)
+	}
+	after, err := uc.Get(ctx, res.Edge.ID)
+	if err != nil || after.DeviceID == nil {
+		t.Fatalf("Get edge / DeviceID: %v", err)
+	}
+	dev, err := devices.Get(ctx, *after.DeviceID)
+	if err != nil {
+		t.Fatalf("Get device: %v", err)
+	}
+	if !dev.Online || dev.LastSeenAt == nil {
+		t.Errorf("device online=%v lastSeen=%v after heartbeat, want online + non-nil lastSeen", dev.Online, dev.LastSeenAt)
+	}
+}
+
+func TestDeleteMarksLinkedDeviceOffline(t *testing.T) {
+	repo := newFakeRepo()
+	devices := newFakeDeviceRepo()
+	uc := NewUsecase(repo, devices, nil, nil)
+	ctx := context.Background()
+
+	res, err := uc.Create(ctx, "edge-del", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info := tunnel.HostInfo{Hostname: "del-host", OS: "linux"}
+	if err := uc.HandleRegister(ctx, res.Edge.ID, info, ""); err != nil {
+		t.Fatalf("HandleRegister: %v", err)
+	}
+	after, err := uc.Get(ctx, res.Edge.ID)
+	if err != nil || after.DeviceID == nil {
+		t.Fatalf("Get edge / DeviceID: %v", err)
+	}
+	deviceID := *after.DeviceID
+	if dev, _ := devices.Get(ctx, deviceID); dev == nil || !dev.Online {
+		t.Fatalf("precondition: device should be online before delete")
+	}
+
+	// Deleting the edge must flip the linked device offline — otherwise the
+	// host stays "online" forever in the device list with no live edge.
+	if err := uc.Delete(ctx, res.Edge.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	dev, err := devices.Get(ctx, deviceID)
+	if err != nil {
+		t.Fatalf("Get device after delete: %v", err)
+	}
+	if dev.Online {
+		t.Errorf("device still online after edge delete — orphan ghost not prevented")
 	}
 }
 


### PR DESCRIPTION
Fixes #145.

## 问题（用户反馈）
聊天 `query_devices` 与「全部设备」页对不上：一台持续在线的设备显示「最后上报 26.7 小时前」（实际心跳 9 秒前）；聊天列 5 台、设备页 4 台，多一台没有活边端却 `online=true` 的幽灵设备。

## 根因
`Device.Online`/`LastSeenAt` 从 Edge 反范式同步，但两处断链：
1. **心跳不刷设备 last_seen**：`HandleHeartbeat` 只刷 Edge 行；Device 的 last_seen 只在 `HandleRegister`(重连)时 `MarkOnline` 一次 → 持续在线的设备 last_seen 冻结在上次重连，且 `last_seen within N 分钟` 过滤不可用。
2. **删边端留幽灵**：`Delete` 只删 Edge 行，关联 Device 永远停在 online。

## 改动
- `HandleHeartbeat`：心跳时对关联 Device 也 `MarkOnline`（best-effort，失败不影响心跳）。
- `Delete`：删边端前先把关联 Device `MarkOffline`。
- 新增两个单测覆盖上述行为。

## ⚠️ 附带修了一个既有编译回归（需 reviewer 知悉）
PR #123 把 `Edge.DeletedAt` 从 `gorm.DeletedAt` 改成 `*time.Time`，但没更新 edge fakeRepo 测试（仍用 `.Valid`/`.Time`），导致 **`go test ./internal/manager/biz/edge/...` 在 main 上就编不过**（feat/skill-marketplace 合了 v0.8.7 后也坏了）。本 PR 把 fakeRepo 的软删判断改成 `*time.Time` 的 nil 比较，让包恢复可编译——否则新测试无处落脚。**如果想把这个测试修复单独成 PR，我可以拆。**

## 验证
- `go test ./internal/manager/biz/edge/...` 全绿；`go build ./cmd/ongrid` 通过；gofmt 干净。
- 不改 schema、不改 API、不动 edge agent。

## 后续（不在本 PR）
在线状态 reconciler ticker：按关联边端心跳新鲜度周期性重算，自愈**存量**孤儿（本次的 `VM-1-64-tencentos`）+ 覆盖 manager 重启空窗。需动 main.go，故留作单独跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)