### PR TITLE
fix(release): reuse existing immutable images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,13 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh
+        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh
 
       - name: Verify Compose image routing
         run: make verify-compose-images
+
+      - name: Verify release image helpers
+        run: make test-release-image-publish
 
       - name: Lint and render Kubernetes chart
         run: |

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ K8S_CHART_REF ?= oci://helm.cnb.cool/ongridio/ongrid-edge
 K8S_CHART_PUSH_TARGET ?= oci://helm.cnb.cool/ongridio
 CNB_HELM_REGISTRY ?= helm.cnb.cool
 CNB_HELM_USERNAME ?= cnb
+RELEASE_MANIFEST_PLATFORM_FILTER ?= $(CURDIR)/scripts/release-manifest-platforms.jq
+RELEASE_IMAGE_PUBLISHER ?= $(CURDIR)/scripts/publish-release-image.sh
 
 DB_DSN     ?= root:root@tcp(127.0.0.1:3306)/ongrid?charset=utf8mb4&parseTime=true&loc=Local
 MIGRATIONS := db/migrations
@@ -263,16 +265,22 @@ docker-build-web: ## [release] 构建 ongrid-web:$(VERSION) 镜像（前端 SPA 
 		$(DOCKER_BUILD_WEB_CACHE_ARGS) \
 		--load .
 
-.PHONY: docker-push-cloud-images docker-push-release-images release-image-refs verify-release-images
+.PHONY: docker-push-cloud-images docker-push-release-images release-image-refs verify-release-images test-release-manifest-filter test-release-image-publish
 docker-push-cloud-images: ## [release] 发布 manager + Web 多架构镜像到 CNB
-	docker buildx build \
+	bash "$(RELEASE_IMAGE_PUBLISHER)" \
+		"$(CLOUD_MANAGER_IMAGE_REF)" \
+		"$(RELEASE_MANIFEST_PLATFORM_FILTER)" \
+		-- docker buildx build \
 		--platform $(CLOUD_IMAGE_PLATFORMS) \
 		--build-arg VERSION=$(VERSION) \
 		-t $(CLOUD_MANAGER_IMAGE_REF) \
 		-f deploy/Dockerfile.ongrid \
 		$(DOCKER_BUILD_CACHE_ARGS) \
 		--push .
-	docker buildx build \
+	bash "$(RELEASE_IMAGE_PUBLISHER)" \
+		"$(CLOUD_WEB_IMAGE_REF)" \
+		"$(RELEASE_MANIFEST_PLATFORM_FILTER)" \
+		-- docker buildx build \
 		--platform $(CLOUD_IMAGE_PLATFORMS) \
 		--build-arg VERSION=$(VERSION) \
 		-t $(CLOUD_WEB_IMAGE_REF) \
@@ -295,7 +303,10 @@ docker-build-k8s-edge: ## [dev] 构建本地 Kubernetes ongrid-edge 镜像（默
 		--load .
 
 docker-push-k8s-edge: ## [release] 发布 Kubernetes ongrid-edge 多架构镜像到 CNB
-	docker buildx build \
+	bash "$(RELEASE_IMAGE_PUBLISHER)" \
+		"$(K8S_EDGE_IMAGE_REF)" \
+		"$(RELEASE_MANIFEST_PLATFORM_FILTER)" \
+		-- docker buildx build \
 		--platform $(K8S_EDGE_IMAGE_PLATFORMS) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg PROMTAIL_VERSION=$(PROMTAIL_VERSION) \
@@ -316,12 +327,21 @@ release-image-refs: ## [release] 打印本次发布的项目自身镜像
 
 verify-release-images: ## [release] 校验项目自身镜像均包含 amd64 + arm64 manifest
 	@command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
