### PR TITLE
fix(k8s): mount host root without setns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,11 @@ jobs:
           grep -q -- '- install-k8s-host-runtime' /tmp/ongrid-edge.yaml
           grep -A16 'name: install-host-runtime' /tmp/ongrid-edge.yaml | grep -q 'memory: 128Mi'
           grep -q -- '- enter-k8s-host' /tmp/ongrid-edge.yaml
+          test "$(grep -F -c 'mountPath: /host/root' /tmp/ongrid-edge.yaml)" -eq 2
+          grep -q 'mountPropagation: HostToContainer' /tmp/ongrid-edge.yaml
           grep -A1 'name: ONGRID_EDGE_COLLECTOR_MODE' /tmp/ongrid-edge.yaml | grep -q 'value: "off"'
           grep -q 'add: \["CHOWN", "DAC_OVERRIDE", "FOWNER"\]' /tmp/ongrid-edge.yaml
-          grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE"\]' /tmp/ongrid-edge.yaml
+          grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"\]' /tmp/ongrid-edge.yaml
+          ! grep -q 'SYS_ADMIN\|SYS_PTRACE' /tmp/ongrid-edge.yaml
           ! grep -q 'privileged: true' /tmp/ongrid-edge.yaml
           ! grep -q 'supplementalGroups:' /tmp/ongrid-edge.yaml

