### PR TITLE
fix(edge): support Kubernetes edge image registration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,13 @@ local/
 .cache/
 tmp/
 
-bin/
+bin/*
+!bin/linux-*/
+bin/linux-*/*
+!bin/linux-*/node_exporter
+!bin/linux-*/process_exporter
+!bin/linux-*/promtail
+!bin/linux-*/otelcol-contrib
 dist/stage/
 dist/out/
 

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,13 @@ docker: docker-ongrid docker-ongrid-edge ## 构建全部镜像
 docker-ongrid: ## 构建 ongrid 镜像
 	docker build --build-arg VERSION=$(VERSION) -t ongrid:$(VERSION) -f deploy/Dockerfile.ongrid .
 
-docker-ongrid-edge: ## 构建 ongrid-edge 镜像
-	docker build -t ongrid-edge:$(VERSION) -f deploy/Dockerfile.ongrid-edge .
+docker-ongrid-edge: fetch-promtail fetch-otelcol fetch-node-exporter fetch-process-exporter ## 构建 ongrid-edge 镜像
+	docker build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg TARGETOS=$(TARGET_OS) \
+		--build-arg TARGETARCH=$(TARGET_ARCH) \
+		-t ongrid-edge:$(VERSION) \
+		-f deploy/Dockerfile.ongrid-edge .
 
 # ----------------------------------------------------------------------------
 # compose

--- a/deploy/Dockerfile.ongrid-edge
+++ b/deploy/Dockerfile.ongrid-edge
@@ -14,6 +14,8 @@ ARG VERSION=dev
 FROM golang:1.25-alpine AS builder
 
 ARG VERSION
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=${GOPROXY}
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -26,13 +28,35 @@ RUN CGO_ENABLED=0 GOOS=linux \
     -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/ongrid-edge ./cmd/ongrid-edge
 
-# ---------- Stage 2: runtime (distroless, nonroot) ----------
-FROM gcr.io/distroless/static-debian12:nonroot
+# ---------- Stage 2: runtime ----------
+FROM alpine:3.20
 
-COPY --from=builder /out/ongrid-edge /ongrid-edge
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk add --no-cache ca-certificates coreutils findutils \
+    && addgroup -S ongrid-edge \
+    && adduser -S -D -H -G ongrid-edge ongrid-edge \
+    && mkdir -p /usr/local/lib/ongrid-edge /var/lib/ongrid-edge/plugins /var/log/ongrid-edge \
+    && ln -s /usr/local/bin/ongrid-edge /ongrid-edge \
+    && chown -R ongrid-edge:ongrid-edge /var/lib/ongrid-edge /var/log/ongrid-edge
+
+COPY --from=builder /out/ongrid-edge /usr/local/bin/ongrid-edge
+COPY bin/${TARGETOS}-${TARGETARCH}/node_exporter /usr/local/lib/ongrid-edge/node_exporter
+COPY bin/${TARGETOS}-${TARGETARCH}/process_exporter /usr/local/lib/ongrid-edge/process_exporter
+COPY bin/${TARGETOS}-${TARGETARCH}/promtail /usr/local/lib/ongrid-edge/promtail
+COPY bin/${TARGETOS}-${TARGETARCH}/otelcol-contrib /usr/local/lib/ongrid-edge/otelcol-contrib
+RUN chmod 0755 /usr/local/lib/ongrid-edge/node_exporter \
+    /usr/local/lib/ongrid-edge/process_exporter \
+    /usr/local/lib/ongrid-edge/promtail \
+    /usr/local/lib/ongrid-edge/otelcol-contrib
+
+ENV ONGRID_EDGE_PLUGIN_BIN_DIR=/usr/local/lib/ongrid-edge \
+    ONGRID_EDGE_PLUGIN_WORK_DIR=/var/lib/ongrid-edge/plugins \
+    ONGRID_EDGE_UPGRADE_STAGE_DIR=
 
 # Local /metrics only — edge dials cloud, no inbound service ports.
 EXPOSE 9101
 
