### PR TITLE
feat(release): publish cloud images to CNB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,10 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh
+        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh
+
+      - name: Verify Compose image routing
+        run: make verify-compose-images
 
       - name: Lint and render Kubernetes chart
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ concurrency:
 
 jobs:
   image:
-    name: Publish Kubernetes artifacts
+    name: Publish release images and Helm chart
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 180
 
     steps:
       - name: Checkout
@@ -49,20 +49,17 @@ jobs:
           username: cnb
           password: ${{ secrets.CNB_TOKEN }}
 
-      - name: Publish multi-arch image
+      - name: Publish project multi-arch images
         shell: bash
         run: |
           set -euo pipefail
-          make docker-push-k8s-edge
+          make docker-push-release-images
 
-      - name: Verify multi-arch manifest
+      - name: Verify multi-arch manifests
         shell: bash
         run: |
           set -euo pipefail
-          image_ref="$(make --no-print-directory k8s-edge-image-ref)"
-          docker buildx imagetools inspect --raw "$image_ref" > "$RUNNER_TEMP/manifest.json"
-          jq -e '[.manifests[].platform | "\(.os)/\(.architecture)"] | index("linux/amd64") != null and index("linux/arm64") != null' \
-            "$RUNNER_TEMP/manifest.json"
+          make verify-release-images
 
       - name: Publish Helm chart
         env:
@@ -89,20 +86,11 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
 
-    env:
-      FRONTIER_VERSION: v1.2.4
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set release paths
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "FRONTIER_SRC=${RUNNER_TEMP}/frontier" >> "$GITHUB_ENV"
 
       - name: Resolve tag
         id: tag
@@ -127,21 +115,12 @@ jobs:
           go-version: '1.25.x'
           cache: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Install host tools
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xz-utils unzip
-
-      - name: Checkout frontier
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch "$FRONTIER_VERSION" https://github.com/singchia/frontier.git "$FRONTIER_SRC"
 
       - name: Fetch bundled embedding model
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ OUT         := dist/out
 PACKAGE_CLEAN ?= 1
 # Local builds default to amd64. Release publishing produces one multi-arch
 # manifest independently of the manager package architecture.
+CLOUD_IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
+CLOUD_IMAGE_REPO ?= docker.cnb.cool/ongridio/ongrid
+CLOUD_MANAGER_IMAGE_REF ?= $(CLOUD_IMAGE_REPO):$(VERSION)
+CLOUD_WEB_IMAGE_REF ?= $(CLOUD_IMAGE_REPO)/ongrid-web:$(VERSION)
+FRONTIER_VERSION ?= v1.2.4
+CNB_FRONTIER_IMAGE_REF ?= $(CLOUD_IMAGE_REPO)/frontier:$(FRONTIER_VERSION)
 K8S_EDGE_IMAGE_PLATFORM ?= linux/amd64
 K8S_EDGE_IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 K8S_EDGE_IMAGE_TAG ?= $(VERSION)
@@ -180,16 +186,16 @@ run-ongrid-edge: ## 本地直接跑 ongrid-edge
 # ----------------------------------------------------------------------------
 # Release / packaging
 # ----------------------------------------------------------------------------
-# Produces a single, self-contained tarball ready to scp to any Linux box with
-# docker + docker compose installed:
+# Produces a release tarball ready to scp to any Linux box with docker +
+# docker compose installed. Compose runtime images are pulled from CNB:
 #
 #     dist/out/ongrid-$(VERSION)-linux-amd64.tar.xz
 #     dist/out/ongrid-$(VERSION)-linux-arm64.tar.xz  (make package TARGET_ARCH=arm64)
 #
 # Pipeline (wired via `make package`):
-#   1. build-edge-all   — cross-compile ongrid-edge for 4 targets.
-#   2. docker-build     — docker build ongrid:$(VERSION) for $(PLATFORM).
-#   3. dist/package.sh  — stage + docker save + tar.xz + sha256.
+#   1. build-edge-all   — cross-compile ongrid-edge targets.
+#   2. dist/package.sh  — extract systemd binaries from the published CNB
+#                        images, stage files, then emit tar.xz + sha256.
 
 .PHONY: build-linux
 build-linux: ## [release] 交叉编译 ongrid linux/amd64
@@ -257,6 +263,23 @@ docker-build-web: ## [release] 构建 ongrid-web:$(VERSION) 镜像（前端 SPA 
 		$(DOCKER_BUILD_WEB_CACHE_ARGS) \
 		--load .
 
+.PHONY: docker-push-cloud-images docker-push-release-images release-image-refs verify-release-images
+docker-push-cloud-images: ## [release] 发布 manager + Web 多架构镜像到 CNB
+	docker buildx build \
+		--platform $(CLOUD_IMAGE_PLATFORMS) \
+		--build-arg VERSION=$(VERSION) \
+		-t $(CLOUD_MANAGER_IMAGE_REF) \
+		-f deploy/Dockerfile.ongrid \
+		$(DOCKER_BUILD_CACHE_ARGS) \
+		--push .
+	docker buildx build \
+		--platform $(CLOUD_IMAGE_PLATFORMS) \
+		--build-arg VERSION=$(VERSION) \
+		-t $(CLOUD_WEB_IMAGE_REF) \
+		-f deploy/Dockerfile.web \
+		$(DOCKER_BUILD_WEB_CACHE_ARGS) \
+		--push .
+
 .PHONY: docker-build-k8s-edge docker-push-k8s-edge k8s-edge-image-ref
 docker-build-k8s-edge: ## [dev] 构建本地 Kubernetes ongrid-edge 镜像（默认 linux/amd64）
 	docker buildx build \
@@ -286,15 +309,31 @@ docker-push-k8s-edge: ## [release] 发布 Kubernetes ongrid-edge 多架构镜像
 k8s-edge-image-ref:
 	@printf '%s\n' "$(K8S_EDGE_IMAGE_REF)"
 
-# Frontier broker is upstream singchia/frontier (ADR-007). Docker Hub pull
-# is unreliable in some networks, so we build the image locally from the
-# upstream source and ship it in the release tarball.
+docker-push-release-images: docker-push-cloud-images docker-push-k8s-edge ## [release] 发布全部项目自身多架构镜像
+
+release-image-refs: ## [release] 打印本次发布的项目自身镜像
+	@printf '%s\n' "$(CLOUD_MANAGER_IMAGE_REF)" "$(CLOUD_WEB_IMAGE_REF)" "$(K8S_EDGE_IMAGE_REF)"
+
+verify-release-images: ## [release] 校验项目自身镜像均包含 amd64 + arm64 manifest
+	@command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+	@for image in $(CLOUD_MANAGER_IMAGE_REF) $(CLOUD_WEB_IMAGE_REF) $(K8S_EDGE_IMAGE_REF); do \
+		echo "[verify] $$image"; \
+		docker buildx imagetools inspect --raw "$$image" \
+			| jq -e '[.manifests[].platform | "\(.os)/\(.architecture)"] \
+				| index("linux/amd64") != null and index("linux/arm64") != null' >/dev/null; \
+	done
+
+.PHONY: verify-compose-images
+verify-compose-images: ## [test] 渲染并校验 Compose 运行镜像全部按预期指向 CNB
+	bash scripts/verify-cnb-compose-images.sh
+
+# Optional local-dev fallback for rebuilding the upstream Frontier broker.
+# Release packages and Compose deployments use the existing CNB mirror.
 FRONTIER_SRC     ?= $(HOME)/frontier
