### PR TITLE
fix(k8s): preserve metrics beyond the sample limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,16 @@ jobs:
           expected_image="image: \"${image_ref}\""
           test "$(grep -F -c "$expected_image" /tmp/ongrid-edge.yaml)" -eq 3
           grep -q 'k8s-inventory-full-sync-interval: "10m"' /tmp/ongrid-edge.yaml
+          grep -q 'k8s-metrics-timeout: "15s"' /tmp/ongrid-edge.yaml
+          grep -q 'k8s-metrics-push-timeout: "30s"' /tmp/ongrid-edge.yaml
+          grep -q 'k8s-metrics-sample-limit: "250000"' /tmp/ongrid-edge.yaml
+          grep -q 'k8s-metrics-batch-sample-limit: "10000"' /tmp/ongrid-edge.yaml
+          grep -q 'k8s-metrics-batch-byte-limit: "4194304"' /tmp/ongrid-edge.yaml
+          grep -q 'name: ONGRID_K8S_METRICS_TIMEOUT' /tmp/ongrid-edge.yaml
+          grep -q 'name: ONGRID_K8S_METRICS_PUSH_TIMEOUT' /tmp/ongrid-edge.yaml
+          grep -q 'name: ONGRID_K8S_METRICS_SAMPLE_LIMIT' /tmp/ongrid-edge.yaml
+          grep -q 'name: ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT' /tmp/ongrid-edge.yaml
+          grep -q 'name: ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT' /tmp/ongrid-edge.yaml
           grep -q 'hostNetwork: true' /tmp/ongrid-edge.yaml
           grep -q 'name: install-host-runtime' /tmp/ongrid-edge.yaml
           grep -q -- '- install-k8s-host-runtime' /tmp/ongrid-edge.yaml

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -219,14 +219,18 @@ func main() {
 				*k8sInfo,
 				agent.EdgeID,
 				edgek8s.MetricsConfig{
-					Endpoint:        metricsEndpoint,
-					GatewayEndpoint: gatewayMetricsEndpoint,
-					Interval:        parseDurationEnv("ONGRID_K8S_METRICS_INTERVAL", 30*time.Second),
-					Timeout:         parseDurationEnv("ONGRID_K8S_METRICS_TIMEOUT", 5*time.Second),
-					SampleLimit:     parseIntEnv("ONGRID_K8S_METRICS_SAMPLE_LIMIT", 20000),
-					DiscoverApps:    appMetricsDiscovery,
+					Endpoint:         metricsEndpoint,
+					GatewayEndpoint:  gatewayMetricsEndpoint,
+					Interval:         parseDurationEnv("ONGRID_K8S_METRICS_INTERVAL", 30*time.Second),
+					Timeout:          parseDurationEnv("ONGRID_K8S_METRICS_TIMEOUT", 15*time.Second),
+					PushTimeout:      parseDurationEnv("ONGRID_K8S_METRICS_PUSH_TIMEOUT", 30*time.Second),
+					SampleLimit:      parseIntEnv("ONGRID_K8S_METRICS_SAMPLE_LIMIT", 250000),
+					BatchSampleLimit: parseIntEnv("ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT", 10000),
+					BatchByteLimit:   parseIntEnv("ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT", 4<<20),
+					DiscoverApps:     appMetricsDiscovery,
 				},
 				log.With(slog.String("comp", "k8s-metrics")),
+				edgek8s.WithMetricsRegisterer(reg),
 			)
 			if err != nil {
 				log.Warn("k8s metrics disabled", slog.Any("err", err))

--- a/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
@@ -20,6 +20,9 @@ data:
   k8s-inventory-full-sync-interval: {{ default "10m" $controllerInventory.fullSyncInterval | quote }}
   k8s-metrics-endpoint: {{ default "" $ksmEndpoint | quote }}
   k8s-metrics-interval: {{ default "30s" $controllerMetrics.interval | quote }}
-  k8s-metrics-timeout: {{ default "5s" $controllerMetrics.timeout | quote }}
-  k8s-metrics-sample-limit: {{ default 20000 $controllerMetrics.sampleLimit | quote }}
+  k8s-metrics-timeout: {{ default "15s" $controllerMetrics.timeout | quote }}
+  k8s-metrics-push-timeout: {{ default "30s" $controllerMetrics.pushTimeout | quote }}
+  k8s-metrics-sample-limit: {{ default 250000 $controllerMetrics.sampleLimit | int | quote }}
+  k8s-metrics-batch-sample-limit: {{ default 10000 $controllerMetrics.batchSampleLimit | int | quote }}
+  k8s-metrics-batch-byte-limit: {{ default 4194304 $controllerMetrics.batchByteLimit | int | quote }}
   k8s-app-metrics-discovery: {{ default false $appMetricsDiscovery.enabled | quote }}

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -132,11 +132,26 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ongrid-edge.fullname" . }}-config
                   key: k8s-metrics-timeout
+            - name: ONGRID_K8S_METRICS_PUSH_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-push-timeout
             - name: ONGRID_K8S_METRICS_SAMPLE_LIMIT
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "ongrid-edge.fullname" . }}-config
                   key: k8s-metrics-sample-limit
