### PR TITLE
fix(device): preserve identity across fingerprint changes

### DIFF
--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -285,6 +286,9 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 			u.log.Warn("device fingerprint rebind failed", "old", oldFP, "new", fp, "err", err)
 		}
 	}
+	if err := u.rebindLinkedDeviceFingerprint(ctx, edge, info, fp); err != nil && u.log != nil {
+		u.log.Warn("linked device fingerprint rebind failed", "edge_id", edgeID, "device_id", edge.DeviceID, "new", fp, "err", err)
+	}
 	seed := &devicemodel.Device{
 		Fingerprint:   fp,
 		UserID:        edge.CreatedBy,
@@ -364,6 +368,41 @@ func (u *Usecase) HandleRegister(ctx context.Context, edgeID uint64, info tunnel
 		}
 	}
 	return nil
+}
+
+func (u *Usecase) rebindLinkedDeviceFingerprint(ctx context.Context, edge *model.Edge, info tunnel.HostInfo, newFP string) error {
+	if edge == nil || edge.DeviceID == nil || newFP == "" {
+		return nil
+	}
+	linked, err := u.devices.Get(ctx, *edge.DeviceID)
+	if err != nil {
+		if errors.Is(err, errs.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if linked.Fingerprint == "" || linked.Fingerprint == newFP || !sameRegisteredHost(linked, info) {
+		return nil
+	}
+	return u.devices.RebindFingerprint(ctx, linked.Fingerprint, newFP)
+}
+
+func sameRegisteredHost(device *devicemodel.Device, info tunnel.HostInfo) bool {
+	if device == nil {
+		return false
+	}
+	hostname := normalizeHostID(info.Hostname)
+	if hostname != "" {
+		if normalizeHostID(device.Hostname) == hostname || normalizeHostID(device.Name) == hostname {
+			return true
+		}
+	}
+	ip := strings.TrimSpace(info.IPAddress)
+	return ip != "" && strings.TrimSpace(device.IPAddress) == ip
+}
+
+func normalizeHostID(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // deviceFingerprint derives the stable per-host id stored in

--- a/internal/manager/biz/edge/usecase_test.go
+++ b/internal/manager/biz/edge/usecase_test.go
@@ -878,3 +878,67 @@ func TestHandleRegisterMigratesLegacyFingerprintInPlace(t *testing.T) {
 		t.Fatalf("old fingerprint %q still present after migration", oldFP)
 	}
 }
+
+func TestHandleRegisterRebindsPreviouslyLinkedDeviceWhenFingerprintChanges(t *testing.T) {
+	repo := newFakeRepo()
+	devices := newFakeDeviceRepo()
+	uc := NewUsecase(repo, devices, nil, nil)
+	ctx := context.Background()
+
+	res, err := uc.Create(ctx, "edge-linked", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	oldFP := "legacy:edge:25"
+	pre, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{
+		Fingerprint: oldFP,
+		Name:        "aigc-sit-work2",
+		Hostname:    "aigc-sit-work2",
+	})
+	if err != nil {
+		t.Fatalf("seed linked device: %v", err)
+	}
+	if err := repo.SetDeviceID(ctx, res.Edge.ID, pre.ID); err != nil {
+		t.Fatalf("seed edge device id: %v", err)
+	}
+
+	info := tunnel.HostInfo{
+		Fingerprint:         "uuid-that-does-not-match-old-row",
+		HardwareFingerprint: "new-mac-cpu-disk",
+		Hostname:            "aigc-sit-work2",
+		OS:                  "linux",
+		Arch:                "amd64",
+		IPAddress:           "192.168.0.42",
+		CPUCount:            8,
+		MemTotalBytes:       16 << 30,
+		KernelVersion:       "6.8.0",
+	}
+	if err := uc.HandleRegister(ctx, res.Edge.ID, info, ""); err != nil {
+		t.Fatalf("HandleRegister: %v", err)
+	}
+
+	newFP := deviceFingerprint(info)
+	if newFP == oldFP || newFP == deviceFingerprintLegacy(info) {
+		t.Fatal("precondition: test must exercise the linked-device rebind path")
+	}
+	after, err := uc.Get(ctx, res.Edge.ID)
+	if err != nil || after.DeviceID == nil {
+		t.Fatalf("Get edge / DeviceID: %v", err)
+	}
+	if *after.DeviceID != pre.ID {
+		t.Fatalf("edge moved to device %d, want existing linked device %d", *after.DeviceID, pre.ID)
+	}
+	got, err := devices.FindOrCreateByFingerprint(ctx, &devicemodel.Device{Fingerprint: newFP})
+	if err != nil {
+		t.Fatalf("lookup new fp: %v", err)
+	}
+	if got.ID != pre.ID {
+		t.Fatalf("new fingerprint points to device %d, want existing linked device %d", got.ID, pre.ID)
+	}
+	if len(devices.byID) != 1 {
+		t.Fatalf("device rows = %d, want 1 (no orphan duplicate)", len(devices.byID))
+	}
+	if _, stillThere := devices.byFP[oldFP]; stillThere {
+		t.Fatalf("old linked fingerprint %q still present after rebind", oldFP)
+	}
+}

--- a/internal/manager/data/device/store/device.go
+++ b/internal/manager/data/device/store/device.go
@@ -6,10 +6,10 @@ package store
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	biz "github.com/ongridio/ongrid/internal/manager/biz/device"
 	model "github.com/ongridio/ongrid/internal/manager/model/device"
@@ -28,28 +28,49 @@ func NewRepo(db *gorm.DB) *Repo { return &Repo{db: db} }
 var _ biz.Repo = (*Repo)(nil)
 
 // FindOrCreateByFingerprint returns the existing row for seed.Fingerprint
-// or creates a fresh row populated from seed. Implementation uses an
-// ON CONFLICT DO NOTHING insert plus a follow-up select; this works on
-// both MySQL and SQLite without requiring database-level locking.
+// or creates a fresh row populated from seed. The read-first path avoids
+// burning MySQL AUTO_INCREMENT values on every duplicate register.
 func (r *Repo) FindOrCreateByFingerprint(ctx context.Context, seed *model.Device) (*model.Device, error) {
 	if seed == nil || seed.Fingerprint == "" {
 		return nil, errs.ErrInvalid
 	}
-	tx := r.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "fingerprint"}, {Name: "delete_marker"}},
-		DoNothing: true,
-	}).Create(seed)
-	if tx.Error != nil {
-		return nil, tx.Error
+	out, err := r.findLiveByFingerprint(ctx, seed.Fingerprint)
+	if err == nil {
+		return out, nil
 	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	if err := r.db.WithContext(ctx).Create(seed).Error; err != nil {
+		if isDuplicateKey(err) {
+			return r.findLiveByFingerprint(ctx, seed.Fingerprint)
+		}
+		return nil, err
+	}
+	return seed, nil
+}
+
+func (r *Repo) findLiveByFingerprint(ctx context.Context, fp string) (*model.Device, error) {
 	var out model.Device
-	if err := r.db.WithContext(ctx).Where("fingerprint = ?", seed.Fingerprint).First(&out).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("fingerprint = ? AND delete_marker = 0", fp).First(&out).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errs.ErrNotFound
+			return nil, gorm.ErrRecordNotFound
 		}
 		return nil, err
 	}
 	return &out, nil
