### PR TITLE
fix(grafana): sync Loki datasource settings

### DIFF
--- a/deploy/grafana/provisioning/datasources/loki.yml
+++ b/deploy/grafana/provisioning/datasources/loki.yml
@@ -12,7 +12,7 @@ datasources:
     # (v0.7.40 fix). Default lives in the grafana service compose env.
     url: ${ONGRID_LOG_URL}
     isDefault: false
-    editable: false
+    editable: true
     jsonData:
       timeout: 60
       maxLines: 5000

--- a/deploy/install/grafana/provisioning/datasources/loki.yml
+++ b/deploy/install/grafana/provisioning/datasources/loki.yml
@@ -14,7 +14,7 @@ datasources:
     # the grafana service compose env now; keep this a plain ${VAR}.
     url: ${ONGRID_LOG_URL}
     isDefault: false
-    editable: false
+    editable: true
     jsonData:
       timeout: 60
       maxLines: 5000

--- a/internal/manager/biz/grafana/datasource_test.go
+++ b/internal/manager/biz/grafana/datasource_test.go
@@ -1,0 +1,117 @@
+package grafana
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	settingbiz "github.com/ongridio/ongrid/internal/manager/biz/setting"
+	settingmodel "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+type fakeSettingRepo struct {
+	mu   sync.Mutex
+	rows map[string]*settingmodel.Setting
+}
+
+func newFakeSettingRepo() *fakeSettingRepo {
+	return &fakeSettingRepo{rows: map[string]*settingmodel.Setting{}}
+}
+
+func (r *fakeSettingRepo) key(category, key string) string { return category + "|" + key }
+
+func (r *fakeSettingRepo) Get(_ context.Context, category, key string) (*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[r.key(category, key)]
+	if !ok {
+		return nil, errs.ErrNotFound
+	}
+	cp := *row
+	return &cp, nil
+}
+
+func (r *fakeSettingRepo) Set(_ context.Context, category, key, value string, sensitive bool) (*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row := &settingmodel.Setting{
+		Category:  category,
+		Key:       key,
+		Value:     value,
+		Sensitive: sensitive,
+		UpdatedAt: time.Now(),
+	}
+	r.rows[r.key(category, key)] = row
+	return row, nil
+}
+
+func (r *fakeSettingRepo) List(_ context.Context, category string) ([]*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*settingmodel.Setting, 0, len(r.rows))
+	for _, row := range r.rows {
+		if category != "" && row.Category != category {
+			continue
+		}
+		cp := *row
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (r *fakeSettingRepo) Delete(_ context.Context, category, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.rows, r.key(category, key))
+	return nil
+}
+
+func TestLokiDatasourceFromSettings(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	for _, row := range []struct {
+		key       string
+		value     string
+		sensitive bool
+	}{
+		{settingmodel.KeyLokiURL, "https://loki.example.com/", false},
+		{settingmodel.KeyLokiBasicUser, "alice", false},
+		{settingmodel.KeyLokiBasicPassword, "secret", true},
+		{settingmodel.KeyLokiTLSInsecure, "true", false},
+	} {
+		if err := settings.Set(ctx, settingmodel.CategoryLoki, row.key, row.value, row.sensitive); err != nil {
+			t.Fatalf("set %s: %v", row.key, err)
+		}
+	}
+
+	ds := New(settings, false, nil).lokiDatasource(ctx)
+	if ds == nil {
+		t.Fatal("loki datasource = nil")
+	}
+	if ds.UID != lokiDatasourceUID || ds.Name != lokiDatasourceName || ds.Type != "loki" {
+		t.Fatalf("identity = (%s,%s,%s)", ds.UID, ds.Name, ds.Type)
+	}
+	if ds.URL != "https://loki.example.com" {
+		t.Fatalf("url = %q", ds.URL)
+	}
+	if !ds.BasicAuth || ds.BasicAuthUser != "alice" {
+		t.Fatalf("basic auth = %v user=%q", ds.BasicAuth, ds.BasicAuthUser)
+	}
+	if got := ds.SecureJSONData["basicAuthPassword"]; got != "secret" {
+		t.Fatalf("basic password = %q", got)
+	}
+	if got, ok := ds.JSONData["tlsSkipVerify"].(bool); !ok || !got {
+		t.Fatalf("tlsSkipVerify = %v", ds.JSONData["tlsSkipVerify"])
+	}
+}
+
+func TestLokiDatasourceEmptyURLSkipsSync(t *testing.T) {
+	t.Parallel()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	if ds := New(settings, false, nil).lokiDatasource(context.Background()); ds != nil {
+		t.Fatalf("loki datasource = %#v, want nil", ds)
+	}
+}

