### PR TITLE
feat(device): presence reconciler ticker — heal orphan ghost devices (#145)

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1951,6 +1951,32 @@ func main() {
 		})
 	}
 
+	// Device presence reconciler: per-event MarkOnline/MarkOffline can't
+	// flip a device offline when its edge no longer exists (hard delete) or
+	// re-registered under a new fingerprint, and a manager restart while an
+	// edge is offline leaves the denormalised flag stale. This sweep flips
+	// online devices back offline when no linked edge is online — healing
+	// orphan "ghost" devices that otherwise read as perpetually online in
+	// the device list / query_devices. Runs once at boot, then every 60s
+	// (same cadence as edge offline detection). See #145.
+	eg.Go(func() error {
+		if _, err := deviceUC.ReconcilePresence(egCtx); err != nil {
+			log.Warn("device presence reconcile (boot) failed", slog.Any("err", err))
+		}
+		t := time.NewTicker(60 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-egCtx.Done():
+				return nil
+			case <-t.C:
+				if _, err := deviceUC.ReconcilePresence(egCtx); err != nil {
+					log.Warn("device presence reconcile failed", slog.Any("err", err))
+				}
+			}
+		}
+	})
+
 	// Pipeline evaluator: runs metric_raw / metric_anomaly /
 	// metric_forecast / metric_burn_rate rules on a ticker. Also refreshes
 	// the edge_last_seen_seconds_ago gauge (replacement

--- a/internal/manager/biz/device/repo.go
+++ b/internal/manager/biz/device/repo.go
@@ -89,6 +89,15 @@ type Repo interface {
 	// Delete soft-deletes a device (does NOT touch its junction rows;
 	// callers should remove the junction first if they want a clean cut).
 	Delete(ctx context.Context, id uint64) error
+
+	// ReconcileOfflineOrphans flips online=true devices back to offline
+	// when none of their linked (non-deleted) edges is online. Heals
+	// orphan "ghost" devices — a device whose edge was deleted, or whose
+	// host re-registered under a new fingerprint, used to stay online
+	// forever because only a tunnel-close (HandleOffline) flipped it.
+	// Returns the number of rows flipped. Run periodically by the
+	// presence reconciler.
+	ReconcileOfflineOrphans(ctx context.Context) (int64, error)
 }
 
 // HostFacts is the subset of Device columns updated on register.

--- a/internal/manager/biz/device/usecase.go
+++ b/internal/manager/biz/device/usecase.go
@@ -33,6 +33,25 @@ func (u *Usecase) Repo() Repo { return u.repo }
 // Links returns the underlying junction repo. May be nil.
 func (u *Usecase) Links() EdgeDeviceRepo { return u.links }
 