+            - name: ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-batch-sample-limit
+            - name: ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-batch-byte-limit
             {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -44,8 +44,15 @@ controller:
     enabled: false
     endpoint: ""
     interval: 30s
-    timeout: 5s
-    sampleLimit: 20000
+    timeout: 15s
+    # Maximum duration of each tunnel batch push. Every batch, including the
+    # final scrape-status batch, receives a fresh timeout.
+    pushTimeout: 30s
+    # Bound total work per target while sending tunnel requests in smaller,
+    # conservatively sized batches.
+    sampleLimit: 250000
+    batchSampleLimit: 10000
+    batchByteLimit: 4194304
     appDiscovery:
       enabled: false
   resources:

--- a/internal/edgeagent/k8s/metrics.go
+++ b/internal/edgeagent/k8s/metrics.go
@@ -14,33 +14,40 @@ import (
 )
 
 const (
-	defaultK8sMetricsInterval = 30 * time.Second
-	defaultK8sMetricsTimeout  = 5 * time.Second
-	defaultK8sMetricsLimit    = 20000
-	k8sMetricsSource          = "k8s:kube-state-metrics"
-	k8sAppMetricsSource       = "k8s:app-metrics"
-	k8sGatewayMetricsSource   = "k8s:otlp-gateway-metrics"
+	defaultK8sMetricsInterval         = 30 * time.Second
+	defaultK8sMetricsTimeout          = 15 * time.Second
+	defaultK8sMetricsPushTimeout      = 30 * time.Second
+	defaultK8sMetricsLimit            = 250000
+	defaultK8sMetricsBatchSampleLimit = 10000
+	defaultK8sMetricsBatchByteLimit   = 4 << 20
+	k8sMetricsSource                  = "k8s:kube-state-metrics"
+	k8sAppMetricsSource               = "k8s:app-metrics"
+	k8sGatewayMetricsSource           = "k8s:otlp-gateway-metrics"
 )
 
 type MetricsConfig struct {
-	Endpoint        string
-	GatewayEndpoint string
-	Interval        time.Duration
-	Timeout         time.Duration
-	SampleLimit     int
-	DiscoverApps    bool
+	Endpoint         string
+	GatewayEndpoint  string
+	Interval         time.Duration
+	Timeout          time.Duration
+	PushTimeout      time.Duration
+	SampleLimit      int
+	BatchSampleLimit int
+	BatchByteLimit   int
+	DiscoverApps     bool
 }
 
 type MetricsPusher struct {
-	client tunnel.Client
-	info   tunnel.KubernetesInfo
-	edgeID func() uint64
-	cfg    MetricsConfig
-	log    *slog.Logger
-	api    *apiClient
+	client  tunnel.Client
+	info    tunnel.KubernetesInfo
+	edgeID  func() uint64
+	cfg     MetricsConfig
+	log     *slog.Logger
+	api     *apiClient
+	metrics *metricsObserver
 }
 
-func NewMetricsPusher(client tunnel.Client, info tunnel.KubernetesInfo, edgeID func() uint64, cfg MetricsConfig, log *slog.Logger) (*MetricsPusher, error) {
+func NewMetricsPusher(client tunnel.Client, info tunnel.KubernetesInfo, edgeID func() uint64, cfg MetricsConfig, log *slog.Logger, opts ...MetricsPusherOption) (*MetricsPusher, error) {
 	if client == nil {
 		return nil, errors.New("k8s metrics: tunnel client is required")
 	}
@@ -79,8 +86,17 @@ func NewMetricsPusher(client tunnel.Client, info tunnel.KubernetesInfo, edgeID f
 	if cfg.Timeout > cfg.Interval {
 		cfg.Timeout = cfg.Interval
 	}
+	if cfg.PushTimeout <= 0 {
+		cfg.PushTimeout = defaultK8sMetricsPushTimeout
+	}
 	if cfg.SampleLimit <= 0 {
 		cfg.SampleLimit = defaultK8sMetricsLimit
+	}
+	if cfg.BatchSampleLimit <= 0 {
+		cfg.BatchSampleLimit = defaultK8sMetricsBatchSampleLimit
+	}
+	if cfg.BatchByteLimit <= 0 {
+		cfg.BatchByteLimit = defaultK8sMetricsBatchByteLimit
 	}
 	if edgeID == nil {
 		edgeID = func() uint64 { return 0 }
@@ -88,13 +104,24 @@ func NewMetricsPusher(client tunnel.Client, info tunnel.KubernetesInfo, edgeID f
 	if log == nil {
 		log = slog.Default()
 	}
+	var options metricsPusherOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	observer, err := newMetricsObserver(options.registerer)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricsPusher{
-		client: client,
-		info:   info,
-		edgeID: edgeID,
-		cfg:    cfg,
-		log:    log,
-		api:    api,
+		client:  client,
+		info:    info,
+		edgeID:  edgeID,
+		cfg:     cfg,
+		log:     log,
+		api:     api,
+		metrics: observer,
 	}, nil
 }
 
@@ -144,31 +171,120 @@ func (p *MetricsPusher) scrapeAndPush(ctx context.Context, edgeID uint64) {
 }
 
 func (p *MetricsPusher) scrapeTargetAndPush(ctx context.Context, edgeID uint64, target metricscommon.Target, plugin, source string) {
+	batchSampleLimit := p.cfg.BatchSampleLimit
+	if batchSampleLimit <= 0 {
+		batchSampleLimit = defaultK8sMetricsBatchSampleLimit
+	}
+	batchByteLimit := p.cfg.BatchByteLimit
+	if batchByteLimit <= 0 {
+		batchByteLimit = defaultK8sMetricsBatchByteLimit
+	}
+	pushTimeout := p.cfg.PushTimeout
+	if pushTimeout <= 0 {
+		pushTimeout = defaultK8sMetricsPushTimeout
+	}
+	batcher, err := newMetricsBatcher(edgeID, source, batchSampleLimit, batchByteLimit, func(samples []tunnel.PromSample) error {
+		return p.pushWithTimeout(ctx, edgeID, source, samples, pushTimeout)
+	})
+	if err != nil {
+		p.log.Error("k8s metrics batcher initialization failed", slog.Any("err", err))
+		return
+	}
 	rctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
 	defer cancel()
-	samples, err := metricscommon.Scrape(rctx, target)
+	stats, err := metricscommon.ScrapeIncremental(rctx, target, func(samples []tunnel.PromSample) error {
+		batcher.Add(samples...)
+		return nil
+	})
 	now := time.Now()
-	if err != nil {
-		up := metricscommon.ScrapeUpSample(now, plugin, target, false)
-		if pushErr := p.push(ctx, edgeID, source, []tunnel.PromSample{up}); pushErr != nil {
-			p.log.Warn("k8s metrics scrape up push failed", slog.Any("err", pushErr))
-		}
-		p.log.Warn("k8s metrics scrape failed", slog.String("endpoint", target.URL), slog.Any("err", err))
+	if !target.ReportScrapeStatus {
+		batcher.Add(metricscommon.ScrapeUpSample(now, plugin, target, err == nil))
+		batcher.Flush()
+		pushStats := batcher.Stats()
+		p.metrics.observeScrape(source, stats.Accepted, stats.LimitExceeded)
+		p.metrics.observePush(source, pushStats)
+		p.logScrapeOutcome(target, stats, pushStats, err)
 		return
 	}
-	samples = append(samples, metricscommon.ScrapeUpSample(now, plugin, target, true))
-	if err := p.push(ctx, edgeID, source, samples); err != nil {
-		p.log.Warn("k8s metrics push failed",
+
+	batcher.Flush()
+	dataStats := batcher.Stats()
+	p.metrics.observeScrape(source, stats.Accepted, stats.LimitExceeded)
+	p.metrics.observePush(source, dataStats)
+
+	partial := stats.LimitExceeded || dataStats.FailedBatches > 0 || dataStats.RejectedSamples > 0
+	if err != nil && stats.Accepted > 0 {
+		partial = true
+	}
+	statusSamples := scrapeStatusSamples(now, plugin, target, partial, dataStats.SuccessfulSamples, err == nil)
+	statusStats := p.pushStatus(ctx, edgeID, source, statusSamples, pushTimeout)
+	p.metrics.observePush(source, statusStats)
+
+	p.logScrapeOutcome(target, stats, dataStats, err)
+	if statusStats.FirstError != nil {
+		p.log.Warn("k8s metrics status push failed",
 			slog.String("endpoint", target.URL),
-			slog.Int("samples", len(samples)),
-			slog.Any("err", err),
+			slog.Any("err", statusStats.FirstError),
 		)
-		return
 	}
-	p.log.Debug("k8s metrics pushed",
-		slog.String("endpoint", target.URL),
-		slog.Int("samples", len(samples)),
-	)
+}
+
+func scrapeStatusSamples(now time.Time, plugin string, target metricscommon.Target, partial bool, accepted int, up bool) []tunnel.PromSample {
+	capacity := 1
+	if target.ReportScrapeStatus {
+		capacity += 2
+	}
+	samples := make([]tunnel.PromSample, 0, capacity)
+	if target.ReportScrapeStatus {
+		samples = append(samples, metricscommon.ScrapeStatusSamples(now, plugin, target, partial, accepted)...)
+	}
+	return append(samples, metricscommon.ScrapeUpSample(now, plugin, target, up))
+}
+
+func (p *MetricsPusher) pushStatus(ctx context.Context, edgeID uint64, source string, samples []tunnel.PromSample, timeout time.Duration) metricsBatchStats {
+	stats := metricsBatchStats{}
+	if err := p.pushWithTimeout(ctx, edgeID, source, samples, timeout); err != nil {
+		stats.FailedBatches = 1
+		stats.FailedSamples = len(samples)
+		stats.FirstError = err
+		return stats
+	}
+	stats.SuccessfulBatches = 1
+	stats.SuccessfulSamples = len(samples)
+	return stats
+}
+
+func (p *MetricsPusher) logScrapeOutcome(target metricscommon.Target, stats metricscommon.ScrapeStats, pushStats metricsBatchStats, scrapeErr error) {
+	if scrapeErr != nil {
+		p.log.Warn("k8s metrics scrape failed", slog.String("endpoint", target.URL), slog.Any("err", scrapeErr))
+	}
+	if stats.LimitExceeded {
+		p.log.Warn("k8s metrics sample limit exceeded; pushing bounded scrape",
+			slog.String("endpoint", target.URL),
+			slog.Int("observed_samples_at_least", stats.Observed),
+			slog.Int("sample_limit", target.SampleLimit),
+			slog.Int("accepted_samples", stats.Accepted),
+		)
+	}
+	if pushStats.FailedBatches > 0 || pushStats.RejectedSamples > 0 {
+		p.log.Warn("k8s metrics push partially failed",
+			slog.String("endpoint", target.URL),
+			slog.Int("successful_batches", pushStats.SuccessfulBatches),
+			slog.Int("failed_batches", pushStats.FailedBatches),
+			slog.Int("successful_samples", pushStats.SuccessfulSamples),
+			slog.Int("failed_samples", pushStats.FailedSamples),
+			slog.Int("rejected_samples", pushStats.RejectedSamples),
+			slog.Any("err", pushStats.FirstError),
+		)
+	}
+	if scrapeErr == nil && pushStats.FailedBatches == 0 && pushStats.RejectedSamples == 0 {
+		p.log.Debug("k8s metrics pushed",
+			slog.String("endpoint", target.URL),
+			slog.Int("observed_samples", stats.Observed),
+			slog.Int("pushed_samples", pushStats.SuccessfulSamples),
+			slog.Int("batches", pushStats.SuccessfulBatches),
+		)
+	}
 }
 
 func (p *MetricsPusher) discoverAndPushAppMetrics(ctx context.Context, edgeID uint64) {
@@ -192,8 +308,8 @@ func (p *MetricsPusher) discoverAndPushAppMetrics(ctx context.Context, edgeID ui
 	p.log.Debug("k8s app metrics discovery completed", slog.Int("targets", discovered))
 }
 
-func (p *MetricsPusher) push(ctx context.Context, edgeID uint64, source string, samples []tunnel.PromSample) error {
-	pctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+func (p *MetricsPusher) pushWithTimeout(ctx context.Context, edgeID uint64, source string, samples []tunnel.PromSample, timeout time.Duration) error {
+	pctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	var resp tunnel.PushPromSamplesResponse
 	if err := p.client.Call(pctx, tunnel.MethodPushPromSamples, tunnel.PushPromSamplesRequest{
@@ -203,20 +319,24 @@ func (p *MetricsPusher) push(ctx context.Context, edgeID uint64, source string, 
 	}, &resp); err != nil {
 		return fmt.Errorf("push_prom_samples: %w", err)
 	}
+	if resp.Accepted != len(samples) {
+		return fmt.Errorf("push_prom_samples: accepted %d of %d samples", resp.Accepted, len(samples))
+	}
 	return nil
 }
 
 func (p *MetricsPusher) kubeStateMetricsTarget() metricscommon.Target {
 	return metricscommon.Target{
-		ID:          "kube-state-metrics",
-		Name:        "kube-state-metrics",
-		URL:         p.cfg.Endpoint,
-		Enabled:     true,
-		Interval:    p.cfg.Interval,
-		Timeout:     p.cfg.Timeout,
-		SourceLabel: k8sMetricsSource,
-		SampleLimit: p.cfg.SampleLimit,
-		Kind:        "kubernetes",
+		ID:                 "kube-state-metrics",
+		Name:               "kube-state-metrics",
+		URL:                p.cfg.Endpoint,
+		Enabled:            true,
+		Interval:           p.cfg.Interval,
+		Timeout:            p.cfg.Timeout,
+		SourceLabel:        k8sMetricsSource,
+		SampleLimit:        p.cfg.SampleLimit,
+		Kind:               "kubernetes",
+		ReportScrapeStatus: true,
 		LabelDrop: []string{
 			"uid",
 			"pod_uid",
@@ -231,15 +351,16 @@ func (p *MetricsPusher) kubeStateMetricsTarget() metricscommon.Target {
 
 func (p *MetricsPusher) gatewayMetricsTarget() metricscommon.Target {
 	return metricscommon.Target{
-		ID:          "telemetry-gateway",
-		Name:        "telemetry-gateway",
-		URL:         p.cfg.GatewayEndpoint,
-		Enabled:     true,
-		Interval:    p.cfg.Interval,
-		Timeout:     p.cfg.Timeout,
-		SourceLabel: k8sGatewayMetricsSource,
-		SampleLimit: p.cfg.SampleLimit,
-		Kind:        "kubernetes-telemetry-gateway",
+		ID:                 "telemetry-gateway",
+		Name:               "telemetry-gateway",
+		URL:                p.cfg.GatewayEndpoint,
+		Enabled:            true,
+		Interval:           p.cfg.Interval,
+		Timeout:            p.cfg.Timeout,
+		SourceLabel:        k8sGatewayMetricsSource,
+		SampleLimit:        p.cfg.SampleLimit,
+		Kind:               "kubernetes-telemetry-gateway",
+		ReportScrapeStatus: true,
 		LabelDrop: []string{
 			"uid",
 			"pod_uid",

--- a/internal/edgeagent/k8s/metrics_batch.go
+++ b/internal/edgeagent/k8s/metrics_batch.go
@@ -1,0 +1,119 @@
+package k8s
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+type metricsBatchStats struct {
+	SuccessfulBatches int
+	FailedBatches     int
+	SuccessfulSamples int
+	FailedSamples     int
+	RejectedSamples   int
+	FirstError        error
+}
+
+type metricsBatcher struct {
+	maxSamples       int
+	maxBytes         int
+	baseEncodedBytes int
+	encodedBytes     int
+	samples          []tunnel.PromSample
+	push             func([]tunnel.PromSample) error
+	stats            metricsBatchStats
+}
+
+func newMetricsBatcher(edgeID uint64, source string, maxSamples, maxBytes int, push func([]tunnel.PromSample) error) (*metricsBatcher, error) {
+	if maxSamples <= 0 {
+		return nil, fmt.Errorf("batch sample limit must be positive")
+	}
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("batch byte limit must be positive")
+	}
+	if push == nil {
+		return nil, fmt.Errorf("batch push function is required")
+	}
+	empty, err := json.Marshal(tunnel.PushPromSamplesRequest{
+		EdgeID:  edgeID,
+		Source:  source,
+		Samples: []tunnel.PromSample{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal empty batch: %w", err)
+	}
+	// The empty array brackets remain in the populated request; each sample
+	// adds its encoded size and subsequent samples add one comma separator.
+	baseBytes := len(empty)
+	if baseBytes >= maxBytes {
+		return nil, fmt.Errorf("batch byte limit %d is smaller than request metadata %d", maxBytes, baseBytes)
+	}
+	return &metricsBatcher{
+		maxSamples:       maxSamples,
+		maxBytes:         maxBytes,
+		baseEncodedBytes: baseBytes,
+		encodedBytes:     baseBytes,
+		samples:          make([]tunnel.PromSample, 0, min(maxSamples, 1024)),
+		push:             push,
+	}, nil
+}
+
+func (b *metricsBatcher) Add(samples ...tunnel.PromSample) {
+	for _, sample := range samples {
+		encoded, err := json.Marshal(sample)
+		if err != nil {
+			b.rejectSample(fmt.Errorf("marshal sample %q: %w", sample.Name, err))
+			continue
+		}
+		separatorBytes := 0
+		if len(b.samples) > 0 {
+			separatorBytes = 1
+		}
+		nextBytes := b.encodedBytes + separatorBytes + len(encoded)
+		if len(b.samples) >= b.maxSamples || nextBytes > b.maxBytes {
+			b.Flush()
+			separatorBytes = 0
+			nextBytes = b.encodedBytes + len(encoded)
+		}
+		if nextBytes > b.maxBytes {
+			b.rejectSample(fmt.Errorf("encoded sample %q is %d bytes and exceeds batch byte limit %d", sample.Name, len(encoded), b.maxBytes))
+			continue
+		}
+		b.samples = append(b.samples, sample)
+		b.encodedBytes = nextBytes
+	}
+}
+
+func (b *metricsBatcher) Flush() {
+	if len(b.samples) == 0 {
+		return
+	}
+	count := len(b.samples)
+	batch := append([]tunnel.PromSample(nil), b.samples...)
+	if err := b.push(batch); err != nil {
+		b.stats.FailedBatches++
+		b.stats.FailedSamples += count
+		if b.stats.FirstError == nil {
+			b.stats.FirstError = err
+		}
+	} else {
+		b.stats.SuccessfulBatches++
+		b.stats.SuccessfulSamples += count
+	}
+	clear(b.samples)
+	b.samples = b.samples[:0]
+	b.encodedBytes = b.baseEncodedBytes
+}
+
+func (b *metricsBatcher) Stats() metricsBatchStats {
+	return b.stats
+}
+
+func (b *metricsBatcher) rejectSample(err error) {
+	b.stats.RejectedSamples++
+	if b.stats.FirstError == nil {
+		b.stats.FirstError = err
+	}
+}

--- a/internal/edgeagent/k8s/metrics_batch_test.go
+++ b/internal/edgeagent/k8s/metrics_batch_test.go
@@ -1,0 +1,121 @@
+package k8s
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+func TestMetricsBatcherHonorsSampleLimitAndContinuesAfterFailure(t *testing.T) {
+	var batches [][]tunnel.PromSample
+	batcher, err := newMetricsBatcher(41, k8sMetricsSource, 2, 1<<20, func(samples []tunnel.PromSample) error {
+		batches = append(batches, samples)
+		if len(batches) == 2 {
+			return errors.New("temporary push failure")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newMetricsBatcher() error = %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		batcher.Add(tunnel.PromSample{Name: "kube_pod_info", Value: float64(i), TsMs: 1})
+	}
+	batcher.Flush()
+
+	if len(batches) != 3 {
+		t.Fatalf("batches = %d, want 3", len(batches))
+	}
+	for i, batch := range batches {
+		if len(batch) > 2 {
+			t.Fatalf("batch %d has %d samples, want at most 2", i, len(batch))
+		}
+	}
+	stats := batcher.Stats()
+	if stats.SuccessfulBatches != 2 || stats.FailedBatches != 1 {
+		t.Fatalf("batch stats = %#v, want 2 successful and 1 failed", stats)
+	}
+	if stats.SuccessfulSamples != 3 || stats.FailedSamples != 2 {
+		t.Fatalf("sample stats = %#v, want 3 successful and 2 failed", stats)
+	}
+}
+
+func TestMetricsBatcherHonorsEncodedByteLimit(t *testing.T) {
+	sample := tunnel.PromSample{
+		Name:   "kube_pod_labels",
+		Labels: map[string]string{"namespace": "default", "pod": "api-1"},
+		Value:  1,
+		TsMs:   1,
+	}
+	oneSampleRequest, err := json.Marshal(tunnel.PushPromSamplesRequest{
+		EdgeID:  41,
+		Source:  k8sMetricsSource,
+		Samples: []tunnel.PromSample{sample},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	maxBytes := len(oneSampleRequest)
+	var encodedSizes []int
+	batcher, err := newMetricsBatcher(41, k8sMetricsSource, 100, maxBytes, func(samples []tunnel.PromSample) error {
+		payload, marshalErr := json.Marshal(tunnel.PushPromSamplesRequest{
+			EdgeID:  41,
+			Source:  k8sMetricsSource,
+			Samples: samples,
+		})
+		if marshalErr != nil {
+			return marshalErr
+		}
+		encodedSizes = append(encodedSizes, len(payload))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newMetricsBatcher() error = %v", err)
+	}
+	batcher.Add(sample, sample, sample)
+	batcher.Flush()
+
+	if len(encodedSizes) != 3 {
+		t.Fatalf("encoded batches = %d, want 3", len(encodedSizes))
+	}
+	for i, size := range encodedSizes {
+		if size > maxBytes {
+			t.Fatalf("batch %d encoded size = %d, exceeds %d", i, size, maxBytes)
+		}
+	}
+}
+
+func TestMetricsBatcherHandlesDefaultLargeClusterLimit(t *testing.T) {
+	var batches, samples int
+	batcher, err := newMetricsBatcher(41, k8sMetricsSource, defaultK8sMetricsBatchSampleLimit, defaultK8sMetricsBatchByteLimit, func(batch []tunnel.PromSample) error {
+		batches++
+		samples += len(batch)
+		if len(batch) > defaultK8sMetricsBatchSampleLimit {
+			t.Fatalf("batch samples = %d, exceeds %d", len(batch), defaultK8sMetricsBatchSampleLimit)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newMetricsBatcher() error = %v", err)
+	}
+	sample := tunnel.PromSample{
+		Name:   "kube_pod_info",
+		Labels: map[string]string{"namespace": "default", "pod": "api"},
+		Value:  1,
+		TsMs:   1,
+	}
+	for i := 0; i < defaultK8sMetricsLimit; i++ {
+		batcher.Add(sample)
+	}
+	batcher.Flush()
+
+	wantBatches := defaultK8sMetricsLimit / defaultK8sMetricsBatchSampleLimit
+	if batches != wantBatches {
+		t.Fatalf("batches = %d, want %d", batches, wantBatches)
+	}
+	if samples != defaultK8sMetricsLimit {
+		t.Fatalf("samples = %d, want %d", samples, defaultK8sMetricsLimit)
+	}
+}

--- a/internal/edgeagent/k8s/metrics_observer.go
+++ b/internal/edgeagent/k8s/metrics_observer.go
@@ -1,0 +1,90 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsResultSuccess  = "success"
+	metricsResultFailure  = "failure"
+	metricsResultRejected = "rejected"
+)
+
+type metricsObserver struct {
+	scrapeSamples       *prometheus.CounterVec
+	scrapeLimitExceeded *prometheus.CounterVec
+	pushBatches         *prometheus.CounterVec
+	pushSamples         *prometheus.CounterVec
+}
+
+type metricsPusherOptions struct {
+	registerer prometheus.Registerer
+}
+
+// MetricsPusherOption configures optional process-local instrumentation.
+type MetricsPusherOption func(*metricsPusherOptions)
+
+// WithMetricsRegisterer exports K8s scrape and push counters on the edge
+// process registry. The counters use only the bounded source/result labels.
+func WithMetricsRegisterer(reg prometheus.Registerer) MetricsPusherOption {
+	return func(options *metricsPusherOptions) {
+		options.registerer = reg
+	}
+}
+
+func newMetricsObserver(reg prometheus.Registerer) (*metricsObserver, error) {
+	observer := &metricsObserver{}
+	if reg == nil {
+		return observer, nil
+	}
+	observer.scrapeSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ongrid_edge_k8s_metrics_scrape_samples_total",
+		Help: "Kubernetes metrics samples admitted by the edge streaming scraper.",
+	}, []string{"source"})
+	observer.scrapeLimitExceeded = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ongrid_edge_k8s_metrics_scrape_limit_exceeded_total",
+		Help: "Kubernetes metrics scrapes stopped after exceeding the configured sample limit.",
+	}, []string{"source"})
+	observer.pushBatches = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ongrid_edge_k8s_metrics_push_batches_total",
+		Help: "Kubernetes metrics batches sent through the edge tunnel, partitioned by result.",
+	}, []string{"source", "result"})
+	observer.pushSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ongrid_edge_k8s_metrics_push_samples_total",
+		Help: "Kubernetes metrics samples sent through the edge tunnel, partitioned by result.",
+	}, []string{"source", "result"})
+	for _, collector := range []prometheus.Collector{
+		observer.scrapeSamples,
+		observer.scrapeLimitExceeded,
+		observer.pushBatches,
+		observer.pushSamples,
+	} {
+		if err := reg.Register(collector); err != nil {
+			return nil, fmt.Errorf("register k8s metrics observer: %w", err)
+		}
+	}
+	return observer, nil
+}
+
+func (o *metricsObserver) observeScrape(source string, accepted int, limitExceeded bool) {
+	if o == nil || o.scrapeSamples == nil || o.scrapeLimitExceeded == nil {
+		return
+	}
+	o.scrapeSamples.WithLabelValues(source).Add(float64(accepted))
+	if limitExceeded {
+		o.scrapeLimitExceeded.WithLabelValues(source).Inc()
+	}
+}
+
+func (o *metricsObserver) observePush(source string, stats metricsBatchStats) {
+	if o == nil || o.pushBatches == nil || o.pushSamples == nil {
+		return
+	}
+	o.pushBatches.WithLabelValues(source, metricsResultSuccess).Add(float64(stats.SuccessfulBatches))
+	o.pushBatches.WithLabelValues(source, metricsResultFailure).Add(float64(stats.FailedBatches))
+	o.pushSamples.WithLabelValues(source, metricsResultSuccess).Add(float64(stats.SuccessfulSamples))
+	o.pushSamples.WithLabelValues(source, metricsResultFailure).Add(float64(stats.FailedSamples))
+	o.pushSamples.WithLabelValues(source, metricsResultRejected).Add(float64(stats.RejectedSamples))
+}

--- a/internal/edgeagent/k8s/metrics_test.go
+++ b/internal/edgeagent/k8s/metrics_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/ongridio/ongrid/internal/edgeagent/plugins/metricscommon"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestMetricsPusherScrapesAndPushesKubeStateMetrics(t *testing.T) {
@@ -41,19 +44,10 @@ kube_pod_status_phase{namespace="default",pod="api-1",phase="Running",uid="drop-
 	if fc.lastMethod != tunnel.MethodPushPromSamples {
 		t.Fatalf("lastMethod = %q, want %q", fc.lastMethod, tunnel.MethodPushPromSamples)
 	}
-	req, ok := fc.lastRequest.(tunnel.PushPromSamplesRequest)
+	samples := pushedSamplesForSource(t, fc.requests, 41, k8sMetricsSource)
+	podSample, ok := findSample(samples, "kube_pod_status_phase")
 	if !ok {
-		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", fc.lastRequest)
-	}
-	if req.EdgeID != 41 {
-		t.Fatalf("EdgeID = %d, want 41", req.EdgeID)
-	}
-	if req.Source != k8sMetricsSource {
-		t.Fatalf("Source = %q, want %q", req.Source, k8sMetricsSource)
-	}
-	podSample, ok := findSample(req.Samples, "kube_pod_status_phase")
-	if !ok {
-		t.Fatalf("kube_pod_status_phase sample missing: %#v", req.Samples)
+		t.Fatalf("kube_pod_status_phase sample missing: %#v", samples)
 	}
 	if podSample.Labels["namespace"] != "default" || podSample.Labels["pod"] != "api-1" || podSample.Labels["phase"] != "Running" {
 		t.Fatalf("pod labels missing: %#v", podSample.Labels)
@@ -64,15 +58,23 @@ kube_pod_status_phase{namespace="default",pod="api-1",phase="Running",uid="drop-
 	if _, ok := podSample.Labels["pod_uid"]; ok {
 		t.Fatalf("pod_uid label should be dropped: %#v", podSample.Labels)
 	}
-	up, ok := findSample(req.Samples, metricscommon.ScrapeUpMetricName)
+	up, ok := findSample(samples, metricscommon.ScrapeUpMetricName)
 	if !ok {
-		t.Fatalf("up sample missing: %#v", req.Samples)
+		t.Fatalf("up sample missing: %#v", samples)
 	}
 	if up.Value != 1 {
 		t.Fatalf("up = %v, want 1", up.Value)
 	}
 	if up.Labels["plugin"] != "k8s" || up.Labels["target_id"] != "kube-state-metrics" {
 		t.Fatalf("up labels missing: %#v", up.Labels)
+	}
+	partial, ok := findSample(samples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 0 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=0", partial, ok)
+	}
+	accepted, ok := findSample(samples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != 1 {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=1", accepted, ok)
 	}
 }
 
@@ -99,16 +101,10 @@ ongrid_gateway_metric_smoke_total{service_name="api",pod_uid="drop-me",instance=
 	}
 
 	pusher.scrapeAndPush(context.Background(), 41)
-	req, ok := fc.lastRequest.(tunnel.PushPromSamplesRequest)
+	samples := pushedSamplesForSource(t, fc.requests, 41, k8sGatewayMetricsSource)
+	sample, ok := findSample(samples, "ongrid_gateway_metric_smoke_total")
 	if !ok {
-		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", fc.lastRequest)
-	}
-	if req.Source != k8sGatewayMetricsSource {
-		t.Fatalf("Source = %q, want %q", req.Source, k8sGatewayMetricsSource)
-	}
-	sample, ok := findSample(req.Samples, "ongrid_gateway_metric_smoke_total")
-	if !ok {
-		t.Fatalf("ongrid_gateway_metric_smoke_total sample missing: %#v", req.Samples)
+		t.Fatalf("ongrid_gateway_metric_smoke_total sample missing: %#v", samples)
 	}
 	if sample.Labels["service_name"] != "api" {
 		t.Fatalf("service label missing: %#v", sample.Labels)
@@ -119,9 +115,9 @@ ongrid_gateway_metric_smoke_total{service_name="api",pod_uid="drop-me",instance=
 	if _, ok := sample.Labels["instance"]; ok {
 		t.Fatalf("instance label should be dropped: %#v", sample.Labels)
 	}
-	up, ok := findSample(req.Samples, metricscommon.ScrapeUpMetricName)
+	up, ok := findSample(samples, metricscommon.ScrapeUpMetricName)
 	if !ok {
-		t.Fatalf("up sample missing: %#v", req.Samples)
+		t.Fatalf("up sample missing: %#v", samples)
 	}
 	if up.Value != 1 || up.Labels["plugin"] != "k8s_otlp_gateway" || up.Labels["kind"] != "kubernetes-telemetry-gateway" {
 		t.Fatalf("unexpected up sample: %#v", up)
@@ -149,11 +145,312 @@ func TestMetricsPusherPushesDownSampleOnScrapeFailure(t *testing.T) {
 	if !ok {
 		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", fc.lastRequest)
 	}
-	if len(req.Samples) != 1 {
-		t.Fatalf("samples len = %d, want 1", len(req.Samples))
+	if len(req.Samples) != 3 {
+		t.Fatalf("samples len = %d, want partial, accepted, and up status", len(req.Samples))
 	}
-	if req.Samples[0].Name != metricscommon.ScrapeUpMetricName || req.Samples[0].Value != 0 {
-		t.Fatalf("sample = %#v, want up=0", req.Samples[0])
+	up, ok := findSample(req.Samples, metricscommon.ScrapeUpMetricName)
+	if !ok || up.Value != 0 {
+		t.Fatalf("up sample = %#v, found=%t; want up=0", up, ok)
+	}
+	partial, ok := findSample(req.Samples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 0 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=0", partial, ok)
+	}
+	accepted, ok := findSample(req.Samples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != 0 {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=0", accepted, ok)
+	}
+}
+
+func TestMetricsPusherPushesBoundedSamplesWhenSampleLimitExceeded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte(`
+# HELP kube_pod_info Kubernetes pod information.
+# TYPE kube_pod_info gauge
+kube_pod_info{namespace="default",pod="api-1"} 1
+kube_pod_info{namespace="default",pod="api-2"} 1
+kube_pod_info{namespace="default",pod="api-3"} 1
+`)); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	fc := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	pusher, err := NewMetricsPusher(fc, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint:    srv.URL,
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		SampleLimit: 2,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	samples := pushedSamplesForSource(t, fc.requests, 41, k8sMetricsSource)
+	if len(samples) != 5 {
+		t.Fatalf("samples len = %d, want 2 bounded samples plus 3 status samples", len(samples))
+	}
+	pods := make(map[string]struct{})
+	for _, sample := range samples {
+		if sample.Name == "kube_pod_info" {
+			pods[sample.Labels["pod"]] = struct{}{}
+		}
+	}
+	if len(pods) != 2 {
+		t.Fatalf("bounded pod samples = %#v, want 2", pods)
+	}
+	if _, ok := pods["api-3"]; ok {
+		t.Fatalf("sample beyond limit was pushed: %#v", pods)
+	}
+	up, ok := findSample(samples, metricscommon.ScrapeUpMetricName)
+	if !ok || up.Value != 1 {
+		t.Fatalf("up sample = %#v, found=%t; want up=1", up, ok)
+	}
+	partial, ok := findSample(samples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 1 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=1", partial, ok)
+	}
+	accepted, ok := findSample(samples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != 2 {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=2", accepted, ok)
+	}
+}
+
+func TestMetricsPusherBatchesBoundedScrapeAndExportsCounters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte(`# TYPE kube_pod_info gauge
+kube_pod_info{pod="api-1"} 1
+kube_pod_info{pod="api-2"} 1
+kube_pod_info{pod="api-3"} 1
+kube_pod_info{pod="api-4"} 1
+kube_pod_info{pod="api-5"} 1
+`)); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewRegistry()
+	fc := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	pusher, err := NewMetricsPusher(fc, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint:         srv.URL,
+		Interval:         time.Second,
+		Timeout:          time.Second,
+		SampleLimit:      4,
+		BatchSampleLimit: 2,
+		BatchByteLimit:   1 << 20,
+	}, nil, WithMetricsRegisterer(reg))
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	if len(fc.requests) != 3 {
+		t.Fatalf("push requests = %d, want 2 data batches and 1 status batch", len(fc.requests))
+	}
+	var pushed int
+	for i, raw := range fc.requests {
+		req, ok := raw.(tunnel.PushPromSamplesRequest)
+		if !ok {
+			t.Fatalf("request %d = %T, want PushPromSamplesRequest", i, raw)
+		}
+		if i < 2 && len(req.Samples) > 2 {
+			t.Fatalf("request %d samples = %d, want at most 2", i, len(req.Samples))
+		}
+		pushed += len(req.Samples)
+	}
+	if pushed != 7 {
+		t.Fatalf("pushed samples = %d, want 4 metrics plus 3 status samples", pushed)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.scrapeSamples.WithLabelValues(k8sMetricsSource)); got != 4 {
+		t.Fatalf("accepted counter = %v, want 4", got)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.scrapeLimitExceeded.WithLabelValues(k8sMetricsSource)); got != 1 {
+		t.Fatalf("limit exceeded counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.pushBatches.WithLabelValues(k8sMetricsSource, metricsResultSuccess)); got != 3 {
+		t.Fatalf("successful batch counter = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.pushSamples.WithLabelValues(k8sMetricsSource, metricsResultSuccess)); got != 7 {
+		t.Fatalf("successful sample counter = %v, want 7", got)
+	}
+}
+
+func TestMetricsPusherReportsPartialWhenMiddleDataBatchFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte(`kube_pod_info{pod="api-1"} 1
+kube_pod_info{pod="api-2"} 1
+kube_pod_info{pod="api-3"} 1
+kube_pod_info{pod="api-4"} 1
+`)); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewRegistry()
+	baseClient := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	client := &failNthPushClient{fakeTunnelClient: baseClient, failAt: 2}
+	pusher, err := NewMetricsPusher(client, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint:         srv.URL,
+		Interval:         time.Second,
+		Timeout:          time.Second,
+		PushTimeout:      time.Second,
+		SampleLimit:      20,
+		BatchSampleLimit: 2,
+		BatchByteLimit:   1 << 20,
+	}, nil, WithMetricsRegisterer(reg))
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	if len(baseClient.requests) != 3 {
+		t.Fatalf("push requests = %d, want 2 data batches and 1 status batch", len(baseClient.requests))
+	}
+	statusReq, ok := baseClient.lastRequest.(tunnel.PushPromSamplesRequest)
+	if !ok {
+		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", baseClient.lastRequest)
+	}
+	partial, ok := findSample(statusReq.Samples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 1 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=1", partial, ok)
+	}
+	accepted, ok := findSample(statusReq.Samples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != 2 {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=2", accepted, ok)
+	}
+	up, ok := findSample(statusReq.Samples, metricscommon.ScrapeUpMetricName)
+	if !ok || up.Value != 1 {
+		t.Fatalf("up sample = %#v, found=%t; want scrape up=1", up, ok)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.pushBatches.WithLabelValues(k8sMetricsSource, metricsResultFailure)); got != 1 {
+		t.Fatalf("failed batch counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(pusher.metrics.pushSamples.WithLabelValues(k8sMetricsSource, metricsResultFailure)); got != 2 {
+		t.Fatalf("failed sample counter = %v, want 2", got)
+	}
+}
+
+func TestMetricsPusherHandlesDefaultLargeClusterLimitEndToEnd(t *testing.T) {
+	const sampleLimit = defaultK8sMetricsLimit
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		writer := bufio.NewWriterSize(w, 64<<10)
+		for i := 0; i <= sampleLimit; i++ {
+			if _, err := writer.WriteString("kube_pod_info{namespace=\"default\",pod=\"api\"} 1\n"); err != nil {
+				return
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := &countingPromClient{fakeTunnelClient: &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}}
+	pusher, err := NewMetricsPusher(client, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint: srv.URL,
+		Interval: 30 * time.Second,
+		Timeout:  15 * time.Second,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	if client.dataSamples != sampleLimit {
+		t.Fatalf("data samples = %d, want %d", client.dataSamples, sampleLimit)
+	}
+	if client.maxDataBatch > defaultK8sMetricsBatchSampleLimit {
+		t.Fatalf("max data batch = %d, exceeds %d", client.maxDataBatch, defaultK8sMetricsBatchSampleLimit)
+	}
+	if client.dataBatches != sampleLimit/defaultK8sMetricsBatchSampleLimit {
+		t.Fatalf("data batches = %d, want %d", client.dataBatches, sampleLimit/defaultK8sMetricsBatchSampleLimit)
+	}
+	partial, ok := findSample(client.statusSamples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 1 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=1", partial, ok)
+	}
+	accepted, ok := findSample(client.statusSamples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != sampleLimit {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=%d", accepted, ok, sampleLimit)
+	}
+	up, ok := findSample(client.statusSamples, metricscommon.ScrapeUpMetricName)
+	if !ok || up.Value != 1 {
+		t.Fatalf("up sample = %#v, found=%t; want up=1", up, ok)
+	}
+}
+
+func TestMetricsPusherStartsPushTimeoutAfterScrapeProducesData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte("kube_pod_info 1\n")); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	baseClient := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	client := &contextAwareTunnelClient{fakeTunnelClient: baseClient}
+	pusher, err := NewMetricsPusher(client, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint:    srv.URL,
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		PushTimeout: 50 * time.Millisecond,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	if baseClient.lastMethod != tunnel.MethodPushPromSamples {
+		t.Fatalf("lastMethod = %q, want %q", baseClient.lastMethod, tunnel.MethodPushPromSamples)
+	}
+}
+
+func TestMetricsPusherUsesFreshTimeoutForStatusAfterDataTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte("kube_pod_info 1\n")); err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	baseClient := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	client := &timeoutFirstPushClient{fakeTunnelClient: baseClient}
+	pusher, err := NewMetricsPusher(client, tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, func() uint64 { return 41 }, MetricsConfig{
+		Endpoint:    srv.URL,
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		PushTimeout: 20 * time.Millisecond,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsPusher() error = %v", err)
+	}
+
+	pusher.scrapeAndPush(context.Background(), 41)
+	if client.calls != 2 {
+		t.Fatalf("push calls = %d, want timed-out data batch and fresh status batch", client.calls)
+	}
+	statusReq, ok := baseClient.lastRequest.(tunnel.PushPromSamplesRequest)
+	if !ok {
+		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", baseClient.lastRequest)
+	}
+	partial, ok := findSample(statusReq.Samples, metricscommon.ScrapePartialMetricName)
+	if !ok || partial.Value != 1 {
+		t.Fatalf("partial sample = %#v, found=%t; want partial=1", partial, ok)
+	}
+	accepted, ok := findSample(statusReq.Samples, metricscommon.ScrapeAcceptedSamplesMetricName)
+	if !ok || accepted.Value != 0 {
+		t.Fatalf("accepted sample = %#v, found=%t; want accepted=0", accepted, ok)
 	}
 }
 
@@ -224,16 +521,13 @@ demo_requests_total{instance="pod-ip",pod_uid="drop-me"} 3
 	if metricsHits != 1 {
 		t.Fatalf("metricsHits = %d, want 1", metricsHits)
 	}
-	req, ok := fc.lastRequest.(tunnel.PushPromSamplesRequest)
-	if !ok {
-		t.Fatalf("lastRequest = %T, want PushPromSamplesRequest", fc.lastRequest)
+	if len(fc.requests) != 1 {
+		t.Fatalf("app metric push requests = %d, want data and up in one batch", len(fc.requests))
 	}
-	if req.Source != k8sAppMetricsSource {
-		t.Fatalf("Source = %q, want %q", req.Source, k8sAppMetricsSource)
-	}
-	sample, ok := findSample(req.Samples, "demo_requests_total")
+	samples := pushedSamplesForSource(t, fc.requests, 41, k8sAppMetricsSource)
+	sample, ok := findSample(samples, "demo_requests_total")
 	if !ok {
-		t.Fatalf("demo_requests_total sample missing: %#v", req.Samples)
+		t.Fatalf("demo_requests_total sample missing: %#v", samples)
 	}
 	if sample.Labels["namespace"] != "default" || sample.Labels["pod"] != "api-1" || sample.Labels["node"] != "node-a" {
 		t.Fatalf("k8s labels missing: %#v", sample.Labels)
@@ -247,13 +541,37 @@ demo_requests_total{instance="pod-ip",pod_uid="drop-me"} 3
 	if _, ok := sample.Labels["instance"]; ok {
 		t.Fatalf("instance label should be dropped: %#v", sample.Labels)
 	}
-	up, ok := findSample(req.Samples, metricscommon.ScrapeUpMetricName)
+	up, ok := findSample(samples, metricscommon.ScrapeUpMetricName)
 	if !ok {
-		t.Fatalf("up sample missing: %#v", req.Samples)
+		t.Fatalf("up sample missing: %#v", samples)
 	}
 	if up.Value != 1 || up.Labels["plugin"] != "k8s_app" || up.Labels["kind"] != "kubernetes-app" {
 		t.Fatalf("unexpected up sample: %#v", up)
 	}
+	for _, name := range []string{metricscommon.ScrapePartialMetricName, metricscommon.ScrapeAcceptedSamplesMetricName} {
+		if _, exists := findSample(samples, name); exists {
+			t.Fatalf("high-cardinality app target must not emit %q: %#v", name, samples)
+		}
+	}
+}
+
+func pushedSamplesForSource(t *testing.T, requests []any, edgeID uint64, source string) []tunnel.PromSample {
+	t.Helper()
+	var samples []tunnel.PromSample
+	for i, raw := range requests {
+		req, ok := raw.(tunnel.PushPromSamplesRequest)
+		if !ok {
+			t.Fatalf("request %d = %T, want PushPromSamplesRequest", i, raw)
+		}
+		if req.Source != source {
+			continue
+		}
+		if req.EdgeID != edgeID {
+			t.Fatalf("request %d edge_id = %d, want %d", i, req.EdgeID, edgeID)
+		}
+		samples = append(samples, req.Samples...)
+	}
+	return samples
 }
 
 func findSample(samples []tunnel.PromSample, name string) (tunnel.PromSample, bool) {
@@ -263,4 +581,78 @@ func findSample(samples []tunnel.PromSample, name string) (tunnel.PromSample, bo
 		}
 	}
 	return tunnel.PromSample{}, false
+}
+
+type contextAwareTunnelClient struct {
+	*fakeTunnelClient
+}
+
+type failNthPushClient struct {
+	*fakeTunnelClient
+	failAt int
+	calls  int
+}
+
+type timeoutFirstPushClient struct {
+	*fakeTunnelClient
+	calls int
+}
+
+type countingPromClient struct {
+	*fakeTunnelClient
+	dataBatches   int
+	dataSamples   int
+	maxDataBatch  int
+	statusSamples []tunnel.PromSample
+}
+
+func (c *countingPromClient) Call(ctx context.Context, method string, req any, resp any) error {
+	if method != tunnel.MethodPushPromSamples {
+		return c.fakeTunnelClient.Call(ctx, method, req, resp)
+	}
+	in, ok := req.(tunnel.PushPromSamplesRequest)
+	if !ok {
+		return fmt.Errorf("unexpected push request %T", req)
+	}
+	if _, status := findSample(in.Samples, metricscommon.ScrapeUpMetricName); status {
+		c.statusSamples = append(c.statusSamples[:0], in.Samples...)
+	} else {
+		c.dataBatches++
+		c.dataSamples += len(in.Samples)
+		c.maxDataBatch = max(c.maxDataBatch, len(in.Samples))
+	}
+	if out, ok := resp.(*tunnel.PushPromSamplesResponse); ok {
+		out.Accepted = len(in.Samples)
+	}
+	return nil
+}
+
+func (c *timeoutFirstPushClient) Call(ctx context.Context, method string, req any, resp any) error {
+	c.calls++
+	if c.calls == 1 {
+		c.lastMethod = method
+		c.lastRequest = req
+		c.requests = append(c.requests, req)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return c.fakeTunnelClient.Call(ctx, method, req, resp)
+}
+
+func (c *failNthPushClient) Call(ctx context.Context, method string, req any, resp any) error {
+	c.calls++
+	if c.calls == c.failAt {
+		c.lastMethod = method
+		c.lastRequest = req
+		c.requests = append(c.requests, req)
+		return fmt.Errorf("injected push failure at call %d", c.calls)
+	}
+	return c.fakeTunnelClient.Call(ctx, method, req, resp)
+}
+
+func (c *contextAwareTunnelClient) Call(ctx context.Context, method string, req any, resp any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.fakeTunnelClient.Call(ctx, method, req, resp)
 }

--- a/internal/edgeagent/k8s/readonly_test.go
+++ b/internal/edgeagent/k8s/readonly_test.go
@@ -415,6 +415,7 @@ type fakeTunnelClient struct {
 	handlers    map[string]tunnel.Handler
 	lastMethod  string
 	lastRequest any
+	requests    []any
 }
 
 func (f *fakeTunnelClient) Dial(context.Context) error { return nil }
@@ -426,6 +427,7 @@ func (f *fakeTunnelClient) RegisterHandler(method string, h tunnel.Handler) {
 func (f *fakeTunnelClient) Call(_ context.Context, method string, req any, resp any) error {
 	f.lastMethod = method
 	f.lastRequest = req
+	f.requests = append(f.requests, req)
 	if out, ok := resp.(*tunnel.KubernetesInventoryResponse); ok {
 		*out = tunnel.KubernetesInventoryResponse{}
 	}

--- a/internal/edgeagent/plugins/metricscommon/scrape.go
+++ b/internal/edgeagent/plugins/metricscommon/scrape.go
@@ -11,34 +11,32 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 	"time"
 
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
-	"github.com/ongridio/ongrid/internal/edgeagent/collector"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
 // Target is one HTTP /metrics endpoint to scrape.
 type Target struct {
-	ID            string
-	Name          string
-	URL           string
-	Enabled       bool
-	Interval      time.Duration
-	Timeout       time.Duration
-	TLSInsecure   bool
-	BearerToken   string
-	BasicUsername string
-	BasicPassword string
-	SourceLabel   string
-	ExtraLabels   map[string]string
-	SampleLimit   int
-	LabelDrop     []string
-	Kind          string
+	ID                 string
+	Name               string
+	URL                string
+	Enabled            bool
+	Interval           time.Duration
+	Timeout            time.Duration
+	TLSInsecure        bool
+	BearerToken        string
+	BasicUsername      string
+	BasicPassword      string
+	SourceLabel        string
+	ExtraLabels        map[string]string
+	SampleLimit        int
+	LabelDrop          []string
+	Kind               string
+	ReportScrapeStatus bool
 }
 
 const (
@@ -47,12 +45,76 @@ const (
 	// ScrapeUpMetricName mirrors Prometheus's synthetic scrape health metric.
 	// Edge-side scrapers push it because these targets are not scraped by the
 	// central Prometheus server directly.
-	ScrapeUpMetricName = "up"
+	ScrapeUpMetricName              = "up"
+	ScrapePartialMetricName         = "ongrid_scrape_partial"
+	ScrapeAcceptedSamplesMetricName = "ongrid_scrape_samples_accepted"
 )
+
+// SampleLimitError reports that a streaming scrape observed at least one
+// sample beyond the target limit. Observed is a lower bound because parsing
+// stops immediately after the first excess sample.
+type SampleLimitError struct {
+	Observed int
+	Limit    int
+}
+
+func (e *SampleLimitError) Error() string {
+	return fmt.Sprintf("sample limit exceeded: observed at least %d limit %d", e.Observed, e.Limit)
+}
+
+// ScrapeStats describes one streaming scrape. Observed is exact for complete
+// scrapes and Accepted+1 when LimitExceeded is true because parsing stops at
+// the first excess sample.
+type ScrapeStats struct {
+	Observed      int
+	Accepted      int
+	LimitExceeded bool
+}
 
 // Scrape performs one GET, parses the Prometheus text response, applies
 // target-side cardinality controls, and returns flat samples.
 func Scrape(ctx context.Context, target Target) ([]tunnel.PromSample, error) {
+	var samples []tunnel.PromSample
+	stats, err := ScrapeIncremental(ctx, target, func(chunk []tunnel.PromSample) error {
+		samples = append(samples, chunk...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if stats.LimitExceeded {
+		return samples, &SampleLimitError{
+			Observed: stats.Observed,
+			Limit:    target.SampleLimit,
+		}
+	}
+	return samples, nil
+}
+
+// ScrapeIncremental performs one GET and parses Prometheus text exposition one
+// line at a time. It stops reading after the first sample beyond SampleLimit,
+// so response size, parser memory, and flattened sample work stay bounded.
+func ScrapeIncremental(ctx context.Context, target Target, consume func([]tunnel.PromSample) error) (ScrapeStats, error) {
+	var stats ScrapeStats
+	if consume == nil {
+		return stats, fmt.Errorf("sample consumer required")
+	}
+	resp, err := openScrapeResponse(ctx, target)
+	if err != nil {
+		return stats, err
+	}
+	stats, scrapeErr := streamTextSamples(ctx, resp.Body, target, consume)
+	closeErr := resp.Body.Close()
+	if scrapeErr != nil {
+		return stats, scrapeErr
+	}
+	if closeErr != nil {
+		return stats, fmt.Errorf("close response body: %w", closeErr)
+	}
+	return stats, nil
+}
+
+func openScrapeResponse(ctx context.Context, target Target) (*http.Response, error) {
 	if target.URL == "" {
 		return nil, fmt.Errorf("target_url required")
 	}
@@ -71,29 +133,63 @@ func Scrape(ctx context.Context, target Target) ([]tunnel.PromSample, error) {
 	if err != nil {
 		return nil, fmt.Errorf("http: %w", err)
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, drainErr := io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+		closeErr := resp.Body.Close()
+		if drainErr != nil {
+			return nil, fmt.Errorf("http status %d: drain response: %w", resp.StatusCode, drainErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("http status %d: close response: %w", resp.StatusCode, closeErr)
+		}
 		return nil, fmt.Errorf("http status %d", resp.StatusCode)
 	}
-
-	var parser expfmt.TextParser
-	families, err := parser.TextToMetricFamilies(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
-	samples := collector.FlattenSamples(time.Now(), target.SourceLabel, familiesToSlice(families), target.ExtraLabels)
-	applyLabelDrop(samples, target.LabelDrop)
-	if target.SampleLimit > 0 && len(samples) > target.SampleLimit {
-		return nil, fmt.Errorf("sample limit exceeded: got %d limit %d", len(samples), target.SampleLimit)
-	}
-	return samples, nil
+	return resp, nil
 }
 
 // ScrapeUpSample returns the synthetic target availability sample for one
 // edge-side scrape. Labels are intentionally limited to low-cardinality source
 // metadata; target URL and error text must not become metric labels.
 func ScrapeUpSample(now time.Time, plugin string, target Target, up bool) tunnel.PromSample {
+	labels := scrapeStatusLabels(plugin, target)
+	value := 0.0
+	if up {
+		value = 1
+	}
+	return tunnel.PromSample{
+		Name:   ScrapeUpMetricName,
+		Labels: labels,
+		Value:  value,
+		TsMs:   now.UnixMilli(),
+	}
+}
+
+// ScrapeStatusSamples exposes whether a streamed scrape was partial and the
+// caller-reported accepted sample count. These travel through the same tunnel
+// as the scraped data, so central Prometheus can distinguish complete and
+// truncated scrapes even when the edge process /metrics endpoint is not scraped.
+func ScrapeStatusSamples(now time.Time, plugin string, target Target, partial bool, accepted int) []tunnel.PromSample {
+	partialValue := 0.0
+	if partial {
+		partialValue = 1
+	}
+	return []tunnel.PromSample{
+		{
+			Name:   ScrapePartialMetricName,
+			Labels: scrapeStatusLabels(plugin, target),
+			Value:  partialValue,
+			TsMs:   now.UnixMilli(),
+		},
+		{
+			Name:   ScrapeAcceptedSamplesMetricName,
+			Labels: scrapeStatusLabels(plugin, target),
+			Value:  float64(accepted),
+			TsMs:   now.UnixMilli(),
+		},
+	}
+}
+
+func scrapeStatusLabels(plugin string, target Target) map[string]string {
 	labels := make(map[string]string, len(target.ExtraLabels)+4)
 	for k, v := range target.ExtraLabels {
 		k = strings.TrimSpace(k)
@@ -113,16 +209,7 @@ func ScrapeUpSample(now time.Time, plugin string, target Target, up bool) tunnel
 	if target.Kind != "" {
 		labels["kind"] = target.Kind
 	}
-	value := 0.0
-	if up {
-		value = 1
-	}
-	return tunnel.PromSample{
-		Name:   ScrapeUpMetricName,
-		Labels: labels,
-		Value:  value,
-		TsMs:   now.UnixMilli(),
-	}
+	return labels
 }
 
 // ValidateURL checks the target URL shape early during plugin Configure.
@@ -158,19 +245,6 @@ func httpClient(target Target) *http.Client {
 		timeout = DefaultTimeout
 	}
 	return &http.Client{Transport: tr, Timeout: timeout}
-}
-
-func familiesToSlice(in map[string]*dto.MetricFamily) []*dto.MetricFamily {
-	keys := make([]string, 0, len(in))
-	for k := range in {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	out := make([]*dto.MetricFamily, 0, len(keys))
-	for _, k := range keys {
-		out = append(out, in[k])
-	}
-	return out
 }
 
 func applyLabelDrop(samples []tunnel.PromSample, drops []string) {

--- a/internal/edgeagent/plugins/metricscommon/scrape_test.go
+++ b/internal/edgeagent/plugins/metricscommon/scrape_test.go
@@ -2,10 +2,15 @@ package metricscommon
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
 func TestScrapeAppliesLabelDropAndSampleLimit(t *testing.T) {
@@ -47,7 +52,7 @@ demo_total{query="select 1",service="api"} 7
 	}
 }
 
-func TestScrapeRejectsSampleLimitOverflow(t *testing.T) {
+func TestScrapeReturnsBoundedSamplesWithSampleLimitError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		_, _ = w.Write([]byte(`# HELP demo_total Demo counter.
@@ -58,7 +63,7 @@ demo_total{series="b"} 2
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := Scrape(context.Background(), Target{
+	samples, err := Scrape(context.Background(), Target{
 		ID:          "api",
 		URL:         srv.URL + "/metrics",
 		Timeout:     time.Second,
@@ -67,6 +72,59 @@ demo_total{series="b"} 2
 	})
 	if err == nil {
 		t.Fatal("Scrape() error = nil, want sample limit error")
+	}
+	var limitErr *SampleLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("Scrape() error = %T %v, want *SampleLimitError", err, err)
+	}
+	if limitErr.Observed != 2 || limitErr.Limit != 1 {
+		t.Fatalf("SampleLimitError = %#v, want observed=2 limit=1", limitErr)
+	}
+	if len(samples) != 1 || samples[0].Labels["series"] != "a" {
+		t.Fatalf("samples = %#v, want first bounded sample", samples)
+	}
+}
+
+func TestScrapeIncrementalBoundsStreamedChunksAndStopsAtLimit(t *testing.T) {
+	var body strings.Builder
+	body.WriteString("# TYPE demo_value gauge\n")
+	for i := 0; i < 2501; i++ {
+		value := strconv.Itoa(i)
+		body.WriteString("demo_value{series=\"")
+		body.WriteString(value)
+		body.WriteString("\"} ")
+		body.WriteString(value)
+		body.WriteByte('\n')
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		if _, err := w.Write([]byte(body.String())); err != nil {
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var chunks, accepted int
+	stats, err := ScrapeIncremental(context.Background(), Target{
+		URL:         srv.URL + "/metrics",
+		Timeout:     time.Second,
+		SampleLimit: 2200,
+	}, func(samples []tunnel.PromSample) error {
+		chunks++
+		accepted += len(samples)
+		if len(samples) > streamSampleChunkSize {
+			t.Fatalf("chunk samples = %d, exceeds %d", len(samples), streamSampleChunkSize)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ScrapeIncremental() error = %v", err)
+	}
+	if chunks != 3 {
+		t.Fatalf("chunks = %d, want 3", chunks)
+	}
+	if stats.Observed != 2201 || stats.Accepted != 2200 || !stats.LimitExceeded || accepted != 2200 {
+		t.Fatalf("stats = %#v accepted=%d, want observed=2201 accepted=2200 limit exceeded", stats, accepted)
 	}
 }
 

--- a/internal/edgeagent/plugins/metricscommon/text_stream.go
+++ b/internal/edgeagent/plugins/metricscommon/text_stream.go
@@ -1,0 +1,236 @@
+package metricscommon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+const (
+	streamSampleChunkSize    = 1000
+	maxPrometheusTextLineLen = 1 << 20
+)
+
+func streamTextSamples(ctx context.Context, r io.Reader, target Target, consume func([]tunnel.PromSample) error) (ScrapeStats, error) {
+	var stats ScrapeStats
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64<<10), maxPrometheusTextLineLen)
+	defaultTimestamp := time.Now().UnixMilli()
+	chunk := make([]tunnel.PromSample, 0, streamSampleChunkSize)
+	lineNumber := 0
+	admitted := 0
+	for scanner.Scan() {
+		lineNumber++
+		if err := ctx.Err(); err != nil {
+			return stats, fmt.Errorf("read exposition: %w", err)
+		}
+		sample, ok, err := parseTextSample(scanner.Bytes(), defaultTimestamp, target.ExtraLabels)
+		if err != nil {
+			return stats, fmt.Errorf("parse line %d: %w", lineNumber, err)
+		}
+		if !ok {
+			continue
+		}
+		stats.Observed++
+		if target.SampleLimit > 0 && admitted >= target.SampleLimit {
+			stats.LimitExceeded = true
+			break
+		}
+		chunk = append(chunk, sample)
+		admitted++
+		if len(chunk) == streamSampleChunkSize {
+			applyLabelDrop(chunk, target.LabelDrop)
+			if err := consume(chunk); err != nil {
+				return stats, fmt.Errorf("consume samples: %w", err)
+			}
+			stats.Accepted += len(chunk)
+			clear(chunk)
+			chunk = chunk[:0]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return stats, fmt.Errorf("read exposition: %w", err)
+	}
+	if len(chunk) > 0 {
+		applyLabelDrop(chunk, target.LabelDrop)
+		if err := consume(chunk); err != nil {
+			return stats, fmt.Errorf("consume samples: %w", err)
+		}
+		stats.Accepted += len(chunk)
+	}
+	return stats, nil
+}
+
+func parseTextSample(line []byte, defaultTimestamp int64, extraLabels map[string]string) (tunnel.PromSample, bool, error) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || line[0] == '#' {
+		return tunnel.PromSample{}, false, nil
+	}
+
+	nameEnd := 0
+	for nameEnd < len(line) && line[nameEnd] != '{' && !isBlank(line[nameEnd]) {
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return tunnel.PromSample{}, false, fmt.Errorf("metric name required")
+	}
+	name := string(line[:nameEnd])
+	if !model.IsValidMetricName(model.LabelValue(name)) {
+		return tunnel.PromSample{}, false, fmt.Errorf("invalid metric name %q", name)
+	}
+
+	labels := make(map[string]string, len(extraLabels)+4)
+	position := skipBlanks(line, nameEnd)
+	if position < len(line) && line[position] == '{' {
+		var err error
+		position, err = parseTextLabels(line, position, labels)
+		if err != nil {
+			return tunnel.PromSample{}, false, err
+		}
+	}
+	for key, value := range extraLabels {
+		if _, exists := labels[key]; !exists {
+			labels[key] = value
+		}
+	}
+	position = skipBlanks(line, position)
+	if position >= len(line) {
+		return tunnel.PromSample{}, false, fmt.Errorf("value required for metric %q", name)
+	}
+	valueEnd := position
+	for valueEnd < len(line) && !isBlank(line[valueEnd]) {
+		valueEnd++
+	}
+	valueToken := string(line[position:valueEnd])
+	value, err := strconv.ParseFloat(valueToken, 64)
+	if err != nil {
+		return tunnel.PromSample{}, false, fmt.Errorf("invalid value %q for metric %q: %w", valueToken, name, err)
+	}
+
+	timestamp := defaultTimestamp
+	position = skipBlanks(line, valueEnd)
+	if position < len(line) {
+		timestampEnd := position
+		for timestampEnd < len(line) && !isBlank(line[timestampEnd]) {
+			timestampEnd++
+		}
+		timestampToken := string(line[position:timestampEnd])
+		parsedTimestamp, parseErr := strconv.ParseInt(timestampToken, 10, 64)
+		if parseErr != nil {
+			return tunnel.PromSample{}, false, fmt.Errorf("invalid timestamp %q for metric %q: %w", timestampToken, name, parseErr)
+		}
+		if parsedTimestamp > 0 {
+			timestamp = parsedTimestamp
+		}
+		if trailing := bytes.TrimSpace(line[timestampEnd:]); len(trailing) > 0 {
+			return tunnel.PromSample{}, false, fmt.Errorf("unexpected trailing data %q", string(trailing))
+		}
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return tunnel.PromSample{}, false, nil
+	}
+	if len(labels) == 0 {
+		labels = nil
+	}
+	return tunnel.PromSample{Name: name, Labels: labels, Value: value, TsMs: timestamp}, true, nil
+}
+
+func parseTextLabels(line []byte, position int, labels map[string]string) (int, error) {
+	position++
+	for {
+		position = skipBlanks(line, position)
+		if position >= len(line) {
+			return position, fmt.Errorf("unterminated label set")
+		}
+		if line[position] == '}' {
+			return position + 1, nil
+		}
+		nameStart := position
+		for position < len(line) && line[position] != '=' && !isBlank(line[position]) {
+			position++
+		}
+		labelName := string(line[nameStart:position])
+		if !model.LabelName(labelName).IsValid() || labelName == string(model.MetricNameLabel) {
+			return position, fmt.Errorf("invalid label name %q", labelName)
+		}
+		if _, exists := labels[labelName]; exists {
+			return position, fmt.Errorf("duplicate label name %q", labelName)
+		}
+		position = skipBlanks(line, position)
+		if position >= len(line) || line[position] != '=' {
+			return position, fmt.Errorf("expected '=' after label %q", labelName)
+		}
+		position = skipBlanks(line, position+1)
+		if position >= len(line) || line[position] != '"' {
+			return position, fmt.Errorf("expected quoted value for label %q", labelName)
+		}
+		value, next, err := parseTextLabelValue(line, position+1)
+		if err != nil {
+			return position, fmt.Errorf("label %q: %w", labelName, err)
+		}
+		if !model.LabelValue(value).IsValid() {
+			return position, fmt.Errorf("invalid value for label %q", labelName)
+		}
+		labels[labelName] = value
+		position = skipBlanks(line, next)
+		if position >= len(line) {
+			return position, fmt.Errorf("unterminated label set")
+		}
+		switch line[position] {
+		case ',':
+			position++
+		case '}':
+			return position + 1, nil
+		default:
+			return position, fmt.Errorf("expected ',' or '}' after label %q", labelName)
+		}
+	}
+}
+
+func parseTextLabelValue(line []byte, position int) (string, int, error) {
+	var value strings.Builder
+	for position < len(line) {
+		switch line[position] {
+		case '"':
+			return value.String(), position + 1, nil
+		case '\\':
+			position++
+			if position >= len(line) {
+				return "", position, fmt.Errorf("unterminated escape sequence")
+			}
+			switch line[position] {
+			case '\\', '"':
+				value.WriteByte(line[position])
+			case 'n':
+				value.WriteByte('\n')
+			default:
+				return "", position, fmt.Errorf("invalid escape sequence \\%c", line[position])
+			}
+		default:
+			value.WriteByte(line[position])
+		}
+		position++
+	}
+	return "", position, fmt.Errorf("unterminated quoted label value")
+}
+
+func skipBlanks(line []byte, position int) int {
+	for position < len(line) && isBlank(line[position]) {
+		position++
+	}
+	return position
+}
+
+func isBlank(value byte) bool {
+	return value == ' ' || value == '\t'
+}

--- a/internal/edgeagent/plugins/metricscommon/text_stream_test.go
+++ b/internal/edgeagent/plugins/metricscommon/text_stream_test.go
@@ -1,0 +1,154 @@
+package metricscommon
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+func TestParseTextSamplePreservesFlatPrometheusSeries(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		wantName   string
+		wantLabels map[string]string
+		wantValue  float64
+		wantTs     int64
+		wantOK     bool
+	}{
+		{
+			name:       "escaped labels and timestamp",
+			line:       `demo_total{slash="a\\b",quote="a\"b",newline="a\nb"} 12.5 123`,
+			wantName:   "demo_total",
+			wantLabels: map[string]string{"slash": `a\b`, "quote": `a"b`, "newline": "a\nb", "cluster": "test"},
+			wantValue:  12.5,
+			wantTs:     123,
+			wantOK:     true,
+		},
+		{
+			name:       "histogram bucket remains flat",
+			line:       `request_duration_seconds_bucket{le="0.5"} 7`,
+			wantName:   "request_duration_seconds_bucket",
+			wantLabels: map[string]string{"le": "0.5", "cluster": "test"},
+			wantValue:  7,
+			wantTs:     999,
+			wantOK:     true,
+		},
+		{
+			name:       "whitespace before label set",
+			line:       `demo_total { service = "api", }3`,
+			wantName:   "demo_total",
+			wantLabels: map[string]string{"service": "api", "cluster": "test"},
+			wantValue:  3,
+			wantTs:     999,
+			wantOK:     true,
+		},
+		{name: "comment", line: "# TYPE demo_total counter", wantOK: false},
+		{name: "non-finite", line: "demo_value NaN", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sample, ok, err := parseTextSample([]byte(tt.line), 999, map[string]string{"cluster": "test"})
+			if err != nil {
+				t.Fatalf("parseTextSample() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if sample.Name != tt.wantName || sample.Value != tt.wantValue || sample.TsMs != tt.wantTs {
+				t.Fatalf("sample = %#v, want name=%q value=%v ts=%d", sample, tt.wantName, tt.wantValue, tt.wantTs)
+			}
+			if len(sample.Labels) != len(tt.wantLabels) {
+				t.Fatalf("labels = %#v, want %#v", sample.Labels, tt.wantLabels)
+			}
+			for key, want := range tt.wantLabels {
+				if got := sample.Labels[key]; got != want {
+					t.Fatalf("label %q = %q, want %q", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTextSampleRejectsMalformedLines(t *testing.T) {
+	for _, line := range []string{
+		`bad-name 1`,
+		`demo{label="unterminated} 1`,
+		`demo{label="a",label="b"} 1`,
+		`demo 1 not-a-timestamp`,
+		`demo 1 123 trailing`,
+	} {
+		t.Run(line, func(t *testing.T) {
+			if _, _, err := parseTextSample([]byte(line), 999, nil); err == nil {
+				t.Fatalf("parseTextSample(%q) error = nil", line)
+			}
+		})
+	}
+}
+
+func TestScrapeIncrementalStreamsDefaultLargeClusterLimit(t *testing.T) {
+	const sampleLimit = 250000
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		writer := bufio.NewWriterSize(w, 64<<10)
+		for i := 0; i <= sampleLimit; i++ {
+			if _, err := writer.WriteString("kube_pod_info{namespace=\"default\",pod=\"api\"} 1\n"); err != nil {
+				return
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	accepted := 0
+	stats, err := ScrapeIncremental(context.Background(), Target{
+		URL:         srv.URL + "/metrics",
+		Timeout:     15 * time.Second,
+		SampleLimit: sampleLimit,
+	}, func(samples []tunnel.PromSample) error {
+		if len(samples) > streamSampleChunkSize {
+			t.Fatalf("chunk samples = %d, exceeds %d", len(samples), streamSampleChunkSize)
+		}
+		accepted += len(samples)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ScrapeIncremental() error = %v", err)
+	}
+	if stats.Accepted != sampleLimit || stats.Observed != sampleLimit+1 || !stats.LimitExceeded {
+		t.Fatalf("stats = %#v, want accepted=%d observed=%d limit exceeded", stats, sampleLimit, sampleLimit+1)
+	}
+	if accepted != sampleLimit {
+		t.Fatalf("consumer accepted = %d, want %d", accepted, sampleLimit)
+	}
+}
+
+func FuzzParseTextSample(f *testing.F) {
+	for _, seed := range []string{
+		`demo_total{service="api"} 1`,
+		`request_duration_seconds_bucket{le="+Inf"} 10 123`,
+		`# HELP demo_total demo`,
+		`demo{label="a\nb"} NaN`,
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, line string) {
+		sample, ok, err := parseTextSample([]byte(line), 1, nil)
+		if err != nil {
+			return
+		}
+		if ok && sample.Name == "" {
+			t.Fatal("parsed sample has an empty name")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- stream Prometheus text exposition incrementally instead of materializing the entire scrape in memory
- preserve and push bounded Kubernetes metrics when a target exceeds its sample limit
- split tunnel payloads by sample count and encoded byte size, with independent push timeouts and partial-delivery status
- expose bounded local scrape/push counters and wire the new defaults through the Helm chart and CI render checks

## Root cause

The previous Kubernetes metrics path parsed the full response before checking the sample limit. When a large cluster produced more than 20,000 samples, the scraper returned an error and discarded the complete scrape, so no usable Kubernetes metrics reached Prometheus.

## Impact

Kube-state-metrics and the Kubernetes telemetry gateway now admit up to 250,000 samples per target and forward them in batches capped at 10,000 samples or 4 MiB. If the limit is exceeded or a data batch fails, successfully delivered samples remain available and the final status series reports partial delivery and the accepted count. Pod application discovery does not emit the additional detailed status series, avoiding new high-cardinality targets.

## Validation

- `go test -race ./internal/edgeagent/... ./cmd/ongrid-edge`
- `go vet ./internal/edgeagent/... ./cmd/ongrid-edge`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/ongrid-edge`
- Helm lint, package, and rendered manifest checks
- end-to-end 250,001-sample limit test and injected middle-batch/timeout failure tests
- `git diff --check`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
