### PR TITLE
fix(llm): omit fixed sampling params for reasoning models

### DIFF
--- a/internal/pkg/llm/client.go
+++ b/internal/pkg/llm/client.go
@@ -204,6 +204,16 @@ type openaiClient struct {
 	resolveMu  sync.Mutex
 	resolved   resolvedCreds
 	resolvedAt time.Time
+
+	// noSampling records models discovered at runtime to reject custom
+	// sampling params (temperature / top_p / n / penalties) — the OpenAI
+	// reasoning families (o-series, gpt-5.x) fix these at 1/0 and 400 on any
+	// other value. Seeded reactively from CreateChatCompletion's "params
+	// fixed at 1" rejection so every later call for that model proactively
+	// omits the params instead of eating a failed round-trip. Read alongside
+	// the isReasoningModel name heuristic. Keyed by the raw model string.
+	noSamplingMu sync.RWMutex
+	noSampling   map[string]bool
 }
 
 type sdkKey struct {
@@ -387,6 +397,22 @@ func (c *openaiClient) Chat(ctx context.Context, req ChatReq) (*ChatResp, error)
 	sdk := c.sdkFor(apiKey, baseURL)
 	start := time.Now()
 	sdkResp, err := sdk.CreateChatCompletion(callCtx, sdkReq)
+
+	// Reactive self-heal for reasoning models the name heuristic did not
+	// catch (custom gateway aliases like "gpt-5.6-sol"). These fix
+	// temperature/top_p/n at 1 and penalties at 0, and 400 on any other
+	// value. If that's what we hit AND we actually sent a sampling param,
+	// remember the model, strip the params, and retry once. Safe: this is
+	// still the single completion call — no tool has executed yet, so the
+	// no-retry-on-tools rule below does not apply.
+	if err != nil && isSamplingParamError(err) && hasCustomSampling(sdkReq) {
+		c.rememberNoSampling(model)
+		stripSamplingParams(&sdkReq)
+		c.log.Warn("llm: model rejects custom sampling params; retrying without them",
+			slog.String("model", model))
+		sdkResp, err = sdk.CreateChatCompletion(callCtx, sdkReq)
+	}
+
 	dur := time.Since(start)
 	c.metrics.requestSeconds.WithLabelValues(model).Observe(dur.Seconds())
 
@@ -449,9 +475,20 @@ func (c *openaiClient) Chat(ctx context.Context, req ChatReq) (*ChatResp, error)
 
 // toOpenAIReq translates the public ChatReq to the SDK request shape.
 func (c *openaiClient) toOpenAIReq(req ChatReq, model string) (openai.ChatCompletionRequest, error) {
+	// Reasoning models (o-series, gpt-5.x) fix temperature/top_p/n at 1 and
+	// 400 on any other value, so we must NOT send a temperature for them.
+	// A zero Temperature is dropped by the SDK's `omitempty` tag, letting the
+	// provider apply its fixed default. Every other (chat-completion) model
+	// keeps the deterministic 0.1 default the AIOps loop relies on.
+	//
+	// isReasoningModel is the fast path for known families; noSampling is the
+	// reactively-learned set for gateway aliases the heuristic missed.
 	temp := req.Temperature
-	if temp == 0 {
+	if temp == 0 && !isReasoningModel(model) && !c.modelRejectsSampling(model) {
 		temp = 0.1
+	}
+	if isReasoningModel(model) || c.modelRejectsSampling(model) {
+		temp = 0
 	}
 
 	msgs := make([]openai.ChatCompletionMessage, 0, len(req.Messages))
@@ -542,6 +579,100 @@ func fromOpenAIMessage(m openai.ChatCompletionMessage) (Message, error) {
 		}
 	}
 	return out, nil
+}
+
+// isReasoningModel reports whether model is an OpenAI-style reasoning model
+// that fixes its sampling params (temperature / top_p / n at 1, penalties at
+// 0) and rejects any override with a 400. Matched by name family so the
+// common cases skip a doomed round-trip; anything this misses is still caught
+// reactively by isSamplingParamError + the noSampling cache.
+//
+// Covered families:
+//   - OpenAI o-series: o1, o1-mini, o3, o3-mini, o4-mini, …
+//   - GPT-5 family: gpt-5, gpt-5.5, gpt-5-mini, gpt-5.6-sol, … (all reasoning)
+//   - Any name tagged "reasoner"/"reasoning" (e.g. deepseek-reasoner)
+func isReasoningModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return false
+	}
+	switch {
+	case m == "o1" || m == "o3" || m == "o4":
+		return true
+	case strings.HasPrefix(m, "o1-") || strings.HasPrefix(m, "o3-") || strings.HasPrefix(m, "o4-"):
+		return true
+	case strings.HasPrefix(m, "gpt-5"):
+		return true
+	case strings.Contains(m, "reasoner") || strings.Contains(m, "reasoning"):
+		return true
+	}
+	return false
+}
+
+// modelRejectsSampling reports whether we've reactively learned that model
+// 400s on custom sampling params. Complements the isReasoningModel heuristic.
+func (c *openaiClient) modelRejectsSampling(model string) bool {
+	if model == "" {
+		return false
+	}
+	c.noSamplingMu.RLock()
+	defer c.noSamplingMu.RUnlock()
+	return c.noSampling[model]
+}
+
+// rememberNoSampling records that model rejects custom sampling params so
+// later calls omit them up front.
+func (c *openaiClient) rememberNoSampling(model string) {
+	if model == "" {
+		return
+	}
+	c.noSamplingMu.Lock()
+	defer c.noSamplingMu.Unlock()
+	if c.noSampling == nil {
+		c.noSampling = make(map[string]bool)
+	}
+	c.noSampling[model] = true
+}
+
+// isSamplingParamError reports whether err is a provider 400 rejecting a
+// sampling param (temperature/top_p/n/penalties) as unsupported/fixed — the
+// signature of a reasoning model. Matched on message text because the shape
+// differs across the OpenAI-compatible gateways we front (dmxapi, Azure, …).
+func isSamplingParamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "temperature") &&
+		!strings.Contains(msg, "top_p") &&
+		!strings.Contains(msg, "sampling") {
+		return false
+	}
+	return strings.Contains(msg, "fixed at 1") ||
+		strings.Contains(msg, "beta-limitations") ||
+		strings.Contains(msg, "only the default") ||
+		strings.Contains(msg, "does not support") ||
+		strings.Contains(msg, "unsupported value") ||
+		strings.Contains(msg, "unsupported_value")
+}
+
+// hasCustomSampling reports whether req carries any sampling param that a
+// reasoning model would reject. Guards the reactive retry so we only re-issue
+// when stripping the params can actually change the outcome.
+func hasCustomSampling(req openai.ChatCompletionRequest) bool {
+	return req.Temperature != 0 || req.TopP != 0 || req.N != 0 ||
+		req.PresencePenalty != 0 || req.FrequencyPenalty != 0
+}
+
+// stripSamplingParams zeroes every sampling param so the SDK's `omitempty`
+// tags drop them from the wire, letting a reasoning model apply its fixed
+// defaults.
+func stripSamplingParams(req *openai.ChatCompletionRequest) {
+	req.Temperature = 0
+	req.TopP = 0
+	req.N = 0
+	req.PresencePenalty = 0
+	req.FrequencyPenalty = 0
 }
 
 // estimatePromptTokens is a cheap pre-call estimate: ~4 chars per token is a