--- a/internal/manager/biz/grafana/service.go
+++ b/internal/manager/biz/grafana/service.go
@@ -1,11 +1,11 @@
 // Package grafana orchestrates the manager-side Grafana auto-config flow
 // (PR-2). The biz layer bridges three things:
 //
-//   1. system_settings.{category=grafana} for the operator-supplied root
-//      URL + service-account token
-//   2. system_settings.{category=prom}.query_url so the auto-created
-//      datasource points at the same TSDB the manager is writing to
-//   3. embedded dashboard JSON shipped inside the manager binary
+//  1. system_settings.{category=grafana} for the operator-supplied root
+//     URL + service-account token
+//  2. system_settings.{category=prom}.query_url so the auto-created
+//     datasource points at the same TSDB the manager is writing to
+//  3. embedded dashboard JSON shipped inside the manager binary
 //
 // Two ops are exposed:
 //   - Test: build a Client from settings, hit /api/health
@@ -37,10 +37,15 @@ import (
 // them as keys for "is this already there?". Renaming them would create
 // duplicates instead of replacing.
 const (
-	folderUID    = "ongrid"
-	folderTitle  = "ongrid"
-	datasourceUID  = "ongrid-prometheus"
-	datasourceName = "ongrid-prometheus"
+	folderUID      = "ongrid"
+	folderTitle    = "ongrid"
+	datasourceUID  = promDatasourceUID
+	datasourceName = promDatasourceName
+
+	promDatasourceUID  = "ongrid-prometheus"
+	promDatasourceName = "ongrid-prometheus"
+	lokiDatasourceUID  = "ongrid-loki"
+	lokiDatasourceName = "ongrid-loki"
 )
 
 //go:embed dashboards/*.json
@@ -172,6 +177,7 @@ func (s *Service) BootstrapEmbedded(ctx context.Context, adminUser, adminPasswor
 type SyncResult struct {
 	Folder      string   `json:"folder"`
 	Datasource  string   `json:"datasource"`
+	Datasources []string `json:"datasources,omitempty"`
 	Dashboards  []string `json:"dashboards"` // titles synced
 }
 
@@ -216,8 +222,8 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicPassword)
 
 	ds := pkggrafana.Datasource{
-		UID:    datasourceUID,
-		Name:   datasourceName,
+		UID:    promDatasourceUID,
+		Name:   promDatasourceName,
 		Type:   "prometheus",
 		URL:    promURL,
 		Access: "proxy",
@@ -235,7 +241,15 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
 	}
 	if err := c.UpsertDatasource(ctx, ds); err != nil {
-		return nil, fmt.Errorf("upsert datasource: %w", err)
+		return nil, fmt.Errorf("upsert prometheus datasource: %w", err)
+	}
+
+	datasources := []string{promDatasourceName}
+	if lokiDS := s.lokiDatasource(ctx); lokiDS != nil {
+		if err := c.UpsertDatasource(ctx, *lokiDS); err != nil {
+			return nil, fmt.Errorf("upsert loki datasource: %w", err)
+		}
+		datasources = append(datasources, lokiDatasourceName)
 	}
 
 	titles, err := s.pushDashboards(ctx, c)
@@ -244,16 +258,47 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 	}
 
 	res := &SyncResult{
-		Folder:     folderTitle,
-		Datasource: datasourceName,
-		Dashboards: titles,
+		Folder:      folderTitle,
+		Datasource:  promDatasourceName,
+		Datasources: datasources,
+		Dashboards:  titles,
 	}
 	s.log.Info("grafana sync done",
 		slog.String("folder", res.Folder),
-		slog.String("datasource", res.Datasource),
+		slog.Any("datasources", res.Datasources),
 		slog.Int("dashboards", len(res.Dashboards)),
 	)
 	return res, nil
+}
+
+func (s *Service) lokiDatasource(ctx context.Context) *pkggrafana.Datasource {
+	lokiURL, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiURL)
+	lokiURL = strings.TrimRight(strings.TrimSpace(lokiURL), "/")
+	if lokiURL == "" {
+		return nil
+	}
+	ds := &pkggrafana.Datasource{
+		UID:    lokiDatasourceUID,
+		Name:   lokiDatasourceName,
+		Type:   "loki",
+		URL:    lokiURL,
+		Access: "proxy",
+		JSONData: map[string]any{
+			"timeout":  60,
+			"maxLines": 5000,
+		},
+	}
+	if tlsInsecure, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiTLSInsecure); strings.EqualFold(strings.TrimSpace(tlsInsecure), "true") {
+		ds.JSONData["tlsSkipVerify"] = true
+	}
+	basicUser, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiBasicUser)
+	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiBasicPassword)
+	if basicUser = strings.TrimSpace(basicUser); basicUser != "" {
+		ds.BasicAuth = true
+		ds.BasicAuthUser = basicUser
+		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
+	}
+	return ds
 }
 
 // client builds a pkg/grafana.Client from settings; returns a friendly