+}
+
+func isDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE") || strings.Contains(msg, "Duplicate") || strings.Contains(msg, "duplicate")
 }
 
 // RebindFingerprint moves a device from oldFP to newFP in place. See the

--- a/internal/manager/data/device/store/device_test.go
+++ b/internal/manager/data/device/store/device_test.go
@@ -74,6 +74,39 @@ func TestFindOrCreateByFingerprintSoftDeleteAllowsReuse(t *testing.T) {
 	}
 }
 
+func TestFindOrCreateByFingerprintDoesNotInsertExistingLiveRow(t *testing.T) {
+	db := newDeviceTestDB(t)
+	var createCalls int
+	if err := db.Callback().Create().Before("gorm:create").Register("test:count_device_creates", func(tx *gorm.DB) {
+		if _, ok := tx.Statement.Dest.(*model.Device); ok {
+			createCalls++
+		}
+	}); err != nil {
+		t.Fatalf("register create callback: %v", err)
+	}
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	first, err := repo.FindOrCreateByFingerprint(ctx, sampleDevice("stable-host"))
+	if err != nil {
+		t.Fatalf("first FindOrCreateByFingerprint: %v", err)
+	}
+	if createCalls != 1 {
+		t.Fatalf("create calls after first register = %d, want 1", createCalls)
+	}
+
+	again, err := repo.FindOrCreateByFingerprint(ctx, sampleDevice("stable-host"))
+	if err != nil {
+		t.Fatalf("second FindOrCreateByFingerprint: %v", err)
+	}
+	if again.ID != first.ID {
+		t.Fatalf("second register returned id %d, want existing id %d", again.ID, first.ID)
+	}
+	if createCalls != 1 {
+		t.Fatalf("create calls after duplicate register = %d, want still 1", createCalls)
+	}
+}
+
 func TestEdgeDeviceLinkSoftDeleteAllowsReuse(t *testing.T) {
 	db := newDeviceTestDB(t)
 	repo := NewEdgeDeviceRepo(db)

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Plus, RotateCw, Trash2, MoreVertical, Copy, Check, ExternalLink, TerminalSquare } from 'lucide-react';
+import { Plus, RotateCw, Trash2, MoreVertical, Copy, Check, ExternalLink, TerminalSquare, Search } from 'lucide-react';
 import { StatusPill } from '@/components/StatusPill';
 import { Modal } from '@/components/Modal';
 import { cn } from '@/lib/cn';
