### PR TITLE
feat(aiops): expose IP address in device search and LLM tools

### DIFF
--- a/internal/manager/biz/aiops/mentions/search.go
+++ b/internal/manager/biz/aiops/mentions/search.go
@@ -329,7 +329,11 @@ func (s *Searcher) resolveOne(ctx context.Context, m Mention) string {
 		if d.Online {
 			online = "online"
 		}
-		return fmt.Sprintf("- device #%d %s (%s, hostname=%s)", d.ID, displayDeviceName(d), online, d.Hostname)
+		ipPart := ""
+		if d.IPAddress != "" {
+			ipPart = ", ip=" + d.IPAddress
+		}
+		return fmt.Sprintf("- device #%d %s (%s, hostname=%s%s)", d.ID, displayDeviceName(d), online, d.Hostname, ipPart)
 	case TypeIncident:
 		if s.alerts == nil {
 			break
@@ -380,11 +384,15 @@ func deviceToItem(d *devicemodel.Device) Item {
 	if len(roleNames) > 0 {
 		rolePart = " · " + strings.Join(roleNames, ",")
 	}
+	ipPart := ""
+	if d.IPAddress != "" {
+		ipPart = " · " + d.IPAddress
+	}
 	return Item{
 		Type:     TypeDevice,
 		ID:       fmt.Sprintf("%d", d.ID),
 		Label:    displayDeviceName(d),
-		Subtitle: online + rolePart,
+		Subtitle: online + rolePart + ipPart,
 	}
 }
 

--- a/internal/manager/biz/aiops/tools/query_edges.go
+++ b/internal/manager/biz/aiops/tools/query_edges.go
@@ -25,9 +25,9 @@ const ToolNameQueryEdges = "query_devices"
 // QueryEdgesDescription is the single-sentence description shown to the LLM.
 // Phrased to direct the model here whenever the question is about which
 // devices (machines) match a coarse status / role / freshness filter.
-const QueryEdgesDescription = "List ongrid-managed devices (hosts) filtered by role, online status, last-seen freshness or a name substring. " +
+const QueryEdgesDescription = "List ongrid-managed devices (hosts) filtered by role, online status, last-seen freshness, name substring, or IP address. " +
 	"Use this whenever the question is about which machines exist or which ones match a coarse attribute. " +
-	"Returns an array of {device_id, name, hostname, online, roles, last_seen_at}; use device_id (NOT edge_id) in any PromQL/LogQL/TraceQL you generate."
+	"Returns an array of {device_id, name, hostname, ip_address, online, roles, last_seen_at}; use device_id (NOT edge_id) in any PromQL/LogQL/TraceQL you generate."
 
 // QueryEdgesSchema is the JSON Schema of the tool's argument object.
 var QueryEdgesSchema = json.RawMessage(`{
@@ -52,6 +52,10 @@ var QueryEdgesSchema = json.RawMessage(`{
       "type": "string",
       "description": "Substring filter against device name (case-sensitive)."
     },
+    "ip_contains": {
+      "type": "string",
+      "description": "Substring filter against device IP address. Optional."
+    },
     "limit": {
       "type": "integer",
       "minimum": 1,
@@ -67,6 +71,7 @@ type QueryEdgesArgs struct {
 	Status                string `json:"status,omitempty"`
 	LastSeenWithinMinutes int    `json:"last_seen_within_minutes,omitempty"`
 	NameContains          string `json:"name_contains,omitempty"`
+	IPContains            string `json:"ip_contains,omitempty"`
 	Limit                 int    `json:"limit,omitempty"`
 }
 
@@ -78,6 +83,7 @@ type EdgeRow struct {
 	ID         uint64     `json:"device_id"`
 	Name       string     `json:"name"`
 	Hostname   string     `json:"hostname,omitempty"`
+	IPAddress  string     `json:"ip_address,omitempty"`
 	Online     bool       `json:"online"`
 	Roles      []string   `json:"roles"`
 	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
@@ -110,8 +116,9 @@ func (r *Registry) executeQueryEdges(ctx context.Context, args json.RawMessage) 
 	// (older test fixtures).
 	if r.devices != nil {
 		f := devicebiz.ListFilter{
-			Name:  in.NameContains,
-			Limit: in.Limit,
+			Name:      in.NameContains,
+			IPAddress: in.IPContains,
+			Limit:     in.Limit,
 		}
 		switch in.Status {
 		case "":
@@ -158,6 +165,7 @@ func (r *Registry) executeQueryEdges(ctx context.Context, args json.RawMessage) 
 				ID:         d.ID,
 				Name:       d.Name,
 				Hostname:   d.Hostname,
+				IPAddress:  d.IPAddress,
 				Online:     d.Online,
 				Roles:      devicemodel.DecodeRoles(d.Roles),
 				LastSeenAt: d.LastSeenAt,

--- a/internal/manager/biz/aiops/tools/query_edges_basetool.go
+++ b/internal/manager/biz/aiops/tools/query_edges_basetool.go
@@ -36,7 +36,7 @@ func NewQueryEdgesTool(devices *devicebiz.Usecase, edges *edgebiz.Usecase, log *
 // queryEdgesWhenToUse — usually the FIRST tool in any incident triage
 // chain. Reverse-guards against drilling into specific signals before
 // pinning the device id.
-const queryEdgesWhenToUse = "When the user wants the LIST of devices / hosts (filter by role / online / freshness / name substring), " +
+const queryEdgesWhenToUse = "When the user wants the LIST of devices / hosts (filter by role / online / freshness / name substring / IP address), " +
 	"or as the FIRST step to grab a device_id you'll then feed into get_host_load / query_promql / get_edge_summary. " +
 	"NOT for the per-device deep dive (use get_edge_summary or correlate_incident). " +
 	"NOT for log/metric/trace content (use the matching query_* tool)."
@@ -74,8 +74,9 @@ func (t *QueryEdgesTool) InvokableRun(ctx context.Context, argsJSON string, _ ..
 
 	if t.devices != nil {
 		f := devicebiz.ListFilter{
-			Name:  in.NameContains,
-			Limit: in.Limit,
+			Name:      in.NameContains,
+			IPAddress: in.IPContains,
+			Limit:     in.Limit,
 		}
 		switch in.Status {
 		case "":
@@ -122,6 +123,7 @@ func (t *QueryEdgesTool) InvokableRun(ctx context.Context, argsJSON string, _ ..
 				ID:         d.ID,
 				Name:       d.Name,
 				Hostname:   d.Hostname,
+				IPAddress:  d.IPAddress,
 				Online:     d.Online,
 				Roles:      devicemodel.DecodeRoles(d.Roles),
 				LastSeenAt: d.LastSeenAt,

--- a/internal/manager/biz/device/repo.go
+++ b/internal/manager/biz/device/repo.go
@@ -17,13 +17,14 @@ import (
 // RolesUnknownOnly, when true, narrows to rows with roles == 0 (the
 // "未分类" bucket); it is mutually exclusive with RolesAny — set one or
 // the other, not both. Online filters by the live online flag.
-// Hostname / Name are substring matches.
+// Hostname / Name / IPAddress are substring matches.
 type ListFilter struct {
 	RolesAny         uint8
 	RolesUnknownOnly bool
 	Online           *bool
 	Hostname         string
 	Name             string
+	IPAddress        string
 	Limit            int
 	Offset           int
 }

--- a/internal/manager/data/device/store/device.go
+++ b/internal/manager/data/device/store/device.go
@@ -272,6 +272,9 @@ func (r *Repo) List(ctx context.Context, f biz.ListFilter) ([]*model.Device, err
 	if f.Name != "" {
 		tx = tx.Where("name LIKE ?", "%"+f.Name+"%")
 	}
+	if f.IPAddress != "" {
+		tx = tx.Where("ip_address LIKE ?", f.IPAddress+"%")
+	}
 	if f.Limit > 0 {
 		tx = tx.Limit(f.Limit)
 	}


### PR DESCRIPTION
1，可以在设备搜索@ 显示ip
用户在消息中引用了以下平台对象，请在回答时考虑： - device #1 cn-idc-test-03 (online, hostname=cn-idc-rancher-test-03, ip=10.238.241.139) @device:1(cn-idc-rancher-test-03) 巡检

2，可以通过ip与llm交互，不仅仅是设备名
<img width="2366" height="710" alt="image" src="https://github.com/user-attachments/assets/ab5fa202-fdec-492e-8b97-c49e3b972e29" />