@@ -473,14 +518,14 @@ func buildMonitorDashboardJSON(uid, title string, panels []*monitormodel.Panel) 
 		})
 	}
 	return map[string]any{
-		"uid":         uid,
-		"title":       title,
-		"description": "Auto-managed by ongrid. Edits in Grafana will be overwritten — change panels in the ongrid Monitor page.",
-		"tags":        []string{"ongrid", "managed"},
-		"editable":    true,
-		"timezone":    "",
+		"uid":           uid,
+		"title":         title,
+		"description":   "Auto-managed by ongrid. Edits in Grafana will be overwritten — change panels in the ongrid Monitor page.",
+		"tags":          []string{"ongrid", "managed"},
+		"editable":      true,
+		"timezone":      "",
 		"schemaVersion": 38,
-		"panels":      gPanels,
+		"panels":        gPanels,
 		"time": map[string]any{
 			"from": "now-1h",
 			"to":   "now",

--- a/internal/manager/biz/grafana/service.go
+++ b/internal/manager/biz/grafana/service.go
@@ -246,7 +246,7 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 
 	datasources := []string{promDatasourceName}
 	if lokiDS := s.lokiDatasource(ctx); lokiDS != nil {
-		if err := c.UpsertDatasource(ctx, *lokiDS); err != nil {
+		if err := s.syncLokiDatasource(ctx, c); err != nil {
 			return nil, fmt.Errorf("upsert loki datasource: %w", err)
 		}
 		datasources = append(datasources, lokiDatasourceName)
@@ -269,6 +269,24 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 		slog.Int("dashboards", len(res.Dashboards)),
 	)
 	return res, nil
+}
+
+// SyncLoki updates only the managed Loki datasource. It is intentionally
+// separate from Sync so changing Loki settings does not rewrite dashboards.
+func (s *Service) SyncLoki(ctx context.Context) error {
+	c, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	return s.syncLokiDatasource(ctx, c)
+}
+
+func (s *Service) syncLokiDatasource(ctx context.Context, c *pkggrafana.Client) error {
+	lokiDS := s.lokiDatasource(ctx)
+	if lokiDS == nil {
+		return errors.New("grafana: cannot sync Loki — loki.url is empty")
+	}
+	return c.UpsertDatasource(ctx, *lokiDS)
 }
 
 func (s *Service) lokiDatasource(ctx context.Context) *pkggrafana.Datasource {

--- a/internal/manager/server/integration/http.go
+++ b/internal/manager/server/integration/http.go
@@ -24,6 +24,7 @@ import (
 type GrafanaService interface {
 	Test(ctx context.Context) error
 	Sync(ctx context.Context) (*bizgrafana.SyncResult, error)
+	SyncLoki(ctx context.Context) error
 	FetchDashboardJSON(ctx context.Context, uid string) ([]byte, error)
 }
 
@@ -103,6 +104,7 @@ func (h *Handler) SetLLMRouter(r LLMRouterInvalidator) { h.llmRouter = r }
 //
 //	POST /v1/integrations/grafana/test           (admin)  — verify connectivity
 //	POST /v1/integrations/grafana/sync           (admin)  — push folder + datasource + dashboards
+//	POST /v1/integrations/grafana/sync-loki      (admin)  — push only the Loki datasource
 //	POST /v1/integrations/prom/test              (admin)  — run "up" PromQL probe
 //	GET  /v1/observability/dashboards/{uid}      (any auth user) — proxy Grafana dashboard JSON
 //
@@ -114,6 +116,7 @@ func (h *Handler) SetLLMRouter(r LLMRouterInvalidator) { h.llmRouter = r }
 func (h *Handler) Register(r chi.Router) {
 	r.Post("/v1/integrations/grafana/test", h.testGrafana)
 	r.Post("/v1/integrations/grafana/sync", h.syncGrafana)
+	r.Post("/v1/integrations/grafana/sync-loki", h.syncLoki)
 	r.Post("/v1/integrations/prom/test", h.testProm)
 	r.Post("/v1/integrations/loki/test", h.testLoki)
 	r.Post("/v1/integrations/tempo/test", h.testTempo)
@@ -193,6 +196,17 @@ func (h *Handler) syncGrafana(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, res)
+}
+
+func (h *Handler) syncLoki(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+	if err := h.grafana.SyncLoki(r.Context()); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // testProm runs a tiny PromQL probe ("up") against the configured Prom

--- a/internal/manager/server/integration/http_test.go
+++ b/internal/manager/server/integration/http_test.go
@@ -21,11 +21,18 @@ import (
 type stubGrafana struct {
 	test           func(ctx context.Context) error
 	sync           func(ctx context.Context) (*bizgrafana.SyncResult, error)
+	syncLoki       func(ctx context.Context) error
 	fetchDashboard func(ctx context.Context, uid string) ([]byte, error)
 }
 
-func (s stubGrafana) Test(ctx context.Context) error                        { return s.test(ctx) }
+func (s stubGrafana) Test(ctx context.Context) error                           { return s.test(ctx) }
 func (s stubGrafana) Sync(ctx context.Context) (*bizgrafana.SyncResult, error) { return s.sync(ctx) }
+func (s stubGrafana) SyncLoki(ctx context.Context) error {
+	if s.syncLoki == nil {
+		return nil
+	}
+	return s.syncLoki(ctx)
+}
 func (s stubGrafana) FetchDashboardJSON(ctx context.Context, uid string) ([]byte, error) {
 	return s.fetchDashboard(ctx, uid)
 }
@@ -135,5 +142,32 @@ func TestFetchDashboardMapsTransportErrorTo502(t *testing.T) {
 
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSyncLokiRequiresAdminAndInvokesService(t *testing.T) {
+	t.Parallel()
+	called := false
+	g := stubGrafana{
+		test: func(_ context.Context) error { return nil },
+		sync: func(_ context.Context) (*bizgrafana.SyncResult, error) { return nil, nil },
+		syncLoki: func(_ context.Context) error {
+			called = true
+			return nil
+		},
+		fetchDashboard: func(_ context.Context, _ string) ([]byte, error) { return nil, nil },
+	}
+	router := newRouter(NewHandler(g, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/integrations/grafana/sync-loki", nil)
+	req = req.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 7, Role: "admin"}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("SyncLoki was not invoked")
 	}
 }

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -70,6 +70,10 @@ export function syncGrafana(): Promise<GrafanaSyncResult> {
   return request<GrafanaSyncResult>('POST', '/integrations/grafana/sync');
 }
 
+export function syncLokiDatasource(): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/grafana/sync-loki');
+}
+
 // testPromConnection runs a tiny "up" PromQL probe via the manager. Used
 // by the Prom integration card to validate URL + Bearer/Basic before the
 // user trusts that the wiring is good.

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -33,6 +33,7 @@ import {
   revealSetting,
   testGrafanaConnection,
   syncGrafana,
+  syncLokiDatasource,
   testPromConnection,
   testLokiConnection,
   testTempoConnection,
@@ -838,6 +839,7 @@ function LokiCard() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savedOk, setSavedOk] = useState(false);
+  const [grafanaSyncWarning, setGrafanaSyncWarning] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [probe, setProbe] = useState<
     | { kind: 'idle' }
@@ -894,6 +896,7 @@ function LokiCard() {
   const submit = async () => {
     setSaving(true);
     setErr(null);
+    setGrafanaSyncWarning(null);
     try {
       for (const k of LOKI_KEYS) {
         if (draft[k] === server[k]) continue;
@@ -901,6 +904,16 @@ function LokiCard() {
       }
       await refresh();
       setSavedOk(true);
+      try {
+        await syncLokiDatasource();
+      } catch (e) {
+        setGrafanaSyncWarning(
+          tr(
+            `Loki 已保存，但 Grafana 数据源同步失败：${e instanceof ApiError ? e.message : (e as Error).message}`,
+            `Loki was saved, but the Grafana datasource sync failed: ${e instanceof ApiError ? e.message : (e as Error).message}`
+          )
+        );
+      }
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : (e as Error).message);
     } finally {
@@ -1002,6 +1015,7 @@ function LokiCard() {
         </button>
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
       </div>
+      {grafanaSyncWarning && <p className="mt-3 break-all text-xs text-amber-400">{grafanaSyncWarning}</p>}
       <ProbeLine probe={probe} okLabel={tr('✓ Loki 可达，/ready 返回成功', '✓ Loki reachable, /ready returned success')} />
     </Card>
   );


### PR DESCRIPTION
## Summary
- sync the Grafana Loki datasource from system_settings.loki during Grafana Sync
- keep the legacy datasource field while returning all synced datasources
- mark provisioned Loki datasources editable so Grafana API updates are allowed

## Tests
- go test ./internal/manager/biz/grafana

Fixes #122

## Author confirmation

- [x] I have read and agree to the project contribution guide in CONTRIBUTING.md.