### PR TITLE
fix(web): respect IME composition before chat submit

### DIFF
--- a/web/src/components/AgentSidePanel.tsx
+++ b/web/src/components/AgentSidePanel.tsx
@@ -4,6 +4,7 @@ import { Send, Loader2, X, ExternalLink, Bot } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/cn';
+import { isImeComposing } from '@/lib/keyboard';
 import { createSession, postMessage } from '@/api/chat';
 import { invalidateChatSessions } from '@/store/chatSessions';
 import { useI18n } from '@/i18n/locale';
@@ -127,6 +128,8 @@ export function AgentSidePanel({ open, onClose }: Props) {
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isImeComposing(e)) return;
+
     if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       e.preventDefault();
       void send();

--- a/web/src/components/ChatInput.test.tsx
+++ b/web/src/components/ChatInput.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatInput } from './ChatInput';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderChatInput(onSubmit = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <ChatInput value="能看到l" onSubmit={onSubmit} />
+    </MemoryRouter>,
+  );
+  return {
+    textarea: screen.getByRole('textbox', { name: /message input/i }),
+    onSubmit,
+  };
+}
+
+describe('ChatInput keyboard submit', () => {
+  it('does not submit while an IME composition is active', () => {
+    const { textarea, onSubmit } = renderChatInput();
+
+    fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit Safari-style IME Enter events', () => {
+    const { textarea, onSubmit } = renderChatInput();
+
+    fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('still submits on plain Enter after composition is done', () => {
+    const { textarea, onSubmit } = renderChatInput();
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onSubmit).toHaveBeenCalledWith({ text: '能看到l', mentions: [] });
+  });
+});

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -23,6 +23,7 @@ import {
   FileText,
 } from 'lucide-react';
 import { cn } from '@/lib/cn';
+import { isImeComposing } from '@/lib/keyboard';
 import type { IconType } from '@/lib/icon';
 import {
   searchMentions,
@@ -202,7 +203,6 @@ export function ChatInput({
       }
     }, 150);
     return () => clearTimeout(handle);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [popoverOpen, value]);
 
   function onTextareaChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
@@ -258,6 +258,8 @@ export function ChatInput({
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isImeComposing(e)) return;
+
     // Popover navigation takes priority when open.
     if (popoverOpen && popoverItems.length > 0) {
       if (e.key === 'ArrowDown') {

--- a/web/src/lib/keyboard.ts
+++ b/web/src/lib/keyboard.ts
@@ -1,0 +1,5 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+export function isImeComposing(e: ReactKeyboardEvent<HTMLElement>): boolean {
+  return e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229;
+}


### PR DESCRIPTION
## Summary
- prevent chat textarea Enter handlers from submitting while IME composition is active
- share the IME guard across the main chat input and the floating assistant panel
- add regression coverage for `isComposing`, Safari-style `keyCode === 229`, and normal Enter submit

## Root Cause
The chat inputs treated every plain Enter keydown as a submit action, so IME candidate confirmation could send a partial message before composition completed.

## Validation
- `npm test -- ChatInput.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/ChatInput.tsx src/components/AgentSidePanel.tsx src/components/ChatInput.test.tsx src/lib/keyboard.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 50`