@@ -18,6 +18,7 @@ import {
   EDGE_ROLE_LABELS,
   EDGE_ROLE_LABELS_EN,
   type Edge,
+  type EdgeStatus,
   type EdgeRole,
   type CreateEdgeResponse,
   type RotateSecretResponse,
@@ -41,16 +42,33 @@ const ROLE_FILTER_TITLES: Record<string, [string, string]> = {
   '': ['全部设备', 'All devices'],
   server: ['服务器', 'Servers'],
   storage: ['存储', 'Storage'],
+  database: ['数据库', 'Databases'],
   network: ['网络设备', 'Network devices'],
   unknown: ['未分类设备', 'Uncategorized devices'],
 };
+
+const STATUS_FILTERS: { value: '' | EdgeStatus; zh: string; en: string }[] = [
+  { value: '', zh: '全部状态', en: 'All statuses' },
+  { value: 'online', zh: '在线', en: 'Online' },
+  { value: 'offline', zh: '离线', en: 'Offline' },
+  { value: 'unknown', zh: '未知', en: 'Unknown' },
+];
+
+const ROLE_FILTERS: { value: string; zh: string; en: string }[] = [
+  { value: '', zh: '全部角色', en: 'All roles' },
+  { value: 'server', zh: '服务器', en: 'Servers' },
+  { value: 'storage', zh: '存储', en: 'Storage' },
+  { value: 'database', zh: '数据库', en: 'Databases' },
+  { value: 'network', zh: '网络设备', en: 'Network' },
+  { value: 'unknown', zh: '未分类', en: 'Uncategorized' },
+];
 
 export default function EdgesPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { tr } = useI18n();
   const { canMutate } = usePermissions();
-  // Sidebar sub-items navigate by appending ?roles=server|storage|network|unknown.
+  // Sidebar sub-items navigate by appending ?roles=server|storage|database|network|unknown.
   // No param = "全部". We forward the param to the backend so filtering uses the
   // sargable IN-list path (see internal/manager/biz/edge.ListFilter).
   const rolesFilter = useMemo(() => {
@@ -65,6 +83,9 @@ export default function EdgesPage() {
   const [edges, setEdges] = useState<Edge[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'' | EdgeStatus>('');
+  const [agentFilter, setAgentFilter] = useState('');
   // managerVersion drives the Agent column's drift chip — fetched once
   // on mount; failures degrade silently to "no chip" rather than red
   // because version mismatch isn't operationally critical.
@@ -101,17 +122,9 @@ export default function EdgesPage() {
       const r = await listEdges(rolesFilter ? { roles: rolesFilter } : undefined);
       // Backend currently doesn't filter by roles (the param is sent
       // for forward-compat); the post-split device.roles lives on
-      // each row in `Roles []string`. Filter client-side so the
-      // 服务器 / 存储 / 网络 sub-views show only matching devices,
-      // and 未分类 lands in its own bucket — never mixed in.
-      let items = r.items ?? [];
-      if (rolesFilter === 'unknown') {
-        items = items.filter((e) => !e.roles || e.roles.length === 0);
-      } else if (rolesFilter) {
-        items = items.filter(
-          (e) => Array.isArray(e.roles) && (e.roles as string[]).includes(rolesFilter),
-        );
-      }
+      // each row in `Roles []string`. `filteredEdges` below applies the
+      // role/status/agent/search facets to the raw fleet response.
+      const items = r.items ?? [];
       setEdges(items);
       // Drop any selected ids that no longer appear (deleted / filtered out)
       // so the toolbar count never lies.
@@ -133,6 +146,44 @@ export default function EdgesPage() {
     void refresh();
   }, [refresh]);
   usePoll(refresh, 10_000);
+
+  const agentOptions = useMemo(() => {
+    const versions = Array.from(
+      new Set(edges.map((e) => e.agent_version?.trim()).filter((v): v is string => !!v)),
+    ).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    return versions;
+  }, [edges]);
+
+  const filteredEdges = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return edges.filter((e) => {
+      if (rolesFilter === 'unknown') {
+        if (e.roles && e.roles.length > 0) return false;
+      } else if (rolesFilter) {
+        if (!Array.isArray(e.roles) || !(e.roles as string[]).includes(rolesFilter)) return false;
+      }
+      if (statusFilter && e.status !== statusFilter) return false;
+      if (agentFilter === '__outdated') {
+        if (!managerVersion || !e.agent_version || e.agent_version === managerVersion) return false;
+      } else if (agentFilter === '__missing') {
+        if (e.agent_version) return false;
+      } else if (agentFilter && e.agent_version !== agentFilter) {
+        return false;
+      }
+      if (!q) return true;
+      const roleLabels = (e.roles ?? []).map((r) => `${r} ${EDGE_ROLE_LABELS[r]} ${EDGE_ROLE_LABELS_EN[r]}`);
+      return [
+        e.id,
+        e.device_id ?? '',
+        e.name,
+        extractHostname(e.host_info) ?? '',
+        extractIP(e.host_info) ?? '',
+        e.access_key_id,
+        e.agent_version ?? '',
+        ...roleLabels,
+      ].some((v) => String(v).toLowerCase().includes(q));
+    });
+  }, [agentFilter, edges, managerVersion, query, rolesFilter, statusFilter]);
 
   async function onCreate(name: string) {
     const created: CreateEdgeResponse = await createEdge({ name });
@@ -206,7 +257,8 @@ export default function EdgesPage() {
   }
 
   const selectedIds = useMemo(() => [...selected], [selected]);
-  const allVisibleSelected = edges.length > 0 && edges.every((e) => selected.has(e.id));
+  const allVisibleSelected = filteredEdges.length > 0 && filteredEdges.every((e) => selected.has(e.id));
+  const hasFilters = !!query.trim() || !!statusFilter || !!rolesFilter || !!agentFilter;
 
   const toggleOne = (id: number) => {
     setSelected((prev) => {
@@ -218,18 +270,31 @@ export default function EdgesPage() {
   };
   const toggleAllVisible = () => {
     setSelected((prev) => {
-      if (edges.every((e) => prev.has(e.id))) {
+      if (filteredEdges.every((e) => prev.has(e.id))) {
         // all selected → clear the visible ones
         const next = new Set(prev);
-        edges.forEach((e) => next.delete(e.id));
+        filteredEdges.forEach((e) => next.delete(e.id));
         return next;
       }
       const next = new Set(prev);
-      edges.forEach((e) => next.add(e.id));
+      filteredEdges.forEach((e) => next.add(e.id));
       return next;
     });
   };
   const clearSelection = () => setSelected(new Set());
+  const clearFilters = () => {
+    setQuery('');
+    setStatusFilter('');
+    setAgentFilter('');
+    if (rolesFilter) navigate('/devices', { replace: true });
+  };
+  const updateRoleFilter = (value: string) => {
+    if (!value) {
+      navigate('/devices', { replace: true });
+      return;
+    }
+    navigate(`/devices?${new URLSearchParams({ roles: value }).toString()}`, { replace: true });
+  };
 
   // summarizeBatch turns a per-id envelope into a single toast. All-ok →
   // green; any failure → amber-red with the failed ids so the operator
@@ -301,7 +366,12 @@ export default function EdgesPage() {
           <div>
             <h1 className="text-base font-semibold text-zinc-100">{headerTitle}</h1>
             <p className="mt-0.5 text-xs text-zinc-500">
-              {tr(`${edges.length} 台设备 · 每 10 秒自动刷新`, `${edges.length} device(s) · auto-refresh every 10s`)}
+              {hasFilters
+                ? tr(
+                    `${filteredEdges.length} / ${edges.length} 台设备 · 每 10 秒自动刷新`,
+                    `${filteredEdges.length} / ${edges.length} device(s) · auto-refresh every 10s`,
+                  )
+                : tr(`${edges.length} 台设备 · 每 10 秒自动刷新`, `${edges.length} device(s) · auto-refresh every 10s`)}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -332,6 +402,52 @@ export default function EdgesPage() {
               {error}
             </div>
           )}
+
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-[12px]">
+            <label className="inline-flex min-w-64 items-center gap-1 rounded-md border border-zinc-800/60 bg-zinc-950/40 px-2 py-1 text-zinc-300 focus-within:border-zinc-600">
+              <Search size={12} className="text-zinc-500" />
+              <span className="text-[11px] text-zinc-500">{tr('搜索', 'Search')}</span>
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={tr('名称 / 主机 / IP / ID', 'Name / host / IP / ID')}
+                className="min-w-0 flex-1 border-none bg-transparent px-1 text-[12px] text-zinc-100 placeholder:text-zinc-600 focus:outline-none"
+              />
+            </label>
+            <DeviceToolbarSelect
+              label={tr('状态', 'Status')}
+              value={statusFilter}
+              options={STATUS_FILTERS.map((o) => ({ value: o.value, label: tr(o.zh, o.en) }))}
+              onChange={(v) => setStatusFilter(v as '' | EdgeStatus)}
+            />
+            <DeviceToolbarSelect
+              label={tr('角色', 'Role')}
+              value={rolesFilter}
+              options={ROLE_FILTERS.map((o) => ({ value: o.value, label: tr(o.zh, o.en) }))}
+              onChange={updateRoleFilter}
+            />
+            <DeviceToolbarSelect
+              label="Agent"
+              value={agentFilter}
+              options={[
+                { value: '', label: tr('全部版本', 'All versions') },
+                ...(managerVersion ? [{ value: '__outdated', label: tr('与 Manager 不一致', 'Out of sync') }] : []),
+                { value: '__missing', label: tr('未上报版本', 'Not reported') },
+                ...agentOptions.map((v) => ({ value: v, label: v })),
+              ]}
+              onChange={setAgentFilter}
+            />
+            {hasFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="rounded-md border border-zinc-800/60 bg-zinc-950/40 px-2.5 py-1.5 text-[12px] text-zinc-300 hover:bg-zinc-900"
+              >
+                {tr('清除筛选', 'Clear filters')}
+              </button>
+            )}
+          </div>
 
           {selected.size > 0 && (
             <div className="mb-3 flex items-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-3 py-2 text-xs">
@@ -373,8 +489,8 @@ export default function EdgesPage() {
             </div>
           )}
 
-          <div className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
-            <table className="w-full text-sm">
+          <div className="overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+            <table className="min-w-[1320px] w-full text-sm">
               <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
                 <tr>
                   <th className="w-10 px-4 py-2.5 text-left">
@@ -389,7 +505,8 @@ export default function EdgesPage() {
                       onChange={toggleAllVisible}
                     />
                   </th>
-                  <th className="px-4 py-2.5 text-left">ID</th>
+                  <th className="whitespace-nowrap px-4 py-2.5 text-left">Edge ID</th>
+                  <th className="whitespace-nowrap px-4 py-2.5 text-left">Device ID</th>
                   <th className="px-4 py-2.5 text-left">{tr('名称', 'Name')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('主机名', 'Hostname')}</th>
                   <th className="px-4 py-2.5 text-left">IP</th>
@@ -404,14 +521,16 @@ export default function EdgesPage() {
               <tbody className="divide-y divide-zinc-800/40">
                 {loading && edges.length === 0 ? (
                   <tr>
-                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={12} className="px-4 py-10 text-center text-zinc-500">
                       {tr('加载中…', 'Loading…')}
                     </td>
                   </tr>
-                ) : edges.length === 0 ? (
+                ) : filteredEdges.length === 0 ? (
                   <tr>
-                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
-                      {rolesFilter
+                    <td colSpan={12} className="px-4 py-10 text-center text-zinc-500">
+                      {hasFilters
+                        ? tr('没有匹配当前筛选条件的设备。', 'No devices match the current filters.')
+                        : rolesFilter
                         ? tr(
                             `没有 ${ROLE_FILTER_TITLES[rolesFilter]?.[0] ?? rolesFilter} 设备。点设备名打开详情后可在右上角分配角色。`,
                             `No ${ROLE_FILTER_TITLES[rolesFilter]?.[1] ?? rolesFilter} devices. Open a device detail page to assign roles.`,
@@ -423,7 +542,7 @@ export default function EdgesPage() {
                     </td>
                   </tr>
                 ) : (
-                  edges.map((e) => (
+                  filteredEdges.map((e) => (
                     <tr
                       key={e.id}
                       className="cursor-pointer transition-colors hover:bg-zinc-900/40"
@@ -449,6 +568,9 @@ export default function EdgesPage() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
                         {e.id}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
+                        {e.device_id ?? '—'}
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 text-zinc-100">
                         {e.name || (
@@ -603,6 +725,35 @@ export default function EdgesPage() {
       deviceId,
     });
   }
+}
+
+function DeviceToolbarSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange(value: string): void;
+}) {
+  return (
+    <label className="inline-flex items-center gap-1 rounded-md border border-zinc-800/60 bg-zinc-950/40 pl-2 pr-1 py-1 text-zinc-300 hover:border-zinc-700">
+      <span className="text-[11px] text-zinc-500">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none border-none bg-transparent pl-1 pr-4 text-[12px] text-zinc-100 focus:outline-none"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value} className="bg-zinc-900">
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
 }
 
 // AgentVersionCell shows the edge's reported agent_version + a drift
@@ -1425,4 +1576,3 @@ function InstallCommandRow({ accessKey, secretKey }: { accessKey: string; secret
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

Fixes two device identity regressions in the edge registration path:

- avoids burning MySQL `AUTO_INCREMENT` ids on every duplicate device registration by reading the live fingerprint row before inserting
- preserves the already-linked device row when an edge reports a changed hardware fingerprint but still matches the previously linked host by hostname or IP

## Root Cause

`FindOrCreateByFingerprint` used an insert-first `ON CONFLICT DO NOTHING` pattern. On MySQL/InnoDB, duplicate insert attempts can still advance the auto-increment counter even when no row is written.

Separately, the hardware fingerprint migration only handled legacy fingerprints that could be recomputed from the new `HostInfo`. If an edge already had a `DeviceID` linked to a historical fingerprint that could not be recomputed, a later register could create a second device row for the same host and leave the old row as an offline duplicate.

## Changes

- Make device lookup read-first, insert only when missing, with a duplicate-key fallback for concurrent races.
- Rebind a previously linked device fingerprint in place when the edge's current `DeviceID` matches the registering host by hostname or IP.
- Add regression coverage for duplicate register insert avoidance and linked-device fingerprint rebinding.

## Validation

```bash
go test ./internal/manager/data/device/store ./internal/manager/biz/edge
go test -race ./internal/manager/data/device/store ./internal/manager/biz/edge
```

## Author confirmation

- [ ] I have read and agree to the project contribution guide in CONTRIBUTING.md.