+// ReconcilePresence flips orphan "ghost" devices (online=true with no
+// online linked edge) back to offline and returns how many it healed.
+// Called once at boot and then on a ticker so device presence converges
+// even across manager restarts and hard edge deletes — the per-event
+// MarkOnline/MarkOffline paths can't see an edge that no longer exists.
+func (u *Usecase) ReconcilePresence(ctx context.Context) (int64, error) {
+	if u.repo == nil {
+		return 0, errs.ErrNotWiredYet
+	}
+	n, err := u.repo.ReconcileOfflineOrphans(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 && u.log != nil {
+		u.log.Info("device presence reconcile: flipped orphan devices offline", "count", n)
+	}
+	return n, nil
+}
+
 // Get returns one device by id.
 func (u *Usecase) Get(ctx context.Context, id uint64) (*model.Device, error) {
 	if u.repo == nil {

--- a/internal/manager/data/device/store/device.go
+++ b/internal/manager/data/device/store/device.go
@@ -198,6 +198,34 @@ func (r *Repo) MarkOffline(ctx context.Context, id uint64) error {
 	return nil
 }
 
+// reconcileOfflineOrphansSQL flips online devices back to offline when no
+// linked, non-deleted edge is online. Correlated NOT EXISTS over the
+// edge_devices junction joined to edges. Plain SQL (no GORM soft-delete
+// scope) so the delete_marker filters are explicit and the statement is
+// portable across the MySQL and SQLite backends. delete_marker = 0 is the
+// soft_delete.DeletedAt "live row" sentinel.
+const reconcileOfflineOrphansSQL = `
+UPDATE devices SET online = ?, updated_at = ?
+WHERE delete_marker = 0 AND online = ?
+  AND NOT EXISTS (
+    SELECT 1 FROM edge_devices ed
+    JOIN edges e ON e.id = ed.edge_id
+    WHERE ed.device_id = devices.id
+      AND ed.delete_marker = 0
+      AND e.delete_marker = 0
+      AND e.status = ?
+  )`
+
+// ReconcileOfflineOrphans implements biz/device.Repo. See the interface doc.
+func (r *Repo) ReconcileOfflineOrphans(ctx context.Context) (int64, error) {
+	now := time.Now().UTC()
+	res := r.db.WithContext(ctx).Exec(reconcileOfflineOrphansSQL, false, now, true, "online")
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
 // Get returns the device by primary key.
 func (r *Repo) Get(ctx context.Context, id uint64) (*model.Device, error) {
 	var d model.Device

--- a/internal/manager/data/device/store/device_test.go
+++ b/internal/manager/data/device/store/device_test.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm/logger"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/device"
+	edgemodel "github.com/ongridio/ongrid/internal/manager/model/edge"
 )
 
 func newDeviceTestDB(t *testing.T) *gorm.DB {
@@ -104,5 +105,82 @@ func TestEdgeDeviceLinkSoftDeleteAllowsReuse(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Fatalf("active relink count = %d, want 1", len(rows))
+	}
+}
+
+func TestReconcileOfflineOrphans(t *testing.T) {
+	db := newDeviceTestDB(t)
+	// The device store Migrate creates devices + edge_devices; the reconcile
+	// join also needs the edges table.
+	if err := db.AutoMigrate(&edgemodel.Edge{}); err != nil {
+		t.Fatalf("AutoMigrate edges: %v", err)
+	}
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	mkOnlineDevice := func(fp string) uint64 {
+		d, err := repo.FindOrCreateByFingerprint(ctx, sampleDevice(fp))
+		if err != nil {
+			t.Fatalf("create device %s: %v", fp, err)
+		}
+		if err := repo.MarkOnline(ctx, d.ID); err != nil {
+			t.Fatalf("MarkOnline %s: %v", fp, err)
+		}
+		return d.ID
+	}
+	linkEdge := func(ak, status string, deviceID uint64, deleted bool) {
+		e := &edgemodel.Edge{AccessKeyID: ak, SecretKeyHash: "x", Status: status}
+		if err := db.Create(e).Error; err != nil {
+			t.Fatalf("create edge %s: %v", ak, err)
+		}
+		if err := db.Create(&model.EdgeDevice{EdgeID: e.ID, DeviceID: deviceID, Type: model.EdgeDeviceRelationHost}).Error; err != nil {
+			t.Fatalf("link edge %s: %v", ak, err)
+		}
+		if deleted {
+			if err := db.Delete(&edgemodel.Edge{}, e.ID).Error; err != nil {
+				t.Fatalf("soft-delete edge %s: %v", ak, err)
+			}
+		}
+	}
+
+	devOnline := mkOnlineDevice("dev-online")    // online edge linked -> stays online
+	devOffEdge := mkOnlineDevice("dev-off-edge") // offline edge linked -> flipped offline
+	devDelEdge := mkOnlineDevice("dev-del-edge") // edge soft-deleted -> flipped offline
+	devNoEdge := mkOnlineDevice("dev-no-edge")   // no edge at all -> flipped offline
+
+	linkEdge("ak-online", "online", devOnline, false)
+	linkEdge("ak-offline", "offline", devOffEdge, false)
+	linkEdge("ak-deleted", "online", devDelEdge, true) // online status but deleted row
+
+	n, err := repo.ReconcileOfflineOrphans(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOfflineOrphans: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("flipped count = %d, want 3 (off-edge, del-edge, no-edge)", n)
+	}
+
+	assertOnline := func(id uint64, want bool, label string) {
+		d, err := repo.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get %s: %v", label, err)
+		}
+		if d.Online != want {
+			t.Errorf("%s online=%v, want %v", label, d.Online, want)
+		}
+	}
+	assertOnline(devOnline, true, "dev-online")
+	assertOnline(devOffEdge, false, "dev-off-edge")
+	assertOnline(devDelEdge, false, "dev-del-edge")
+	assertOnline(devNoEdge, false, "dev-no-edge")
+
+	// Idempotent: a second pass flips nothing (the live device stays online,
+	// the rest are already offline).
+	n2, err := repo.ReconcileOfflineOrphans(ctx)
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second reconcile flipped %d, want 0 (idempotent)", n2)
 	}
 }


### PR DESCRIPTION
Refs #145. **Stacked on #146** (base = `fix/device-presence-sync`); review/merge #146 first, then this re-targets `main`.

## 为什么还需要这个
#146 在 happy path 上把设备在线状态修对了（心跳刷 last_seen、删边端级联 offline）。但有些情况**没有事件能触达**：
- 边端被硬删/换指纹后，旧 Device 行没有任何活边端去翻它；
- manager 在边端离线期间重启，反范式的 online 标记停在旧值。

这些就是用户看到的**存量幽灵**（如 `VM-1-64-tencentos`：online=true 但设备页没有对应边端）。#146 不会清它们。

## 改动
- `Repo.ReconcileOfflineOrphans`：一条可移植 UPDATE，把「online=true 但没有任何活（未删）边端在线」的设备翻回 offline（`edge_devices JOIN edges` 上的相关子查询 NOT EXISTS，显式 `delete_marker=0` 过滤，MySQL/SQLite 通用）。
- `device.Usecase.ReconcilePresence`：包一层 + 日志。
- main.go ticker：**启动时跑一次**（立即自愈存量孤儿）+ 之后每 60s（与边端离线检测同节奏）。
- 单测 `TestReconcileOfflineOrphans`：在线边端→保持在线；离线/已删/无边端→翻 offline；幂等。

## 验证
`go test ./internal/manager/data/device/...` 全绿；`go build ./cmd/ongrid` 通过；gofmt 干净。不改 schema、不改 API、不动 edge agent。

## 部署后效果
启动那次 reconcile 会把测试环境现存的 `VM-1-64-tencentos` 幽灵直接翻成 offline——**不需要手动 SQL 清理**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)