-	@for image in $(CLOUD_MANAGER_IMAGE_REF) $(CLOUD_WEB_IMAGE_REF) $(K8S_EDGE_IMAGE_REF); do \
-		echo "[verify] $$image"; \
-		docker buildx imagetools inspect --raw "$$image" \
-			| jq -e '[.manifests[].platform | "\(.os)/\(.architecture)"] \
-				| index("linux/amd64") != null and index("linux/arm64") != null' >/dev/null; \
-	done
+	bash scripts/verify-release-images.sh \
+		"$(RELEASE_MANIFEST_PLATFORM_FILTER)" \
+		"$(CLOUD_MANAGER_IMAGE_REF)" \
+		"$(CLOUD_WEB_IMAGE_REF)" \
+		"$(K8S_EDGE_IMAGE_REF)"
+
+test-release-manifest-filter: ## [test] 校验 release manifest 架构过滤器
+	@command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+	@printf '%s\n' '{"manifests":[{"platform":{"os":"linux","architecture":"amd64"}},{"platform":{"os":"linux","architecture":"arm64"}},{"platform":{"os":"unknown","architecture":"unknown"}}]}' \
+		| jq -e -f "$(RELEASE_MANIFEST_PLATFORM_FILTER)" >/dev/null
+	@! printf '%s\n' '{"manifests":[{"platform":{"os":"linux","architecture":"amd64"}}]}' \
+		| jq -e -f "$(RELEASE_MANIFEST_PLATFORM_FILTER)" >/dev/null
+
+test-release-image-publish: test-release-manifest-filter ## [test] 校验 release 镜像幂等发布
+	bash scripts/test-publish-release-image.sh
 
 .PHONY: verify-compose-images
 verify-compose-images: ## [test] 渲染并校验 Compose 运行镜像全部按预期指向 CNB

--- a/scripts/publish-release-image.sh
+++ b/scripts/publish-release-image.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 4 || $3 != -- ]]; then
+  echo "usage: $0 <image> <jq-filter> -- <build-command>..." >&2
+  exit 2
+fi
+
+image=$1
+filter=$2
+shift 3
+build_command=("$@")
+
+if [[ ! -f "$filter" ]]; then
+  echo "release manifest filter not found: $filter" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 2
+fi
+
+attempts=${RELEASE_IMAGE_CHECK_ATTEMPTS:-5}
+retry_delay=${RELEASE_IMAGE_CHECK_RETRY_DELAY:-3}
+if [[ ! $attempts =~ ^[1-9][0-9]*$ || ! $retry_delay =~ ^[0-9]+$ ]]; then
+  echo "release image check retry settings must be non-negative integers and attempts must be positive" >&2
+  exit 2
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+manifest_file="$tmp_dir/manifest.json"
+error_file="$tmp_dir/inspect.err"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if docker buildx imagetools inspect --raw "$image" >"$manifest_file" 2>"$error_file"; then
+    if jq -e -f "$filter" "$manifest_file" >/dev/null; then
+      echo "[publish] $image already contains linux/amd64 and linux/arm64; skipping immutable tag"
+      exit 0
+    fi
+    echo "[publish] immutable tag exists but is missing linux/amd64 or linux/arm64: $image" >&2
+    exit 1
+  fi
+
+  if grep -Eiq '(^|[^[:alpha:]])(404|not found)([^[:alpha:]]|$)' "$error_file"; then
+    echo "[publish] $image does not exist; building"
+    "${build_command[@]}"
+    exit 0
+  fi
+
+  if ((attempt < attempts)); then
+    echo "[publish] inspect attempt $attempt failed; retrying $image" >&2
+    sleep "$retry_delay"
+  fi
+done
+
+cat "$error_file" >&2
+echo "[publish] unable to determine immutable tag state: $image" >&2
+exit 1

--- a/scripts/release-manifest-platforms.jq
+++ b/scripts/release-manifest-platforms.jq
@@ -1,0 +1,6 @@
+[
+  .manifests[]?.platform
+  | "\(.os)/\(.architecture)"
+]
+| index("linux/amd64") != null
+  and index("linux/arm64") != null

