### PR TITLE
fix(edge): apply staged upgrades on systemd <231 via root oneshot

### DIFF
--- a/deploy/install/apply-pending-upgrade.sh
+++ b/deploy/install/apply-pending-upgrade.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
-# apply-pending-upgrade.sh — systemd ExecStartPre hook for ongrid-edge.
+# apply-pending-upgrade.sh — pre-start upgrade hook for ongrid-edge.
 #
-# Runs as root (the unit's ExecStartPre line uses the `+` prefix to
-# bypass User=ongrid-edge for this single command). Looks for a staged
-# upgrade bundle the agent dropped at /var/lib/ongrid-edge/.upgrade/
-# incoming/ and atomically swaps every file listed in MANIFEST.txt
-# into its declared dest path.
+# Runs as root via the ongrid-edge-upgrade.service oneshot, which
+# ongrid-edge.service pulls in (Wants= + After=) so this runs before every
+# agent start — including each Restart=always auto-restart. It runs as a
+# separate root unit (not the agent's own ExecStartPre) because ongrid-edge
+# runs sandboxed + non-root and cannot write /usr/local; the old
+# `ExecStartPre=-+...` relied on the `+` root-exec prefix, which systemd < 231
+# (CentOS 7 = 219) silently ignores, so the swap never applied there.
+#
+# Looks for a staged upgrade bundle the agent dropped at
+# /var/lib/ongrid-edge/.upgrade/incoming/ and atomically swaps every file
+# listed in MANIFEST.txt into its declared dest path.
 #
 # Three modes covered, in priority order:
 #
@@ -49,9 +55,10 @@ log() { logger -t ongrid-edge-upgrade "$*"; }
 # Bundle upgrades (ADR-024) DON'T re-run install-edge.sh, so a box that was
 # installed before that grant — or one whose groups got dropped — would
 # silently ship empty logs forever. Re-assert membership here: this hook
