### PR TITLE
feat(devices): show device identities and filter the fleet

### DIFF
--- a/web/src/lib/deviceStatus.test.ts
+++ b/web/src/lib/deviceStatus.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import type { Incident } from '@/api/alerts';
+import { buildOfflineAlertDeviceIDs, resolveDevicePresence } from './deviceStatus';
+
+describe('deviceStatus', () => {
+  it('prefers an open device_offline alert over tunnel status', () => {
+    const alerts = buildOfflineAlertDeviceIDs([
+      { id: 1, rule_key: 'device_offline', rule_name: '设备离线', severity: 'critical', status: 'open', summary: '', target_id: '42', event_count: 1, fired_at: '', last_fired_at: '', updated_at: '' },
+    ] as Incident[]);
+
+    expect(resolveDevicePresence({ device_id: 42, status: 'online', last_seen_at: new Date().toISOString() }, alerts)).toBe('offline-alert');
+  });
+
+  it('marks stale heartbeats as degraded while tunnel status is still online', () => {
+    const now = Date.parse('2026-07-03T10:00:00.000Z');
+    expect(resolveDevicePresence({ device_id: 7, status: 'online', last_seen_at: '2026-07-03T09:58:00.000Z' }, new Set(), now)).toBe('heartbeat-stale');
+  });
+
+  it('keeps fresh online status unchanged', () => {
+    const now = Date.parse('2026-07-03T10:00:00.000Z');
+    expect(resolveDevicePresence({ device_id: 7, status: 'online', last_seen_at: '2026-07-03T09:59:30.000Z' }, new Set(), now)).toBe('online');
+  });
+});

