### PR TITLE
fix(web): drill down to Grafana by device_id, not edge_id

### DIFF
--- a/web/src/lib/drilldown.ts
+++ b/web/src/lib/drilldown.ts
@@ -53,7 +53,13 @@ type DrilldownInput = {
   rangeInput?: string;
   stepInput?: string;
   title?: string;
-  edgeId?: string | number;
+  // device_id label value used for the Grafana `var-device_id` template
+  // variable. This is the linked Device.ID — NOT edge.id. The two only
+  // coincide for pre-split / back-filled hosts; after the entity split a
+  // re-installed edge gets a fresh edge.id while keeping its device_id,
+  // so passing edge.id here points the dashboard at a non-existent series
+  // (#96).
+  deviceId?: string | number;
 };
 
 function trimTrailingSlash(value: string): string {
@@ -155,8 +161,8 @@ async function buildGrafanaUrl(input: DrilldownInput): Promise<string | null> {
   if (grafanaOrgId.trim()) {
     params.set('orgId', grafanaOrgId.trim());
   }
-  if (input.edgeId !== undefined && input.edgeId !== null && String(input.edgeId).trim() !== '') {
-    params.set('var-device_id', String(input.edgeId));
+  if (input.deviceId !== undefined && input.deviceId !== null && String(input.deviceId).trim() !== '') {
+    params.set('var-device_id', String(input.deviceId));
   }
   return `${baseUrl}/d/${dashboardUid}/server-detail?${params.toString()}`;
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -264,12 +264,15 @@ export default function DashboardPage() {
 
   const openCPUDrilldown = useCallback(async (edge: Edge) => {
     try {
+      // Prometheus series are labelled by device_id, not edge.id. Fall
+      // back to edge.id only when the host-device junction is missing (#96).
+      const deviceId = edge.device_id ?? edge.id;
       await openMetricDrilldown({
-        expr: `100 * (1 - avg by (device_id) (rate(node_cpu_seconds_total{device_id="${edge.id}",mode="idle"}[5m])))`,
+        expr: `100 * (1 - avg by (device_id) (rate(node_cpu_seconds_total{device_id="${deviceId}",mode="idle"}[5m])))`,
         rangeInput: '1h',
         stepInput: '30s',
         title: `${edge.name} CPU`,
-        edgeId: edge.id,
+        deviceId,
       });
       setPromErr(null);
     } catch (err) {

--- a/web/src/pages/EdgeDetail.tsx
+++ b/web/src/pages/EdgeDetail.tsx
@@ -233,14 +233,16 @@ export default function EdgeDetailPage() {
           rangeInput: '6h',
           stepInput: '1m',
           title,
-          edgeId: edge?.id,
+          // device_id label, not edge.id (#96). expr above already uses
+          // device_id; keep var-device_id consistent with it.
+          deviceId: edge?.device_id ?? edge?.id,
         });
         setPromErr(null);
       } catch (err) {
         setPromErr((err as Error).message || tr('打开图表失败', 'Failed to open chart'));
       }
     },
-    [edge?.id],
+    [edge?.id, edge?.device_id],
   );
 
   const toggleSeries = (panel: PanelKey, key: string) => {

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -399,12 +399,15 @@ export default function EdgesPage() {
   );
 
   async function openServerChart(edge: Edge) {
+    // Prometheus series are labelled by device_id, not edge.id. Fall back
+    // to edge.id only when the host-device junction is missing (#96).
+    const deviceId = edge.device_id ?? edge.id;
     await openMetricDrilldown({
-      expr: `100 * (1 - avg by (device_id) (rate(node_cpu_seconds_total{device_id="${edge.id}",mode="idle"}[5m])))`,
+      expr: `100 * (1 - avg by (device_id) (rate(node_cpu_seconds_total{device_id="${deviceId}",mode="idle"}[5m])))`,
       rangeInput: '1h',
       stepInput: '30s',
       title: `${edge.name} CPU`,
-      edgeId: edge.id,
+      deviceId,
     });
   }
 }


### PR DESCRIPTION
## Problem

The "open in Grafana" drilldown from the Edges list, Dashboard and Edge
detail built the server-detail link with `var-device_id = edge.id` (and a
`device_id="<edge.id>"` PromQL filter in the local-fallback expr).

Prometheus series are labelled by `device_id`, which equals `edge.id` only
for pre-split / back-filled hosts. After the edge/device entity split, a
re-installed or batch-registered host gets a fresh `edge.id` while keeping
its `device_id`, so the link pointed at a non-existent series and the
dashboard showed no data — even though the metrics were present under the
real `device_id`.

## Fix

Pass `edge.device_id` (falling back to `edge.id` only when the host-device
junction is missing, preserving prior behaviour) and rename the drilldown
input field `edgeId` → `deviceId` to match its semantics. `EdgeDetail`'s
expr already used `device_id`; only its `var-device_id` was wrong.
`IncidentDetail` already passes a `device_id`, so it is unchanged.

This is the frontend half of #96 (Monitor device_id diverges from Devices
id), not covered by the ingestion-side fix.

## Testing

Built and deployed on a v0.9.0 production instance; verified the Grafana
drilldown from Edges / Dashboard / Edge detail now opens the correct
server-detail dashboard with data for hosts whose `device_id` ≠ `edge.id`.