-# runs as root on every start (the unit's `+`-prefixed ExecStartPre), and
-# systemd resolves supplementary groups when it forks ExecStart, so a group
-# added now takes effect for the agent that starts moments later. Idempotent
+# runs as root on every start (via the ongrid-edge-upgrade.service oneshot,
+# ordered Before=ongrid-edge.service), and systemd resolves supplementary
+# groups when it forks the agent's ExecStart, so a group added now takes
+# effect for the agent that starts moments later. Idempotent
 # (usermod -aG is a no-op if already a member).
 ensure_log_groups() {
   id ongrid-edge >/dev/null 2>&1 || return 0

--- a/deploy/install/edge/install-edge.sh
+++ b/deploy/install/edge/install-edge.sh
@@ -31,6 +31,7 @@ PLUGIN_WORK_DIR="${STATE_DIR}/plugins"       # rendered plugin configs + subproc
 CONFIG_DIR=/etc/ongrid-edge
 ENV_FILE="${CONFIG_DIR}/ongrid-edge.env"
 UNIT_FILE=/etc/systemd/system/ongrid-edge.service
+UPGRADE_UNIT_FILE=/etc/systemd/system/ongrid-edge-upgrade.service
 LOG_DIR=/var/log/ongrid-edge
 
 UNINSTALL=0
@@ -65,7 +66,7 @@ if [[ $UNINSTALL -eq 1 ]]; then
     log_info "stopping ongrid-edge"
     systemctl stop ongrid-edge 2>/dev/null || true
     systemctl disable ongrid-edge 2>/dev/null || true
-    rm -f "$UNIT_FILE"
+    rm -f "$UNIT_FILE" "$UPGRADE_UNIT_FILE"
     systemctl daemon-reload || true
     rm -f "$BIN_DEST"
     rm -rf "$CONFIG_DIR"
@@ -172,12 +173,11 @@ else
     log_warn "promtail-${OS}-${ARCH} not bundled; logs plugin will fail to start until present"
 fi
 
-# C11 Phase-B remote upgrade hook — `apply-pending-upgrade.sh` runs as
-# root via systemd ExecStartPre and swaps the staged binary into place
-# at the next process restart. Idempotent / safe with no pending file
-# (exits 0). The unit file references this absolute path; missing
-# script makes the `-` prefix tolerate the failure but disables remote
-# upgrade. See ADR-018 / HLD-007.
+# C11 Phase-B / ADR-024 remote upgrade hook — `apply-pending-upgrade.sh`
+# runs as root via the ongrid-edge-upgrade.service oneshot (installed
+# below) before every agent start, and swaps the staged bundle into place.
+# Idempotent / safe with no pending file (exits 0). The oneshot unit
+# references this absolute path. See ADR-018 / ADR-024 / HLD-007.
 SWAP_SRC="${SCRIPT_DIR}/apply-pending-upgrade.sh"
 if [[ -f "$SWAP_SRC" ]]; then
     log_info "installing apply-pending-upgrade.sh to ${PLUGIN_BIN_DIR}/apply-pending-upgrade.sh"
@@ -265,8 +265,17 @@ mkdir -p "$LOG_DIR"
 chown "$SERVICE_USER":"$SERVICE_GROUP" "$LOG_DIR" 2>/dev/null || true
 chmod 750 "$LOG_DIR"
 
-# ---------- systemd unit ----------
-log_info "installing systemd unit"
+# ---------- systemd units ----------
+log_info "installing systemd units"
+# Privileged apply oneshot (ADR-024) — runs apply-pending-upgrade.sh as root
+# before the agent. ongrid-edge.service pulls it via Wants=. Guarded so an
+# older bundle without this file still installs the agent unit.
+UPGRADE_UNIT_SRC="${SCRIPT_DIR}/ongrid-edge-upgrade.service"
+if [[ -f "$UPGRADE_UNIT_SRC" ]]; then
+    install -m 0644 -o root -g root "$UPGRADE_UNIT_SRC" "$UPGRADE_UNIT_FILE"
+else
+    log_warn "ongrid-edge-upgrade.service not bundled; remote whole-bundle upgrade won't apply on this host"
+fi
 install -m 0644 -o root -g root "${SCRIPT_DIR}/ongrid-edge.service" "$UNIT_FILE"
 systemctl daemon-reload
 

--- a/deploy/install/edge/install.sh
+++ b/deploy/install/edge/install.sh
@@ -32,6 +32,7 @@ INSTALL_DIR="/usr/local/bin"
 ENV_DIR="/etc/ongrid-edge"
 ENV_FILE="${ENV_DIR}/ongrid-edge.env"
 SERVICE_FILE="/etc/systemd/system/ongrid-edge.service"
+UPGRADE_SERVICE_FILE="/etc/systemd/system/ongrid-edge-upgrade.service"
 LOG_DIR="/var/log/ongrid-edge"
 STATE_DIR="/var/lib/ongrid-edge"
 SERVICE_USER="ongrid-edge"
@@ -276,22 +277,44 @@ mkdir -p "$STATE_DIR"
 chown "$SERVICE_USER":"$SERVICE_GROUP" "$STATE_DIR"
 chmod 0755 "$STATE_DIR"
 
-# --- systemd unit ------------------------------------------------------------
+# --- systemd units -----------------------------------------------------------
+
+# ADR-024 privileged apply oneshot. Runs apply-pending-upgrade.sh as root
+# (no sandbox) before the agent, so it can write the root-owned binary paths
+# under /usr/local. ongrid-edge.service pulls it via Wants=, which re-runs it
+# on every Restart=always auto-restart (verified on systemd 219). This
+# replaces the old `ExecStartPre=-+...`: the `+` root-exec prefix is
+# unsupported on systemd < 231 and was silently ignored there, so upgrades
+# never applied on CentOS 7's systemd 219.
+cat > "$UPGRADE_SERVICE_FILE" <<'EOF'
+[Unit]
+Description=ongrid edge pending-upgrade apply (root, pre-start)
+Documentation=ADR-024
+Before=ongrid-edge.service
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+EOF
 
 cat > "$SERVICE_FILE" <<'EOF'
 [Unit]
 Description=ongrid edge agent
 After=network-online.target
 Wants=network-online.target
+# ADR-024 remote upgrade: the privileged "apply staged bundle + rollback
+# check" step runs as the separate root oneshot ongrid-edge-upgrade.service
+# (this unit is sandboxed + non-root and cannot write /usr/local). Wants=
+# pulls it on every (re)start incl. Restart=always; After= guarantees the
+# swap lands before the agent execs.
+Wants=ongrid-edge-upgrade.service
+After=ongrid-edge-upgrade.service
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/ongrid-edge/ongrid-edge.env
-# ADR-024 ExecStartPre — applies a staged whole-bundle upgrade then
-# rolls back on next boot if no healthy_marker landed. `+` runs as
-# root regardless of User=; `-` lets a missing/failing script exit 0
-# without blocking the unit so the pre-upgrade binary still starts.
-ExecStartPre=-+/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
 ExecStart=/usr/local/bin/ongrid-edge
 Restart=always
 RestartSec=5

--- a/deploy/install/edge/ongrid-edge-upgrade.service
+++ b/deploy/install/edge/ongrid-edge-upgrade.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=ongrid edge pending-upgrade apply (root, pre-start)
+Documentation=file:///usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+# Ordered before the agent so a staged whole-bundle upgrade is swapped in
+# (and the previous boot's health / auto-rollback check runs) BEFORE
+# ongrid-edge starts. ongrid-edge.service pulls this in via Wants=, which
+# re-runs this oneshot on EVERY start of the agent — including each
+# Restart=always auto-restart (verified on systemd 219 / CentOS 7). The
+# agent stages a bundle then exits; systemd restarts it and this hook
+# applies the swap first, so the agent comes back on the new binary.
+Before=ongrid-edge.service
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+# Runs as root (no User=, no sandbox) so it can write the root-owned binary
+# paths under /usr/local that the sandboxed ongrid-edge.service cannot.
+#
+# This REPLACES the agent unit's old
+#   ExecStartPre=-+/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+# The `+` (run-this-Exec-line-as-root) prefix only exists on systemd >= 231,
+# so on systemd 219 (CentOS/RHEL 7) it was SILENTLY IGNORED: the apply line
+# ran as the unprivileged User=ongrid-edge, couldn't write /usr/local, and
+# every fleet device on old systemd looped forever on the pre-upgrade binary.
+ExecStart=/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+# The script is best-effort and already exits 0 on any internal error. It is
+# pulled via Wants= (not Requires=) and ordered with After=, so even a
+# missing or failing apply never blocks the agent from starting whatever
+# binary is already on disk — preserving the old `-` prefix's tolerance.

--- a/deploy/install/edge/ongrid-edge.service
+++ b/deploy/install/edge/ongrid-edge.service
@@ -2,17 +2,22 @@
 Description=ongrid edge agent
 After=network-online.target
 Wants=network-online.target
+# C11 Phase-B / ADR-024 remote upgrade. The privileged "apply staged bundle"
+# step runs as a SEPARATE root oneshot (ongrid-edge-upgrade.service) because
+# this unit runs sandboxed (ProtectSystem=strict) and non-root (User=) and so
+# cannot write the binary paths under /usr/local. Wants= pulls the oneshot on
+# every (re)start of this unit — including Restart=always auto-restarts — and
+# After= guarantees the swap lands before the agent execs.
+#
+# This replaces the old `ExecStartPre=-+.../apply-pending-upgrade.sh`, whose
+# `+` root-exec prefix is unsupported on systemd < 231 (CentOS 7 = 219) and
+# was silently ignored there, so upgrades never applied on old systemd.
+Wants=ongrid-edge-upgrade.service
+After=ongrid-edge-upgrade.service
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/ongrid-edge/ongrid-edge.env
-# C11 Phase-B remote upgrade — `+` runs as root regardless of User=,
-# `-` lets a missing/failing script exit 0 without blocking the unit.
-# Script no-ops when no /var/lib/ongrid-edge/.upgrade/pending exists;
-# when it does, it sha256-verifies and atomically swaps it over the
-# binary path. Worst case (script wedged) the unit still starts the
-# pre-upgrade binary because of the `-` prefix.
-ExecStartPre=-+/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
 ExecStart=/usr/local/bin/ongrid-edge
 Restart=always
 RestartSec=5

--- a/deploy/install/edge/uninstall.sh
+++ b/deploy/install/edge/uninstall.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 INSTALL_DIR="/usr/local/bin"
 ENV_DIR="/etc/ongrid-edge"
 SERVICE_FILE="/etc/systemd/system/ongrid-edge.service"
+UPGRADE_SERVICE_FILE="/etc/systemd/system/ongrid-edge-upgrade.service"
 LOG_DIR="/var/log/ongrid-edge"
 SERVICE_USER="ongrid-edge"
 # Wholesale plugin dirs: bundled binaries (promtail, node_exporter,
@@ -36,8 +37,8 @@ fi
 # was still running — agent + every subprocess survived, printed [OK].
 # `systemctl stop` is safe to call on an unknown unit (logs to stderr,
 # returns non-zero) so we just suppress + ignore failures.
-systemctl stop    ongrid-edge ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
-systemctl disable ongrid-edge ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
+systemctl stop    ongrid-edge ongrid-edge-upgrade ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
+systemctl disable ongrid-edge ongrid-edge-upgrade ongrid-node-exporter ongrid-process-exporter 2>/dev/null || true
 
 # Defensive: if systemd never actually managed the agent (manual
 # install, broken unit file, etc.), kill the supervisor and any
@@ -46,7 +47,7 @@ systemctl disable ongrid-edge ongrid-node-exporter ongrid-process-exporter 2>/de
 # enumerating them.
 pkill -9 -f '/usr/local/bin/ongrid-edge|/usr/local/lib/ongrid-edge/' 2>/dev/null || true
 
-rm -f "$SERVICE_FILE" "$INSTALL_DIR/ongrid-edge"
+rm -f "$SERVICE_FILE" "$UPGRADE_SERVICE_FILE" "$INSTALL_DIR/ongrid-edge"
 rm -f /etc/systemd/system/ongrid-node-exporter.service
 rm -f /etc/systemd/system/ongrid-process-exporter.service
 rm -rf "$ENV_DIR"

--- a/deploy/install/uninstall.sh
+++ b/deploy/install/uninstall.sh
@@ -207,9 +207,9 @@ if (( local_edge_present )); then
         if [[ -x "$SCRIPT_DIR/edge/uninstall.sh" ]]; then
             bash "$SCRIPT_DIR/edge/uninstall.sh" 2>&1 | tail -5 || true
         else
-            systemctl stop ongrid-edge 2>/dev/null || true
-            systemctl disable ongrid-edge 2>/dev/null || true
-            rm -f /etc/systemd/system/ongrid-edge.service
+            systemctl stop ongrid-edge ongrid-edge-upgrade 2>/dev/null || true
+            systemctl disable ongrid-edge ongrid-edge-upgrade 2>/dev/null || true
+            rm -f /etc/systemd/system/ongrid-edge.service /etc/systemd/system/ongrid-edge-upgrade.service
             rm -f /usr/local/bin/ongrid-edge
             rm -rf /etc/ongrid-edge /var/lib/ongrid-edge /var/log/ongrid-edge
             systemctl daemon-reload

--- a/dist/package.sh
+++ b/dist/package.sh
@@ -499,10 +499,16 @@ copy_opt "${REPO_ROOT}/deploy/install/edge/ongrid-edge.env.example" \
          "${STAGE_DIR}/edge/ongrid-edge.env.example"
 copy_opt "${REPO_ROOT}/deploy/install/edge/ongrid-edge.service" \
          "${STAGE_DIR}/edge/ongrid-edge.service"
+# ADR-024 privileged apply oneshot — ongrid-edge.service pulls it via Wants=
+# so apply-pending-upgrade.sh runs as root before each agent start. Required
+# on systemd 219 (CentOS 7) where the old ExecStartPre `+` prefix was ignored.
+copy_opt "${REPO_ROOT}/deploy/install/edge/ongrid-edge-upgrade.service" \
+         "${STAGE_DIR}/edge/ongrid-edge-upgrade.service"
 
-# C11 Phase-B remote upgrade — ExecStartPre script runs as root before
-# each ongrid-edge start; swaps a sha256-verified pending binary into
-# place. install-edge.sh installs this to /usr/local/lib/ongrid-edge/.
+# C11 Phase-B / ADR-024 remote upgrade — apply script runs as root (via the
+# ongrid-edge-upgrade.service oneshot) before each ongrid-edge start; swaps a
+# sha256-verified staged bundle into place. install-edge.sh installs this to
+# /usr/local/lib/ongrid-edge/.
 copy_opt "${REPO_ROOT}/deploy/install/apply-pending-upgrade.sh" \
          "${STAGE_DIR}/edge/apply-pending-upgrade.sh" 755
 


### PR DESCRIPTION
## Summary
On systemd < 231 (CentOS/RHEL 7 = 219), the agent unit applied staged whole-bundle upgrades through `ExecStartPre=-+.../apply-pending-upgrade.sh`. The `+` (run-as-root) Exec prefix only exists on systemd >= 231, so on 219 it was **silently ignored**: the apply hook ran as the unprivileged `User=ongrid-edge`, could not write `/usr/local`, and every device on old systemd looped forever on the pre-upgrade binary (e.g. stuck at the old version after a UI whole-bundle upgrade push).

## Fix
- Move the privileged apply into a separate **root oneshot** `ongrid-edge-upgrade.service` (no `User=`, no sandbox), ordered `Before=ongrid-edge.service` and pulled in via `Wants=` so it re-runs on every agent (re)start including each `Restart=always` auto-restart.
- `Wants=` (not `Requires=`) preserves the old `-` prefix failure tolerance: a missing/failing apply never blocks the agent.
- The agent unit keeps its sandbox (`User=ongrid-edge`, `ProtectSystem=strict`, `NoNewPrivileges=true`) and just gains `Wants=`/`After=` the oneshot.
- Both installers (`install-edge.sh` + curl-pipe `install.sh`), the uninstallers, and `dist/package.sh` ship/remove the new unit.

## Test plan
- [x] Verified on systemd 219 (CentOS 7): oneshot deps re-run on every auto-restart, the swap lands as root, and the agent comes back on the new binary.
- [ ] Verify on systemd >= 231 that behavior is unchanged.