--- a/internal/pkg/llm/client_test.go
+++ b/internal/pkg/llm/client_test.go
@@ -314,6 +314,105 @@ func TestTemperatureDefault(t *testing.T) {
 	}
 }
 
+// TestReasoningModelOmitsTemperature — a reasoning model (gpt-5.x) must NOT
+// carry a temperature: the SDK's omitempty drops the zero value so the
+// provider applies its fixed default (1) instead of 400-ing on 0.1.
+func TestReasoningModelOmitsTemperature(t *testing.T) {
+	var present bool
+	_, cfg := fakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		// Probe the raw body: a present key means we sent it, even if 0.
+		var probe map[string]json.RawMessage
+		_ = json.Unmarshal(raw, &probe)
+		_, present = probe["temperature"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(sampleChatResponse("ok", nil))
+	})
+	client := newTestClient(t, cfg, nil)
+	_, err := client.Chat(context.Background(), ChatReq{
+		Model:    "gpt-5.5",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if present {
+		t.Errorf("temperature was sent for a reasoning model, want omitted")
+	}
+}
+
+// TestSamplingErrorTriggersRetry — a gateway alias the name heuristic misses
+// still recovers: the first attempt carries 0.1 and 400s, we strip sampling
+// params and retry, the second attempt succeeds, and the model is remembered
+// so the next call omits the param up front.
+func TestSamplingErrorTriggersRetry(t *testing.T) {
+	var calls int
+	var tempsSeen []float32
+	_, cfg := fakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		raw, _ := io.ReadAll(r.Body)
+		var body struct {
+			Temperature float32 `json:"temperature"`
+		}
+		_ = json.Unmarshal(raw, &body)
+		tempsSeen = append(tempsSeen, body.Temperature)
+		if body.Temperature != 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0","type":"invalid_request_error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(sampleChatResponse("ok", nil))
+	})
+	client := newTestClient(t, cfg, nil)
+
+	// "sol-max" is not matched by isReasoningModel, so the first attempt
+	// sends 0.1 and gets rejected; the reactive path strips + retries.
+	_, err := client.Chat(context.Background(), ChatReq{
+		Model:    "sol-max",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("server calls = %d, want 2 (initial 400 + retry)", calls)
+	}
+	if tempsSeen[0] == 0 || tempsSeen[1] != 0 {
+		t.Errorf("temps seen = %v, want [~0.1, 0]", tempsSeen)
+	}
+
+	// Second call for the same model must omit temperature up front (learned).
+	calls = 0
+	_, err = client.Chat(context.Background(), ChatReq{
+		Model:    "sol-max",
+		Messages: []Message{{Role: "user", Content: "hi again"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat (learned): %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("server calls after learning = %d, want 1 (no failed round-trip)", calls)
+	}
+}
+
+// TestIsReasoningModel spot-checks the name heuristic.
+func TestIsReasoningModel(t *testing.T) {
+	reasoning := []string{"gpt-5", "gpt-5.5", "gpt-5.6-sol", "GPT-5-mini", "o1", "o1-mini", "o3-mini", "o4-mini", "deepseek-reasoner"}
+	for _, m := range reasoning {
+		if !isReasoningModel(m) {
+			t.Errorf("isReasoningModel(%q) = false, want true", m)
+		}
+	}
+	chat := []string{"gpt-4o", "gpt-4.1", "qwen3.7-max", "claude-3.5", "", "deepseek-chat"}
+	for _, m := range chat {
+		if isReasoningModel(m) {
+			t.Errorf("isReasoningModel(%q) = true, want false", m)
+		}
+	}
+}
+
 // TestToolResultMessageRoundTrip — a role=tool message carries ToolCallID.
 func TestToolResultMessageRoundTrip(t *testing.T) {
 	var gotToolCallID string


### PR DESCRIPTION
## What & why

Reasoning models (OpenAI o-series, `gpt-5.x`) fix `temperature`/`top_p`/`n`
at `1` and `presence_penalty`/`frequency_penalty` at `0`, and return
**HTTP 400** on any other value:

```
this model has beta-limitations, temperature, top_p and n are fixed at 1,
while presence_penalty and frequency_penalty are fixed at 0
```

`toOpenAIReq` unconditionally forces `temperature=0.1`, so **every reasoning
model fails** and the chat surfaces a generic `stream error` (the 400 bubbles
up through the buffered-stream path).

## The fix

Three layers, so both known families and unknown gateway aliases work, while
regular chat-completion models keep their deterministic default:

1. **`isReasoningModel()` heuristic** — for `gpt-5*` / `o1|o3|o4*` /
   `*reasoner*`, omit the sampling params up front. A zero `Temperature` is
   dropped by the SDK's `omitempty` tag, so the provider applies its fixed
   default.
2. **Reactive self-heal** — if a completion is still rejected with a
   "sampling param fixed" 400, strip the sampling params and retry once. No
   tool has executed yet, so the retry is safe. This catches OpenAI-compatible
   gateway aliases the name heuristic can't know about.
3. **Learned cache** — a model discovered reactively is remembered, so later
   calls omit the params up front instead of eating a failed round-trip.

Regular chat-completion models are unaffected (still sent at `0.1`).

## Testing

- `go test ./internal/pkg/llm/...` — new tests cover the heuristic, the
  reactive retry (initial 400 → strip → retry → success), and the learned
  cache (second call makes a single request).
- `go vet ./internal/pkg/llm/...`, `gofmt` clean.

## Scope

One logical change, backend-only (`internal/pkg/llm/client.go` +
`client_test.go`). No API or config surface changes.
