### PR TITLE
feat(edge): batch device operations — package/custom upgrade + delete

### DIFF
--- a/internal/manager/server/edge/http.go
+++ b/internal/manager/server/edge/http.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -153,6 +154,14 @@ func (h *Handler) Register(r chi.Router) {
 	// the stage ack) apply_package. URL+sha auto-resolved here so
 	// admin never types a hash.
 	r.With(h.writeMW("edge:*")).Post("/v1/edges/{id}/upgrade-package", h.upgradePackage)
+	// Batch fleet operations. Each takes {"ids":[...]} and fans out the
+	// per-edge service call with bounded concurrency, returning a
+	// per-id result envelope (never a single 500 — partial failures are
+	// the norm when some edges are offline). Static "batch" segment
+	// coexists with the {id} param above; chi matches static first.
+	r.With(h.writeMW("edge:*")).Post("/v1/edges/batch/upgrade-package", h.batchUpgradePackage)
+	r.With(h.writeMW("edge:*")).Post("/v1/edges/batch/upgrade", h.batchUpgradeAgent)
+	r.With(h.deleteMW("edge:*")).Post("/v1/edges/batch/delete", h.batchDelete)
 	// Process list — read-only host introspection. Monitor page's
 	// per-device process panel calls this; same RPC the LLM tool uses.
 	r.Get("/v1/edges/{id}/processes", h.getProcesses)
@@ -632,6 +641,213 @@ type upgradePkgResp struct {
 	ManifestFiles int    `json:"manifest_files"`
 	Applied       bool   `json:"applied"`
 	ApplyError    string `json:"apply_error,omitempty"`
+}
+
+// --------- batch fleet operations ---------
+
+// maxBatchIDs caps a single batch request. Generous enough for a
+// whole fleet click-through but bounded so a malformed/huge body can't
+// pin the manager fanning out RPCs.
+const maxBatchIDs = 500
+
+// batchConcurrency bounds in-flight per-edge RPCs. Upgrades download a
+// bundle on the far side, so we don't want to hammer every edge at
+// once; 8 is a balance between throughput and manager/network load.
+const batchConcurrency = 8
+
+// batchReq is the common envelope: just the target ids. Operation-
+// specific fields are embedded by the per-endpoint request structs.
+type batchReq struct {
+	IDs []uint64 `json:"ids"`
+}
+
+type batchUpgradePkgReq struct {
+	IDs     []uint64 `json:"ids"`
+	Arch    string   `json:"arch,omitempty"`
+	Version string   `json:"version,omitempty"`
+}
+
+type batchUpgradeAgentReq struct {
+	IDs    []uint64 `json:"ids"`
+	URL    string   `json:"url"`
+	SHA256 string   `json:"sha256"`
+}
+
+// batchResultItem is one edge's outcome. OK + Error are always set;
+// the upgrade-package extras (Version/ManifestFiles/Applied) are
+// populated only for that endpoint and dropped via omitempty otherwise.
+type batchResultItem struct {
+	ID            uint64 `json:"id"`
+	OK            bool   `json:"ok"`
+	Error         string `json:"error,omitempty"`
+	Code          string `json:"code,omitempty"`
+	Version       string `json:"version,omitempty"`
+	ManifestFiles int    `json:"manifest_files,omitempty"`
+	Applied       bool   `json:"applied,omitempty"`
+}
+
+type batchResp struct {
+	Total     int               `json:"total"`
+	Succeeded int               `json:"succeeded"`
+	Failed    int               `json:"failed"`
+	Results   []batchResultItem `json:"results"`
+}
+
+// normalizeBatchIDs validates + de-dupes the requested ids (order
+// preserved). Returns ErrInvalid for empty or over-cap requests.
+func normalizeBatchIDs(ids []uint64) ([]uint64, error) {
+	if len(ids) == 0 || len(ids) > maxBatchIDs {
+		return nil, errs.ErrInvalid
+	}
+	seen := make(map[uint64]struct{}, len(ids))
+	out := make([]uint64, 0, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			return nil, errs.ErrInvalid
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+// runEdgeBatch fans fn out over ids with bounded concurrency, preserving
+// input order in the result slice, and tallies the succeeded/failed
+// counts. fn must return a fully-populated batchResultItem (including ID
+// and OK) for its edge.
+func runEdgeBatch(ctx context.Context, ids []uint64, fn func(ctx context.Context, id uint64) batchResultItem) batchResp {
+	results := make([]batchResultItem, len(ids))
+	sem := make(chan struct{}, batchConcurrency)
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, id uint64) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = fn(ctx, id)
+		}(i, id)
+	}
+	wg.Wait()
+	resp := batchResp{Total: len(ids), Results: results}
+	for _, r := range results {
+		if r.OK {
+			resp.Succeeded++
+		} else {
+			resp.Failed++
+		}
+	}
+	return resp
+}
+
+// batchDelete soft-deletes every requested edge. Partial failures (e.g.
+// an id that's already gone) are reported per-id rather than aborting
+// the whole batch.
+func (h *Handler) batchDelete(w http.ResponseWriter, r *http.Request) {
+	var req batchReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	ids, err := normalizeBatchIDs(req.IDs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	resp := runEdgeBatch(r.Context(), ids, func(ctx context.Context, id uint64) batchResultItem {
+		if err := h.svc.Delete(ctx, id); err != nil {
+			return batchResultItem{ID: id, OK: false, Error: err.Error(), Code: errCode(err)}
+		}
+		return batchResultItem{ID: id, OK: true}
+	})
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// batchUpgradeAgent dispatches the same agent_upgrade RPC (URL + sha256)
+// to every requested edge. Mirrors the single upgradeAgent validation.
+func (h *Handler) batchUpgradeAgent(w http.ResponseWriter, r *http.Request) {
+	var req batchUpgradeAgentReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	if strings.TrimSpace(req.URL) == "" || strings.TrimSpace(req.SHA256) == "" {
+		writeErr(w, errs.ErrInvalid)
+		return
+	}
+	ids, err := normalizeBatchIDs(req.IDs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	url, sha := strings.TrimSpace(req.URL), strings.TrimSpace(req.SHA256)
+	resp := runEdgeBatch(r.Context(), ids, func(ctx context.Context, id uint64) batchResultItem {
+		if _, err := h.svc.UpgradeAgent(ctx, id, url, sha); err != nil {
+			return batchResultItem{ID: id, OK: false, Error: err.Error(), Code: errCode(err)}
+		}
+		return batchResultItem{ID: id, OK: true}
+	})
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// batchUpgradePackage runs the one-button bundle upgrade across the
+// fleet. The bundle (url+sha) is resolved once from the shared arch +
+// version, then each edge does fetch_package + apply_package. A staged-
+// but-not-applied edge is reported OK=false with Applied=false so the
+// operator can see exactly which ones need a re-trigger.
+func (h *Handler) batchUpgradePackage(w http.ResponseWriter, r *http.Request) {
+	if h.pkgRes == nil {
+		writeErr(w, fmt.Errorf("%w: edge bundle not baked into this manager image", errs.ErrNotWiredYet))
+		return
+	}
+	var req batchUpgradePkgReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	ids, err := normalizeBatchIDs(req.IDs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	arch := strings.TrimSpace(req.Arch)
+	if arch == "" {
+		arch = "linux-amd64"
+	}
+	url, sha, ver, err := h.pkgRes.ResolveBundle(arch, strings.TrimSpace(req.Version))
+	if err != nil {
+		writeErr(w, fmt.Errorf("%w: resolve bundle: %v", errs.ErrInvalid, err))
+		return
+	}
+	resp := runEdgeBatch(r.Context(), ids, func(ctx context.Context, id uint64) batchResultItem {
+		stageResp, err := h.svc.FetchPackage(ctx, id, url, sha, ver)
+		if err != nil {
+			return batchResultItem{ID: id, OK: false, Error: fmt.Sprintf("fetch_package: %v", err), Code: errCode(err), Version: ver}
+		}
+		applyResp, err := h.svc.ApplyPackage(ctx, id)
+		if err != nil {
+			// Staged but apply RPC failed — bundle is on disk; flag so
+			// the operator knows this one can be re-triggered.
+			return batchResultItem{
+				ID: id, OK: false,
+				Error:         fmt.Sprintf("staged but apply failed: %v", err),
+				Code:          errCode(err),
+				Version:       ver,
+				ManifestFiles: stageResp.ManifestFiles,
+				Applied:       false,
+			}
+		}
+		return batchResultItem{
+			ID: id, OK: applyResp.Accepted,
+			Version:       ver,
+			ManifestFiles: stageResp.ManifestFiles,
+			Applied:       applyResp.Accepted,
+		}
+	})
+	writeJSON(w, http.StatusOK, resp)
 }
 
 type processDTO struct {

--- a/internal/manager/server/edge/http_test.go
+++ b/internal/manager/server/edge/http_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -109,6 +111,16 @@ type fakeSvc struct {
 	lastRotateID    uint64
 	lastRolesEdgeID uint64
 	lastRolesNames  []string
+
+	// batch-test instrumentation. mu guards the slices/maps because the
+	// batch runner invokes these methods from concurrent goroutines.
+	mu            sync.Mutex
+	deleteIDs     []uint64        // every id passed to Delete (batch-aware)
+	upgradeIDs    []uint64        // every id passed to UpgradeAgent
+	fetchIDs      []uint64        // every id passed to FetchPackage
+	deleteFailIDs map[uint64]bool // ids for which Delete returns ErrNotFound
+	applyAccepted bool            // ApplyPackage.Accepted to report
+	fetchManifest int             // FetchPackage.ManifestFiles to report
 }
 
 func (f *fakeSvc) Create(_ context.Context, _ string, createdBy *uint64) (*biz.CreateResult, error) {
@@ -124,7 +136,13 @@ func (f *fakeSvc) Get(_ context.Context, id uint64) (*model.Edge, error) {
 	return f.getResp, f.getErr
 }
 func (f *fakeSvc) Delete(_ context.Context, id uint64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.lastDeleteID = id
+	f.deleteIDs = append(f.deleteIDs, id)
+	if f.deleteFailIDs[id] {
+		return errs.ErrNotFound
+	}
 	return f.deleteErr
 }
 func (f *fakeSvc) RotateSecret(_ context.Context, id uint64) (string, error) {
@@ -136,14 +154,24 @@ func (f *fakeSvc) UpdateRoles(_ context.Context, id uint64, names []string) erro
 	f.lastRolesNames = names
 	return f.updateRolesErr
 }
-func (f *fakeSvc) UpgradeAgent(_ context.Context, _ uint64, _ string, _ string) (tunnel.AgentUpgradeResponse, error) {
+func (f *fakeSvc) UpgradeAgent(_ context.Context, id uint64, _ string, _ string) (tunnel.AgentUpgradeResponse, error) {
+	f.mu.Lock()
+	f.upgradeIDs = append(f.upgradeIDs, id)
+	f.mu.Unlock()
 	return tunnel.AgentUpgradeResponse{}, nil
 }
-func (f *fakeSvc) FetchPackage(_ context.Context, _ uint64, _ string, _ string, _ string) (tunnel.FetchPackageResponse, error) {
-	return tunnel.FetchPackageResponse{}, nil
+func (f *fakeSvc) FetchPackage(_ context.Context, id uint64, _ string, _ string, _ string) (tunnel.FetchPackageResponse, error) {
+	f.mu.Lock()
+	f.fetchIDs = append(f.fetchIDs, id)
+	mf := f.fetchManifest
+	f.mu.Unlock()
+	return tunnel.FetchPackageResponse{ManifestFiles: mf}, nil
 }
 func (f *fakeSvc) ApplyPackage(_ context.Context, _ uint64) (tunnel.ApplyPackageResponse, error) {
-	return tunnel.ApplyPackageResponse{}, nil
+	f.mu.Lock()
+	accepted := f.applyAccepted
+	f.mu.Unlock()
+	return tunnel.ApplyPackageResponse{Accepted: accepted}, nil
 }
 func (f *fakeSvc) GetProcessList(_ context.Context, _ uint64, _ uint32, _ string) (tunnel.GetProcessListResponse, error) {
 	return tunnel.GetProcessListResponse{}, nil
@@ -384,5 +412,174 @@ func TestRotateSecret_NonAdminForbidden(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+// fakePkgResolver returns a fixed bundle triple so batch upgrade-package
+// tests don't need a real edge-bundles dir.
+type fakePkgResolver struct{}
+
+func (fakePkgResolver) ResolveBundle(_ string, _ string) (string, string, string, error) {
+	return "https://example/ongrid-edge", strings.Repeat("a", 64), "v9.9.9", nil
+}
+
+func postJSON(router http.Handler, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestBatchDelete_AdminHappyPath(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/delete", `{"ids":[1,2,3]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body batchResp
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Total != 3 || body.Succeeded != 3 || body.Failed != 0 {
+		t.Errorf("summary = %+v, want total=3 succeeded=3", body)
+	}
+	sort.Slice(svc.deleteIDs, func(i, j int) bool { return svc.deleteIDs[i] < svc.deleteIDs[j] })
+	if len(svc.deleteIDs) != 3 || svc.deleteIDs[0] != 1 || svc.deleteIDs[2] != 3 {
+		t.Errorf("deleteIDs = %v, want [1 2 3]", svc.deleteIDs)
+	}
+}
+
+func TestBatchDelete_PartialFailure(t *testing.T) {
+	svc := &fakeSvc{deleteFailIDs: map[uint64]bool{2: true}}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/delete", `{"ids":[1,2,3]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body batchResp
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Succeeded != 2 || body.Failed != 1 {
+		t.Errorf("summary = %+v, want succeeded=2 failed=1", body)
+	}
+	for _, r := range body.Results {
+		if r.ID == 2 {
+			if r.OK || r.Code != "not-found" {
+				t.Errorf("id=2 result = %+v, want ok=false code=not-found", r)
+			}
+		}
+	}
+}
+
+func TestBatchDelete_Dedupes(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/delete", `{"ids":[5,5,5]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var body batchResp
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Total != 1 || len(svc.deleteIDs) != 1 {
+		t.Errorf("total=%d deleteIDs=%v, want a single deduped delete", body.Total, svc.deleteIDs)
+	}
+}
+
+func TestBatchDelete_EmptyIDsInvalid(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/delete", `{"ids":[]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchDelete_NonAdminForbidden(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "user"})
+
+	w := postJSON(router, "/v1/edges/batch/delete", `{"ids":[1,2]}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if len(svc.deleteIDs) != 0 {
+		t.Errorf("delete should not run for non-admin; got %v", svc.deleteIDs)
+	}
+}
+
+func TestBatchUpgradeAgent_HappyPath(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	body := `{"ids":[1,2],"url":"https://example/edge","sha256":"` + strings.Repeat("a", 64) + `"}`
+	w := postJSON(router, "/v1/edges/batch/upgrade", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp batchResp
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Succeeded != 2 {
+		t.Errorf("succeeded = %d, want 2", resp.Succeeded)
+	}
+	if len(svc.upgradeIDs) != 2 {
+		t.Errorf("upgradeIDs = %v, want 2 calls", svc.upgradeIDs)
+	}
+}
+
+func TestBatchUpgradeAgent_MissingURLInvalid(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/upgrade", `{"ids":[1],"url":"","sha256":""}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestBatchUpgradePackage_HappyPath(t *testing.T) {
+	svc := &fakeSvc{applyAccepted: true, fetchManifest: 7}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil)
+	h.SetPackageResolver(fakePkgResolver{})
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/upgrade-package", `{"ids":[1,2,3]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp batchResp
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Succeeded != 3 || resp.Failed != 0 {
+		t.Errorf("summary = %+v, want succeeded=3", resp)
+	}
+	for _, r := range resp.Results {
+		if !r.Applied || r.Version != "v9.9.9" || r.ManifestFiles != 7 {
+			t.Errorf("result = %+v, want applied=true version=v9.9.9 manifest=7", r)
+		}
+	}
+}
+
+func TestBatchUpgradePackage_NotWired(t *testing.T) {
+	svc := &fakeSvc{}
+	h := NewHandler(svc, newFakeDeviceRepo(), nil) // no resolver
+	router := buildRouter(h, tenantctx.Tenant{UserID: 1, Role: "admin"})
+
+	w := postJSON(router, "/v1/edges/batch/upgrade-package", `{"ids":[1]}`)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected non-200 when resolver missing; body=%s", w.Body.String())
+	}
+	if len(svc.fetchIDs) != 0 {
+		t.Errorf("fetch should not run when resolver missing; got %v", svc.fetchIDs)
 	}
 }

--- a/web/src/api/edges.ts
+++ b/web/src/api/edges.ts
@@ -73,6 +73,44 @@ export function upgradeEdgePackage(id: number, opts?: { arch?: string; version?:
   return request<UpgradePackageResponse>('POST', `/edges/${id}/upgrade-package`, opts ?? {});
 }
 
+// --- batch fleet operations ---------------------------------------
+// Each endpoint takes a list of edge ids and returns a per-id result
+// envelope (never a single failure — some edges may be offline). The
+// caller renders a "N succeeded / M failed" summary + the failing ids.
+export type BatchResultItem = {
+  id: number;
+  ok: boolean;
+  error?: string;
+  code?: string;
+  // upgrade-package only:
+  version?: string;
+  manifest_files?: number;
+  applied?: boolean;
+};
+
+export type BatchResponse = {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: BatchResultItem[];
+};
+
+// Batch one-button bundle upgrade. Manager resolves url+sha once from
+// the shared arch+version, then fans out fetch_package + apply_package.
+export function batchUpgradeEdgePackage(ids: number[], opts?: { arch?: string; version?: string }) {
+  return request<BatchResponse>('POST', '/edges/batch/upgrade-package', { ids, ...(opts ?? {}) });
+}
+
+// Batch custom upgrade — the same URL + sha256 dispatched to every id.
+export function batchUpgradeEdgeAgent(ids: number[], url: string, sha256: string) {
+  return request<BatchResponse>('POST', '/edges/batch/upgrade', { ids, url, sha256 });
+}
+
+// Batch soft-delete.
+export function batchDeleteEdges(ids: number[]) {
+  return request<BatchResponse>('POST', '/edges/batch/delete', { ids });
+}
+
 export type EdgeProcess = {
   pid: number;
   name: string;

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -23,6 +23,10 @@ import {
   type RotateSecretResponse,
   upgradeEdgeAgent,
   upgradeEdgePackage,
+  batchUpgradeEdgePackage,
+  batchUpgradeEdgeAgent,
+  batchDeleteEdges,
+  type BatchResponse,
 } from '@/api/edges';
 import { getManagerVersion } from '@/api/version';
 import { usePermissions } from '@/store/me';
@@ -82,7 +86,15 @@ export default function EdgesPage() {
   // open a modal — the action is single-click and the result lands in
   // the existing toast pipeline.
   const [pkgUpgradingId, setPkgUpgradingId] = useState<number | null>(null);
-  const [pkgUpgradeToast, setPkgUpgradeToast] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [toast, setToast] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  // Batch selection: set of edge ids ticked via the per-row checkboxes.
+  // The toolbar above the table appears whenever this is non-empty.
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  // When set, the batch custom-upgrade (URL+sha) modal is open for the
+  // currently-selected ids.
+  const [batchUpgradeOpen, setBatchUpgradeOpen] = useState(false);
+  // True while any batch RPC is in flight (disables the toolbar buttons).
+  const [batchBusy, setBatchBusy] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -101,6 +113,14 @@ export default function EdgesPage() {
         );
       }
       setEdges(items);
+      // Drop any selected ids that no longer appear (deleted / filtered out)
+      // so the toolbar count never lies.
+      setSelected((prev) => {
+        if (prev.size === 0) return prev;
+        const live = new Set(items.map((e) => e.id));
+        const next = new Set([...prev].filter((id) => live.has(id)));
+        return next.size === prev.size ? prev : next;
+      });
       setError(null);
     } catch (err) {
       setError((err as Error).message || tr('加载失败', 'Load failed'));
@@ -158,11 +178,11 @@ export default function EdgesPage() {
       `Upgrade ${e.name} package? Agent will briefly restart; failed upgrades auto-rollback to current version.`,
     ))) return;
     setPkgUpgradingId(e.id);
-    setPkgUpgradeToast(null);
+    setToast(null);
     try {
       const resp = await upgradeEdgePackage(e.id);
       const ok = resp.applied;
-      setPkgUpgradeToast({
+      setToast({
         kind: ok ? 'ok' : 'err',
         text: ok
           ? tr(
@@ -176,12 +196,101 @@ export default function EdgesPage() {
       });
       void refresh();
     } catch (err) {
-      setPkgUpgradeToast({
+      setToast({
         kind: 'err',
         text: (err as Error).message || tr('升级失败', 'Upgrade failed'),
       });
     } finally {
       setPkgUpgradingId(null);
+    }
+  }
+
+  const selectedIds = useMemo(() => [...selected], [selected]);
+  const allVisibleSelected = edges.length > 0 && edges.every((e) => selected.has(e.id));
+
+  const toggleOne = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const toggleAllVisible = () => {
+    setSelected((prev) => {
+      if (edges.every((e) => prev.has(e.id))) {
+        // all selected → clear the visible ones
+        const next = new Set(prev);
+        edges.forEach((e) => next.delete(e.id));
+        return next;
+      }
+      const next = new Set(prev);
+      edges.forEach((e) => next.add(e.id));
+      return next;
+    });
+  };
+  const clearSelection = () => setSelected(new Set());
+
+  // summarizeBatch turns a per-id envelope into a single toast. All-ok →
+  // green; any failure → amber-red with the failed ids so the operator
+  // knows exactly which edges to retry.
+  function summarizeBatch(verb: string, resp: BatchResponse) {
+    if (resp.failed === 0) {
+      setToast({
+        kind: 'ok',
+        text: tr(`${verb}：${resp.succeeded} 台成功`, `${verb}: ${resp.succeeded} succeeded`),
+      });
+      return;
+    }
+    const failedIds = resp.results.filter((r) => !r.ok).map((r) => r.id).join(', ');
+    setToast({
+      kind: 'err',
+      text: tr(
+        `${verb}：${resp.succeeded} 成功 / ${resp.failed} 失败（失败 ID：${failedIds}）`,
+        `${verb}: ${resp.succeeded} ok / ${resp.failed} failed (failed IDs: ${failedIds})`,
+      ),
+    });
+  }
+
+  async function onBatchPackageUpgrade() {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    if (!confirm(tr(
+      `升级选中的 ${ids.length} 台设备整包？各 agent 会短暂重启；失败会自动回滚。`,
+      `Upgrade package on ${ids.length} selected device(s)? Each agent briefly restarts; failures auto-rollback.`,
+    ))) return;
+    setBatchBusy(true);
+    setToast(null);
+    try {
+      const resp = await batchUpgradeEdgePackage(ids);
+      summarizeBatch(tr('整包升级', 'Package upgrade'), resp);
+      clearSelection();
+      void refresh();
+    } catch (err) {
+      setToast({ kind: 'err', text: (err as Error).message || tr('升级失败', 'Upgrade failed') });
+    } finally {
+      setBatchBusy(false);
+    }
+  }
+
+  async function onBatchDelete() {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    if (!confirm(tr(
+      `确定要删除选中的 ${ids.length} 台设备？此操作不可恢复。`,
+      `Delete ${ids.length} selected device(s)? This cannot be undone.`,
+    ))) return;
+    setBatchBusy(true);
+    setToast(null);
+    try {
+      const resp = await batchDeleteEdges(ids);
+      summarizeBatch(tr('删除', 'Delete'), resp);
+      clearSelection();
+      void refresh();
+    } catch (err) {
+      setToast({ kind: 'err', text: (err as Error).message || tr('删除失败', 'Delete failed') });
+    } finally {
+      setBatchBusy(false);
     }
   }
 
@@ -224,10 +333,62 @@ export default function EdgesPage() {
             </div>
           )}
 
+          {selected.size > 0 && (
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-3 py-2 text-xs">
+              <span className="font-medium text-zinc-100">
+                {tr(`已选择 ${selected.size} 台`, `${selected.size} selected`)}
+              </span>
+              <span className="flex-1" />
+              <button
+                type="button"
+                disabled={batchBusy}
+                onClick={() => void onBatchPackageUpgrade()}
+                className="inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-zinc-200 hover:bg-zinc-800 disabled:opacity-50"
+              >
+                <ExternalLink size={12} /> {tr('升级整包', 'Upgrade package')}
+              </button>
+              <button
+                type="button"
+                disabled={batchBusy}
+                onClick={() => setBatchUpgradeOpen(true)}
+                className="inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-zinc-200 hover:bg-zinc-800 disabled:opacity-50"
+              >
+                <ExternalLink size={12} /> {tr('自定义升级', 'Custom upgrade')}
+              </button>
+              <button
+                type="button"
+                disabled={batchBusy}
+                onClick={() => void onBatchDelete()}
+                className="inline-flex items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-2.5 py-1.5 text-red-300 hover:bg-red-500/20 disabled:opacity-50"
+              >
+                <Trash2 size={12} /> {tr('删除', 'Delete')}
+              </button>
+              <button
+                type="button"
+                onClick={clearSelection}
+                className="rounded-md px-2 py-1.5 text-zinc-400 hover:text-zinc-200"
+              >
+                {tr('清除', 'Clear')}
+              </button>
+            </div>
+          )}
+
           <div className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
             <table className="w-full text-sm">
               <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
                 <tr>
+                  <th className="w-10 px-4 py-2.5 text-left">
+                    <input
+                      type="checkbox"
+                      aria-label={tr('全选', 'Select all')}
+                      className="h-3.5 w-3.5 accent-accent"
+                      checked={allVisibleSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = selected.size > 0 && !allVisibleSelected;
+                      }}
+                      onChange={toggleAllVisible}
+                    />
+                  </th>
                   <th className="px-4 py-2.5 text-left">ID</th>
                   <th className="px-4 py-2.5 text-left">{tr('名称', 'Name')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('主机名', 'Hostname')}</th>
@@ -243,13 +404,13 @@ export default function EdgesPage() {
               <tbody className="divide-y divide-zinc-800/40">
                 {loading && edges.length === 0 ? (
                   <tr>
-                    <td colSpan={10} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
                       {tr('加载中…', 'Loading…')}
                     </td>
                   </tr>
                 ) : edges.length === 0 ? (
                   <tr>
-                    <td colSpan={10} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
                       {rolesFilter
                         ? tr(
                             `没有 ${ROLE_FILTER_TITLES[rolesFilter]?.[0] ?? rolesFilter} 设备。点设备名打开详情后可在右上角分配角色。`,
@@ -274,6 +435,18 @@ export default function EdgesPage() {
                           wrap than have a name break across lines.
                           Heartbeat / access-key / agent are short and
                           formatted to a known width. */}
+                      <td
+                        className="w-10 px-4 py-2.5"
+                        onClick={(ev) => ev.stopPropagation()}
+                      >
+                        <input
+                          type="checkbox"
+                          aria-label={tr(`选择 ${e.name}`, `Select ${e.name}`)}
+                          className="h-3.5 w-3.5 accent-accent"
+                          checked={selected.has(e.id)}
+                          onChange={() => toggleOne(e.id)}
+                        />
+                      </td>
                       <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
                         {e.id}
                       </td>
@@ -381,18 +554,38 @@ export default function EdgesPage() {
           }}
         />
       )}
-      {pkgUpgradeToast && (
+      {batchUpgradeOpen && (
+        <BatchUpgradeModal
+          count={selected.size}
+          onClose={() => setBatchUpgradeOpen(false)}
+          onSubmit={async (url, sha256) => {
+            setBatchBusy(true);
+            setToast(null);
+            try {
+              const resp = await batchUpgradeEdgeAgent(selectedIds, url, sha256);
+              summarizeBatch(tr('自定义升级', 'Custom upgrade'), resp);
+              setBatchUpgradeOpen(false);
+              clearSelection();
+              // Edges need ~30s to come back on the new version; polling
+              // picks them up. No immediate refresh.
+            } finally {
+              setBatchBusy(false);
+            }
+          }}
+        />
+      )}
+      {toast && (
         <div
           role="status"
-          onClick={() => setPkgUpgradeToast(null)}
+          onClick={() => setToast(null)}
           className={cn(
             'fixed bottom-6 right-6 z-50 max-w-md cursor-pointer rounded-lg px-4 py-2.5 text-sm shadow-2xl ring-1 ring-inset',
-            pkgUpgradeToast.kind === 'ok'
+            toast.kind === 'ok'
               ? 'bg-emerald-500/15 text-emerald-200 ring-emerald-500/40'
               : 'bg-red-500/15 text-red-200 ring-red-500/40',
           )}
         >
-          {pkgUpgradeToast.text}
+          {toast.text}
         </div>
       )}
     </>
@@ -528,6 +721,97 @@ function UpgradeModal({
             'edge downloads, verifies sha256, stages atomically and exits cleanly; on restart systemd ExecStartPre mv\'s the new binary to ',
           )}<code className="font-mono">/usr/local/bin/ongrid-edge</code>{tr('。失败时旧版本保持不变。', '. On failure the old version is left in place.')}
         </p>
+        {err && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-red-300">
+            {err}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-zinc-700 px-3 py-1.5 text-zinc-300 hover:bg-zinc-800"
+          >
+            {tr('取消', 'Cancel')}
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={submit}
+            className="rounded-md bg-accent px-3 py-1.5 text-accent-fg hover:bg-accent/90 disabled:opacity-50"
+          >
+            {submitting ? tr('触发中…', 'Triggering…') : tr('触发升级', 'Trigger upgrade')}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// BatchUpgradeModal — the multi-device equivalent of UpgradeModal. The
+// same URL + sha256 is dispatched to every selected edge. Same explicit
+// URL+sha form (v1); a future revision can pick from an artifact
+// registry instead.
+function BatchUpgradeModal({
+  count,
+  onClose,
+  onSubmit,
+}: {
+  count: number;
+  onClose(): void;
+  onSubmit(url: string, sha256: string): Promise<void>;
+}) {
+  const { tr } = useI18n();
+  const [url, setUrl] = useState(() => {
+    const origin = window.location.origin.replace(/\/+$/, '');
+    return `${origin}/edge/ongrid-edge-linux-amd64`;
+  });
+  const [sha256, setSha256] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const submit = async () => {
+    if (!url.trim() || sha256.trim().length !== 64) {
+      setErr(tr('需要 URL + 64 位小写 sha256', 'URL + 64-char lowercase sha256 required'));
+      return;
+    }
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await onSubmit(url.trim(), sha256.trim().toLowerCase());
+    } catch (e) {
+      setErr((e as Error)?.message ?? tr('触发失败', 'Trigger failed'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+  return (
+    <Modal open title={tr(`批量自定义升级 · ${count} 台`, `Batch custom upgrade · ${count} device(s)`)} onClose={onClose}>
+      <div className="space-y-3 text-xs text-zinc-300">
+        <p className="text-[11px] text-amber-300/90">
+          {tr(
+            `同一个二进制将下发到选中的 ${count} 台设备。请确认它们架构一致（默认 linux-amd64）。`,
+            `The same binary is dispatched to all ${count} selected devices. Make sure they share an architecture (default linux-amd64).`,
+          )}
+        </p>
+        <label className="block">
+          <span className="mb-1 block text-zinc-500">{tr('下载 URL', 'Download URL')}</span>
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 font-mono text-[11px] text-zinc-100 focus:border-zinc-600 focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-zinc-500">{tr('SHA256（64 位小写 hex）', 'SHA256 (64-char lowercase hex)')}</span>
+          <input
+            type="text"
+            value={sha256}
+            onChange={(e) => setSha256(e.target.value)}
+            placeholder="e.g. 3a7f...  by `sha256sum ongrid-edge-linux-amd64`"
+            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 font-mono text-[11px] text-zinc-100 focus:border-zinc-600 focus:outline-none"
+          />
+        </label>
         {err && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-red-300">
             {err}


### PR DESCRIPTION
## Summary
Adds batch device operations to the manager API and web UI:
- **Manager**: new batch endpoints under `internal/manager/server/edge/http.go` for package/custom upgrade and delete across multiple edges. Each returns a result envelope (succeeded/failed counts + failing ids) rather than aborting on the first offline edge.
- **Web**: `Edges` page gains a select-all/per-row checkbox column, a batch action toolbar, and a batch custom-upgrade modal; new client methods in `web/src/api/edges.ts`.

## Test plan
- [x] Unit tests in `internal/manager/server/edge/http_test.go` cover partial-failure envelopes.
- [ ] Manual: select multiple edges, run batch upgrade/delete, confirm per-edge results surface correctly.