-FRONTIER_VERSION ?= v1.2.4
 FRONTIER_BUILD_FORCE ?= 1
 
 .PHONY: docker-build-broker
-docker-build-broker: ## [release] 本地构建 singchia/frontier:$(FRONTIER_VERSION)
+docker-build-broker: ## [dev] 从上游源码本地构建 singchia/frontier:$(FRONTIER_VERSION)
 	@existing_platform=$$(docker image inspect -f '{{.Os}}/{{.Architecture}}' singchia/frontier:$(FRONTIER_VERSION) 2>/dev/null || true); \
 	if [ "$(FRONTIER_BUILD_FORCE)" != "1" ] && [ "$$existing_platform" = "$(PLATFORM)" ]; then \
 		echo "[broker] singchia/frontier:$(FRONTIER_VERSION) already present for $(PLATFORM) — skipping rebuild"; \
@@ -307,12 +346,6 @@ docker-build-broker: ## [release] 本地构建 singchia/frontier:$(FRONTIER_VERS
 			$(DOCKER_BUILD_BROKER_CACHE_ARGS) \
 			--load $(FRONTIER_SRC); \
 	fi
-
-.PHONY: docker-save
-docker-save: ## [release] docker save ongrid:$(VERSION) 到 stage
-	@mkdir -p $(STAGE)/images
-	docker save ongrid:$(VERSION) -o $(STAGE)/images/ongrid.tar
-	@echo "saved $(STAGE)/images/ongrid.tar"
 
 # Promtail bundle (ADR-012 / ADR-015 logs plugin).
 # Cached under bin/<os>-<arch>/promtail to avoid re-downloading on every build.
@@ -505,10 +538,8 @@ fetch-mongodb-exporter: ## [release] 下载 mongodb_exporter 到 bin/<os>-<arch>
 	done
 
 # package deps deliberately exclude `build-linux` and `build-web`:
-#   - build-linux produces a host-side ongrid binary which dist/package.sh
-#     never consumes (the manager binary inside ongrid:VERSION docker
-#     image is what's shipped; the host-side cross-compile was dead
-#     code costing ~1-3 min per run).
+#   - dist/package.sh extracts the systemd manager binary and ONNX runtime
+#     from the already-published, architecture-matched CNB image.
 #   - build-web produces web/dist/ which docker-build-web doesn't use
 #     either — the web Dockerfile runs its own `npm ci && npm run
 #     build` inside the builder stage. Removing the host-side npm pass
@@ -564,11 +595,14 @@ check-release-target:
 # For offline RAG (ONGRID_EMBEDDING_PROVIDER=local) run
 # `make fetch-embedding-model` once before `make package`, otherwise
 # dist/package.sh warns and ships a tarball without the model.
-package: check-release-target fetch-promtail fetch-otelcol fetch-node-exporter fetch-process-exporter fetch-db-exporters build-edge-all docker-build docker-build-broker docker-build-web ## [release] 打单架构 release tarball 到 dist/out/（TARGET_ARCH 可覆盖）
+package: check-release-target fetch-promtail fetch-otelcol fetch-node-exporter fetch-process-exporter fetch-db-exporters build-edge-all ## [release] 打单架构 release tarball 到 dist/out/（TARGET_ARCH 可覆盖）
 	@if [ "$(PACKAGE_CLEAN)" = "1" ]; then rm -rf dist/stage dist/out; fi
 	@mkdir -p dist/stage dist/out
 	@$(MAKE) --no-print-directory build-edge-bundle
-	PACKAGE_TARGET="$(PACKAGE_TARGET)" DOCKER_PLATFORM="$(PLATFORM)" bash dist/package.sh "$(VERSION)" "$(STAGE)" "$(OUT)"
+	PACKAGE_TARGET="$(PACKAGE_TARGET)" DOCKER_PLATFORM="$(PLATFORM)" \
+		ONGRID_IMAGE_REF="$(CLOUD_MANAGER_IMAGE_REF)" \
+		FRONTIER_IMAGE_REF="$(CNB_FRONTIER_IMAGE_REF)" \
+		bash dist/package.sh "$(VERSION)" "$(STAGE)" "$(OUT)"
 	@echo ""
 	@echo "=== release artefact ==="
 	@ls -lh $(OUT)/ongrid-$(VERSION)-$(PACKAGE_TARGET).tar.xz

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -94,7 +94,7 @@ In production, set both to strong values in `.env` **before** the first
 | `localhost:3306`                | MySQL (user `ongrid`, pw `ongrid`, db `ongrid`) |
 
 Data lives in the `mysql_data` Docker volume. Back that volume up with
-`docker run --rm -v mysql_data:/src -v "$PWD":/dst alpine tar czf /dst/mysql.tgz -C /src .`
+`sudo tar czf mysql.tgz -C "$(docker volume inspect -f '{{.Mountpoint}}' mysql_data)" .`
 or the equivalent in your ops tooling.
 
 ## Switching to SQLite (local tinkering)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
   mysql:
-    image: mysql:8.0
+    image: docker.cnb.cool/ongridio/ongrid/mysql:8.0
     container_name: ongrid-mysql
     restart: unless-stopped
     environment:
@@ -208,10 +208,10 @@ services:
       - ongrid_net
 
   frontier:
-    # Upstream broker (ADR-007). No build stanza — image pulled from
-    # Docker Hub. Edge-bound port 40012 is exposed on host:40012 so the
-    # tunnel endpoint URL stays identical to pre-split deployments.
-    image: singchia/frontier:v1.2.4
+    # Upstream broker (ADR-007), mirrored to the project CNB registry.
+    # Edge-bound port 40012 is exposed on host:40012 so the tunnel endpoint
+    # URL stays identical to pre-split deployments.
+    image: docker.cnb.cool/ongridio/ongrid/frontier:v1.2.4
     container_name: ongrid-frontier
     restart: unless-stopped
     volumes:
@@ -226,7 +226,7 @@ services:
   # query backend for the aiops query_promql tool). Dev publishes 9090 to
   # host so you can poke PromQL from the laptop browser; prod doesn't.
   prometheus:
-    image: prom/prometheus:v2.54.0
+    image: docker.cnb.cool/ongridio/ongrid/prometheus:v2.54.0
     container_name: ongrid-prometheus
     restart: unless-stopped
     depends_on:
@@ -259,7 +259,7 @@ services:
   # 3100 — public access flows through nginx /loki/api/v1/push with
   # auth_request → manager edgeauth (ADR-014 §决策).
   loki:
-    image: grafana/loki:3.4.0
+    image: docker.cnb.cool/ongridio/ongrid/loki:3.4.0
     container_name: ongrid-loki
     restart: unless-stopped
     command:
@@ -275,7 +275,7 @@ services:
   # through nginx /v1/traces with auth_request → manager edgeauth
   # (ADR-014 §决策第 1 条).
   tempo:
-    image: grafana/tempo:2.10.0
+    image: docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
     container_name: ongrid-tempo
     restart: unless-stopped
     command:
@@ -294,7 +294,7 @@ services:
   # response. Zero API key, zero quota. Only docker-internal port 8080
   # — manager reaches it at http://searxng:8080/search?q=...&format=json.
   searxng:
