### PR TITLE
fix(alert): show device identity in notifications

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -2450,7 +2450,18 @@ func main() {
 			EdgeLister:      edgeUC,
 			PromQuerier:     alertPromQuerier,
 			LogQuerier:      alertLogQuerier,
-			Log:             log.With(slog.String("comp", "alert-pipeline")),
+			DeviceIdentityResolver: func(ctx context.Context, deviceID uint64) (managerbizalert.DeviceIdentity, error) {
+				device, err := deviceUC.Get(ctx, deviceID)
+				if err != nil {
+					return managerbizalert.DeviceIdentity{}, err
+				}
+				return managerbizalert.DeviceIdentity{
+					Name:      device.Name,
+					Hostname:  device.Hostname,
+					IPAddress: device.IPAddress,
+				}, nil
+			},
+			Log: log.With(slog.String("comp", "alert-pipeline")),
 		})
 		eg.Go(func() error { return pipelineEval.Loop(egCtx) })
 

--- a/internal/manager/biz/alert/pipeline.go
+++ b/internal/manager/biz/alert/pipeline.go
@@ -46,6 +46,20 @@ type LogQuerier interface {
 	QueryRange(ctx context.Context, opts logquery.QueryRangeOptions) (*logquery.QueryRangeResult, error)
 }
 
+// DeviceIdentity is the alert package's narrow projection of device data.
+// Keeping this local avoids coupling the alert bounded context to device
+// persistence models.
+type DeviceIdentity struct {
+	Name      string
+	Hostname  string
+	IPAddress string
+}
+
+// DeviceIdentityResolver maps an incident device_id to human-readable
+// notification fields. Resolution is best-effort; incidents and dedupe keys
+// continue to use the stable numeric ID.
+type DeviceIdentityResolver func(ctx context.Context, deviceID uint64) (DeviceIdentity, error)
+
 // PipelineEvaluatorOpts wires the evaluator. EdgeLister keeps the
 // device_last_seen_seconds_ago gauge fresh; PromQuerier drives every
 // metric_* rule kind. Both are optional; when nil the corresponding
@@ -68,6 +82,8 @@ type PipelineEvaluatorOpts struct {
 	// (the cache still loads the rows so the UI can list them).
 	LogQuerier LogQuerier
 
+	DeviceIdentityResolver DeviceIdentityResolver
+
 	Log *slog.Logger
 	Now func() time.Time
 }
@@ -89,9 +105,10 @@ type PipelineEvaluator struct {
 	cooldown  time.Duration
 	interval  time.Duration
 
-	edges EdgeLister
-	prom  PromQuerier
-	logq  LogQuerier
+	edges          EdgeLister
+	prom           PromQuerier
+	logq           LogQuerier
+	deviceIdentity DeviceIdentityResolver
 
 	// gaugeSnapshot is the previous tick's (device_id, device_name) set
 	// used by refreshDeviceStalenessGauge to garbage-collect series for
@@ -128,19 +145,20 @@ func NewPipelineEvaluator(opts PipelineEvaluatorOpts) *PipelineEvaluator {
 		opts.Now = func() time.Time { return time.Now().UTC() }
 	}
 	return &PipelineEvaluator{
-		uc:        opts.Usecase,
-		rules:     opts.Rules,
-		notifier:  opts.Notifier,
-		resolver:  opts.Resolver,
-		inhibitor: opts.Inhibitor,
-		channels:  append([]string(nil), opts.DefaultChannels...),
-		cooldown: opts.Cooldown,
-		interval: opts.Interval,
-		edges:    opts.EdgeLister,
-		prom:     opts.PromQuerier,
-		logq:     opts.LogQuerier,
-		log:      opts.Log,
-		now:      opts.Now,
+		uc:             opts.Usecase,
+		rules:          opts.Rules,
+		notifier:       opts.Notifier,
+		resolver:       opts.Resolver,
+		inhibitor:      opts.Inhibitor,
+		channels:       append([]string(nil), opts.DefaultChannels...),
+		cooldown:       opts.Cooldown,
+		interval:       opts.Interval,
+		edges:          opts.EdgeLister,
+		prom:           opts.PromQuerier,
+		logq:           opts.LogQuerier,
+		deviceIdentity: opts.DeviceIdentityResolver,
+		log:            opts.Log,
+		now:            opts.Now,
 	}
 }
 
