### PR TITLE
fix(edge/traces): add tls_insecure_skip_verify to otelcol exporter (#144)

### DIFF
--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -64,6 +64,14 @@ exporters:
     headers:
       Authorization: "{{ .AuthHeader }}"
     {{- end }}
+    {{- if .TLSInsecureSkipVerify }}
+    tls:
+      # The standard install ships a self-signed manager cert
+      # (deploy/install/upgrade.sh), so otelcol's default cert verification
+      # fails the OTLP/HTTPS push. Skip verification by default; operators
+      # who plug in a real cert can set spec.tls_insecure_skip_verify=false.
+      insecure_skip_verify: true
+    {{- end }}
     compression: gzip
     timeout: 30s
     sending_queue:
@@ -99,6 +107,10 @@ service:
 //	grpc_endpoint : string (default "127.0.0.1:4317")
 //	http_endpoint : string (default "127.0.0.1:4318")
 //	extra_attrs : map[string]string (extra resource attributes)
+//	tls_insecure_skip_verify : bool (default TRUE — skip cert verification
+//	                          on the OTLP/HTTPS push so the standard
+//	                          self-signed manager cert works; set false
+//	                          when a real cert is installed)
 //
 // The Endpoint must be the manager's public OTLP HTTP write URL (e.g.
 // https://manager.example.com/v1/traces). Auth: when AuthUser is set we
@@ -115,6 +127,17 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 	httpEP := stringOr(cfg.Spec, "http_endpoint", "127.0.0.1:4318")
 	extra := stringMap(cfg.Spec, "extra_attrs")
 
+	// Default to skip-verify because the standard install ships a self-signed
+	// manager cert (deploy/install/upgrade.sh). Symmetric with the logs
+	// plugin. Operators who plug in a real cert set
+	// spec.tls_insecure_skip_verify=false.
+	tlsInsecure := true
+	if v, ok := cfg.Spec["tls_insecure_skip_verify"]; ok {
+		if b, ok := v.(bool); ok {
+			tlsInsecure = b
+		}
+	}
+
 	authHeader := ""
 	if cfg.AuthPass != "" {
 		if cfg.AuthUser != "" {
@@ -127,12 +150,13 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 	// text/template ranges over maps in key-sorted order (Go 1.12+), so
 	// passing the raw map yields stable rendered output across runs.
 	data := map[string]any{
-		"EdgeID":       cfg.EdgeID,
-		"GRPCEndpoint": grpcEP,
-		"HTTPEndpoint": httpEP,
-		"ExtraAttrs":   extra,
-		"Endpoint":     cfg.Endpoint,
-		"AuthHeader":   authHeader,
+		"EdgeID":                cfg.EdgeID,
+		"GRPCEndpoint":          grpcEP,
+		"HTTPEndpoint":          httpEP,
+		"ExtraAttrs":            extra,
+		"Endpoint":              cfg.Endpoint,
+		"AuthHeader":            authHeader,
+		"TLSInsecureSkipVerify": tlsInsecure,
 	}
 
 	tmpl, err := template.New("otelcol").Parse(otelcolTemplate)

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -113,6 +113,43 @@ func TestRenderBasicWhenUserSet(t *testing.T) {
 	}
 }
 
+func TestRenderTLSInsecureSkipVerifyDefaultsOn(t *testing.T) {
+	cfg := plugins.PluginConfig{
+		Enabled:  true,
+		EdgeID:   1,
+		Endpoint: "https://manager.example.com/v1/traces",
+	}
+	out, err := render(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := string(out)
+	// Default-on so the standard self-signed manager cert doesn't fail the
+	// OTLP/HTTPS push (issue #144).
+	if !strings.Contains(body, "insecure_skip_verify: true") {
+		t.Errorf("expected tls.insecure_skip_verify by default, got:\n%s", body)
+	}
+}
+
+func TestRenderTLSInsecureSkipVerifyDisabled(t *testing.T) {
+	cfg := plugins.PluginConfig{
+		Enabled:  true,
+		EdgeID:   1,
+		Endpoint: "https://manager.example.com/v1/traces",
+		Spec:     map[string]interface{}{"tls_insecure_skip_verify": false},
+	}
+	out, err := render(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := string(out)
+	// With a real cert the operator opts out; the tls block must be absent
+	// so otelcol verifies the cert chain.
+	if strings.Contains(body, "insecure_skip_verify") {
+		t.Errorf("tls block must be absent when disabled, got:\n%s", body)
+	}
+}
+
 func TestRenderRejectsMissingEndpoint(t *testing.T) {
 	cfg := plugins.PluginConfig{Enabled: true, EdgeID: 1}
 	if _, err := render(cfg); err == nil {
@@ -126,4 +163,3 @@ func TestRenderRejectsMissingEdgeID(t *testing.T) {
 		t.Errorf("render must reject missing edge_id")
 	}
 }
-


### PR DESCRIPTION
Fixes #144.

## 问题
edge 的 traces 插件渲染 otelcol 的 OTLP/HTTPS exporter 时**没有任何 tls 配置**，对接 manager 的自签证书时 otelcol 证书校验失败 → 报 SSL 证书错误。而配置是每次 reconcile 由 manager 下发的 PluginConfig 重新渲染的（文件头 DO-NOT-EDIT），所以手改 otelcol.yaml 加 skip-verify 会在重启/重连时被覆盖还原。

## 修复
给 `otlphttp/manager` exporter 加 `tls.insecure_skip_verify`，由 `spec.tls_insecure_skip_verify` 控制，**默认 true**——与 logs(promtail) 插件完全对称。配了真证书的运维设为 false 即恢复校验。

## 验证
- 单测：默认渲染含 tls skip-verify；显式 false 时不含。
- `go test ./internal/edgeagent/plugins/traces/...` 绿；`go build ./cmd/ongrid-edge ./cmd/ongrid` 通过；gofmt 干净。

不改 schema/API、manager 侧无改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)