-    image: searxng/searxng:latest
+    image: docker.cnb.cool/ongridio/ongrid/searxng:latest
     container_name: ongrid-searxng
     restart: unless-stopped
     environment:
@@ -306,7 +306,7 @@ services:
       - ongrid_net
 
   qdrant:
-    image: qdrant/qdrant:v1.11.3
+    image: docker.cnb.cool/ongridio/ongrid/qdrant:v1.11.3
     container_name: ongrid-qdrant
     restart: unless-stopped
     volumes:
@@ -315,7 +315,7 @@ services:
       - ongrid_net
 
   grafana:
-    image: grafana/grafana-oss:11.1.4
+    image: docker.cnb.cool/ongridio/ongrid/grafana-oss:11.1.4
     container_name: ongrid-grafana
     restart: unless-stopped
     depends_on:

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -8,7 +8,7 @@
 - Docker >= 24.0；Docker Compose v2（即 `docker compose` 子命令，不是旧版 `docker-compose`）。
 - 至少 2 GB 内存、10 GB 可用磁盘。
 - 以 root 身份或具备 sudo 权限的用户执行脚本。
-- 可出公网访问 `docker.io`（如需拉取 MySQL、Prometheus 镜像；`prom/prometheus:v2.54.0` 由 docker compose 拉取，未随 tarball 发货）；`ongrid` 镜像已打包在发布包内，无需对外连接私有 registry。
+- 可访问 `docker.cnb.cool`；Compose 模式的 manager、Web 及全部静态运行依赖都从项目 CNB 仓库拉取，发布包不再携带镜像 tar。
 
 ## 两种安装形态
 
@@ -18,7 +18,7 @@
 | **manager 进程** | `ongrid` 容器 | `ongrid.service`（`/usr/local/bin/ongrid`）|
 | **依赖** | 同一份 docker-compose 起 mysql / prom / loki / tempo / qdrant / nginx / grafana | mariadb-server / nginx / grafana 走 apt-dnf 包管；prom / loki / tempo / qdrant 安装为 systemd 单元 |
 | **何时选** | 默认推荐；开箱即用，少踩坑 | 禁 docker、合规要求、已有 systemd 运维栈 |
-| **包大小** | ~430M（docker images 占大头） | 同上 + ~15M 裸 binary（`bin/ongrid` + `bin/ongrid-frontier`） |
+| **包内容** | 不含容器镜像 tar；运行时从 CNB 拉取 | 包含 `bin/ongrid`、`bin/ongrid-frontier` 和离线 systemd 依赖 |
 | **卸载** | `uninstall.sh --purge` | `uninstall.sh --purge`（自动派发到 `systemd/uninstall-systemd.sh`）|
 
 systemd 形态详细看 `systemd/README.md`。
@@ -58,8 +58,8 @@ sudo ./install.sh
 2. 创建 `/opt/ongrid/`（可通过 `ONGRID_INSTALL_DIR` 覆盖）。
 3. 拷贝 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION` 到安装目录。
 4. **生成自签 TLS 证书**（首次安装且 `certs/tls.crt` 不存在时）：通过临时 OpenSSL 配置生成 CN=ongrid、SAN 包含 `ongrid` / `localhost` / `127.0.0.1` 的 365 天证书，落到 `${INSTALL_DIR}/certs/`，私钥 `chmod 600`。脚本不交互，直接生成；末尾 banner 提示替换真证书。
-5. `docker load -i images/ongrid.tar`、`images/frontier.tar`、`images/ongrid-web.tar` 加载所有镜像。
-6. 若 `/opt/ongrid/.env` 不存在则从 `.env.example` 创建，并对空字段（`MYSQL_ROOT_PASSWORD`、`MYSQL_PASSWORD`、`ONGRID_JWT_SECRET`、`ONGRID_ADMIN_PASSWORD`）生成随机值，文件权限置 `600`。
+5. 若 `/opt/ongrid/.env` 不存在则从 `.env.example` 创建，并对空字段（`MYSQL_ROOT_PASSWORD`、`MYSQL_PASSWORD`、`ONGRID_JWT_SECRET`、`ONGRID_ADMIN_PASSWORD`）生成随机值，文件权限置 `600`。
+6. 先渲染 Compose 配置并从 `docker.cnb.cool/ongridio/ongrid` 拉取全部精确镜像；任一镜像不可用即停止，不启动半套服务。
 7. `docker compose up -d` 启动 MySQL + ongrid + frontier + nginx + prometheus（ADR-009）。
 8. 轮询 `https://localhost:${ONGRID_HTTP_PORT}/healthz`（nginx 透传到 manager，`-k` 跳过自签校验）最多 60 秒。
 9. 打印安装摘要，包括 **Web URL**、**API URL** 与 **管理员初始密码**（只显示一次，务必立即记录）。
@@ -86,12 +86,11 @@ sudo ./upgrade.sh
 
 升级脚本会：
 
-1. 先 `docker compose down`（保留命名卷，数据不丢）。
-2. 覆盖 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION`。
-3. **不触碰 `.env` 和 `certs/`**，运维之前的自定义配置 / 真证书全部保留。
-4. `docker load` 新镜像（`ongrid` / `frontier` / `ongrid-web`），修改 `.env` 中的 `ONGRID_VERSION`。
-5. `docker compose up -d` 启动新版。
-6. 轮询 `https://localhost:${ONGRID_HTTP_PORT}/healthz`（`-k` 跳过自签校验）最多 90 秒（库迁移可能稍慢）。
+1. 使用新版本号渲染 Compose，并从 CNB 拉取全部运行镜像；任一镜像失败时旧栈保持运行。
+2. `docker compose down`（保留数据），随后覆盖 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION`。
+3. **不覆盖 `.env` 和 `certs/`**；只把 `.env` 中的 `ONGRID_VERSION` 更新为新版本，并补齐新版本必需的缺省项。
+4. `docker compose up -d` 启动新版。
+5. 轮询 `https://localhost:${ONGRID_HTTP_PORT}/healthz`（`-k` 跳过自签校验）最多 90 秒（库迁移可能稍慢）。
 
 数据库 schema 由 gorm AutoMigrate 在 ongrid 启动时自动处理。
 
@@ -202,7 +201,7 @@ sudo ./upgrade.sh --migrate-volumes
 `upgrade.sh` 会：
 
 1. `docker compose down` 停掉旧栈；
-2. 对每个 legacy named volume `docker run --rm alpine cp -a` 到对应 bind path；
+2. 使用已拉取的新版 manager 镜像作为临时工具容器，对每个 legacy named volume 执行 `cp -a` 到对应 bind path；
 3. `chown` 到正确 uid；
 4. `docker compose up -d` 起新栈。
 
@@ -218,7 +217,9 @@ for v in ongrid_mysql_data:mysql prometheus_data:prometheus loki_data:loki tempo
     SRC="${v%%:*}"
     DST="${v##*:}"
     if [[ "$DST" == "ongrid" ]]; then DSTDIR=/var/log/ongrid; else DSTDIR=/var/lib/ongrid/$DST; fi
