### PR TITLE
fix(mcp): refresh chat tools after verification

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -147,6 +147,7 @@ import (
 	managerreportdata "github.com/ongridio/ongrid/internal/manager/data/report/store"
 	manageraiopsmodel "github.com/ongridio/ongrid/internal/manager/model/aiops"
 	managerapprovalmodel "github.com/ongridio/ongrid/internal/manager/model/approval"
+	managermodelmcp "github.com/ongridio/ongrid/internal/manager/model/mcp"
 	managerserveraiops "github.com/ongridio/ongrid/internal/manager/server/aiops"
 	managerserveralert "github.com/ongridio/ongrid/internal/manager/server/alert"
 	managerserverapproval "github.com/ongridio/ongrid/internal/manager/server/approval"
@@ -2170,12 +2171,34 @@ func main() {
 		}
 		mcpCaller := mcpCallerShim{uc: mcpUC}
 		mcpProposer := mcpProposerShim{uc: approvalUC}
-		// Chat path: bolt enabled servers' tools onto the chat toolbag (boot
-		// snapshot; agent-initiated calls respect each server's trusted flag /
-		// approval). The FLOW path uses the LIVE flowMCPSource wired above, so
-		// it isn't touched here.
+		// Keep the graph-facing decorators and ToolSearch's unredacted catalog
+		// in sync. Registration changes call this with one server's fresh test
+		// result, so an admin save never reconnects every MCP endpoint.
+		refreshMCPServerTools := func(ctx context.Context, serverName string, srv *managermodelmcp.Server, discovered []mcpclient.Tool) {
+			prefix := aiopstools.MCPToolName(serverName, "")
+			var rawTools []aiopstoolsbase.BaseTool
+			var graphTools []aiopstoolsbase.BaseTool
+			if srv != nil && srv.Enabled {
+				rawTools = make([]aiopstoolsbase.BaseTool, 0, len(discovered))
+				graphTools = make([]aiopstoolsbase.BaseTool, 0, len(discovered))
+				for _, mt := range discovered {
+					raw := aiopstools.NewMCPTool(srv.Name, mt.Name, mt.Description, mt.InputSchema, srv.Trusted, mcpCaller, mcpProposer, log)
+					rawTools = append(rawTools, raw)
+					graphTools = append(graphTools, aiopstoolsdec.Wrap(raw, mcpDeps))
+				}
+			}
+			chatRT.ReplaceCatalogToolsByNamePrefix(prefix, rawTools)
+			chatRT.ReplaceToolsByNamePrefix(prefix, graphTools)
+			log.Info("mcp tools refreshed in chat runtime",
+				slog.String("server", serverName),
+				slog.Int("tools", len(graphTools)),
+				slog.Int("tool_count", chatRT.ToolCount()))
+		}
+		mcpUC.SetToolChangeHook(refreshMCPServerTools)
+
+		// Chat path: load enabled servers at boot; later changes use the same
+		// per-server refresh hook. The FLOW path uses LIVE flowMCPSource.
 		if servers, err := mcpUC.ListEnabled(rootCtx); err == nil {
-			var mcpTools []aiopstoolsbase.BaseTool
 			for _, srv := range servers {
 				connCtx, cancel := context.WithTimeout(rootCtx, 15*time.Second)
 				cli, berr := mcpUC.BuildClient(connCtx, srv)
@@ -2191,17 +2214,11 @@ func main() {
 					log.Warn("mcp: connect failed, skipping server", slog.String("server", srv.Name), slog.Any("err", berr))
 					continue
 				}
-				for _, mt := range mtools {
-					mcpTools = append(mcpTools, aiopstoolsdec.Wrap(
-						aiopstools.NewMCPTool(srv.Name, mt.Name, mt.Description, mt.InputSchema, srv.Trusted, mcpCaller, mcpProposer, log),
-						mcpDeps))
-				}
+				refreshMCPServerTools(rootCtx, srv.Name, srv, mtools)
 				log.Info("mcp: server connected", slog.String("server", srv.Name), slog.Int("tools", len(mtools)), slog.Bool("trusted", srv.Trusted))
 			}
-			if len(mcpTools) > 0 {
-				chatRT.AppendToolBag(mcpTools)
-				log.Info("mcp tools bolted onto chat runtime bag", slog.Int("mcp_tool_count", len(mcpTools)), slog.Int("tool_count", chatRT.ToolCount()))
-			}
+		} else {
+			log.Warn("mcp: list enabled servers failed", slog.Any("err", err))
 		}
 	}
 	if secretbox.KeyIsWeak() {

--- a/internal/manager/biz/aiops/chatruntime/config_confirm.go
+++ b/internal/manager/biz/aiops/chatruntime/config_confirm.go
@@ -36,7 +36,7 @@ func (rt *Runtime) tryApplyConfirmedConfigDraft(ctx context.Context, req *Reques
 	if parseErr != nil {
 		return rt.persistAndEmitDirectAssistant(ctx, sess.ID, emit, fmt.Sprintf("确认应用失败：%s", parseErr.Error())), true
 	}
-	tool, err := findToolByName(ctx, rt.cfg.ToolBag, applyConfigChangeToolName)
+	tool, err := findToolByName(ctx, rt.toolBagSnapshot(), applyConfigChangeToolName)
 	if err != nil {
 		return rt.persistAndEmitDirectAssistant(ctx, sess.ID, emit, fmt.Sprintf("确认应用失败：%s", err.Error())), true
 	}

--- a/internal/manager/biz/aiops/chatruntime/runtime.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime.go
@@ -273,6 +273,14 @@ type ToolBagProvider interface {
 	AllTools() []basetool.BaseTool
 }
 
+// mutableToolBagProvider is intentionally optional so lightweight test
+// providers remain read-only. The concrete tools.ToolBag implements it and
+// keeps ToolSearch aligned with runtime-discovered MCP tools.
+type mutableToolBagProvider interface {
+	ToolBagProvider
+	ReplaceToolsByNamePrefix(prefix string, replacements []basetool.BaseTool)
+}
+
 // CredentialBinder resolves the vault credential NAMES bound to whichever
 // installed packs ship the given active skills (HLD-017). The marketplace
 // usecase satisfies this structurally. Returns nil when nothing is bound.
@@ -295,6 +303,10 @@ type Runtime struct {
 
 	workersMu sync.Mutex
 	workers   map[string]*Worker
+
+	// toolMu protects cfg.ToolBag, which is updated when an MCP server is
+	// verified, edited, disabled, or deleted while chats are in flight.
+	toolMu sync.RWMutex
 
 	// bag is the unredacted ToolBag handle wired by SetToolBag. nil
 	// when the caller wires the runtime without calling SetToolBag —
@@ -386,6 +398,8 @@ func (rt *Runtime) AppendToolBag(tools []basetool.BaseTool) {
 	if rt == nil || len(tools) == 0 {
 		return
 	}
+	rt.toolMu.Lock()
+	defer rt.toolMu.Unlock()
 	index := map[string]int{}
 	for i, t := range rt.cfg.ToolBag {
 		if t == nil {
@@ -409,6 +423,54 @@ func (rt *Runtime) AppendToolBag(tools []basetool.BaseTool) {
 		}
 		rt.cfg.ToolBag = append(rt.cfg.ToolBag, t)
 	}
+}
+
+// ReplaceToolsByNamePrefix replaces tools in the graph-facing bag whose wire
+// names share prefix. MCP uses one prefix per server, preventing a refresh of
+// one registration from removing tools offered by other servers.
+func (rt *Runtime) ReplaceToolsByNamePrefix(prefix string, replacements []basetool.BaseTool) {
+	if rt == nil || strings.TrimSpace(prefix) == "" {
+		return
+	}
+	rt.toolMu.Lock()
+	defer rt.toolMu.Unlock()
+	next := make([]basetool.BaseTool, 0, len(rt.cfg.ToolBag)+len(replacements))
+	for _, tool := range rt.cfg.ToolBag {
+		if toolNameHasPrefix(tool, prefix) {
+			continue
+		}
+		next = append(next, tool)
+	}
+	rt.cfg.ToolBag = append(next, replacements...)
+}
+
+// ReplaceCatalogToolsByNamePrefix updates the unredacted catalog used by
+// ToolSearch. It is separate from ReplaceToolsByNamePrefix because the graph
+// sees decorated tools while ToolSearch must retain raw schemas.
+func (rt *Runtime) ReplaceCatalogToolsByNamePrefix(prefix string, replacements []basetool.BaseTool) {
+	if rt == nil || strings.TrimSpace(prefix) == "" {
+		return
+	}
+	if bag, ok := rt.bag.(mutableToolBagProvider); ok {
+		bag.ReplaceToolsByNamePrefix(prefix, replacements)
+	}
+}
+
+func (rt *Runtime) toolBagSnapshot() []basetool.BaseTool {
+	if rt == nil {
+		return nil
+	}
+	rt.toolMu.RLock()
+	defer rt.toolMu.RUnlock()
+	return append([]basetool.BaseTool(nil), rt.cfg.ToolBag...)
+}
+
+func toolNameHasPrefix(tool basetool.BaseTool, prefix string) bool {
+	if tool == nil {
+		return false
+	}
+	info, err := tool.Info(context.Background())
+	return err == nil && info != nil && strings.HasPrefix(info.Name, prefix)
 }
 
 // AgentRegistry exposes the registry for narrow read-only callers
@@ -438,7 +500,7 @@ func (rt *Runtime) ToolCount() int {
 	if rt == nil {
 		return 0
 	}
-	return len(rt.cfg.ToolBag)
+	return len(rt.toolBagSnapshot())
 }
 
 // ToolNames returns the resolved tool names (best-effort — Info()
@@ -448,8 +510,9 @@ func (rt *Runtime) ToolNames(ctx context.Context) []string {
 	if rt == nil {
 		return nil
 	}
-	out := make([]string, 0, len(rt.cfg.ToolBag))
-	for _, t := range rt.cfg.ToolBag {
+	tools := rt.toolBagSnapshot()
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
 		if t == nil {
 			continue
 		}
@@ -555,7 +618,8 @@ func (rt *Runtime) Handle(ctx context.Context, req *Request) (*Reply, error) {
 	// the coordinator path now honors it too. Stale agent ids fall back
 	// to the global default with a log line — never crash a session.
 	basePrompt := rt.cfg.BasePrompt
-	sessionToolBag := rt.cfg.ToolBag
+	runtimeToolBag := rt.toolBagSnapshot()
+	sessionToolBag := runtimeToolBag
 	agentReminderForPersona := ""
 	// Coordinator iff session is pinned to "default" or has no
 	// AgentID at all. Specialist personas (= anything else in the
@@ -578,7 +642,7 @@ func (rt *Runtime) Handle(ctx context.Context, req *Request) (*Reply, error) {
 	}
 	readOnly := viewerOnly || !writeEnabled
 	if readOnly {
-		sessionToolBag = filterToolsForAgentRole(rt.cfg.ToolBag, nil, isCoordinator, true)
+		sessionToolBag = filterToolsForAgentRole(runtimeToolBag, nil, isCoordinator, true)
 	}
 	// Resolve the active persona. Sessions with no AgentID still
 	// route through the "default" persona — that's where the curated
@@ -601,7 +665,7 @@ func (rt *Runtime) Handle(ctx context.Context, req *Request) (*Reply, error) {
 			// reach for every deep-dive tool itself. The
 			// coordinatorOnlyTools (AgentTool/SendMessage/TaskStop)
 			// survive the strip via isCoordinator=true.
-			sessionToolBag = filterToolsForAgentRole(rt.cfg.ToolBag, persona, isCoordinator, readOnly)
+			sessionToolBag = filterToolsForAgentRole(runtimeToolBag, persona, isCoordinator, readOnly)
 			agentReminderForPersona = persona.CriticalReminder
 		} else if rt.log != nil && personaName != "default" {
 			rt.log.Info("chatruntime: session agent_id not in registry — using default",

--- a/internal/manager/biz/aiops/chatruntime/runtime_test.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime_test.go
@@ -550,6 +550,39 @@ func TestRuntime_ToolCountAndNames(t *testing.T) {
 	}
 }
 
+func TestRuntime_ReplaceToolsByNamePrefix(t *testing.T) {
+	sess := &model.Session{ID: "s1", UserID: 7}
+	rt, err := NewRuntime(Config{
+		Sessions:  newMemSessions(sess),
+		ChatModel: newScriptedChatModel(),
+		ToolBag: []basetool.BaseTool{
+			&fakeTool{name: "query_promql", schema: `{"type":"object"}`},
+			&fakeTool{name: "mcp__github__old_search", schema: `{"type":"object"}`},
+			&fakeTool{name: "mcp__grafana__query", schema: `{"type":"object"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	rt.ReplaceToolsByNamePrefix("mcp__github__", []basetool.BaseTool{
+		&fakeTool{name: "mcp__github__code_search", schema: `{"type":"object"}`},
+	})
+	names := rt.ToolNames(context.Background())
+	got := map[string]bool{}
+	for _, name := range names {
+		got[name] = true
+	}
+	for _, want := range []string{"query_promql", "mcp__github__code_search", "mcp__grafana__query"} {
+		if !got[want] {
+			t.Errorf("ToolNames missing %q: %v", want, names)
+		}
+	}
+	if got["mcp__github__old_search"] {
+		t.Errorf("stale MCP tool remained in runtime: %v", names)
+	}
+}
+
 // strPtr is a small helper for tool-message content/name pointer
 // fields in the test fixtures below. Inline helpers everywhere bloats
 // the test fixture noise and obscures the assertions.

--- a/internal/manager/biz/aiops/chatruntime/worker.go
+++ b/internal/manager/biz/aiops/chatruntime/worker.go
@@ -558,7 +558,7 @@ func (rt *Runtime) GetWorker(workerID string) (*Worker, bool) {
 // matching Handle()'s "user message lands on disk before the LLM call"
 // invariant — same survival semantics on a graph crash.
 func (rt *Runtime) runWorker(ctx context.Context, agentDef *Agent, sessID, userText, locale string, parentEmit Emit, workerID string) (string, error) {
-	workerTools := filterToolsForAgent(rt.cfg.ToolBag, agentDef, false)
+	workerTools := filterToolsForAgent(rt.toolBagSnapshot(), agentDef, false)
 
 	// Thread the persona-filtered tool view onto ctx so ToolSearch
 	// (which runs inside the worker graph) only returns tools the

--- a/internal/manager/biz/aiops/tools/toolbag.go
+++ b/internal/manager/biz/aiops/tools/toolbag.go
@@ -36,6 +36,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
 )
@@ -164,6 +166,7 @@ func CoreToolNames(all []basetool.BaseTool) []string {
 // deferral is off (the bag is already flat) so callers can chain
 // WithExtra without triggering accidental dual-listing.
 type ToolBag struct {
+	mu        sync.RWMutex
 	core      []basetool.BaseTool
 	deferred  []basetool.BaseTool
 	extras    []basetool.BaseTool
@@ -214,6 +217,8 @@ func (b *ToolBag) SchemasForLLM() []basetool.BaseTool {
 	if b == nil {
 		return nil
 	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	if !b.deferring {
 		// Flat: extras may still hold ToolSearch (registered
 		// unconditionally by BuildBaseTools — harmless when
@@ -240,6 +245,8 @@ func (b *ToolBag) AllTools() []basetool.BaseTool {
 	if b == nil {
 		return nil
 	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	out := make([]basetool.BaseTool, 0, len(b.core)+len(b.extras)+len(b.deferred))
 	out = append(out, b.core...)
 	out = append(out, b.extras...)
@@ -255,6 +262,8 @@ func (b *ToolBag) DeferredTools() []basetool.BaseTool {
 	if b == nil {
 		return nil
 	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	out := make([]basetool.BaseTool, 0, len(b.deferred))
 	out = append(out, b.deferred...)
 	return out
@@ -267,6 +276,8 @@ func (b *ToolBag) IsDeferring() bool {
 	if b == nil {
 		return false
 	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.deferring
 }
 
@@ -275,6 +286,8 @@ func (b *ToolBag) Threshold() int {
 	if b == nil {
 		return 0
 	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.threshold
 }
 
@@ -287,6 +300,8 @@ func (b *ToolBag) WithExtra(t basetool.BaseTool) *ToolBag {
 	if b == nil || t == nil {
 		return b
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.extras = append(b.extras, t)
 	return b
 }
@@ -306,6 +321,8 @@ func (b *ToolBag) Append(t basetool.BaseTool) *ToolBag {
 	if b == nil || t == nil {
 		return b
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if !b.deferring {
 		b.core = append(b.core, t)
 		return b
@@ -316,6 +333,40 @@ func (b *ToolBag) Append(t basetool.BaseTool) *ToolBag {
 		b.deferred = append(b.deferred, t)
 	}
 	return b
+}
+
+// ReplaceToolsByNamePrefix replaces the dynamic tools whose wire name begins
+// with prefix. MCP uses one prefix per server, so updating or deleting one
+// registration cannot remove another server's tools. The caller provides the
+// unwrapped tools; this bag remains ToolSearch's authoritative catalog.
+func (b *ToolBag) ReplaceToolsByNamePrefix(prefix string, replacements []basetool.BaseTool) {
+	if b == nil || strings.TrimSpace(prefix) == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	all := make([]basetool.BaseTool, 0, len(b.core)+len(b.deferred)+len(replacements))
+	for _, tool := range append(append([]basetool.BaseTool{}, b.core...), b.deferred...) {
+		if toolNameHasPrefix(tool, prefix) {
+			continue
+		}
+		all = append(all, tool)
+	}
+	all = append(all, replacements...)
+
+	updated := NewToolBag(all, b.threshold)
+	b.core = updated.core
+	b.deferred = updated.deferred
+	b.deferring = updated.deferring
+}
+
+func toolNameHasPrefix(tool basetool.BaseTool, prefix string) bool {
+	if tool == nil {
+		return false
+	}
+	info, err := tool.Info(context.Background())
+	return err == nil && info != nil && strings.HasPrefix(info.Name, prefix)
 }
 
 // ----- redactedTool wrapper -----

--- a/internal/manager/biz/aiops/tools/toolbag_test.go
+++ b/internal/manager/biz/aiops/tools/toolbag_test.go
@@ -273,6 +273,35 @@ func TestToolBag_AppendBucketsByTier(t *testing.T) {
 	}
 }
 
+func TestToolBag_ReplaceToolsByNamePrefix(t *testing.T) {
+	bag := NewToolBag([]basetool.BaseTool{
+		newStub("query_promql", ""),
+		newStub("mcp__github__old_search", ""),
+		newStub("mcp__grafana__query", ""),
+	}, 30)
+
+	bag.ReplaceToolsByNamePrefix("mcp__github__", []basetool.BaseTool{
+		newStub("mcp__github__code_search", ""),
+	})
+
+	names := map[string]bool{}
+	for _, tool := range bag.AllTools() {
+		info, err := tool.Info(context.Background())
+		if err != nil || info == nil {
+			t.Fatalf("tool info: %v", err)
+		}
+		names[info.Name] = true
+	}
+	for _, want := range []string{"query_promql", "mcp__github__code_search", "mcp__grafana__query"} {
+		if !names[want] {
+			t.Errorf("AllTools missing %q: %v", want, names)
+		}
+	}
+	if names["mcp__github__old_search"] {
+		t.Errorf("stale MCP tool remained in catalog: %v", names)
+	}
+}
+
 func TestCoreToolNames_UsesRegistrationTier(t *testing.T) {
 	in := []basetool.BaseTool{
 		newStub("query_devices", ""),

--- a/internal/manager/biz/mcp/usecase.go
+++ b/internal/manager/biz/mcp/usecase.go
@@ -41,11 +41,32 @@ type SecretResolver interface {
 	ResolveFields(ctx context.Context, name string) (map[string]string, error)
 }
 
+// ToolChangeHook updates the in-memory chat tool catalog after an MCP server
+// changes. It receives one server only: the caller must not reconnect every
+// configured MCP server while handling an admin CRUD request. A nil server
+// removes the tools whose wire names belong to serverName.
+type ToolChangeHook func(ctx context.Context, serverName string, server *model.Server, tools []mcpclient.Tool)
+
 // Usecase is the MCP-server-registration facade.
 type Usecase struct {
-	repo    Repo
-	secrets SecretResolver
-	log     *slog.Logger
+	repo          Repo
+	secrets       SecretResolver
+	log           *slog.Logger
+	onToolsChange ToolChangeHook
+}
+
+// SetToolChangeHook wires the optional runtime catalog updater. It is set
+// once during manager startup before HTTP requests are served.
+func (u *Usecase) SetToolChangeHook(h ToolChangeHook) {
+	if u != nil {
+		u.onToolsChange = h
+	}
+}
+
+func (u *Usecase) notifyToolsChanged(ctx context.Context, serverName string, server *model.Server, tools []mcpclient.Tool) {
+	if u != nil && u.onToolsChange != nil {
+		u.onToolsChange(ctx, serverName, server, tools)
+	}
 }
 
 // NewUsecase wires the repo, credential resolver, and logger.
@@ -78,11 +99,41 @@ func (u *Usecase) Update(ctx context.Context, id uint64, patch *model.Server) er
 	if err := normalizeAndValidate(patch); err != nil {
 		return err
 	}
-	return u.repo.Update(ctx, id, patch)
+	previous, err := u.repo.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := u.repo.Update(ctx, id, patch); err != nil {
+		return err
+	}
+	updated, err := u.repo.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// Remove the old wire-name prefix first. A changed endpoint or credential
+	// must be verified again before the assistant can call its stale tools.
+	u.notifyToolsChanged(ctx, previous.Name, nil, nil)
+	if updated.Enabled && sameToolEndpoint(previous, updated) {
+		tools, err := cachedTools(updated.ToolsCacheJSON)
+		if err == nil && len(tools) > 0 {
+			u.notifyToolsChanged(ctx, updated.Name, updated, tools)
+		}
+	}
+	return nil
 }
 
 // Delete removes a server registration.
-func (u *Usecase) Delete(ctx context.Context, id uint64) error { return u.repo.Delete(ctx, id) }
+func (u *Usecase) Delete(ctx context.Context, id uint64) error {
+	server, err := u.repo.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := u.repo.Delete(ctx, id); err != nil {
+		return err
+	}
+	u.notifyToolsChanged(ctx, server.Name, nil, nil)
+	return nil
+}
 
 // Get returns one server by id.
 func (u *Usecase) Get(ctx context.Context, id uint64) (*model.Server, error) {
@@ -179,23 +230,57 @@ func (u *Usecase) TestConnection(ctx context.Context, id uint64) ([]mcpclient.To
 	}
 	cli, err := u.BuildClient(ctx, s)
 	if err != nil {
-		_ = u.repo.SetStatus(ctx, id, "error", err.Error())
+		if setErr := u.repo.SetStatus(ctx, id, "error", err.Error()); setErr != nil {
+			u.log.Warn("set mcp error status", slog.Uint64("server_id", id), slog.Any("err", setErr))
+		}
 		return nil, err
 	}
 	if err := cli.Initialize(ctx); err != nil {
-		_ = u.repo.SetStatus(ctx, id, "error", err.Error())
+		if setErr := u.repo.SetStatus(ctx, id, "error", err.Error()); setErr != nil {
+			u.log.Warn("set mcp error status", slog.Uint64("server_id", id), slog.Any("err", setErr))
+		}
 		return nil, err
 	}
 	tools, err := cli.ListTools(ctx)
 	if err != nil {
-		_ = u.repo.SetStatus(ctx, id, "error", err.Error())
+		if setErr := u.repo.SetStatus(ctx, id, "error", err.Error()); setErr != nil {
+			u.log.Warn("set mcp error status", slog.Uint64("server_id", id), slog.Any("err", setErr))
+		}
 		return nil, err
 	}
 	if b, mErr := json.Marshal(tools); mErr == nil {
-		_ = u.repo.SetToolsCache(ctx, id, string(b))
+		if setErr := u.repo.SetToolsCache(ctx, id, string(b)); setErr != nil {
+			u.log.Warn("cache mcp tools", slog.Uint64("server_id", id), slog.Any("err", setErr))
+		}
+	} else {
+		u.log.Warn("marshal mcp tools", slog.Uint64("server_id", id), slog.Any("err", mErr))
 	}
-	_ = u.repo.SetStatus(ctx, id, "ok", "")
+	if setErr := u.repo.SetStatus(ctx, id, "ok", ""); setErr != nil {
+		u.log.Warn("set mcp ok status", slog.Uint64("server_id", id), slog.Any("err", setErr))
+	}
+	if s.Enabled {
+		u.notifyToolsChanged(ctx, s.Name, s, tools)
+	}
 	return tools, nil
+}
+
+func cachedTools(raw string) ([]mcpclient.Tool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var tools []mcpclient.Tool
+	if err := json.Unmarshal([]byte(raw), &tools); err != nil {
+		return nil, fmt.Errorf("decode cached MCP tools: %w", err)
+	}
+	return tools, nil
+}
+
+func sameToolEndpoint(a, b *model.Server) bool {
+	return a != nil && b != nil &&
+		a.Endpoint == b.Endpoint &&
+		a.Transport == b.Transport &&
+		a.Credential == b.Credential &&
+		a.HeaderTemplateJSON == b.HeaderTemplateJSON
 }
 
 // --- helpers ---

--- a/internal/manager/biz/mcp/usecase.go
+++ b/internal/manager/biz/mcp/usecase.go
@@ -110,10 +110,20 @@ func (u *Usecase) Update(ctx context.Context, id uint64, patch *model.Server) er
 	if err != nil {
 		return err
 	}
+	connectionChanged := !sameToolEndpoint(previous, updated)
 	// Remove the old wire-name prefix first. A changed endpoint or credential
 	// must be verified again before the assistant can call its stale tools.
 	u.notifyToolsChanged(ctx, previous.Name, nil, nil)
-	if updated.Enabled && sameToolEndpoint(previous, updated) {
+	if connectionChanged {
+		if err := u.repo.SetToolsCache(ctx, id, ""); err != nil {
+			return fmt.Errorf("clear mcp tools cache: %w", err)
+		}
+		if err := u.repo.SetStatus(ctx, id, "", ""); err != nil {
+			return fmt.Errorf("clear mcp probe status: %w", err)
+		}
+		return nil
+	}
+	if updated.Enabled {
 		tools, err := cachedTools(updated.ToolsCacheJSON)
 		if err == nil && len(tools) > 0 {
 			u.notifyToolsChanged(ctx, updated.Name, updated, tools)

--- a/internal/manager/biz/mcp/usecase_test.go
+++ b/internal/manager/biz/mcp/usecase_test.go
@@ -2,11 +2,16 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/mcp"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/mcpclient"
 )
 
 // fakeRepo is an in-memory Repo for tests (no DB, no network).
@@ -132,6 +137,111 @@ func TestBuildClient_HeaderTemplateExpansion(t *testing.T) {
 	}
 	if got := headers["Authorization"]; got != "Bearer abc" {
 		t.Errorf("Authorization = %q, want %q", got, "Bearer abc")
+	}
+}
+
+func TestUsecase_UpdateAndDeleteNotifyRuntimeCatalog(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	u := NewUsecase(repo, fakeSecrets{}, nil)
+	server, err := u.Create(ctx, &model.Server{
+		Name:     "github",
+		Endpoint: "https://example.test/mcp",
+		Enabled:  true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache, err := json.Marshal([]mcpclient.Tool{{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)}})
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := repo.SetToolsCache(ctx, server.ID, string(cache)); err != nil {
+		t.Fatalf("SetToolsCache: %v", err)
+	}
+
+	type event struct {
+		name    string
+		server  *model.Server
+		toolLen int
+	}
+	var events []event
+	u.SetToolChangeHook(func(_ context.Context, name string, current *model.Server, tools []mcpclient.Tool) {
+		events = append(events, event{name: name, server: current, toolLen: len(tools)})
+	})
+
+	if err := u.Update(ctx, server.ID, &model.Server{Name: server.Name, Endpoint: server.Endpoint, Enabled: true}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(events) != 2 || events[0].server != nil || events[1].server == nil || events[1].toolLen != 1 {
+		t.Fatalf("update events = %#v, want remove then cached replacement", events)
+	}
+
+	if err := u.Delete(ctx, server.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(events) != 3 || events[2].name != "github" || events[2].server != nil {
+		t.Fatalf("delete event = %#v, want removal", events)
+	}
+}
+
+func TestUsecase_TestConnectionPublishesVerifiedTools(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request: %v", err)
+		}
+		var request struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.Method == "notifications/initialized" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		var result any
+		switch request.Method {
+		case "initialize":
+			result = map[string]any{"protocolVersion": mcpclient.ProtocolVersion}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name": "search", "description": "search docs", "inputSchema": map[string]any{"type": "object"},
+			}}}
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": result}); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	repo := newFakeRepo()
+	u := NewUsecase(repo, fakeSecrets{}, nil)
+	registered, err := u.Create(ctx, &model.Server{Name: "docs", Endpoint: server.URL, Enabled: true})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var published []mcpclient.Tool
+	u.SetToolChangeHook(func(_ context.Context, name string, current *model.Server, tools []mcpclient.Tool) {
+		if name != "docs" || current == nil {
+			t.Fatalf("unexpected hook target: name=%q server=%#v", name, current)
+		}
+		published = tools
+	})
+
+	tools, err := u.TestConnection(ctx, registered.ID)
+	if err != nil {
+		t.Fatalf("TestConnection: %v", err)
+	}
+	if len(tools) != 1 || len(published) != 1 || published[0].Name != "search" {
+		t.Fatalf("verified=%v published=%v, want one search tool", tools, published)
 	}
 }
 

--- a/internal/manager/biz/mcp/usecase_test.go
+++ b/internal/manager/biz/mcp/usecase_test.go
@@ -185,6 +185,49 @@ func TestUsecase_UpdateAndDeleteNotifyRuntimeCatalog(t *testing.T) {
 	}
 }
 
+func TestUsecase_UpdateChangedConnectionClearsUnverifiedToolCache(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	u := NewUsecase(repo, fakeSecrets{}, nil)
+	server, err := u.Create(ctx, &model.Server{
+		Name:     "github",
+		Endpoint: "https://old.example.test/mcp",
+		Enabled:  true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.SetToolsCache(ctx, server.ID, `[{"name":"old_search"}]`); err != nil {
+		t.Fatalf("SetToolsCache: %v", err)
+	}
+	if err := repo.SetStatus(ctx, server.ID, "ok", ""); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+
+	var events int
+	u.SetToolChangeHook(func(_ context.Context, _ string, _ *model.Server, _ []mcpclient.Tool) {
+		events++
+	})
+	if err := u.Update(ctx, server.ID, &model.Server{
+		Name:     server.Name,
+		Endpoint: "https://new.example.test/mcp",
+		Enabled:  true,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	updated, err := repo.Get(ctx, server.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if updated.ToolsCacheJSON != "" || updated.Status != "" || updated.LastError != "" {
+		t.Fatalf("changed connection retained probe state: %#v", updated)
+	}
+	if events != 1 {
+		t.Fatalf("events = %d, want only stale-prefix removal", events)
+	}
+}
+
 func TestUsecase_TestConnectionPublishesVerifiedTools(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)

--- a/web/src/pages/Agents.test.tsx
+++ b/web/src/pages/Agents.test.tsx
@@ -37,6 +37,7 @@ const userAgent = {
 };
 
 const listURL = '/api/v1/skills';
+const mcpListURL = '/api/v1/mcp/servers';
 
 describe('AgentsPage', () => {
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('AgentsPage', () => {
       ),
       // AgentEditor 打开时拉工具列表
       http.get(listURL, () => HttpResponse.json({ items: [], total: 0 })),
+      http.get(mcpListURL, () => HttpResponse.json({ items: [], total: 0 })),
     );
   });
 
@@ -82,5 +84,29 @@ describe('AgentsPage', () => {
     expect(within(dialog).getByText(/你是数据库专家/)).toBeInTheDocument();
     expect(within(dialog).getByRole('button', { name: /编辑/ })).toBeInTheDocument();
     expect(within(dialog).queryByRole('button', { name: /复制为自定义助理/ })).not.toBeInTheDocument();
+  });
+
+  it('新建助理可选择已测试且启用的 MCP 工具', async () => {
+    server.use(
+      http.get(listURL, () => HttpResponse.json({ items: [{ key: 'query_promql' }], total: 1 })),
+      http.get(mcpListURL, () => HttpResponse.json({
+        items: [{
+          ID: 1,
+          Name: 'demo-operations',
+          Enabled: true,
+          ToolsCacheJSON: JSON.stringify([{ name: 'get_service_health', description: 'Read health.' }]),
+        }],
+        total: 1,
+      })),
+    );
+
+    render(
+      <MemoryRouter>
+        <AgentsPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /新建助理/ }));
+    expect(await screen.findByText('mcp__demo_operations__get_service_health')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -43,7 +43,8 @@ import {
   type AgentSummary,
   type UserAgentInput,
 } from '@/api/agents';
-import { listSkills, type SkillSummary } from '@/api/skills';
+import { listSkills } from '@/api/skills';
+import { listMcpServers, parseToolsCache } from '@/api/mcp';
 import { createSession } from '@/api/chat';
 import { ApiError } from '@/api/client';
 import { tr as trInline, useI18n } from '@/i18n/locale';
@@ -609,12 +610,36 @@ function AgentEditor({
   const [allowedTools, setAllowedTools] = useState<string[]>(base?.tools ?? []);
   const [model, setModel] = useState(base?.model ?? '');
   const [maxTurns, setMaxTurns] = useState<number>(base?.max_turns ?? 0);
-  const [skills, setSkills] = useState<SkillSummary[]>([]);
+  const [toolOptions, setToolOptions] = useState<ToolOption[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
-    void listSkills().then((r) => setSkills(r.items ?? [])).catch(() => setSkills([]));
+    let cancelled = false;
+    void Promise.allSettled([listSkills(), listMcpServers()])
+      .then(([skillsResult, serversResult]) => {
+        if (cancelled) return;
+        const skills = skillsResult.status === 'fulfilled' ? skillsResult.value.items ?? [] : [];
+        const servers = serversResult.status === 'fulfilled' ? serversResult.value : [];
+        const builtin = skills.map((skill) => ({
+          key: skill.key,
+          source: 'skill' as const,
+        }));
+        const mcp = servers
+          .filter((server) => server.enabled)
+          .flatMap((server) =>
+            parseToolsCache(server.tools_cache).map((tool) => ({
+              key: mcpToolWireName(server.name, tool.name),
+              source: 'mcp' as const,
+              server: server.name,
+              description: tool.description,
+            })),
+          );
+        setToolOptions([...builtin, ...mcp]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const submit = async () => {
@@ -740,30 +765,31 @@ function AgentEditor({
           <div className="text-[11px] text-zinc-500 mb-1">
             {tr('留空 = 继承 coordinator 的全部工具', 'Empty = inherit all coordinator tools')}
           </div>
-          {skills.length === 0 ? (
+          {toolOptions.length === 0 ? (
             <div className="text-[11px] text-zinc-500">{tr('加载工具列表中…', 'Loading tool list…')}</div>
           ) : (
             <div className="max-h-48 overflow-y-auto rounded-md border border-zinc-800 bg-zinc-950/40 p-2">
               <div className="grid grid-cols-2 gap-1">
-                {skills.map((s) => (
+                {toolOptions.map((tool) => (
                   <label
-                    key={s.key}
-                    className="flex items-center gap-1.5 rounded px-1.5 py-1 text-[11px] hover:bg-zinc-900/60"
+                    key={tool.key}
+                    title={tool.description}
+                    className="flex min-w-0 items-center gap-1.5 rounded px-1.5 py-1 text-[11px] hover:bg-zinc-900/60"
                   >
                     <input
                       type="checkbox"
-                      checked={allowedTools.includes(s.key)}
-                      onChange={() => toggleTool(s.key)}
+                      checked={allowedTools.includes(tool.key)}
+                      onChange={() => toggleTool(tool.key)}
                       className="h-3 w-3 accent-indigo-500"
                     />
-                    <span className="font-mono">{s.key}</span>
+                    <span className="truncate font-mono">{tool.key}</span>
                   </label>
                 ))}
               </div>
             </div>
           )}
           <div className="mt-1 text-[11px] text-zinc-500">
-            {tr(`已选 ${allowedTools.length} / ${skills.length}`, `Selected ${allowedTools.length} / ${skills.length}`)}
+            {tr(`已选 ${allowedTools.length} / ${toolOptions.length}`, `Selected ${allowedTools.length} / ${toolOptions.length}`)}
           </div>
         </Field>
 
@@ -792,6 +818,29 @@ function AgentEditor({
       </div>
     </Modal>
   );
+}
+
+type ToolOption = {
+  key: string;
+  source: 'skill' | 'mcp';
+  server?: string;
+  description?: string;
+};
+
+// Must mirror tools.MCPToolName: persisted server and MCP tool names do not
+// have an API-level wire-name field, while agent allowlists use that name.
+function mcpToolWireName(server: string, tool: string): string {
+  return `mcp__${sanitizeMcpSegment(server)}__${sanitizeMcpSegment(tool)}`;
+}
+
+function sanitizeMcpSegment(value: string): string {
+  let out = '';
+  for (const char of value.trim()) {
+    if (/^[a-z0-9]$/.test(char)) out += char;
+    else if (/^[A-Z]$/.test(char)) out += char.toLowerCase();
+    else out += '_';
+  }
+  return out;
 }
 
 function Field({


### PR DESCRIPTION
## Summary
- refresh the chat runtime and ToolSearch catalog after a successful MCP connection test
- replace tools by MCP server prefix, so updated or deleted registrations remove stale tools without affecting other servers
- keep MCP CRUD requests free of outbound MCP reconnects; only the explicit test action performs network discovery

Fixes #154

## Validation
- go test -race ./internal/manager/biz/mcp ./internal/manager/biz/aiops/tools ./internal/manager/biz/aiops/chatruntime ./cmd/ongrid

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md