--- a/scripts/test-publish-release-image.sh
+++ b/scripts/test-publish-release-image.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+publisher="$repo_root/scripts/publish-release-image.sh"
+filter="$repo_root/scripts/release-manifest-platforms.jq"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+export PATH="$tmp_dir/bin:$PATH"
+export DOCKER_FAKE_COUNT="$tmp_dir/docker-count"
+export BUILD_MARKER="$tmp_dir/build-marker"
+export RELEASE_IMAGE_CHECK_ATTEMPTS=2
+export RELEASE_IMAGE_CHECK_RETRY_DELAY=0
+
+cat >"$tmp_dir/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 || $1 != buildx || $2 != imagetools || $3 != inspect || $4 != --raw ]]; then
+  echo "unexpected fake docker invocation: $*" >&2
+  exit 2
+fi
+
+count=0
+if [[ -f "$DOCKER_FAKE_COUNT" ]]; then
+  count=$(<"$DOCKER_FAKE_COUNT")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$DOCKER_FAKE_COUNT"
+
+case "$DOCKER_FAKE_MODE" in
+  present)
+    printf '%s\n' '{"manifests":[{"platform":{"os":"linux","architecture":"amd64"}},{"platform":{"os":"linux","architecture":"arm64"}}]}'
+    ;;
+  partial)
+    printf '%s\n' '{"manifests":[{"platform":{"os":"linux","architecture":"amd64"}}]}'
+    ;;
+  missing)
+    echo "ERROR: example.invalid/release:v1.0.0: not found" >&2
+    exit 1
+    ;;
+  transient-then-present)
+    if [[ $count -eq 1 ]]; then
+      echo 'ERROR: registry request failed: EOF' >&2
+      exit 1
+    fi
+    printf '%s\n' '{"manifests":[{"platform":{"os":"linux","architecture":"amd64"}},{"platform":{"os":"linux","architecture":"arm64"}}]}'
+    ;;
+  transient)
+    echo 'ERROR: registry request failed: EOF' >&2
+    exit 1
+    ;;
+  *)
+    echo "unknown DOCKER_FAKE_MODE: $DOCKER_FAKE_MODE" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$tmp_dir/bin/docker"
+
+run_publisher() {
+  bash "$publisher" example.invalid/release:v1.0.0 "$filter" -- \
+    bash -c 'printf built >"$BUILD_MARKER"'
+}
+
+reset_case() {
+  rm -f "$DOCKER_FAKE_COUNT" "$BUILD_MARKER"
+}
+
+reset_case
+export DOCKER_FAKE_MODE=present
+run_publisher
+test ! -e "$BUILD_MARKER"
+
+reset_case
+export DOCKER_FAKE_MODE=missing
+run_publisher
+test -s "$BUILD_MARKER"
+
+reset_case
+export DOCKER_FAKE_MODE=partial
+if run_publisher; then
+  echo "partial immutable manifest unexpectedly passed" >&2
+  exit 1
+fi
+test ! -e "$BUILD_MARKER"
+
+reset_case
+export DOCKER_FAKE_MODE=transient-then-present
+run_publisher
+test "$(<"$DOCKER_FAKE_COUNT")" -eq 2
+test ! -e "$BUILD_MARKER"
+
+reset_case
+export DOCKER_FAKE_MODE=transient
+if run_publisher; then
+  echo "persistent registry error unexpectedly triggered a build" >&2
+  exit 1
+fi
+test ! -e "$BUILD_MARKER"

--- a/scripts/verify-release-images.sh
+++ b/scripts/verify-release-images.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <jq-filter> <image>..." >&2
+  exit 2
+fi
+
+filter=$1
+shift
+
+if [[ ! -f "$filter" ]]; then
+  echo "release manifest filter not found: $filter" >&2
+  exit 2
+fi
+
+for image in "$@"; do
+  echo "[verify] $image"
+  verified=false
+  for ((attempt = 1; attempt <= 5; attempt++)); do
+    if docker buildx imagetools inspect --raw "$image" \
+      | jq -e -f "$filter" >/dev/null; then
+      verified=true
+      break
+    fi
+    if ((attempt < 5)); then
+      echo "[verify] attempt $attempt failed; retrying $image" >&2
+      sleep 3
+    fi
+  done
+  if [[ "$verified" != true ]]; then
+    echo "failed to verify linux/amd64 and linux/arm64 manifest entries: $image" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary

- make release image publication idempotent for immutable CNB tags
- skip builds only when the existing tag contains both linux/amd64 and linux/arm64 manifests
- fail safely for incomplete manifests or indeterminate registry errors, while retrying transient failures
- fix multi-arch manifest verification and add CI coverage for all image-state branches

## Root cause

A release could successfully push immutable images and then fail in a later verification or packaging step. Rerunning the workflow attempted to push the same tags again, which CNB rejects because overwrite is disabled. The previous inline jq verification also contained an invalid continuation character.

## Impact

Release reruns can reuse already-published complete multi-arch images without overwriting them. Missing images are still built, while partial or uncertain remote state stops the release safely.

## Validation

- `make test-release-image-publish`
- `make verify-release-images` against all three v0.10.1 CNB images
- `make verify-compose-images`
- Helm lint, package, and template checks
- release-script syntax and workflow YAML parsing
- `git diff --check`

## Rollback

Revert this commit to restore unconditional release image builds and the previous inline manifest check.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md