-USER nonroot
-ENTRYPOINT ["/ongrid-edge"]
+USER ongrid-edge
+ENTRYPOINT ["/usr/local/bin/ongrid-edge"]

--- a/deploy/kubernetes/ongrid-edge-daemonset.yaml
+++ b/deploy/kubernetes/ongrid-edge-daemonset.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ongrid
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ongrid-edge-credentials
+  namespace: ongrid
+type: Opaque
+stringData:
+  access-key: "<edge-access-key>"
+  secret-key: "<edge-secret-key>"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ongrid-edge
+  namespace: ongrid
+  labels:
+    app.kubernetes.io/name: ongrid-edge
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ongrid-edge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ongrid-edge
+    spec:
+      hostNetwork: true
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: ongrid-edge
+          image: ongrid-edge:v0.9.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ONGRID_EDGE_CLOUD_ADDR
+              value: "<manager-host>:40012"
+            - name: ONGRID_EDGE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ongrid-edge-credentials
+                  key: access-key
+            - name: ONGRID_EDGE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ongrid-edge-credentials
+                  key: secret-key
+            - name: ONGRID_EDGE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ONGRID_EDGE_COLLECTOR_MODE
+              value: "auto"
+          ports:
+            - name: metrics
+              containerPort: 9101
+              protocol: TCP
+          volumeMounts:
+            - name: edge-state
+              mountPath: /var/lib/ongrid-edge
+            - name: host-var-log
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: edge-state
+          hostPath:
+            path: /var/lib/ongrid-edge
+            type: DirectoryOrCreate
+        - name: host-var-log
+          hostPath:
+            path: /var/log
+            type: Directory

--- a/internal/edgeagent/collector/embedded.go
+++ b/internal/edgeagent/collector/embedded.go
@@ -95,6 +95,9 @@ func (c *EmbeddedCollector) HostInfo(ctx context.Context) (tunnel.HostInfo, erro
 		// product_uuid — HardwareFingerprint (below) disambiguates those.
 		hi.Fingerprint = info.HostID
 	}
+	if nodeName := kubernetesNodeName(); nodeName != "" {
+		hi.Hostname = nodeName
+	}
 	// Clone-resistant hardware identity (MAC|CPU|disk). Sent alongside
 	// HostID so the cloud prefers it but can still migrate older device
 	// rows keyed by HostID. "" when no physical NIC is found.

--- a/internal/edgeagent/collector/hwfingerprint.go
+++ b/internal/edgeagent/collector/hwfingerprint.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"os"
 	"sort"
 	"strings"
 
