### PR TITLE
docs(readme): 升级安装版本至 v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Choose the command for your server architecture:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Product Tour

--- a/README_DE.md
+++ b/README_DE.md
@@ -48,15 +48,15 @@ Wählen Sie den Befehl für Ihre Serverarchitektur:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Produkttour

--- a/README_ES.md
+++ b/README_ES.md
@@ -48,15 +48,15 @@ Elige el comando para la arquitectura de tu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Recorrido del producto

--- a/README_FR.md
+++ b/README_FR.md
@@ -48,15 +48,15 @@ Choisissez la commande adaptée à l’architecture de votre serveur :
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Tour du produit

--- a/README_JA.md
+++ b/README_JA.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## 製品ツアー

--- a/README_KO.md
+++ b/README_KO.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## 제품 둘러보기

--- a/README_PT.md
+++ b/README_PT.md
@@ -48,15 +48,15 @@ Escolha o comando para a arquitetura do seu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Tour do produto

--- a/README_RU.md
+++ b/README_RU.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## Обзор продукта

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-amd64.tar.xz
-tar -xf ongrid-v0.9.1-linux-amd64.tar.xz && cd ongrid-v0.9.1-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.10.0-linux-amd64.tar.xz && cd ongrid-v0.10.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.9.1/ongrid-v0.9.1-linux-arm64.tar.xz
-tar -xf ongrid-v0.9.1-linux-arm64.tar.xz && cd ongrid-v0.9.1-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.10.0/ongrid-v0.10.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.10.0-linux-arm64.tar.xz && cd ongrid-v0.10.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.9.1-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.10.0-linux-arm64.tar.xz
 ```
 
 ## 产品导览


### PR DESCRIPTION
## 变更内容

- 将 9 份多语言 README 中的 GitHub 安装包链接从 `v0.9.1` 更新至 `v0.10.0`
- 同步更新 AMD64、ARM64 的解压目录及中国大陆 CDN 镜像地址

## 变更原因与影响

`v0.10.0` 已正式发布，README 的安装命令仍指向旧版本。本次更新后，新用户会直接下载当前版本；不涉及代码、API、配置或运行时行为。

## 验证

- `git diff --check` 通过
- 已扫描所有受跟踪 README，不再包含 `v0.9.1`
- GitHub Release 中 `v0.10.0` 的 AMD64、ARM64 安装包均已确认存在
- `make build` 通过
- `make test-race` 未全量通过：本地被忽略的 `output/native/embedding_probe.go` 与 `output/native/https_proxy.go` 同包重复定义 `main`，与本次文档改动无关
- `make lint` 未运行：本机未安装 `golangci-lint`
- 检查时 `ongrid.cloud` 的 `v0.10.0` CDN 镜像尚未稳定可用，GitHub Release 链接可用

## 贡献指南

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md