-    sudo docker run --rm -v "$SRC":/src:ro -v "$DSTDIR":/dst alpine sh -c 'cp -a /src/. /dst/'
+    MANAGER_IMAGE="docker.cnb.cool/ongridio/ongrid:$(grep '^ONGRID_VERSION=' /opt/ongrid/.env | cut -d= -f2-)"
+    sudo docker run --rm --user 0 --entrypoint sh \
+        -v "$SRC":/src:ro -v "$DSTDIR":/dst "$MANAGER_IMAGE" -c 'cp -a /src/. /dst/'
 done
 sudo docker compose -f /opt/ongrid/docker-compose.yml up -d
 ```
@@ -380,15 +381,6 @@ sudo docker compose -f /opt/ongrid/docker-compose.yml --env-file /opt/ongrid/.en
 ```bash
 sudo docker exec ongrid-prometheus wget -qO- \
     'http://localhost:9090/api/v1/query?query=up' | jq
-```
-
-**备份**：`prometheus_data` 是命名卷，备份姿势同 `ongrid_mysql_data`：
-
-```bash
-sudo docker run --rm \
-    -v prometheus_data:/data \
-    -v "$(pwd)":/out \
-    alpine sh -c 'tar czf /out/prometheus-$(date +%F).tar.gz -C /data .'
 ```
 
 `/opt/ongrid/prometheus.yml` 是 bind-mounted scrape config，改完跑 `docker compose restart prometheus` 或 `curl -XPOST http://prometheus:9090/-/reload`（`--web.enable-lifecycle` 已开）。

--- a/deploy/install/docker-compose.yml
+++ b/deploy/install/docker-compose.yml
@@ -2,16 +2,15 @@
 # Do NOT add a top-level `version:` key (modern compose).
 #
 # Operator flow:
-#   1. scp ongrid-<ver>.tar.gz vps:~/
-#   2. ssh vps 'tar xzf ongrid-*.tar.gz && cd ongrid-* && sudo ./install.sh'
+#   1. scp ongrid-<ver>.tar.xz vps:~/
+#   2. ssh vps 'tar xf ongrid-*.tar.xz && cd ongrid-* && sudo ./install.sh'
 #
 # install.sh copies this file + frontier.yaml + prometheus.yml + edge/ to
-# /opt/ongrid, renders .env, docker-load the ongrid image, and brings the
-# stack up. The frontier image is pulled from Docker Hub on `compose up`
-# (see ADR-007 — ongrid no longer ships a custom broker binary).
+# /opt/ongrid, renders .env, pulls all runtime images from CNB, and brings
+# the stack up.
 #
 # Differences vs deploy/docker-compose.yml (which is for local dev):
-#   - ongrid image is loaded via `docker load -i images/ongrid.tar`; no build stanza.
+#   - ongrid and Web images are pulled from the versioned CNB repositories.
 #   - MySQL port 3306 is NOT published to host (container-network only).
 #   - All secrets come from .env (no hard-coded defaults for passwords).
 #   - prometheus is a core service (ADR-009): it receives remote_write
@@ -20,7 +19,7 @@
 
 services:
   mysql:
-    image: mysql:8.0
+    image: docker.cnb.cool/ongridio/ongrid/mysql:8.0
     container_name: ongrid-mysql
     restart: unless-stopped
     environment:
@@ -51,7 +50,7 @@ services:
         max-file: "5"
 
   ongrid:
-    image: ongrid:${ONGRID_VERSION}
+    image: docker.cnb.cool/ongridio/ongrid:${ONGRID_VERSION}
     container_name: ongrid
     restart: unless-stopped
     depends_on:
@@ -260,11 +259,9 @@ services:
         max-file: "5"
 
   frontier:
-    # Upstream broker. Image is built locally from the frontier source
-    # (images/Dockerfile.frontier) and shipped in the release tarball —
-    # Docker Hub pull is not relied upon. Pinned tag is
-    # bumped via Makefile var FRONTIER_VERSION.
-    image: singchia/frontier:v1.2.4
+    # Upstream broker mirrored to the project CNB registry. The pinned tag is
+    # bumped together with Makefile var FRONTIER_VERSION.
+    image: docker.cnb.cool/ongridio/ongrid/frontier:v1.2.4
     container_name: ongrid-frontier
     restart: unless-stopped
     volumes:
@@ -285,7 +282,7 @@ services:
   # Image bakes web/dist/ in; nginx.conf and certs/ are bind-mounted so
   # operators can edit them without rebuilding the image.
   nginx:
-    image: ongrid-web:${ONGRID_VERSION}
+    image: docker.cnb.cool/ongridio/ongrid/ongrid-web:${ONGRID_VERSION}
     container_name: ongrid-nginx
     restart: unless-stopped
     depends_on:
@@ -312,7 +309,7 @@ services:
   # tool. Not published to host — manager reaches it on the docker network
   # at http://prometheus:9090/prometheus. Retention: 90d / 20GB cap.
   prometheus:
-    image: prom/prometheus:v2.54.0
+    image: docker.cnb.cool/ongridio/ongrid/prometheus:v2.54.0
     container_name: ongrid-prometheus
     restart: unless-stopped
     command:
@@ -354,7 +351,7 @@ services:
   # 3100 — public access flows through nginx /loki/api/v1/push with
   # auth_request → manager edgeauth (ADR-014 §决策).
   loki:
-    image: grafana/loki:3.4.0
+    image: docker.cnb.cool/ongridio/ongrid/loki:3.4.0
     container_name: ongrid-loki
     restart: unless-stopped
     command:
@@ -376,7 +373,7 @@ services:
   # host. Edges push to nginx /v1/traces with auth_request → manager
   # edgeauth (ADR-014 §决策第 1 条); manager Go is NOT on this byte stream.
   tempo:
-    image: grafana/tempo:2.10.0
+    image: docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
     container_name: ongrid-tempo
     restart: unless-stopped
     command:
@@ -401,7 +398,7 @@ services:
   # external port (knowledge-base writes / queries all go through the
   # manager API).
   qdrant:
-    image: qdrant/qdrant:v1.11.3
+    image: docker.cnb.cool/ongridio/ongrid/qdrant:v1.11.3
     container_name: ongrid-qdrant
     restart: unless-stopped
     volumes:
@@ -423,7 +420,7 @@ services:
   # JSON-format API is enabled in settings.yml; SearXNG's secret_key
   # is hard-coded since the service is not exposed publicly.
   searxng:
-    image: searxng/searxng:latest
+    image: docker.cnb.cool/ongridio/ongrid/searxng:latest
     container_name: ongrid-searxng
     restart: unless-stopped
     environment:
@@ -438,7 +435,7 @@ services:
         max-file: "5"
 
   grafana:
-    image: grafana/grafana-oss:11.1.4
+    image: docker.cnb.cool/ongridio/ongrid/grafana-oss:11.1.4
     container_name: ongrid-grafana
     restart: unless-stopped
     depends_on:

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -374,41 +374,6 @@ fi
 
 docker info >/dev/null 2>&1 || { log_error "docker daemon not reachable (permission or not running)"; exit 1; }
 
