### PR TITLE
fix(k8s): restore observability drilldowns and collection defaults

### DIFF
--- a/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
+++ b/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
@@ -48,7 +48,16 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 {{- if kindIs "bool" $gw.enabled -}}
 {{- if $gw.enabled -}}true{{- else -}}false{{- end -}}
 {{- else -}}
-false
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "ongrid-edge.kubeStateMetricsEnabled" -}}
+{{- $ksm := default dict .Values.kubeStateMetrics -}}
+{{- if kindIs "bool" $ksm.enabled -}}
+{{- if $ksm.enabled -}}true{{- else -}}false{{- end -}}
+{{- else -}}
+true
 {{- end -}}
 {{- end -}}
 
@@ -65,18 +74,16 @@ false
 
 {{- define "ongrid-edge.k8sMetricsEndpoint" -}}
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
-{{- $ksm := default dict .Values.kubeStateMetrics -}}
 {{- if $controllerMetrics.endpoint -}}
 {{- $controllerMetrics.endpoint -}}
-{{- else if $ksm.enabled -}}
+{{- else if eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true" -}}
 {{- include "ongrid-edge.kubeStateMetricsEndpoint" . -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "ongrid-edge.k8sMetricsEnabled" -}}
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
-{{- $ksm := default dict .Values.kubeStateMetrics -}}
-{{- if or (default false $controllerMetrics.enabled) (default false $ksm.enabled) -}}true{{- else -}}false{{- end -}}
+{{- if or (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "ongrid-edge.kubeStateMetricsResources" -}}

--- a/deploy/kubernetes/ongrid-edge/templates/kube-state-metrics.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 {{- $ksm := default dict .Values.kubeStateMetrics -}}
-{{- if default false $ksm.enabled }}
+{{- if eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true" }}
 {{- $image := default dict $ksm.image -}}
-{{- $imageRepository := required "kubeStateMetrics.image.repository is required when kubeStateMetrics.enabled=true; use an offline mirror reachable by the cluster" $image.repository -}}
+{{- $imageRepository := default "docker.cnb.cool/ongridio/ongrid-edge/kube-state-metrics" $image.repository -}}
 {{- $resources := default dict $ksm.resources -}}
 {{- $port := default 8080 $ksm.port -}}
 {{- $telemetryPort := default 8081 $ksm.telemetryPort -}}

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -61,12 +61,12 @@ controller:
       memory: 512Mi
 
 kubeStateMetrics:
-  enabled: false
+  enabled: true
   serviceAccountName: ""
   image:
-    # Optional image is not bundled in the offline release. Mirror it to a
-    # registry reachable by the cluster before enabling this component.
-    repository: ""
+    # Ongrid-maintained mirror used by the default online installation.
+    # Offline installations can override this with their internal registry.
+    repository: docker.cnb.cool/ongridio/ongrid-edge/kube-state-metrics
     tag: v2.16.0
     pullPolicy: IfNotPresent
   port: 8080
@@ -81,8 +81,9 @@ kubeStateMetrics:
       memory: 256Mi
 
 telemetryGateway:
-  # Set true to expose the controller OTLP receiver.
-  enabled: null
+  # Expose the controller OTLP receiver by default so instrumented workloads
+  # can export cluster-scoped traces, logs, and metrics without extra Helm flags.
+  enabled: true
   service:
     type: ClusterIP
     grpcPort: 4317

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import KubernetesPage, { KubernetesClusterDetailPage } from './Kubernetes';
+import { invalidateGrafanaRootCache } from '@/lib/drilldown';
 import { server } from '@/test/msw-server';
 
 vi.mock('@/store/me', () => ({
@@ -58,6 +59,7 @@ function renderKubernetesDetail(initialEntry = '/kubernetes/1', includeChatRoute
 describe('KubernetesPage', () => {
   beforeEach(() => {
     localStorage.setItem('ongrid-locale', 'zh-CN');
+    invalidateGrafanaRootCache();
     Element.prototype.scrollIntoView = vi.fn();
     server.use(
       http.get('/api/v1/k8s/clusters', () =>
@@ -399,6 +401,58 @@ describe('KubernetesPage', () => {
     expect(screen.getAllByText('Loki').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Tempo').length).toBeGreaterThan(0);
     expect(screen.getAllByText('查询详情').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('K8s 指标使用 Grafana 11 Explore 深链打开 Prometheus 查询', async () => {
+    let launchPayload: { expr?: string } | null = null;
+    const replace = vi.fn();
+    const open = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      location: { replace },
+    } as unknown as Window);
+    server.use(
+      http.get('/api/v1/system-settings', () => HttpResponse.json({
+        items: [{
+          category: 'grafana',
+          key: 'root_url',
+          value: 'http://grafana:3000/grafana',
+          sensitive: false,
+          updated_at: '2026-06-29T10:00:00Z',
+        }],
+        total: 1,
+      })),
+      http.post('/api/v1/prometheus/launch', async ({ request }) => {
+        launchPayload = await request.json() as { expr?: string };
+        return HttpResponse.json({ url: '/prometheus/graph?g0.expr=up' });
+      }),
+    );
+
+    renderKubernetesDetail('/kubernetes/1');
+
+    const openButtons = await screen.findAllByRole('button', { name: '打开图表' });
+    fireEvent.click(openButtons[0]);
+
+    await waitFor(() => {
+      expect(launchPayload).toEqual({ expr: 'up' });
+      expect(replace).toHaveBeenCalledOnce();
+    });
+    expect(open).toHaveBeenCalledWith('about:blank', '_blank');
+
+    const target = new URL(String(replace.mock.calls[0][0]));
+    expect(target.pathname).toBe('/grafana/explore');
+    expect(target.searchParams.get('schemaVersion')).toBe('1');
+    const panes = JSON.parse(target.searchParams.get('panes') || '{}');
+    expect(panes.og.datasource).toBe('ongrid-prometheus');
+    expect(panes.og.queries[0].datasource).toEqual({
+      type: 'prometheus',
+      uid: 'ongrid-prometheus',
+    });
+    expect(panes.og.queries[0].queryType).toBe('range');
+    expect(panes.og.queries[0].expr).toBe(
+      'sum by (namespace, phase) (kube_pod_status_phase{cluster_id="1",ongrid_source=~"k8s:.*"} == 1)',
+    );
+
+    open.mockRestore();
   });
 
   it('集群详情提供 Helm 升级命令', async () => {

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -32,7 +32,6 @@ import {
   type MutatingProposal,
 } from '@/api/aiops';
 import { createSession } from '@/api/chat';
-import { createPrometheusLaunch } from '@/api/prometheus';
 import {
   listEdges,
   type Edge,
@@ -1696,7 +1695,7 @@ function K8sTelemetryDrilldowns({
 
   const metricsExpr = useMemo(() => {
     if (!clusterID) return '';
-    return `sum by (ongrid_source, namespace, workload_kind, workload_name) (up{cluster_id="${clusterID}",ongrid_source=~"k8s:.*"})`;
+    return `sum by (namespace, phase) (kube_pod_status_phase{cluster_id="${clusterID}",ongrid_source=~"k8s:.*"} == 1)`;
   }, [clusterID]);
   const logsQuery = useMemo(() => {
     if (!clusterID) return '';
@@ -1712,12 +1711,18 @@ function K8sTelemetryDrilldowns({
     setOpening('metrics');
     setError(null);
     try {
-      const launch = await createPrometheusLaunch({
-        expr: metricsExpr,
-        range_input: '1h',
-        step_input: '30s',
+      const base = await fetchGrafanaRootURL();
+      const now = Date.now();
+      const url = buildExploreUrl({
+        base,
+        dsType: 'prometheus',
+        dsUid: 'ongrid-prometheus',
+        query: { expr: metricsExpr, queryType: 'range' },
+        fromMs: now - 60 * 60 * 1000,
+        toMs: now,
+        orgId: grafanaOrgId,
       });
-      window.open(launch.url, '_blank', 'noopener,noreferrer');
+      await openObservabilityUrl(url);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : (e as Error).message);
     } finally {


### PR DESCRIPTION
## Summary

- open Kubernetes metrics in Grafana 11 Explore with the provisioned Prometheus datasource
- replace the target-health `up` query with pod counts grouped by namespace and phase
- enable kube-state-metrics by default using the verified CNB mirror
- enable the controller OTLP telemetry gateway by default
- preserve explicit opt-out values and make `--reuse-values` upgrades inherit the new defaults

## Root cause

The Kubernetes metrics entry still used the legacy Prometheus graph URL, and its default query only showed scrape-target availability. The Helm chart also shipped kube-state-metrics and the OTLP gateway disabled, so standard installs did not expose the Kubernetes state metrics or cluster trace ingestion path that the drilldowns expect.

## Impact

Standard Helm installs and upgrades now provide Kubernetes state metrics and an in-cluster OTLP gateway without extra `--set` flags. Instrumented workloads can export to the gateway and receive the manager-owned `cluster_id` resource attribute. Both components remain explicitly disableable.

## Validation

- `npm test -- --run src/pages/Kubernetes.test.tsx` (28 tests)
- frontend typecheck, ESLint, and production build
- source and packaged Helm chart lint
- Helm template checks for default enablement and explicit disablement
- live-release Helm upgrade dry-run with `--reuse-values`
- Go build, `go test -race`, and `go vet` across tracked packages

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