@@ -395,7 +413,24 @@ func (e *PipelineEvaluator) notify(ctx context.Context, res *FiringResult, summa
 		},
 	}
 	if res.Incident.DeviceID != nil {
-		msg.Labels["device_id"] = fmt.Sprintf("%d", *res.Incident.DeviceID)
+		deviceID := *res.Incident.DeviceID
+		msg.Labels["device_id"] = fmt.Sprintf("%d", deviceID)
+		if e.deviceIdentity != nil {
+			identity, err := e.deviceIdentity(ctx, deviceID)
+			if err != nil {
+				e.log.Warn("alert: resolve device identity for notification failed",
+					slog.Uint64("device_id", deviceID), slog.Any("err", err))
+			} else if display := deviceDisplay(identity); display != "" {
+				msg.Subject = strings.ReplaceAll(msg.Subject,
+					fmt.Sprintf("device_id=%d", deviceID), "device="+display)
+				if identity.Hostname != "" {
+					msg.Labels["device_hostname"] = identity.Hostname
+				}
+				if identity.IPAddress != "" {
+					msg.Labels["device_ip"] = identity.IPAddress
+				}
+			}
+		}
 	}
 	if msg.Severity == "" {
 		msg.Severity = notify.SeverityWarning
@@ -413,6 +448,22 @@ func (e *PipelineEvaluator) notify(ctx context.Context, res *FiringResult, summa
 	// usecase.go:51) — fires only on the isNew transition so reopens /
 	// follow-up notifies don't re-trigger. Pipeline doesn't need its
 	// own hook.
+}
+
+func deviceDisplay(identity DeviceIdentity) string {
+	host := strings.TrimSpace(identity.Hostname)
+	if host == "" {
+		host = strings.TrimSpace(identity.Name)
+	}
+	ip := strings.TrimSpace(identity.IPAddress)
+	switch {
+	case host != "" && ip != "":
+		return fmt.Sprintf("%s (%s)", host, ip)
+	case host != "":
+		return host
+	default:
+		return ip
+	}
 }
 
 // nonIdentityLabels are provenance/collector labels that must NOT split an
@@ -501,4 +552,3 @@ func compareFloat(v float64, op string, threshold float64) bool {
 	}
 	return false
 }
-

--- a/internal/manager/biz/alert/pipeline_test.go
+++ b/internal/manager/biz/alert/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -177,6 +178,63 @@ func TestPipelinePromQueryErrorIsSafe(t *testing.T) {
 	}
 }
 
+func TestPipelineNotification_ResolvesDeviceIDToHostnameAndIP(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	prom := &fakePromQuerier{result: vectorEdgeStaleness(map[string]string{
+		"2|edge-197": "91",
+	})}
+	rules := NewStaticRulesProvider(WithMetricRawRules([]MetricRawRule{
+		{ID: 201, RuleKey: "cpu_high_80", Name: "CPU High", Severity: "warning",
+			ScopeType: model.RuleScopeHost, Expr: "device_cpu_usage_percent > 80"},
+	}))
+	eval := newPipelineEvaluator(t, repo, notifier, rules, PipelineEvaluatorOpts{
+		PromQuerier: prom,
+		DeviceIdentityResolver: func(_ context.Context, deviceID uint64) (DeviceIdentity, error) {
+			if deviceID != 2 {
+				t.Fatalf("deviceID = %d, want 2", deviceID)
+			}
+			return DeviceIdentity{Hostname: "VM-4-8-ubuntu", IPAddress: "10.2.4.8"}, nil
+		},
+	})
+
+	eval.EvaluateOnce(context.Background())
+
+	if len(notifier.msgs) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(notifier.msgs))
+	}
+	msg := notifier.msgs[0]
+	if strings.Contains(msg.Subject, "device_id=2") {
+		t.Fatalf("subject still exposes raw device id: %q", msg.Subject)
+	}
+	if !strings.Contains(msg.Subject, "device=VM-4-8-ubuntu (10.2.4.8)") {
+		t.Fatalf("subject = %q, want resolved device identity", msg.Subject)
+	}
+	if msg.Labels["device_id"] != "2" || msg.Labels["device_hostname"] != "VM-4-8-ubuntu" || msg.Labels["device_ip"] != "10.2.4.8" {
+		t.Fatalf("labels = %#v", msg.Labels)
+	}
+}
+
+func TestDeviceDisplay_UsesAvailableIdentityFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		identity DeviceIdentity
+		want     string
+	}{
+		{name: "hostname and ip", identity: DeviceIdentity{Hostname: "host-a", IPAddress: "10.0.0.1"}, want: "host-a (10.0.0.1)"},
+		{name: "name fallback", identity: DeviceIdentity{Name: "gateway-a"}, want: "gateway-a"},
+		{name: "ip only", identity: DeviceIdentity{IPAddress: "10.0.0.2"}, want: "10.0.0.2"},
+		{name: "empty", identity: DeviceIdentity{}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deviceDisplay(tc.identity); got != tc.want {
+				t.Fatalf("deviceDisplay() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestPipelineEdgeOfflineMultipleMetricRawRules confirms two metric_raw
 // rules with different thresholds against edge_last_seen_seconds_ago
 // each create their own incident — the same multi-rule fan-out the
@@ -233,7 +291,7 @@ func vectorEdgeStaleness(samples map[string]string) *promquery.InstantResult {
 		entries = append(entries, vEntry{
 			Metric: map[string]string{
 				"__name__":  "edge_last_seen_seconds_ago",
-				"device_id":   edgeID,
+				"device_id": edgeID,
 				"edge_name": edgeName,
 			},
 			Value: []json.RawMessage{ts, val},


### PR DESCRIPTION
## Summary

- resolve host-scoped alert `device_id` values through the device use case before notification delivery
- render human-facing subjects as `device=<hostname> (<ip>)`
- retain the numeric `device_id` in notification labels and incident dedupe keys
- fall back to device name, IP, or the original numeric ID when inventory data is incomplete or unavailable

## Verification

- `go test -race ./internal/manager/biz/alert ./cmd/ongrid`

Fixes #193

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
