### PR TITLE
ci: add go build + vet + test gate (+ fix fake missed by #148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+# Compile + unit-test gate. Exists because regressions like a model field
+# rename that left a fakeRepo test using the old API (PR #123 broke
+# `go test ./internal/manager/biz/edge/...` and sat unnoticed for weeks)
+# must fail a PR, not a release build. e2e tests are `//go:build e2e`
+# tagged and intentionally excluded here — they need docker + a live test
+# environment; this gate is the fast unit/compile layer.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: build + vet + test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: go build
+        run: go build ./...
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...

--- a/internal/manager/server/edge/http_test.go
+++ b/internal/manager/server/edge/http_test.go
@@ -44,6 +44,8 @@ func (d *fakeDeviceRepo) UpdateHostFacts(context.Context, uint64, devicebiz.Host
 }
 func (d *fakeDeviceRepo) MarkOnline(context.Context, uint64) error  { return nil }
 func (d *fakeDeviceRepo) MarkOffline(context.Context, uint64) error { return nil }
+
+func (d *fakeDeviceRepo) ReconcileOfflineOrphans(context.Context) (int64, error) { return 0, nil }
 func (d *fakeDeviceRepo) Get(_ context.Context, id uint64) (*devicemodel.Device, error) {
 	if v, ok := d.byID[id]; ok {
 		return v, nil


### PR DESCRIPTION
## 为什么
目前唯一的 workflow 是 tag 触发的 `release.yml`,没有任何 PR/push 时的编译·单测 gate。后果就是这次连环踩的:
- **#123** 改了 model 字段类型但没更新 fakeRepo 测试 → `go test ./internal/manager/biz/edge/...` 编不过,潜伏数周无人发现;
- **#148**(我自己)给 `device.Repo` 加方法只补了一个 fake,漏了 `server/edge/http_test.go` 那个 → main 上 `go vet ./internal/manager/server/edge/...` 编不过。

## 改动
- 新增 `.github/workflows/ci.yml`:每次 push main / 每个 PR 跑 `go build ./...` + `go vet ./...` + `go test ./...`(ubuntu-24.04,setup-go 1.25.x,cache)。
- **顺手修了本 gate 立刻暴露的回归**:给 `server/edge/http_test.go` 的 fakeDeviceRepo 补上 `ReconcileOfflineOrphans` stub(#148 漏的)。

## 范围说明
- **e2e 不纳入**:它们是 `//go:build e2e` 标签隔离的,需要 docker + 实测环境;本 gate 是快速的编译/单测层。
- **gofmt 暂不 gate**:main 上有既有格式漂移(~10+ 文件),现在加会一上线就红。建议后续单独 `gofmt -w` 一遍再开这个检查。

## 验证
本地在 main 上 `go build/vet/test ./...` 全绿(含本 PR 的 fake 修复)。所以本 gate 合入后 main 是绿的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)