-# ---------- CN mirror auto-config ----------
-# Probe Docker Hub once. If unreachable (the typical CN-network case), drop
-# a /etc/docker/daemon.json with a battery of well-known CN mirrors. We only
-# touch the file if it does not already specify registry-mirrors — operators
-# who configured their own mirrors get to keep them.
-log_info "checking Docker Hub reachability"
-if ! curl -sS --max-time 5 -o /dev/null https://registry-1.docker.io/v2/ 2>/dev/null; then
-    if [[ -f /etc/docker/daemon.json ]] && grep -q '"registry-mirrors"' /etc/docker/daemon.json; then
-        log_info "Docker Hub unreachable but /etc/docker/daemon.json already has registry-mirrors; leaving alone"
-    else
-        log_warn "Docker Hub unreachable — configuring CN registry mirrors in /etc/docker/daemon.json"
-        mkdir -p /etc/docker
-        if [[ -f /etc/docker/daemon.json ]]; then
-            cp /etc/docker/daemon.json "/etc/docker/daemon.json.bak.$(date +%s)"
-        fi
-        cat > /etc/docker/daemon.json <<'EOF'
-{
-  "registry-mirrors": [
-    "https://docker.1ms.run",
-    "https://docker.mirrors.ustc.edu.cn",
-    "https://hub.rat.dev",
-    "https://docker.m.daocloud.io"
-  ]
-}
-EOF
-        systemctl restart docker 2>/dev/null || true
-        # Wait up to 5s for the daemon to come back; otherwise the next
-        # `docker compose` call races and fails.
-        for _ in 1 2 3 4 5; do
-            docker info >/dev/null 2>&1 && break
-            sleep 1
-        done
-    fi
-fi
-
 docker compose version >/dev/null 2>&1 || { log_error "docker compose v2 not found (need the 'docker compose' subcommand)"; exit 1; }
 
 # ---------- install dir ----------
@@ -599,28 +564,6 @@ if [[ ! -f "$INSTALL_DIR/certs/tls.crt" || ! -f "$INSTALL_DIR/certs/tls.key" ]];
     log_warn "self-signed cert: browsers will warn — replace with a real cert in $INSTALL_DIR/certs/ later"
 fi
 
-# ---------- load docker images ----------
-# Both ongrid (manager) and frontier (broker) images ship in the tarball.
-# Docker Hub pull is unreliable in some networks, so installers should not
-# depend on it. ADR-007 explains the upstream-frontier-shipped-locally choice.
-if [[ -f "$SCRIPT_DIR/images/ongrid.tar" ]]; then
-    log_info "loading ongrid image (docker load)"
-    docker load -i "$SCRIPT_DIR/images/ongrid.tar"
-else
-    log_warn "images/ongrid.tar not found; assuming image already present"
-fi
-if [[ -f "$SCRIPT_DIR/images/frontier.tar" ]]; then
-    log_info "loading frontier broker image (docker load)"
-    docker load -i "$SCRIPT_DIR/images/frontier.tar"
-else
-    log_warn "images/frontier.tar not found; assuming image already present"
-fi
-if [[ -f "$SCRIPT_DIR/images/ongrid-web.tar" ]]; then
-    log_info "loading ongrid-web (frontend + nginx) image (docker load)"
-    docker load -i "$SCRIPT_DIR/images/ongrid-web.tar"
-else
-    log_warn "images/ongrid-web.tar not found; assuming ongrid-web image already present"
-fi
 # Resolve VERSION from VERSION file or .env.example (fallback)
 VERSION_FROM_FILE=""
 if [[ -f "$INSTALL_DIR/VERSION" ]]; then
@@ -630,12 +573,6 @@ if [[ -z "$VERSION_FROM_FILE" ]]; then
     VERSION_FROM_FILE=$(grep -E '^ONGRID_VERSION=' "$SCRIPT_DIR/.env.example" | cut -d= -f2- | tr -d '[:space:]' || true)
 fi
 [[ -n "$VERSION_FROM_FILE" ]] || { log_error "cannot determine ongrid version"; exit 1; }
