### PR TITLE
fix(devices): clarify offline alert and heartbeat stale states

### DIFF
--- a/web/src/lib/deviceStatus.test.ts
+++ b/web/src/lib/deviceStatus.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import type { Incident } from '@/api/alerts';
+import { buildOfflineAlertDeviceIDs, resolveDevicePresence } from './deviceStatus';
+
+describe('deviceStatus', () => {
+  it('prefers an open device_offline alert over tunnel status', () => {
+    const alerts = buildOfflineAlertDeviceIDs([
+      { id: 1, rule_key: 'device_offline', rule_name: '设备离线', severity: 'critical', status: 'open', summary: '', target_id: '42', event_count: 1, fired_at: '', last_fired_at: '', updated_at: '' },
+    ] as Incident[]);
+
+    expect(resolveDevicePresence({ device_id: 42, status: 'online', last_seen_at: new Date().toISOString() }, alerts)).toBe('offline-alert');
+  });
+
+  it('marks stale heartbeats as degraded while tunnel status is still online', () => {
+    const now = Date.parse('2026-07-03T10:00:00.000Z');
+    expect(resolveDevicePresence({ device_id: 7, status: 'online', last_seen_at: '2026-07-03T09:58:00.000Z' }, new Set(), now)).toBe('heartbeat-stale');
+  });
+
+  it('keeps fresh online status unchanged', () => {
+    const now = Date.parse('2026-07-03T10:00:00.000Z');
+    expect(resolveDevicePresence({ device_id: 7, status: 'online', last_seen_at: '2026-07-03T09:59:30.000Z' }, new Set(), now)).toBe('online');
+  });
+});

--- a/web/src/lib/deviceStatus.ts
+++ b/web/src/lib/deviceStatus.ts
@@ -1,0 +1,59 @@
+import type { Incident } from '@/api/alerts';
+import type { Edge } from '@/api/edges';
+
+export const DEFAULT_HEARTBEAT_STALE_MS = 90_000;
+
+export type DevicePresenceState =
+  | 'offline-alert'
+  | 'heartbeat-stale'
+  | 'online'
+  | 'offline'
+  | 'unknown';
+
+type PresenceEdge = Pick<Edge, 'device_id' | 'last_seen_at' | 'status'>;
+
+export function deviceIDFromIncident(incident: Incident): string | null {
+  const targetID = typeof incident.target_id === 'string' ? incident.target_id.trim() : '';
+  if (targetID) return targetID;
+  const labelID = incident.labels?.device_id?.trim() ?? '';
+  return labelID || null;
+}
+
+export function buildOfflineAlertDeviceIDs(incidents: Incident[]): Set<string> {
+  const ids = new Set<string>();
+  for (const incident of incidents) {
+    if (incident.status !== 'open') continue;
+    if (incident.rule_key !== 'device_offline') continue;
+    const deviceID = deviceIDFromIncident(incident);
+    if (deviceID) ids.add(deviceID);
+  }
+  return ids;
+}
+
+export function isHeartbeatStale(
+  lastSeenAt: string | null | undefined,
+  nowMs = Date.now(),
+  staleMs = DEFAULT_HEARTBEAT_STALE_MS,
+): boolean {
+  if (!lastSeenAt) return false;
+  const lastSeenMs = new Date(lastSeenAt).getTime();
+  if (!Number.isFinite(lastSeenMs)) return false;
+  return nowMs - lastSeenMs > staleMs;
+}
+
+export function resolveDevicePresence(
+  edge: PresenceEdge,
+  offlineAlertDeviceIDs: Set<string>,
+  nowMs = Date.now(),
+): DevicePresenceState {
+  if (edge.device_id != null && offlineAlertDeviceIDs.has(String(edge.device_id))) {
+    return 'offline-alert';
+  }
+  if (edge.status === 'online' && isHeartbeatStale(edge.last_seen_at, nowMs)) {
+    return 'heartbeat-stale';
+  }
+  if (edge.status === 'online' || edge.status === 'offline') {
+    return edge.status;
+  }
+  return 'unknown';
+}

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -24,9 +24,11 @@ import {
   upgradeEdgeAgent,
   upgradeEdgePackage,
 } from '@/api/edges';
+import { listIncidents } from '@/api/alerts';
 import { getManagerVersion } from '@/api/version';
 import { usePermissions } from '@/store/me';
 import { notifyDevicesChanged } from '@/lib/events';