@@ -27,6 +28,9 @@ import (
 // the caller keeps HostID as the fallback fingerprint so such hosts still
 // register. All components are sorted so the value is stable across reboots.
 func hardwareFingerprint() string {
+	if fp := kubernetesNodeFingerprint(); fp != "" {
+		return fp
+	}
 	macs := physicalMACs()
 	if len(macs) == 0 {
 		return "" // no usable hardware signal — caller falls back to HostID
@@ -37,6 +41,35 @@ func hardwareFingerprint() string {
 		diskSignature(),
 	)
 	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// kubernetesNodeFingerprint returns a stable node identity for DaemonSet
+// deployments. In a normal pod network namespace, the agent often sees only
+// veth/cni interfaces, which physicalMACs deliberately filters out. Let the
+// manifest inject the Kubernetes node name/UID via the Downward API so
+// register_edge still maps one edge pod to the node it runs on, not to an
+// unstable pod identity.
+func kubernetesNodeFingerprint() string {
+	if uid := kubernetesNodeUID(); uid != "" {
+		return sha256Hex("k8s-node-uid:" + uid)
+	}
+	if name := kubernetesNodeName(); name != "" {
+		return sha256Hex("k8s-node-name:" + strings.ToLower(name))
+	}
+	return ""
+}
+
+func kubernetesNodeUID() string {
+	return strings.TrimSpace(os.Getenv("ONGRID_EDGE_NODE_UID"))
+}
+
+func kubernetesNodeName() string {
+	return strings.TrimSpace(os.Getenv("ONGRID_EDGE_NODE_NAME"))
+}
+
+func sha256Hex(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/edgeagent/collector/hwfingerprint_test.go
+++ b/internal/edgeagent/collector/hwfingerprint_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -42,5 +43,36 @@ func TestHardwareFingerprintDeterministic(t *testing.T) {
 	}
 	if a != "" && len(a) != 64 {
 		t.Fatalf("non-empty fingerprint must be a sha256 hex (64 chars), got %d", len(a))
+	}
+}
+
+func TestKubernetesNodeFingerprintPrefersUID(t *testing.T) {
+	t.Setenv("ONGRID_EDGE_NODE_NAME", "worker-a")
+	t.Setenv("ONGRID_EDGE_NODE_UID", "node-uid-1")
+
+	got := kubernetesNodeFingerprint()
+	if got == "" || len(got) != 64 {
+		t.Fatalf("kubernetesNodeFingerprint() = %q, want sha256 hex", got)
+	}
+
+	t.Setenv("ONGRID_EDGE_NODE_UID", "node-uid-2")
+	if next := kubernetesNodeFingerprint(); next == got {
+		t.Fatalf("node UID change should change fingerprint")
+	}
+}
+
+func TestKubernetesNodeFingerprintFallsBackToLowercaseNodeName(t *testing.T) {
+	t.Setenv("ONGRID_EDGE_NODE_UID", "")
+	t.Setenv("ONGRID_EDGE_NODE_NAME", "Worker-A")
+	upper := kubernetesNodeFingerprint()
+
+	t.Setenv("ONGRID_EDGE_NODE_NAME", strings.ToLower("Worker-A"))
+	lower := kubernetesNodeFingerprint()
+
+	if upper == "" {
+		t.Fatal("node name fallback returned empty fingerprint")
+	}
+	if upper != lower {
+		t.Fatalf("node name fallback should be case-insensitive: %q vs %q", upper, lower)
 	}
 }

--- a/internal/edgeagent/collector/scrape.go
+++ b/internal/edgeagent/collector/scrape.go
@@ -244,6 +244,9 @@ func (s *Scraper) HostInfo(ctx context.Context) (tunnel.HostInfo, error) {
 		// the rationale.
 		hi.Fingerprint = info.HostID
 	}
+	if nodeName := kubernetesNodeName(); nodeName != "" {
+		hi.Hostname = nodeName
+	}
 	// Clone-resistant hardware identity — see embedded.go.
 	hi.HardwareFingerprint = hardwareFingerprint()
 	// Primary IPv4 address. Best-effort: "" when no suitable address


### PR DESCRIPTION
## Summary
- package ongrid-edge container with required runtime commands and core plugin binaries from existing bin/linux-<arch> artifacts
- preserve the legacy /ongrid-edge path via symlink while running as non-root on Alpine
- use Kubernetes node name/UID as an optional stable device fingerprint source for DaemonSet deployments
- add a DaemonSet example with Downward API node identity injection

Fixes #95

## Compatibility
- Existing systemd edge install path is unchanged.
- Existing custom container commands using /ongrid-edge keep working via symlink.
- ONGRID_EDGE_NODE_NAME / ONGRID_EDGE_NODE_UID are optional; non-K8s installs continue to use existing hardware/HostID fallback.

## Tests
- go test ./internal/edgeagent/collector ./internal/manager/biz/edge
- git diff --check
- Test host 101.34.63.91: built temporary image ongrid-edge:issue-95-test from /tmp source using existing /opt/ongrid/edge plugin artifacts; verified /usr/local/bin/ongrid-edge --version, find, du, node_exporter, process_exporter, promtail, otelcol-contrib, writable plugin workdir, and non-root user.
- Cleaned temporary test image and /tmp/ongrid-issue95-src* after validation.

No release tag, image push, or deployment was performed.

## Author confirmation

- [ ] I have read and agree to the project contribution guide in CONTRIBUTING.md.