--- a/cmd/ongrid-edge/k8s_host_runtime_linux.go
+++ b/cmd/ongrid-edge/k8s_host_runtime_linux.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -14,7 +15,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const defaultLinuxLastCapability = 63
+const (
+	defaultLinuxLastCapability = 63
+	procHostRoot               = "/proc/1/root"
+	procHostMountNamespace     = "/proc/1/ns/mnt"
+)
 
 var k8sHostCapabilities = []int{
 	unix.CAP_DAC_READ_SEARCH,
@@ -31,11 +36,14 @@ func enterK8sHost(ctx context.Context, hostRoot string, uid, gid int) error {
 	}
 	defer unix.Close(rootFD)
 
-	mountNSFD, err := unix.Open("/proc/1/ns/mnt", unix.O_RDONLY|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return fmt.Errorf("open host mount namespace: %w", err)
+	mountNSFD := -1
+	if requiresHostMountNamespace(hostRoot) {
+		mountNSFD, err = unix.Open(procHostMountNamespace, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return fmt.Errorf("open host mount namespace: %w", err)
+		}
+		defer unix.Close(mountNSFD)
 	}
-	defer unix.Close(mountNSFD)
 	lastCapability := linuxLastCapability()
 
 	runtime.LockOSThread()
@@ -43,8 +51,10 @@ func enterK8sHost(ctx context.Context, hostRoot string, uid, gid int) error {
 	if err := unix.Unshare(unix.CLONE_FS); err != nil {
 		return fmt.Errorf("isolate host launcher filesystem context: %w", err)
 	}
-	if err := unix.Setns(mountNSFD, unix.CLONE_NEWNS); err != nil {
-		return fmt.Errorf("enter host mount namespace: %w", err)
+	if mountNSFD >= 0 {
+		if err := unix.Setns(mountNSFD, unix.CLONE_NEWNS); err != nil {
+			return fmt.Errorf("enter host mount namespace: %w", err)
+		}
 	}
 	if err := unix.Fchdir(rootFD); err != nil {
 		return fmt.Errorf("select host root: %w", err)
@@ -62,6 +72,14 @@ func enterK8sHost(ctx context.Context, hostRoot string, uid, gid int) error {
 		return fmt.Errorf("start host edge: %w", err)
 	}
 	return nil
+}
+
+// requiresHostMountNamespace preserves compatibility with older charts that
+// reached the host through hostPID's /proc/1/root. New charts pass the explicit
+// /host/root hostPath mount, which can be chrooted directly without procfs
+// ptrace checks or setns.
+func requiresHostMountNamespace(hostRoot string) bool {
+	return filepath.Clean(hostRoot) == procHostRoot
 }
 
 func linuxLastCapability() int {

--- a/cmd/ongrid-edge/k8s_host_runtime_linux_test.go
+++ b/cmd/ongrid-edge/k8s_host_runtime_linux_test.go
@@ -8,6 +8,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestRequiresHostMountNamespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostRoot string
+		want     bool
+	}{
+		{name: "legacy proc root", hostRoot: "/proc/1/root", want: true},
+		{name: "legacy proc root trailing slash", hostRoot: "/proc/1/root/", want: true},
+		{name: "explicit host mount", hostRoot: "/host/root", want: false},
+		{name: "empty", hostRoot: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requiresHostMountNamespace(tt.hostRoot); got != tt.want {
+				t.Fatalf("requiresHostMountNamespace(%q) = %t, want %t", tt.hostRoot, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestK8sHostCapabilities(t *testing.T) {
 	for _, capability := range []int{unix.CAP_DAC_READ_SEARCH, unix.CAP_NET_ADMIN} {
 		if !isK8sHostCapability(capability) {

--- a/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
@@ -64,7 +64,7 @@ spec:
           workingDir: /
           args:
             - enter-k8s-host
-            - /proc/1/root
+            - /host/root
             - {{ .Values.podSecurity.runAsUser | quote }}
             - {{ .Values.podSecurity.runAsGroup | quote }}
           env:
@@ -139,7 +139,11 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
-              add: ["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE"]
+              add: ["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"]
+          volumeMounts:
+            - name: host-root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
       volumes:
         - name: host-root
           hostPath:

--- a/docs/rfc/RFC-001-kubernetes-edge-adaptation.md
+++ b/docs/rfc/RFC-001-kubernetes-edge-adaptation.md
@@ -201,8 +201,8 @@ kubectl delete namespace ongrid-system --ignore-not-found
 | --- | --- | --- |
 | DaemonSet 复用同一 edge 凭证 | 多节点互相覆盖在线状态和 `device_id` | 使用 bootstrap token 换取 per-node edge credentials |
 | Node Pod 读取共享凭据 Secret | 单节点失陷后可读取或覆盖其他节点密钥 | 每个节点只在宿主机本地持久化自己的 `0600` 凭据文件；ServiceAccount 仅允许读取 `kube-system` Namespace 以校验集群 UID |
-| Node 启动阶段需要进入宿主机 mount namespace | 启动进程短暂持有 `SYS_ADMIN`、`SYS_PTRACE` 等高权限 | 仅固定的内置 launcher 获得最小 capability；进入宿主机后立即降 UID、清空补充组和 capability bounding set，只保留 `NET_ADMIN`、`DAC_READ_SEARCH`，不使用 `privileged: true` |
-| Node Edge 需要与主机安装版一致地读取和修改宿主机文件 | launcher 通过 hostPID 的 `/proc/1/root` 进入节点真实根目录 | Controller 保持隔离；launcher 进入主机后立即以 UID/GID 65532 运行，写操作继续受 Edge 审批与审计链路约束 |
+| Node 启动阶段需要切换到宿主机根文件系统 | 启动进程短暂持有 `SYS_CHROOT` 等最小 capability | Chart 将宿主机 `/` 显式挂载到 `/host/root` 并使用 `HostToContainer` 传播；launcher 完成 `chroot` 后立即降 UID、清空补充组和 capability bounding set，只保留 `NET_ADMIN`、`DAC_READ_SEARCH`，不使用 `privileged: true` |
+| Node Edge 需要与主机安装版一致地读取和修改宿主机文件 | launcher 直接进入 `/host/root`，不依赖受 ptrace、AppArmor/SELinux 或 user namespace 限制的 `/proc/1/root` 与 mount namespace `setns` | Controller 保持隔离；launcher 进入主机后立即以 UID/GID 65532 运行，写操作继续受 Edge 审批与审计链路约束；旧 Chart 的 `/proc/1/root` 参数仍保留兼容路径 |
 | CNB 公共镜像仓库不可达 | Controller 和 Node Edge 出现 ImagePullBackOff | release 先发布并校验 amd64/arm64 多架构 manifest；受限环境通过 `image.repository` 覆盖为集群可达镜像仓库 |
 | 可选 kube-state-metrics 访问公网 | 离线环境启用后出现 ImagePullBackOff | 默认关闭；启用时必须显式提供集群可达的离线镜像仓库地址 |
 | Event 高 churn | MySQL 表膨胀 | 当前快照 prune + TTL + per-cluster cap |


### PR DESCRIPTION
## Summary

- mount each Kubernetes node host root explicitly at `/host/root` with `HostToContainer` propagation
- enter the explicit host root without mount-namespace `setns`, while preserving compatibility with legacy charts that use `/proc/1/root`
- remove `SYS_ADMIN` and `SYS_PTRACE` from the node container capability set
- extend Linux unit tests, Helm rendering checks, and the Kubernetes Edge RFC

The previous launcher depended on host PID `/proc/1/root` and entering PID 1's mount namespace. That path can be blocked by ptrace, AppArmor/SELinux, or user-namespace restrictions even when the workload has the requested capabilities. The explicit hostPath mount avoids those restrictions and reduces the startup capability surface.

## Impact

Kubernetes Node Edge pods can enter the real host filesystem without `setns`. After launch, the process still drops to UID/GID 65532 with only `DAC_READ_SEARCH` and `NET_ADMIN`. Controller pods are unchanged.

## Validation

- `go test -race ./cmd/ongrid-edge`
- Linux/amd64 test binary cross-compilation
- Helm lint, package, and CI-equivalent render assertions
- multi-architecture `v0.10.1` test image and Helm chart published to CNB
- live Helm upgrade on the two-node `ongrid-k8s-vm` cluster
- controller and node pods Ready with zero restarts
- runtime UID/GID, capability mask, host-root access, metrics endpoints, and post-start logs verified

## Rollback

Roll back to the previous Helm revision or reinstall chart version `0.10.0`.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