+import { buildOfflineAlertDeviceIDs, resolveDevicePresence } from '@/lib/deviceStatus';
 import { useI18n } from '@/i18n/locale';
 
 // Sidebar headers that map to ?roles= filters. Empty string = "全部"; the
@@ -59,6 +61,7 @@ export default function EdgesPage() {
   })();
 
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [offlineAlertDeviceIDs, setOfflineAlertDeviceIDs] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // managerVersion drives the Agent column's drift chip — fetched once
@@ -86,7 +89,10 @@ export default function EdgesPage() {
 
   const refresh = useCallback(async () => {
     try {
-      const r = await listEdges(rolesFilter ? { roles: rolesFilter } : undefined);
+      const [r, incidents] = await Promise.all([
+        listEdges(rolesFilter ? { roles: rolesFilter } : undefined),
+        listIncidents({ status: 'open', pageSize: 100 }).catch(() => ({ items: [] })),
+      ]);
       // Backend currently doesn't filter by roles (the param is sent
       // for forward-compat); the post-split device.roles lives on
       // each row in `Roles []string`. Filter client-side so the
@@ -101,13 +107,14 @@ export default function EdgesPage() {
         );
       }
       setEdges(items);
+      setOfflineAlertDeviceIDs(buildOfflineAlertDeviceIDs(incidents.items ?? []));
       setError(null);
     } catch (err) {
       setError((err as Error).message || tr('加载失败', 'Load failed'));
     } finally {
       setLoading(false);
     }
-  }, [rolesFilter]);
+  }, [rolesFilter, tr]);
 
   useEffect(() => {
     void refresh();
@@ -299,7 +306,7 @@ export default function EdgesPage() {
                         <RoleChips roles={e.roles ?? []} />
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5">
-                        <StatusPill status={e.status} />
+                        <DevicePresencePill edge={e} offlineAlertDeviceIDs={offlineAlertDeviceIDs} />
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">
                         {e.last_seen_at ? relativeTime(e.last_seen_at) : '—'}
@@ -787,6 +794,40 @@ function extractIPFromObj(obj: Record<string, unknown>): string | null {
   return null;
 }
 
+function DevicePresencePill({
+  edge,
+  offlineAlertDeviceIDs,
+}: {
+  edge: Edge;
+  offlineAlertDeviceIDs: Set<string>;
+}) {
+  const { tr } = useI18n();
+  const state = resolveDevicePresence(edge, offlineAlertDeviceIDs);
+  if (state === 'offline-alert') {
+    return (
+      <span
+        title={tr('存在未恢复的设备离线告警；tunnel 状态仅供参考', 'An unresolved device-offline alert exists; tunnel status is only a connectivity signal')}
+        className="inline-flex items-center gap-1.5 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-300 ring-1 ring-inset ring-red-500/30"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+        {tr('离线告警', 'Offline alert')}
+      </span>
+    );
+  }
+  if (state === 'heartbeat-stale') {
+    return (
+      <span
+        title={tr('tunnel 仍标记在线，但最后心跳已超时', 'Tunnel is still marked online, but the last heartbeat is stale')}
+        className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-500/30"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+        {tr('心跳超时', 'Heartbeat stale')}
+      </span>
+    );
+  }
+  return <StatusPill status={state} />;
+}
+
 // ShellButton opens the WebSSH page for one device in a NEW tab. The
 // route key is device_id, not edge.id — Prom labels and the backend
 // WS handler both use device_id. Disabled when the edge is offline
@@ -1141,4 +1182,3 @@ function InstallCommandRow({ accessKey, secretKey }: { accessKey: string; secret
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Add a derived device presence helper that prioritizes unresolved `device_offline` alerts over tunnel status.
- Show separate `Offline alert` and `Heartbeat stale` states on the Devices page so operators do not see a misleading plain Online state while Alerts reports the device offline.
- Add focused unit coverage for alert priority and heartbeat staleness.

## Validation
- `cd web && npm run test -- deviceStatus.test.ts`
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `cd web && npx eslint src/lib/deviceStatus.ts src/lib/deviceStatus.test.ts src/pages/Edges.tsx --ext ts,tsx --report-unused-disable-directives` passes with 0 errors and 1 existing warning in `Edges.tsx`.
- `cd web && npm run lint` still fails on pre-existing unrelated repo issues such as `src/api/chat.ts`, `src/components/ChatInput.tsx`, `src/components/MessageBubble.tsx`, `src/pages/DeviceShell.tsx`, and `src/pages/SkillRun.tsx`.

## Author confirmation

- [ ] I have read and agree to the project contribution guide in CONTRIBUTING.md.