-
-if ! docker image inspect "ongrid:${VERSION_FROM_FILE}" >/dev/null 2>&1; then
-    log_error "docker image ongrid:${VERSION_FROM_FILE} not found after load"
-    exit 1
-fi
-log_info "ongrid:${VERSION_FROM_FILE} image ready"
 
 # ---------- secret generator ----------
 gen_secret() {
@@ -824,6 +761,27 @@ COMPOSE_ARGS=(--env-file "$ENV_FILE")
 if [[ $PROFILE_MONITORING -eq 1 ]]; then
     COMPOSE_ARGS+=(--profile monitoring)
 fi
+
+# Pull every rendered image before starting anything. All production Compose
+# images live under docker.cnb.cool/ongridio/ongrid; rendering first also
+# validates the generated .env and any operator-provided override file.
+log_info "validating and pulling runtime images from CNB"
+if ! RUNTIME_IMAGES=$(
+    cd "$INSTALL_DIR"
+    docker compose "${COMPOSE_ARGS[@]}" config --images | sort -u
+); then
+    log_error "docker-compose configuration is invalid; no containers were started"
+    exit 1
+fi
+while IFS= read -r image; do
+    [[ -n "$image" ]] || continue
+    log_info "pulling $image"
+    if ! docker pull "$image"; then
+        log_error "required runtime image is unavailable: $image"
+        log_error "fix access to docker.cnb.cool and re-run sudo ./install.sh"
+        exit 1
+    fi
+done <<<"$RUNTIME_IMAGES"
 
 log_info "starting stack: docker compose ${COMPOSE_ARGS[*]} up -d"
 (

--- a/deploy/install/systemd/install-deps.sh
+++ b/deploy/install/systemd/install-deps.sh
@@ -352,7 +352,7 @@ fi
 # --- libonnxruntime.so (local ONNX embedder, ADR-027 Phase-2) ---
 # The ongrid manager binary is the CGO build (fastembed-go → onnxruntime_go)
 # and dlopens this .so at runtime via ONNX_PATH=/usr/lib/libonnxruntime.so
-# (set in ongrid.service). package.sh extracted it from the docker image
+# (set in ongrid.service). package.sh extracted it from the published CNB image
 # into bin/; install it to /usr/lib + the SONAME symlinks + ldconfig so the
 # loader resolves it. Without this, ONGRID_EMBEDDING_PROVIDER=local fails to
 # load the model. Compose mode bundles the .so inside the image instead.

--- a/deploy/install/uninstall.sh
+++ b/deploy/install/uninstall.sh
@@ -186,8 +186,12 @@ log_info "removing $INSTALL_DIR"
 rm -rf "$INSTALL_DIR"
 
 if [[ -n "$VERSION_FROM_FILE" ]]; then
-    log_info "removing ongrid:${VERSION_FROM_FILE} image"
-    docker image rm "ongrid:${VERSION_FROM_FILE}" 2>/dev/null || true
+    for image in \
+        "docker.cnb.cool/ongridio/ongrid:${VERSION_FROM_FILE}" \
+        "docker.cnb.cool/ongridio/ongrid/ongrid-web:${VERSION_FROM_FILE}"; do
+        log_info "removing $image"
+        docker image rm "$image" 2>/dev/null || true
+    done
 fi
 
 # Co-resident edge daemon — when the operator installed ongrid-edge on

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -154,22 +154,20 @@ preflight_runtime_images() {
     }
 
     local grafana_password images image
+    local compose_args=(--project-directory "$INSTALL_DIR" -f "$compose_file")
+    if [[ -f "$INSTALL_DIR/docker-compose.override.yml" ]]; then
+        compose_args+=(-f "$INSTALL_DIR/docker-compose.override.yml")
+    fi
     grafana_password=$(grep -E '^GRAFANA_ADMIN_PASSWORD=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)
     : "${grafana_password:=preflight-only}"
-    if ! images=$(GRAFANA_ADMIN_PASSWORD="$grafana_password" \
-        docker compose -f "$compose_file" --env-file "$ENV_FILE" config --images); then
+    if ! images=$(ONGRID_VERSION="$NEW_VERSION" GRAFANA_ADMIN_PASSWORD="$grafana_password" \
+        docker compose "${compose_args[@]}" --env-file "$ENV_FILE" config --images | sort -u); then
         log_error "new docker-compose.yml is invalid with the existing .env"
         return 1
     fi
 
     while IFS= read -r image; do
         [[ -n "$image" ]] || continue
-        case "$image" in
-            ongrid:*|ongrid-web:*) continue ;;
-        esac
-        if docker image inspect "$image" >/dev/null 2>&1; then
-            continue
-        fi
         log_info "pulling required runtime image before stopping the old stack: $image"
         if ! docker pull "$image"; then
             log_error "required runtime image is unavailable: $image"
@@ -211,41 +209,14 @@ if [[ -z "$NEW_VERSION" ]]; then
 fi
 [[ -n "$NEW_VERSION" ]] || { log_error "cannot determine new version"; exit 1; }
 log_info "new version: ${NEW_VERSION}"
+MIGRATION_HELPER_IMAGE="docker.cnb.cool/ongridio/ongrid:${NEW_VERSION}"
 
 OLD_VERSION=$(grep -E '^ONGRID_VERSION=' "$ENV_FILE" | cut -d= -f2- | tr -d '[:space:]' || true)
 log_info "old version: ${OLD_VERSION:-unknown}"
 
-# Validate and load release-owned images before stopping the existing stack.
-# A corrupt package or unavailable upstream runtime image must not turn a
-# recoverable upgrade error into service downtime.
-if [[ -f "$SCRIPT_DIR/images/ongrid.tar" ]]; then
-    log_info "loading ongrid:${NEW_VERSION} image"
-    docker load -i "$SCRIPT_DIR/images/ongrid.tar"
-else
-    log_warn "images/ongrid.tar not found; assuming ongrid:${NEW_VERSION} already present"
-fi
-if [[ -f "$SCRIPT_DIR/images/frontier.tar" ]]; then
-    log_info "loading frontier broker image"
-    docker load -i "$SCRIPT_DIR/images/frontier.tar"
-else
-    log_warn "images/frontier.tar not found; assuming frontier image already present"
-fi
-if [[ -f "$SCRIPT_DIR/images/ongrid-web.tar" ]]; then
-    log_info "loading ongrid-web (frontend + nginx) image"
-    docker load -i "$SCRIPT_DIR/images/ongrid-web.tar"
-else
-    log_warn "images/ongrid-web.tar not found; assuming ongrid-web image already present"
-fi
-docker image inspect "ongrid:${NEW_VERSION}" >/dev/null 2>&1 || {
-    log_error "ongrid:${NEW_VERSION} not present after docker load"
-    log_error "the existing stack was not stopped; repair the upgrade package and retry"
-    exit 1
-}
-docker image inspect "ongrid-web:${NEW_VERSION}" >/dev/null 2>&1 || {
-    log_error "ongrid-web:${NEW_VERSION} not present after docker load"
-    log_error "the existing stack was not stopped; repair the upgrade package and retry"
-    exit 1
-}
+# Validate the new Compose model and pull every exact image before stopping the
+# existing stack. Registry or manifest failures therefore leave the old version
+# running untouched.
 preflight_runtime_images
 
 # Stop stack first so legacy named volumes (if any) aren't being written
@@ -370,7 +341,9 @@ if (( ${#LEGACY_FOUND[@]} > 0 )); then
         declare -A SRC_BY_DST=()
         for v in "${LEGACY_FOUND[@]}"; do
             d="${LEGACY_VOL_TO_DST[$v]}"
-            sz=$(docker run --rm -v "$v":/d:ro alpine du -sb /d 2>/dev/null | cut -f1)
+            sz=$(docker run --rm --user 0 --entrypoint sh \
+                -v "$v":/d:ro "$MIGRATION_HELPER_IMAGE" \
+                -c 'du -sb /d' 2>/dev/null | cut -f1)
             sz=${sz:-0}
             if [[ -z "${SIZE_BY_DST[$d]:-}" ]] || (( sz > ${SIZE_BY_DST[$d]} )); then
                 SIZE_BY_DST[$d]=$sz
@@ -380,16 +353,17 @@ if (( ${#LEGACY_FOUND[@]} > 0 )); then
         for dst in "${!SRC_BY_DST[@]}"; do
             v="${SRC_BY_DST[$dst]}"
             log_info "  $v (${SIZE_BY_DST[$dst]} bytes) → $dst"
-            # alpine + cp -a preserves perms. Skip if dst non-empty —
+            # The already-pulled manager image supplies cp/du, so volume
+            # migration does not depend on an extra helper image. Skip if dst non-empty —
             # operator probably ran migration before; don't clobber.
             if [[ -n "$(ls -A "$dst" 2>/dev/null)" ]]; then
                 log_warn "  $dst already populated; skipping ($v left intact for operator review)"
                 continue
             fi
-            docker run --rm \
+            docker run --rm --user 0 --entrypoint sh \
                 -v "$v":/src:ro \
                 -v "$dst":/dst \
-                alpine sh -c 'cp -a /src/. /dst/'
+                "$MIGRATION_HELPER_IMAGE" -c 'cp -a /src/. /dst/'
         done
         log_info "migration complete — legacy volumes preserved; remove with: docker volume rm ${LEGACY_FOUND[*]}"
     elif [[ -n "$NO_MIGRATE_VOLUMES" ]]; then
@@ -585,7 +559,7 @@ fi
 # version bumps and have bitten today (2 disk-full incidents):
 #   1. /tmp/ongrid-vN-linux-<arch>/ — the extracted release tree
 #      (1+ GB per version, never reused after install)
-#   2. Loaded docker images from old versions (ongrid:vN, ongrid-web:vN)
+#   2. Pulled CNB images from old versions (manager + Web)
 #      — Docker keeps them forever; one set is ~500 MB
 #   3. The release tarball itself in $INSTALL_DIR (430 MB per version)
 #
@@ -605,16 +579,19 @@ if [[ $HEALTH_OK -eq 1 ]]; then
         log_info "  pruned /tmp/$(basename "$d")"
     done
 
-    # (2) Old docker images: keep only the version compose just brought
+    # (2) Old project images: keep only the version compose just brought
     # up. `docker image prune -af` would also remove cached build layers
     # for unrelated workloads; filter to ongrid* repos.
-    for repo in ongrid ongrid-web; do
+    for repo in \
+        docker.cnb.cool/ongridio/ongrid \
+        docker.cnb.cool/ongridio/ongrid/ongrid-web; do
         # List image refs matching <repo>:* and drop those that don't
         # match $NEW_VERSION. compose holds the running tag, so docker
         # won't actually delete an in-use image (it'll print "image is
         # being used by stopped container" warn and skip — harmless).
         docker images --format '{{.Repository}}:{{.Tag}}' \
-            | awk -v r="$repo" -v keep="${NEW_VERSION}" '$0 ~ "^"r":" && $0 != r":"keep' \
+            | awk -v prefix="$repo:" -v keep="$repo:${NEW_VERSION}" \
+                'index($0, prefix) == 1 && $0 != keep' \
             | xargs -r docker rmi 2>&1 | grep -v "image is being used" || true
     done
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,8 +1,8 @@
 # dist/ — ongrid release pipeline
 
 This directory owns the **release/packaging** pipeline for ongrid. One command
-produces one artefact, ready to scp to any Linux box with docker + docker
-compose installed.
+produces one installation artefact; Compose runtime images are published and
+pulled separately from the project CNB registry.
 
 ## What `make package` produces
 
@@ -28,8 +28,9 @@ ongrid-v<VERSION>-linux-<arch>/
   .env.example
   prometheus/
     prometheus.yml       (from deploy/prometheus/)
-  images/
-    ongrid.tar           (docker save ongrid:<VERSION>)
+  bin/
+    ongrid               (systemd mode)
+    ongrid-frontier      (systemd mode)
   edge/
     ongrid-edge-linux-amd64
     ongrid-edge-linux-arm64
@@ -40,10 +41,10 @@ ongrid-v<VERSION>-linux-<arch>/
     ongrid-edge.service
 ```
 
-The cloud service ships as a docker image tarball (`images/ongrid.tar`);
-`install.sh` runs `docker load -i images/ongrid.tar` and then
-`docker compose up -d`. Edge agents ship as static binaries for four OS/arch
-combos so users can run them directly on heterogeneous hosts.
+Compose mode does not embed image tarballs. `install.sh` renders the production
+Compose model, pulls every exact image from `docker.cnb.cool/ongridio/ongrid`,
+then runs `docker compose up -d`. Systemd binaries and Edge agents remain in
+the architecture-specific package.
 
 ## Release flow
 
@@ -51,16 +52,17 @@ combos so users can run them directly on heterogeneous hosts.
    the change, then tag that commit with the same value:
    `git tag v0.1.1 && git push origin v0.1.1`.
 2. The `Release` GitHub Actions workflow runs on `v*.*.*` tag pushes and
-   publishes the multi-architecture Kubernetes Edge image and matching Helm
-   chart before building both server packages. The chart is published as an
+   publishes the multi-architecture manager, Web, and Kubernetes Edge images
+   plus the matching Helm chart before building both server packages. The chart is published as an
    OCI artifact at `oci://helm.cnb.cool/ongridio/ongrid-edge`; it is not copied
    into the manager installation tarball. Use
    `make package TARGET_ARCH=arm64` locally only when you need a single ARM64
    package. The release build will:
-   - `docker-push-k8s-edge` — publish the amd64/arm64 Edge image to CNB
+   - `docker-push-release-images` — publish manager, Web, and Edge amd64/arm64 images to CNB
+   - `verify-release-images` — verify both architectures exist on all three image manifests
    - `publish-k8s-chart` — package and publish the version-matched Helm chart
    - `build-edge-all`    — cross-compile ongrid-edge for 4 targets
-   - `docker-build`      — build `ongrid:<VERSION>` image for `linux/<arch>`
+   - `package`           — extract systemd binaries from the published CNB images
    - stage everything under `dist/stage/ongrid-<VERSION>-linux-<arch>/`
    - emit the amd64/arm64 tarballs + sha256 files under `dist/out/`
 3. Ship the matching package, for example:
@@ -75,7 +77,8 @@ Linux or `shasum -a 256 -c` on macOS.
 
 ## Local dry-run
 
-Test the tarball without shipping:
+Test the tarball without shipping after the matching manager image tag exists
+in CNB (or override `CLOUD_MANAGER_IMAGE_REF` when calling `make`):
 
 ```
 make package
@@ -100,5 +103,5 @@ ls -R
   `docker-compose.yml`. Owned by the install-agent.
 - `deploy/Dockerfile.*`, `deploy/docker-compose.yml` — build contexts and dev
   compose file.
-- Images are **never** pushed to a registry from this pipeline. The tarball
-  is the distribution channel.
+- Static third-party runtime images are mirrored out of band; this release
+  pipeline only pushes the project's manager, Web, and Edge images.

--- a/dist/package.sh
+++ b/dist/package.sh
@@ -14,6 +14,8 @@
 # Optional env:
 #   PACKAGE_TARGET  linux-amd64 (default) or linux-arm64
 #   DOCKER_PLATFORM linux/amd64 (default) or linux/arm64
+#   ONGRID_IMAGE_REF published manager image to extract for systemd mode
+#   FRONTIER_IMAGE_REF mirrored frontier image to extract for systemd mode
 #
 # The script is tolerant of missing deploy/install/* files: it warns and
 # continues so the pipeline is testable before the on-target scripts land.
@@ -69,7 +71,7 @@ die()  { printf '[pkg] error: %s\n' "$*" >&2; exit 1; }
 
 # --- docker presence check --------------------------------------------------
 if ! command -v docker >/dev/null 2>&1; then
-    die "docker not found in PATH — required to 'docker save' the ongrid image"
+    die "docker not found in PATH — required to extract systemd binaries from the published images"
 fi
 
 # --- xz presence check ------------------------------------------------------
@@ -82,7 +84,6 @@ fi
 log "target ${PACKAGE_TARGET} (${DOCKER_PLATFORM})"
 log "staging ${PKG_NAME} into ${STAGE_DIR}"
 mkdir -p "${STAGE_DIR}" \
-         "${STAGE_DIR}/images" \
          "${STAGE_DIR}/edge" \
          "${STAGE_DIR}/prometheus" \
          "${STAGE_DIR}/grafana/provisioning/datasources"
@@ -137,9 +138,8 @@ else
 fi
 
 # --- manager + frontier binaries (for --mode=systemd) -----------------------
-# Bundled separately from the docker image. We extract them after the
-# docker save step further down so we know the images are present —
-# search for "bin/ongrid" below.
+# Bundled separately from the Compose runtime. They are extracted from the
+# exact architecture of the already-published CNB images below.
 
 # --- nginx config + certs scaffold (ADR-008) --------------------------------
 # nginx.conf is bind-mounted into the nginx container at runtime; certs/ is
@@ -184,29 +184,23 @@ else
     warn "${REPO_ROOT}/deploy/install/searxng missing; skipping"
 fi
 
-# --- docker image tars ------------------------------------------------------
-IMAGE_REF="ongrid:${VERSION}"
-log "saving docker image ${IMAGE_REF} -> images/ongrid.tar"
-if ! docker image inspect "${IMAGE_REF}" >/dev/null 2>&1; then
-    die "docker image ${IMAGE_REF} not found; run 'make docker-build' first"
-fi
-docker save "${IMAGE_REF}" -o "${STAGE_DIR}/images/ongrid.tar"
-
-# Frontier broker is upstream singchia/frontier (ADR-007). Docker Hub
-# pull is unreliable in some networks, so we build it locally (see
-# Makefile target `docker-build-broker`) and ship the image tar.
-FRONTIER_VERSION="${FRONTIER_VERSION:-v1.2.4}"
-FRONTIER_REF="singchia/frontier:${FRONTIER_VERSION}"
-log "saving docker image ${FRONTIER_REF} -> images/frontier.tar"
-if ! docker image inspect "${FRONTIER_REF}" >/dev/null 2>&1; then
-    die "docker image ${FRONTIER_REF} not found; run 'make docker-build-broker' first"
-fi
-docker save "${FRONTIER_REF}" -o "${STAGE_DIR}/images/frontier.tar"
-
 # --- raw manager + frontier binaries (for systemd mode) ---------------------
 # install-systemd.sh installs these to /usr/local/bin/ when --mode=systemd.
-# Extract from the docker images we just saved so we don't drift from the
-# compose-mode artefact (single source of truth = the docker image).
+# Pull and extract from the release images so the systemd and Compose modes
+# use the same binaries without embedding image tarballs in the package.
+ONGRID_IMAGE_REF="${ONGRID_IMAGE_REF:-docker.cnb.cool/ongridio/ongrid:${VERSION}}"
+FRONTIER_IMAGE_REF="${FRONTIER_IMAGE_REF:-docker.cnb.cool/ongridio/ongrid/frontier:v1.2.4}"
+
+pull_image_for_platform() {
+    local image="$1"
+    log "pulling ${image} for ${DOCKER_PLATFORM}"
+    docker pull --platform "${DOCKER_PLATFORM}" "${image}" >/dev/null \
+        || die "could not pull ${image} for ${DOCKER_PLATFORM}"
+}
+
+pull_image_for_platform "${ONGRID_IMAGE_REF}"
+pull_image_for_platform "${FRONTIER_IMAGE_REF}"
+
 mkdir -p "${STAGE_DIR}/bin"
 extract_bin_from_image() {
     # extract_bin_from_image <image-ref> <dst> <candidate-path...>
@@ -235,9 +229,9 @@ extract_bin_from_image() {
     fi
     return $rc
 }
-extract_bin_from_image "${IMAGE_REF}"    "${STAGE_DIR}/bin/ongrid" \
+extract_bin_from_image "${ONGRID_IMAGE_REF}" "${STAGE_DIR}/bin/ongrid" \
     "/ongrid"
-extract_bin_from_image "${FRONTIER_REF}" "${STAGE_DIR}/bin/ongrid-frontier" \
+extract_bin_from_image "${FRONTIER_IMAGE_REF}" "${STAGE_DIR}/bin/ongrid-frontier" \
     "/usr/bin/frontier" "/usr/local/bin/frontier" "/frontier"
 
 # libonnxruntime.so for the local ONNX embedder (systemd mode). The ongrid
@@ -247,7 +241,7 @@ extract_bin_from_image "${FRONTIER_REF}" "${STAGE_DIR}/bin/ongrid-frontier" \
 # /usr/lib + symlinks + ldconfig. Keep ONNXRUNTIME_VERSION in lockstep with
 # deploy/Dockerfile.ongrid.
 ONNXRUNTIME_VERSION="${ONNXRUNTIME_VERSION:-1.20.1}"
-extract_bin_from_image "${IMAGE_REF}" \
+extract_bin_from_image "${ONGRID_IMAGE_REF}" \
     "${STAGE_DIR}/bin/libonnxruntime.so.${ONNXRUNTIME_VERSION}" \
     "/usr/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION}"
 
@@ -367,16 +361,6 @@ if [[ "$BUNDLE_EMB" == "1" ]]; then
         log "  + embeddings/fast-bge-small-zh-v1.5/ ($(du -sh "$EMB_CACHE_HOST" | awk '{print $1}'))"
     fi
 fi
-
-# Frontend + nginx image (ADR-008). Bakes web/dist/ + nginx.conf into the
-# image; nginx.conf and TLS certs are bind-mounted by docker-compose at
-# runtime so operators can edit them without rebuilding.
-WEB_REF="ongrid-web:${VERSION}"
-log "saving docker image ${WEB_REF} -> images/ongrid-web.tar"
-if ! docker image inspect "${WEB_REF}" >/dev/null 2>&1; then
-    die "docker image ${WEB_REF} not found; run 'make docker-build-web' first"
-fi
-docker save "${WEB_REF}" -o "${STAGE_DIR}/images/ongrid-web.tar"
 
 # --- edge binaries -----------------------------------------------------------
 # Edges are amd64-only in our deployments (the user's directive), so we ship a

--- a/scripts/verify-cnb-compose-images.sh
+++ b/scripts/verify-cnb-compose-images.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+render_images() {
+    local compose_file="$1" output="$2"
+    VERSION=v9.9.9 \
+    ONGRID_VERSION=v9.9.9 \
+    MYSQL_ROOT_PASSWORD=ci-root \
+    MYSQL_PASSWORD=ci-user \
+    ONGRID_JWT_SECRET=ci-jwt-secret \
+    GRAFANA_ADMIN_PASSWORD=ci-grafana \
+        docker compose -f "$compose_file" config --images | sort -u >"$output"
+}
+
+render_images "$repo_root/deploy/install/docker-compose.yml" "$tmp_dir/install.actual"
+cat >"$tmp_dir/install.expected" <<'EOF'
+docker.cnb.cool/ongridio/ongrid/ongrid-web:v9.9.9
+docker.cnb.cool/ongridio/ongrid:v9.9.9
+docker.cnb.cool/ongridio/ongrid/frontier:v1.2.4
+docker.cnb.cool/ongridio/ongrid/grafana-oss:11.1.4
+docker.cnb.cool/ongridio/ongrid/loki:3.4.0
+docker.cnb.cool/ongridio/ongrid/mysql:8.0
+docker.cnb.cool/ongridio/ongrid/prometheus:v2.54.0
+docker.cnb.cool/ongridio/ongrid/qdrant:v1.11.3
+docker.cnb.cool/ongridio/ongrid/searxng:latest
+docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
+EOF
+sort -o "$tmp_dir/install.expected" "$tmp_dir/install.expected"
+diff -u "$tmp_dir/install.expected" "$tmp_dir/install.actual"
+
+render_images "$repo_root/deploy/docker-compose.yml" "$tmp_dir/dev.actual"
+cat >"$tmp_dir/dev.expected" <<'EOF'
+docker.cnb.cool/ongridio/ongrid/frontier:v1.2.4
+docker.cnb.cool/ongridio/ongrid/grafana-oss:11.1.4
+docker.cnb.cool/ongridio/ongrid/loki:3.4.0
+docker.cnb.cool/ongridio/ongrid/mysql:8.0
+docker.cnb.cool/ongridio/ongrid/prometheus:v2.54.0
+docker.cnb.cool/ongridio/ongrid/qdrant:v1.11.3
+docker.cnb.cool/ongridio/ongrid/searxng:latest
+docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
+ongrid-web:v9.9.9
+ongrid:v9.9.9
+EOF
+sort -o "$tmp_dir/dev.expected" "$tmp_dir/dev.expected"
+diff -u "$tmp_dir/dev.expected" "$tmp_dir/dev.actual"
+
+printf 'verified CNB image routing for install and dev Compose files\n'


### PR DESCRIPTION
## Summary

- publish the manager, web, and edge multi-architecture images to `docker.cnb.cool` using the repository `VERSION`
- route Docker Compose runtime dependencies to the mirrored CNB images without republishing static dependencies
- update package, install, upgrade, uninstall, and documentation flows for CNB-hosted images
- add CI validation for rendered Compose image references

## Validation

- `make verify-compose-images`
- shell syntax checks for the modified install and packaging scripts
- release workflow YAML parsing and Make target dry runs
- remote manifest verification for the mirrored static dependencies on `linux/amd64` and `linux/arm64`
- `git diff --check origin/main...HEAD`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