--- a/web/src/lib/deviceStatus.ts
+++ b/web/src/lib/deviceStatus.ts
@@ -1,0 +1,59 @@
+import type { Incident } from '@/api/alerts';
+import type { Edge } from '@/api/edges';
+
+export const DEFAULT_HEARTBEAT_STALE_MS = 90_000;
+
+export type DevicePresenceState =
+  | 'offline-alert'
+  | 'heartbeat-stale'
+  | 'online'
+  | 'offline'
+  | 'unknown';
+
+type PresenceEdge = Pick<Edge, 'device_id' | 'last_seen_at' | 'status'>;
+
+export function deviceIDFromIncident(incident: Incident): string | null {
+  const targetID = typeof incident.target_id === 'string' ? incident.target_id.trim() : '';
+  if (targetID) return targetID;
+  const labelID = incident.labels?.device_id?.trim() ?? '';
+  return labelID || null;
+}
+
+export function buildOfflineAlertDeviceIDs(incidents: Incident[]): Set<string> {
+  const ids = new Set<string>();
+  for (const incident of incidents) {
+    if (incident.status !== 'open') continue;
+    if (incident.rule_key !== 'device_offline') continue;
+    const deviceID = deviceIDFromIncident(incident);
+    if (deviceID) ids.add(deviceID);
+  }
+  return ids;
+}
+
+export function isHeartbeatStale(
+  lastSeenAt: string | null | undefined,
+  nowMs = Date.now(),
+  staleMs = DEFAULT_HEARTBEAT_STALE_MS,
+): boolean {
+  if (!lastSeenAt) return false;
+  const lastSeenMs = new Date(lastSeenAt).getTime();
+  if (!Number.isFinite(lastSeenMs)) return false;
+  return nowMs - lastSeenMs > staleMs;
+}
+
+export function resolveDevicePresence(
+  edge: PresenceEdge,
+  offlineAlertDeviceIDs: Set<string>,
+  nowMs = Date.now(),
+): DevicePresenceState {
+  if (edge.device_id != null && offlineAlertDeviceIDs.has(String(edge.device_id))) {
+    return 'offline-alert';
+  }
+  if (edge.status === 'online' && isHeartbeatStale(edge.last_seen_at, nowMs)) {
+    return 'heartbeat-stale';
+  }
+  if (edge.status === 'online' || edge.status === 'offline') {
+    return edge.status;
+  }
+  return 'unknown';
+}

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -18,7 +18,6 @@ import {
   EDGE_ROLE_LABELS,
   EDGE_ROLE_LABELS_EN,
   type Edge,
-  type EdgeStatus,
   type EdgeRole,
   type CreateEdgeResponse,
   type RotateSecretResponse,
@@ -33,7 +32,7 @@ import { listIncidents } from '@/api/alerts';
 import { getManagerVersion } from '@/api/version';
 import { usePermissions } from '@/store/me';
 import { notifyDevicesChanged } from '@/lib/events';
-import { buildOfflineAlertDeviceIDs, resolveDevicePresence } from '@/lib/deviceStatus';
+import { buildOfflineAlertDeviceIDs, resolveDevicePresence, type DevicePresenceState } from '@/lib/deviceStatus';
 import { useI18n } from '@/i18n/locale';
 
 // Sidebar headers that map to ?roles= filters. Empty string = "全部"; the
@@ -49,9 +48,11 @@ const ROLE_FILTER_TITLES: Record<string, [string, string]> = {
   unknown: ['未分类设备', 'Uncategorized devices'],
 };
 
-const STATUS_FILTERS: { value: '' | EdgeStatus; zh: string; en: string }[] = [
+const STATUS_FILTERS: { value: '' | DevicePresenceState; zh: string; en: string }[] = [
   { value: '', zh: '全部状态', en: 'All statuses' },
   { value: 'online', zh: '在线', en: 'Online' },
+  { value: 'heartbeat-stale', zh: '心跳超时', en: 'Heartbeat stale' },
+  { value: 'offline-alert', zh: '离线告警', en: 'Offline alert' },
   { value: 'offline', zh: '离线', en: 'Offline' },
   { value: 'unknown', zh: '未知', en: 'Unknown' },
 ];
@@ -87,7 +88,7 @@ export default function EdgesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'' | EdgeStatus>('');
+  const [statusFilter, setStatusFilter] = useState<'' | DevicePresenceState>('');
   const [agentFilter, setAgentFilter] = useState('');
   // managerVersion drives the Agent column's drift chip — fetched once
   // on mount; failures degrade silently to "no chip" rather than red
@@ -169,7 +170,7 @@ export default function EdgesPage() {
       } else if (rolesFilter) {
         if (!Array.isArray(e.roles) || !(e.roles as string[]).includes(rolesFilter)) return false;
       }
-      if (statusFilter && e.status !== statusFilter) return false;
+      if (statusFilter && resolveDevicePresence(e, offlineAlertDeviceIDs) !== statusFilter) return false;
       if (agentFilter === '__outdated') {
         if (!managerVersion || !e.agent_version || e.agent_version === managerVersion) return false;
       } else if (agentFilter === '__missing') {
@@ -190,7 +191,7 @@ export default function EdgesPage() {
         ...roleLabels,
       ].some((v) => String(v).toLowerCase().includes(q));
     });
-  }, [agentFilter, edges, managerVersion, query, rolesFilter, statusFilter]);
+  }, [agentFilter, edges, managerVersion, offlineAlertDeviceIDs, query, rolesFilter, statusFilter]);
 
   async function onCreate(name: string) {
     const created: CreateEdgeResponse = await createEdge({ name });
@@ -426,7 +427,7 @@ export default function EdgesPage() {
               label={tr('状态', 'Status')}
               value={statusFilter}
               options={STATUS_FILTERS.map((o) => ({ value: o.value, label: tr(o.zh, o.en) }))}
-              onChange={(v) => setStatusFilter(v as '' | EdgeStatus)}
+              onChange={(v) => setStatusFilter(v as '' | DevicePresenceState)}
             />
             <DeviceToolbarSelect
               label={tr('角色', 'Role')}

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -24,9 +24,11 @@ import {
   upgradeEdgeAgent,
   upgradeEdgePackage,
 } from '@/api/edges';
+import { listIncidents } from '@/api/alerts';
 import { getManagerVersion } from '@/api/version';
 import { usePermissions } from '@/store/me';
 import { notifyDevicesChanged } from '@/lib/events';
+import { buildOfflineAlertDeviceIDs, resolveDevicePresence } from '@/lib/deviceStatus';
 import { useI18n } from '@/i18n/locale';
 
 // Sidebar headers that map to ?roles= filters. Empty string = "全部"; the
@@ -59,6 +61,7 @@ export default function EdgesPage() {
   })();
 
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [offlineAlertDeviceIDs, setOfflineAlertDeviceIDs] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // managerVersion drives the Agent column's drift chip — fetched once
@@ -86,7 +89,10 @@ export default function EdgesPage() {
 
   const refresh = useCallback(async () => {
     try {
-      const r = await listEdges(rolesFilter ? { roles: rolesFilter } : undefined);
+      const [r, incidents] = await Promise.all([
+        listEdges(rolesFilter ? { roles: rolesFilter } : undefined),
+        listIncidents({ status: 'open', pageSize: 100 }).catch(() => ({ items: [] })),
+      ]);
       // Backend currently doesn't filter by roles (the param is sent
       // for forward-compat); the post-split device.roles lives on
       // each row in `Roles []string`. Filter client-side so the
@@ -101,13 +107,14 @@ export default function EdgesPage() {
         );
       }
       setEdges(items);
+      setOfflineAlertDeviceIDs(buildOfflineAlertDeviceIDs(incidents.items ?? []));
       setError(null);
     } catch (err) {
       setError((err as Error).message || tr('加载失败', 'Load failed'));
     } finally {
       setLoading(false);
     }
-  }, [rolesFilter]);
+  }, [rolesFilter, tr]);
 
   useEffect(() => {
     void refresh();
@@ -299,7 +306,7 @@ export default function EdgesPage() {
                         <RoleChips roles={e.roles ?? []} />
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5">
-                        <StatusPill status={e.status} />
+                        <DevicePresencePill edge={e} offlineAlertDeviceIDs={offlineAlertDeviceIDs} />
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">
                         {e.last_seen_at ? relativeTime(e.last_seen_at) : '—'}
@@ -787,6 +794,40 @@ function extractIPFromObj(obj: Record<string, unknown>): string | null {
   return null;
 }
 
+function DevicePresencePill({
+  edge,
+  offlineAlertDeviceIDs,
+}: {
+  edge: Edge;
+  offlineAlertDeviceIDs: Set<string>;
+}) {
+  const { tr } = useI18n();
+  const state = resolveDevicePresence(edge, offlineAlertDeviceIDs);
+  if (state === 'offline-alert') {
+    return (
+      <span
+        title={tr('存在未恢复的设备离线告警；tunnel 状态仅供参考', 'An unresolved device-offline alert exists; tunnel status is only a connectivity signal')}
+        className="inline-flex items-center gap-1.5 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-300 ring-1 ring-inset ring-red-500/30"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+        {tr('离线告警', 'Offline alert')}
+      </span>
+    );
+  }
+  if (state === 'heartbeat-stale') {
+    return (
+      <span
+        title={tr('tunnel 仍标记在线，但最后心跳已超时', 'Tunnel is still marked online, but the last heartbeat is stale')}
+        className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-500/30"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+        {tr('心跳超时', 'Heartbeat stale')}
+      </span>
+    );
+  }
+  return <StatusPill status={state} />;
+}
+
 // ShellButton opens the WebSSH page for one device in a NEW tab. The
 // route key is device_id, not edge.id — Prom labels and the backend
 // WS handler both use device_id. Disabled when the edge is offline
@@ -1141,4 +1182,3 @@ function InstallCommandRow({ accessKey, secretKey }: { accessKey: string; secret
     </div>
   );
 }
-

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Plus, RotateCw, Trash2, MoreVertical, Copy, Check, ExternalLink, TerminalSquare } from 'lucide-react';
+import { Plus, RotateCw, Trash2, MoreVertical, Copy, Check, ExternalLink, TerminalSquare, Search } from 'lucide-react';
 import { StatusPill } from '@/components/StatusPill';
 import { Modal } from '@/components/Modal';
 import { cn } from '@/lib/cn';
@@ -18,6 +18,7 @@ import {
   EDGE_ROLE_LABELS,
   EDGE_ROLE_LABELS_EN,
   type Edge,
+  type EdgeStatus,
   type EdgeRole,
   type CreateEdgeResponse,
   type RotateSecretResponse,
@@ -43,16 +44,33 @@ const ROLE_FILTER_TITLES: Record<string, [string, string]> = {
   '': ['全部设备', 'All devices'],
   server: ['服务器', 'Servers'],
   storage: ['存储', 'Storage'],
+  database: ['数据库', 'Databases'],
   network: ['网络设备', 'Network devices'],
   unknown: ['未分类设备', 'Uncategorized devices'],
 };
+
+const STATUS_FILTERS: { value: '' | EdgeStatus; zh: string; en: string }[] = [
+  { value: '', zh: '全部状态', en: 'All statuses' },
+  { value: 'online', zh: '在线', en: 'Online' },
+  { value: 'offline', zh: '离线', en: 'Offline' },
+  { value: 'unknown', zh: '未知', en: 'Unknown' },
+];
+
+const ROLE_FILTERS: { value: string; zh: string; en: string }[] = [
+  { value: '', zh: '全部角色', en: 'All roles' },
+  { value: 'server', zh: '服务器', en: 'Servers' },
+  { value: 'storage', zh: '存储', en: 'Storage' },
+  { value: 'database', zh: '数据库', en: 'Databases' },
+  { value: 'network', zh: '网络设备', en: 'Network' },
+  { value: 'unknown', zh: '未分类', en: 'Uncategorized' },
+];
 
 export default function EdgesPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { tr } = useI18n();
   const { canMutate } = usePermissions();
-  // Sidebar sub-items navigate by appending ?roles=server|storage|network|unknown.
+  // Sidebar sub-items navigate by appending ?roles=server|storage|database|network|unknown.
   // No param = "全部". We forward the param to the backend so filtering uses the
   // sargable IN-list path (see internal/manager/biz/edge.ListFilter).
   const rolesFilter = useMemo(() => {
@@ -68,6 +86,9 @@ export default function EdgesPage() {
   const [offlineAlertDeviceIDs, setOfflineAlertDeviceIDs] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'' | EdgeStatus>('');
+  const [agentFilter, setAgentFilter] = useState('');
   // managerVersion drives the Agent column's drift chip — fetched once
   // on mount; failures degrade silently to "no chip" rather than red
   // because version mismatch isn't operationally critical.
@@ -107,17 +128,9 @@ export default function EdgesPage() {
       ]);
       // Backend currently doesn't filter by roles (the param is sent
       // for forward-compat); the post-split device.roles lives on
-      // each row in `Roles []string`. Filter client-side so the
-      // 服务器 / 存储 / 网络 sub-views show only matching devices,
-      // and 未分类 lands in its own bucket — never mixed in.
-      let items = r.items ?? [];
-      if (rolesFilter === 'unknown') {
-        items = items.filter((e) => !e.roles || e.roles.length === 0);
-      } else if (rolesFilter) {
-        items = items.filter(
-          (e) => Array.isArray(e.roles) && (e.roles as string[]).includes(rolesFilter),
-        );
-      }
+      // each row in `Roles []string`. `filteredEdges` below applies the
+      // role/status/agent/search facets to the raw fleet response.
+      const items = r.items ?? [];
       setEdges(items);
       setOfflineAlertDeviceIDs(buildOfflineAlertDeviceIDs(incidents.items ?? []));
       // Drop any selected ids that no longer appear (deleted / filtered out)
@@ -140,6 +153,44 @@ export default function EdgesPage() {
     void refresh();
   }, [refresh]);
   usePoll(refresh, 10_000);
+
+  const agentOptions = useMemo(() => {
+    const versions = Array.from(
+      new Set(edges.map((e) => e.agent_version?.trim()).filter((v): v is string => !!v)),
+    ).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    return versions;
+  }, [edges]);
+
+  const filteredEdges = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return edges.filter((e) => {
+      if (rolesFilter === 'unknown') {
+        if (e.roles && e.roles.length > 0) return false;
+      } else if (rolesFilter) {
+        if (!Array.isArray(e.roles) || !(e.roles as string[]).includes(rolesFilter)) return false;
+      }
+      if (statusFilter && e.status !== statusFilter) return false;
+      if (agentFilter === '__outdated') {
+        if (!managerVersion || !e.agent_version || e.agent_version === managerVersion) return false;
+      } else if (agentFilter === '__missing') {
+        if (e.agent_version) return false;
+      } else if (agentFilter && e.agent_version !== agentFilter) {
+        return false;
+      }
+      if (!q) return true;
+      const roleLabels = (e.roles ?? []).map((r) => `${r} ${EDGE_ROLE_LABELS[r]} ${EDGE_ROLE_LABELS_EN[r]}`);
+      return [
+        e.id,
+        e.device_id ?? '',
+        e.name,
+        extractHostname(e.host_info) ?? '',
+        extractIP(e.host_info) ?? '',
+        e.access_key_id,
+        e.agent_version ?? '',
+        ...roleLabels,
+      ].some((v) => String(v).toLowerCase().includes(q));
+    });
+  }, [agentFilter, edges, managerVersion, query, rolesFilter, statusFilter]);
 
   async function onCreate(name: string) {
     const created: CreateEdgeResponse = await createEdge({ name });
@@ -213,7 +264,8 @@ export default function EdgesPage() {
   }
 
   const selectedIds = useMemo(() => [...selected], [selected]);
-  const allVisibleSelected = edges.length > 0 && edges.every((e) => selected.has(e.id));
+  const allVisibleSelected = filteredEdges.length > 0 && filteredEdges.every((e) => selected.has(e.id));
+  const hasFilters = !!query.trim() || !!statusFilter || !!rolesFilter || !!agentFilter;
 
   const toggleOne = (id: number) => {
     setSelected((prev) => {
@@ -225,18 +277,31 @@ export default function EdgesPage() {
   };
   const toggleAllVisible = () => {
     setSelected((prev) => {
-      if (edges.every((e) => prev.has(e.id))) {
+      if (filteredEdges.every((e) => prev.has(e.id))) {
         // all selected → clear the visible ones
         const next = new Set(prev);
-        edges.forEach((e) => next.delete(e.id));
+        filteredEdges.forEach((e) => next.delete(e.id));
         return next;
       }
       const next = new Set(prev);
-      edges.forEach((e) => next.add(e.id));
+      filteredEdges.forEach((e) => next.add(e.id));
       return next;
     });
   };
   const clearSelection = () => setSelected(new Set());
+  const clearFilters = () => {
+    setQuery('');
+    setStatusFilter('');
+    setAgentFilter('');
+    if (rolesFilter) navigate('/devices', { replace: true });
+  };
+  const updateRoleFilter = (value: string) => {
+    if (!value) {
+      navigate('/devices', { replace: true });
+      return;
+    }
+    navigate(`/devices?${new URLSearchParams({ roles: value }).toString()}`, { replace: true });
+  };
 
   // summarizeBatch turns a per-id envelope into a single toast. All-ok →
   // green; any failure → amber-red with the failed ids so the operator
@@ -308,7 +373,12 @@ export default function EdgesPage() {
           <div>
             <h1 className="text-base font-semibold text-zinc-100">{headerTitle}</h1>
             <p className="mt-0.5 text-xs text-zinc-500">
-              {tr(`${edges.length} 台设备 · 每 10 秒自动刷新`, `${edges.length} device(s) · auto-refresh every 10s`)}
+              {hasFilters
+                ? tr(
+                    `${filteredEdges.length} / ${edges.length} 台设备 · 每 10 秒自动刷新`,
+                    `${filteredEdges.length} / ${edges.length} device(s) · auto-refresh every 10s`,
+                  )
+                : tr(`${edges.length} 台设备 · 每 10 秒自动刷新`, `${edges.length} device(s) · auto-refresh every 10s`)}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -339,6 +409,52 @@ export default function EdgesPage() {
               {error}
             </div>
           )}
+
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-[12px]">
+            <label className="inline-flex min-w-64 items-center gap-1 rounded-md border border-zinc-800/60 bg-zinc-950/40 px-2 py-1 text-zinc-300 focus-within:border-zinc-600">
+              <Search size={12} className="text-zinc-500" />
+              <span className="text-[11px] text-zinc-500">{tr('搜索', 'Search')}</span>
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={tr('名称 / 主机 / IP / ID', 'Name / host / IP / ID')}
+                className="min-w-0 flex-1 border-none bg-transparent px-1 text-[12px] text-zinc-100 placeholder:text-zinc-600 focus:outline-none"
+              />
+            </label>
+            <DeviceToolbarSelect
+              label={tr('状态', 'Status')}
+              value={statusFilter}
+              options={STATUS_FILTERS.map((o) => ({ value: o.value, label: tr(o.zh, o.en) }))}
+              onChange={(v) => setStatusFilter(v as '' | EdgeStatus)}
+            />
+            <DeviceToolbarSelect
+              label={tr('角色', 'Role')}
+              value={rolesFilter}
+              options={ROLE_FILTERS.map((o) => ({ value: o.value, label: tr(o.zh, o.en) }))}
+              onChange={updateRoleFilter}
+            />
+            <DeviceToolbarSelect
+              label="Agent"
+              value={agentFilter}
+              options={[
+                { value: '', label: tr('全部版本', 'All versions') },
+                ...(managerVersion ? [{ value: '__outdated', label: tr('与 Manager 不一致', 'Out of sync') }] : []),
+                { value: '__missing', label: tr('未上报版本', 'Not reported') },
+                ...agentOptions.map((v) => ({ value: v, label: v })),
+              ]}
+              onChange={setAgentFilter}
+            />
+            {hasFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="rounded-md border border-zinc-800/60 bg-zinc-950/40 px-2.5 py-1.5 text-[12px] text-zinc-300 hover:bg-zinc-900"
+              >
+                {tr('清除筛选', 'Clear filters')}
+              </button>
+            )}
+          </div>
 
           {selected.size > 0 && (
             <div className="mb-3 flex items-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-3 py-2 text-xs">
@@ -380,8 +496,8 @@ export default function EdgesPage() {
             </div>
           )}
 
-          <div className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
-            <table className="w-full text-sm">
+          <div className="overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+            <table className="min-w-[1320px] w-full text-sm">
               <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
                 <tr>
                   <th className="w-10 px-4 py-2.5 text-left">
@@ -396,7 +512,8 @@ export default function EdgesPage() {
                       onChange={toggleAllVisible}
                     />
                   </th>
-                  <th className="px-4 py-2.5 text-left">ID</th>
+                  <th className="whitespace-nowrap px-4 py-2.5 text-left">Edge ID</th>
+                  <th className="whitespace-nowrap px-4 py-2.5 text-left">Device ID</th>
                   <th className="px-4 py-2.5 text-left">{tr('名称', 'Name')}</th>
                   <th className="px-4 py-2.5 text-left">{tr('主机名', 'Hostname')}</th>
                   <th className="px-4 py-2.5 text-left">IP</th>
@@ -411,14 +528,16 @@ export default function EdgesPage() {
               <tbody className="divide-y divide-zinc-800/40">
                 {loading && edges.length === 0 ? (
                   <tr>
-                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
+                    <td colSpan={12} className="px-4 py-10 text-center text-zinc-500">
                       {tr('加载中…', 'Loading…')}
                     </td>
                   </tr>
-                ) : edges.length === 0 ? (
+                ) : filteredEdges.length === 0 ? (
                   <tr>
-                    <td colSpan={11} className="px-4 py-10 text-center text-zinc-500">
-                      {rolesFilter
+                    <td colSpan={12} className="px-4 py-10 text-center text-zinc-500">
+                      {hasFilters
+                        ? tr('没有匹配当前筛选条件的设备。', 'No devices match the current filters.')
+                        : rolesFilter
                         ? tr(
                             `没有 ${ROLE_FILTER_TITLES[rolesFilter]?.[0] ?? rolesFilter} 设备。点设备名打开详情后可在右上角分配角色。`,
                             `No ${ROLE_FILTER_TITLES[rolesFilter]?.[1] ?? rolesFilter} devices. Open a device detail page to assign roles.`,
@@ -430,7 +549,7 @@ export default function EdgesPage() {
                     </td>
                   </tr>
                 ) : (
-                  edges.map((e) => (
+                  filteredEdges.map((e) => (
                     <tr
                       key={e.id}
                       className="cursor-pointer transition-colors hover:bg-zinc-900/40"
@@ -456,6 +575,9 @@ export default function EdgesPage() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
                         {e.id}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
+                        {e.device_id ?? '—'}
                       </td>
                       <td className="whitespace-nowrap px-4 py-2.5 text-zinc-100">
                         {e.name || (
@@ -610,6 +732,35 @@ export default function EdgesPage() {
       deviceId,
     });
   }
+}
+
+function DeviceToolbarSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange(value: string): void;
+}) {
+  return (
+    <label className="inline-flex items-center gap-1 rounded-md border border-zinc-800/60 bg-zinc-950/40 pl-2 pr-1 py-1 text-zinc-300 hover:border-zinc-700">
+      <span className="text-[11px] text-zinc-500">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none border-none bg-transparent pl-1 pr-4 text-[12px] text-zinc-100 focus:outline-none"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value} className="bg-zinc-900">
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
 }
 
 // AgentVersionCell shows the edge's reported agent_version + a drift


### PR DESCRIPTION
## Summary

Depends on #166.

This builds on the device presence semantics from #166 and the already-merged batch device operations from #161. It makes the Devices table easier to operate by:

- splitting the identity column into `Edge ID` and `Device ID`
- adding search across name, host, IP, access key, agent version, roles, Edge ID, and Device ID
- adding status, role, and Agent version filters
- applying the status filter to the rendered presence state, so `Online` does not include heartbeat-stale or offline-alert devices
- keeping select-all/batch operations scoped to the currently filtered rows

## Validation

- `cd web && npm run typecheck`
- `cd web && npm test -- deviceStatus`
- `cd web && npm run build`
- Chrome screenshots with mocked Devices API in dark and light themes

## Notes

#161 is already merged into `main`; #166 was updated with `main` first so its status semantics now coexist with the batch operations UI.

## Author confirmation

- [ ] I have read and agree to the project contribution guide in CONTRIBUTING.md.