### PR TITLE
feat(edge/windows): add platform scaffolding (DPAPI, install, edgedirs)

### DIFF
--- a/.github/workflows/ci-windows-cross.yml
+++ b/.github/workflows/ci-windows-cross.yml
@@ -1,0 +1,68 @@
+name: CI Windows Cross-Build
+
+# Windows 交叉编译 + vet gate。覆盖 edgeagent Windows 子包
+# （dpapi / edgedirs / install / config），配合 ci.yml 形成双平台覆盖。
+#
+# Linux runner 上通过 GOOS=windows 交叉编译，不启动 Windows VM。
+# 涉及 Windows SCM / DPAPI 实际行为的集成测试需要 windows-latest runner，
+# 将在 supervisor PR 落地后补充。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'internal/edgeagent/**'
+      - 'cmd/ongrid-edge*/**'
+      - '.github/workflows/ci-windows-cross.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-win-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-cross-build:
+    name: GOOS=windows build + vet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: go build (GOOS=windows)
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        # 只编译 PR1 scope 的 4 个 Windows 子包
+        run: go build ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+
+      - name: go vet (GOOS=windows)
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        run: |
+          # vet 只跑 Windows 子包（避免 Linux-only 文件的误报）
+          go vet ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+
+      - name: go test (GOOS=windows, no-cgo)
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        # 注：Linux runner 上可以 GOOS=windows go test 编译 Windows test binary，
+        # 但 wine 层不稳定。这里只编译测试 binary（go test -c -o /dev/null），
+        # 不实际执行；实际执行留给后续 windows-latest runner job（PR2 落地后加）。
+        run: |
+          for pkg in ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...; do
+            echo "compile test binary: $pkg"
+            go test -c -o /dev/null "$pkg"
+          done

--- a/internal/edgeagent/config/rotation.go
+++ b/internal/edgeagent/config/rotation.go
@@ -1,0 +1,36 @@
+package config
+
+import "time"
+
+// token 轮转周期常量（ADR-037 A2 CR4）。
+const (
+	defaultRotationDays = 90
+	minRotationDays     = 30
+	maxRotationDays     = 365
+)
+
+// CheckTokenRotation 检查 token 是否需要轮转。
+//
+// tokenAge 是当前 token 的存活时间（通常从 secrets.enc 文件修改时间计算）。
+// rotationDays 是配置的轮转周期，钳制到 [30, 365]，0 或负值用默认 90。
+//
+// 返回 true 表示需要轮转（tokenAge >= rotationDays 天）。
+func CheckTokenRotation(tokenAge time.Duration, rotationDays int) bool {
+	threshold := time.Duration(clampRotationDays(rotationDays)) * 24 * time.Hour
+	return tokenAge >= threshold
+}
+
+// clampRotationDays 将 rotationDays 钳制到 [30, 365]。
+// 0 或负值 → 默认 90；<30 → 30；>365 → 365。
+func clampRotationDays(days int) int {
+	if days <= 0 {
+		return defaultRotationDays
+	}
+	if days < minRotationDays {
+		return minRotationDays
+	}
+	if days > maxRotationDays {
+		return maxRotationDays
+	}
+	return days
+}

--- a/internal/edgeagent/config/rotation.go
+++ b/internal/edgeagent/config/rotation.go
@@ -2,7 +2,7 @@ package config
 
 import "time"
 
-// token 轮转周期常量（ADR-037 A2 CR4）。
+// token 轮转周期常量。
 const (
 	defaultRotationDays = 90
 	minRotationDays     = 30

--- a/internal/edgeagent/config/rotation_test.go
+++ b/internal/edgeagent/config/rotation_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCheckTokenRotation_NotExpired 验证未过期返回 false。
+func TestCheckTokenRotation_NotExpired(t *testing.T) {
+	cases := []struct {
+		name         string
+		tokenAge     time.Duration
+		rotationDays int
+	}{
+		{"89_days_default_90", 89 * 24 * time.Hour, 90},
+		{"1_day_default_90", 1 * 24 * time.Hour, 90},
+		{"0_age", 0, 90},
+		{"29_days_custom_30", 29 * 24 * time.Hour, 30},
+		{"364_days_custom_365", 364 * 24 * time.Hour, 365},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if CheckTokenRotation(tc.tokenAge, tc.rotationDays) {
+				t.Errorf("CheckTokenRotation(%v, %d) = true, want false", tc.tokenAge, tc.rotationDays)
+			}
+		})
+	}
+}
+
+// TestCheckTokenRotation_Expired 验证过期返回 true。
+func TestCheckTokenRotation_Expired(t *testing.T) {
+	cases := []struct {
+		name         string
+		tokenAge     time.Duration
+		rotationDays int
+	}{
+		{"90_days_default_90", 90 * 24 * time.Hour, 90},
+		{"91_days_default_90", 91 * 24 * time.Hour, 90},
+		{"365_days_default_90", 365 * 24 * time.Hour, 90},
+		{"30_days_custom_30", 30 * 24 * time.Hour, 30},
+		{"365_days_custom_365", 365 * 24 * time.Hour, 365},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !CheckTokenRotation(tc.tokenAge, tc.rotationDays) {
+				t.Errorf("CheckTokenRotation(%v, %d) = false, want true", tc.tokenAge, tc.rotationDays)
+			}
+		})
+	}
+}
+
+// TestCheckTokenRotation_ClampDays 验证 rotationDays 钳制到 [30, 365]。
+func TestCheckTokenRotation_ClampDays(t *testing.T) {
+	// 负值 → 默认 90
+	if CheckTokenRotation(89*24*time.Hour, -1) {
+		t.Error("negative days should clamp to 90, 89 days should not rotate")
+	}
+	if !CheckTokenRotation(90*24*time.Hour, -1) {
+		t.Error("negative days should clamp to 90, 90 days should rotate")
+	}
+
+	// 0 → 默认 90
+	if CheckTokenRotation(89*24*time.Hour, 0) {
+		t.Error("zero days should clamp to 90, 89 days should not rotate")
+	}
+	if !CheckTokenRotation(90*24*time.Hour, 0) {
+		t.Error("zero days should clamp to 90, 90 days should rotate")
+	}
+
+	// <30 → 钳制到 30
+	if CheckTokenRotation(29*24*time.Hour, 10) {
+		t.Error("10 days should clamp to 30, 29 days should not rotate")
+	}
+	if !CheckTokenRotation(30*24*time.Hour, 10) {
+		t.Error("10 days should clamp to 30, 30 days should rotate")
+	}
+
+	// >365 → 钳制到 365
+	if CheckTokenRotation(364*24*time.Hour, 999) {
+		t.Error("999 days should clamp to 365, 364 days should not rotate")
+	}
+	if !CheckTokenRotation(365*24*time.Hour, 999) {
+		t.Error("999 days should clamp to 365, 365 days should rotate")
+	}
+}
+
+// TestClampRotationDays 验证 clampRotationDays 独立函数。
+func TestClampRotationDays(t *testing.T) {
+	cases := []struct {
+		input int
+		want  int
+	}{
+		{-1, 90},       // 负值 → 默认 90
+		{0, 90},        // 0 → 默认 90
+		{1, 30},        // <30 → 30
+		{29, 30},       // <30 → 30
+		{30, 30},       // 边界 → 30
+		{90, 90},       // 默认值
+		{180, 180},     // 正常值
+		{365, 365},     // 边界 → 365
+		{366, 365},     // >365 → 365
+		{9999, 365},    // 远超上限 → 365
+	}
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := clampRotationDays(tc.input)
+			if got != tc.want {
+				t.Errorf("clampRotationDays(%d) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/edgeagent/config/secrets.go
+++ b/internal/edgeagent/config/secrets.go
@@ -1,0 +1,38 @@
+// Package config 提供 edge agent 的运行时配置加载逻辑，
+// 包括 DPAPI 加密的 secrets.enc 读取（ADR-037 A2 CR4）。
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// LoadSecrets 读取 secrets.enc 文件并使用 DPAPI 解密 broker token。
+//
+// 流程：os.ReadFile → dpapi.Unprotect → 返回明文 token。
+//
+// 返回值：
+//   - (token, nil)：成功解密
+//   - ("", err)：文件不存在 / 解密失败 / token 为空
+//
+// 调用方应在失败时回退到 ONGRID_EDGE_SECRET_KEY 环境变量（向后兼容）。
+func LoadSecrets(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("secrets: read %s: %w", path, err)
+	}
+
+	plaintext, err := dpapi.Unprotect(data)
+	if err != nil {
+		return "", fmt.Errorf("secrets: decrypt: %w", err)
+	}
+
+	token := string(plaintext)
+	if token == "" {
+		return "", fmt.Errorf("secrets: decrypted token is empty")
+	}
+
+	return token, nil
+}

--- a/internal/edgeagent/config/secrets.go
+++ b/internal/edgeagent/config/secrets.go
@@ -1,5 +1,5 @@
 // Package config 提供 edge agent 的运行时配置加载逻辑，
-// 包括 DPAPI 加密的 secrets.enc 读取（ADR-037 A2 CR4）。
+// 包括 DPAPI 加密的 secrets.enc 读取。
 package config
 
 import (

--- a/internal/edgeagent/config/secrets_test.go
+++ b/internal/edgeagent/config/secrets_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// TestLoadSecrets_ValidFile 验证合法 secrets.enc 能正确解密出 token。
+func TestLoadSecrets_ValidFile(t *testing.T) {
+	token := "ed_bk_test_token_abc123"
+	encrypted, err := dpapi.Protect([]byte(token))
+	if err != nil {
+		t.Fatalf("dpapi.Protect failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	if err := os.WriteFile(path, encrypted, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	got, err := LoadSecrets(path)
+	if err != nil {
+		t.Fatalf("LoadSecrets failed: %v", err)
+	}
+	if got != token {
+		t.Errorf("token mismatch:\n  want %q\n  got  %q", token, got)
+	}
+}
+
+// TestLoadSecrets_FileNotFound 验证文件不存在时返回可识别错误。
+func TestLoadSecrets_FileNotFound(t *testing.T) {
+	_, err := LoadSecrets(filepath.Join(t.TempDir(), "nonexistent.enc"))
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+}
+
+// TestLoadSecrets_InvalidPayload 验证损坏文件返回错误。
+func TestLoadSecrets_InvalidPayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.enc")
+	if err := os.WriteFile(path, []byte("not a valid dpapi blob"), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err := LoadSecrets(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt file, got nil")
+	}
+}
+
+// TestLoadSecrets_EmptyFile 验证空文件返回错误。
+func TestLoadSecrets_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.enc")
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err := LoadSecrets(path)
+	if err == nil {
+		t.Fatal("expected error for empty file, got nil")
+	}
+}
+

--- a/internal/edgeagent/dpapi/dpapi_other.go
+++ b/internal/edgeagent/dpapi/dpapi_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+// Package dpapi 提供 DPAPI（Data Protection API）加密/解密功能。
+//
+// 在非 Windows 平台上，所有操作返回 ErrUnsupportedPlatform。
+// 这使得 manager（Linux）可以引用 dpapi 包的符号而不编译失败。
+package dpapi
+
+import "errors"
+
+// ErrUnsupportedPlatform 表示当前平台不支持 DPAPI（仅 Windows 可用）。
+var ErrUnsupportedPlatform = errors.New("dpapi: unsupported platform (Windows only)")
+
+// Protect 在非 Windows 平台始终返回 ErrUnsupportedPlatform。
+func Protect(_ []byte) ([]byte, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+// Unprotect 在非 Windows 平台始终返回 ErrUnsupportedPlatform。
+func Unprotect(_ []byte) ([]byte, error) {
+	return nil, ErrUnsupportedPlatform
+}

--- a/internal/edgeagent/dpapi/dpapi_windows.go
+++ b/internal/edgeagent/dpapi/dpapi_windows.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+// Package dpapi 提供 DPAPI（Data Protection API）加密/解密功能，
+// 用于保护 broker token 等敏感凭证（ADR-037 A2 CR4）。
+//
+// DPAPI scope：CRYPTPROTECT_LOCAL_MACHINE（绑定机器 + SystemCredential scope）。
+//   - LocalSystem 和 NetworkService 都能解密（同为 System 身份）
+//   - 拷贝到其他机器无法解密（防横向移动）
+//   - 不防本机 System 服务被攻破（威胁模型见 ADR-037）
+//
+// 使用 golang.org/x/sys/windows 的高层 CryptProtectData/CryptUnprotectData 包装，
+// 无需 raw syscall。
+package dpapi
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// CRYPTPROTECT_LOCAL_MACHINE 绑定密文到机器而非用户 logon session。
+// Windows Service 跑在 session 0，没有交互式 user logon，必须用此 flag。
+const CRYPTPROTECT_LOCAL_MACHINE = 0x1
+
+// Protect 使用 DPAPI 加密数据（CRYPTPROTECT_LOCAL_MACHINE scope）。
+//
+// 加密后的 blob 只能在同一机器上由 System 身份进程解密。
+// 同一明文每次加密产生不同密文（DPAPI 使用随机 IV）。
+func Protect(plaintext []byte) ([]byte, error) {
+	if len(plaintext) == 0 {
+		return nil, fmt.Errorf("dpapi: Protect: empty plaintext")
+	}
+
+	dataIn := windows.DataBlob{
+		Size: uint32(len(plaintext)),
+		Data: &plaintext[0],
+	}
+	var dataOut windows.DataBlob
+
+	err := windows.CryptProtectData(
+		&dataIn,
+		nil, // name（可选描述，不设）
+		nil, // optionalEntropy（不使用额外熵）
+		0,   // reserved
+		nil, // promptStruct（不弹 UI）
+		CRYPTPROTECT_LOCAL_MACHINE,
+		&dataOut,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dpapi: CryptProtectData: %w", err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(dataOut.Data)))
+
+	return blobToBytes(dataOut), nil
+}
+
+// Unprotect 使用 DPAPI 解密数据（需与加密时相同的机器 + System 身份）。
+func Unprotect(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) == 0 {
+		return nil, fmt.Errorf("dpapi: Unprotect: empty ciphertext")
+	}
+
+	dataIn := windows.DataBlob{
+		Size: uint32(len(ciphertext)),
+		Data: &ciphertext[0],
+	}
+	var dataOut windows.DataBlob
+
+	err := windows.CryptUnprotectData(
+		&dataIn,
+		nil, // name（可选描述指针，不接收）
+		nil, // optionalEntropy
+		0,   // reserved
+		nil, // promptStruct
+		0,   // flags（解密时不需要 flag）
+		&dataOut,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dpapi: CryptUnprotectData: %w", err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(dataOut.Data)))
+
+	return blobToBytes(dataOut), nil
+}
+
+// blobToBytes 将 windows.DataBlob 转为 Go []byte（拷贝，不持有原生内存）。
+func blobToBytes(blob windows.DataBlob) []byte {
+	if blob.Data == nil || blob.Size == 0 {
+		return nil
+	}
+	// unsafe.Slice 创建指向原生内存的切片，copy 拷贝到 Go 堆
+	src := unsafe.Slice(blob.Data, blob.Size)
+	result := make([]byte, blob.Size)
+	copy(result, src)
+	return result
+}

--- a/internal/edgeagent/dpapi/dpapi_windows.go
+++ b/internal/edgeagent/dpapi/dpapi_windows.go
@@ -1,12 +1,12 @@
 //go:build windows
 
 // Package dpapi 提供 DPAPI（Data Protection API）加密/解密功能，
-// 用于保护 broker token 等敏感凭证（ADR-037 A2 CR4）。
+// 用于保护 broker token 等敏感凭证。
 //
 // DPAPI scope：CRYPTPROTECT_LOCAL_MACHINE（绑定机器 + SystemCredential scope）。
 //   - LocalSystem 和 NetworkService 都能解密（同为 System 身份）
 //   - 拷贝到其他机器无法解密（防横向移动）
-//   - 不防本机 System 服务被攻破（威胁模型见 ADR-037）
+//   - 不防本机 System 服务被攻破（本机 System 已被攻破等价于全失陷）
 //
 // 使用 golang.org/x/sys/windows 的高层 CryptProtectData/CryptUnprotectData 包装，
 // 无需 raw syscall。

--- a/internal/edgeagent/dpapi/dpapi_windows_test.go
+++ b/internal/edgeagent/dpapi/dpapi_windows_test.go
@@ -1,0 +1,173 @@
+//go:build windows
+
+package dpapi
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestProtect_Unprotect_RoundTrip 验证加密→解密还原原始数据。
+func TestProtect_Unprotect_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"short_string", []byte("hello world")},
+		{"broker_token_like", []byte("ed_bk_abc123xyz789")},
+		{"unicode", []byte("中文token")},
+		{"binary_data", []byte{0x00, 0x01, 0xFF, 0xFE, 0x80, 0x7F}},
+		{"exact_1kb", bytes.Repeat([]byte("A"), 1024)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encrypted, err := Protect(tc.plaintext)
+			if err != nil {
+				t.Fatalf("Protect failed: %v", err)
+			}
+			if bytes.Equal(encrypted, tc.plaintext) {
+				t.Error("encrypted output should differ from plaintext")
+			}
+			decrypted, err := Unprotect(encrypted)
+			if err != nil {
+				t.Fatalf("Unprotect failed: %v", err)
+			}
+			if !bytes.Equal(decrypted, tc.plaintext) {
+				t.Errorf("round-trip mismatch:\n  want %x\n  got  %x", tc.plaintext, decrypted)
+			}
+		})
+	}
+}
+
+// TestProtect_EmptyInput_ReturnsError 验证空输入返回错误。
+func TestProtect_EmptyInput_ReturnsError(t *testing.T) {
+	_, err := Protect(nil)
+	if err == nil {
+		t.Fatal("expected error for nil input, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty, got: %v", err)
+	}
+
+	_, err = Protect([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty slice, got nil")
+	}
+}
+
+// TestUnprotect_EmptyInput_ReturnsError 验证空密文返回错误。
+func TestUnprotect_EmptyInput_ReturnsError(t *testing.T) {
+	_, err := Unprotect(nil)
+	if err == nil {
+		t.Fatal("expected error for nil input, got nil")
+	}
+	_, err = Unprotect([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty slice, got nil")
+	}
+}
+
+// TestProtect_LargeInput 验证大块数据（1MB+）正确加密解密。
+func TestProtect_LargeInput(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("ONGRID"), 200*1024) // ~1.2MB
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect 1MB+ failed: %v", err)
+	}
+	decrypted, err := Unprotect(encrypted)
+	if err != nil {
+		t.Fatalf("Unprotect 1MB+ failed: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("large input round-trip mismatch (len want=%d got=%d)", len(plaintext), len(decrypted))
+	}
+}
+
+// TestUnprotect_InvalidPayload_ReturnsError 验证损坏数据返回错误。
+func TestUnprotect_InvalidPayload_ReturnsError(t *testing.T) {
+	// 完全无效的 payload
+	_, err := Unprotect([]byte("not a valid dpapi blob"))
+	if err == nil {
+		t.Fatal("expected error for invalid payload, got nil")
+	}
+
+	// 篡改有效密文
+	original := []byte("secret token data")
+	encrypted, err := Protect(original)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+	tampered := make([]byte, len(encrypted))
+	copy(tampered, encrypted)
+	// 翻转最后一个字节
+	tampered[len(tampered)-1] ^= 0xFF
+	_, err = Unprotect(tampered)
+	if err == nil {
+		t.Error("expected error for tampered ciphertext, got nil")
+	}
+}
+
+// TestProtect_OutputIsNonDeterministic 验证同一明文加密两次产生不同密文
+// （DPAPI 使用随机 IV，确保相同输入不产生相同输出）。
+func TestProtect_OutputIsNonDeterministic(t *testing.T) {
+	plaintext := []byte("same input twice")
+	enc1, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("first Protect failed: %v", err)
+	}
+	enc2, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("second Protect failed: %v", err)
+	}
+	if bytes.Equal(enc1, enc2) {
+		t.Error("DPAPI output should be non-deterministic (random IV), but two calls produced identical output")
+	}
+
+	// 两者都应能正确解密
+	dec1, err := Unprotect(enc1)
+	if err != nil {
+		t.Fatalf("Unprotect enc1 failed: %v", err)
+	}
+	dec2, err := Unprotect(enc2)
+	if err != nil {
+		t.Fatalf("Unprotect enc2 failed: %v", err)
+	}
+	if !bytes.Equal(dec1, plaintext) || !bytes.Equal(dec2, plaintext) {
+		t.Error("both non-deterministic outputs should decrypt to original")
+	}
+}
+
+// TestProtect_LocalMachineScope 验证使用 CRYPTPROTECT_LOCAL_MACHINE flag。
+//
+// LOCAL_MACHINE scope 的语义：加密绑定到机器而非用户 logon session。
+// 本测试验证加密结果可以被同机器上的当前进程解密（基础验证）。
+// 跨用户/跨机器解密失败是 adversarial test，需要多用户/多机器 CI 环境验证。
+func TestProtect_LocalMachineScope(t *testing.T) {
+	plaintext := []byte("machine-bound secret")
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+
+	// 同一进程解密应成功（LOCAL_MACHINE scope 下，同一机器的 System 进程都能解密）
+	decrypted, err := Unprotect(encrypted)
+	if err != nil {
+		t.Fatalf("Unprotect failed: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("LOCAL_MACHINE round-trip mismatch")
+	}
+}
+
+// TestProtect_DoesNotLeakPlaintextInOutput 验证加密输出不含明文。
+func TestProtect_DoesNotLeakPlaintextInOutput(t *testing.T) {
+	plaintext := []byte("supersecret_broker_token_12345")
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+	if bytes.Contains(encrypted, plaintext) {
+		t.Error("encrypted output contains plaintext — DPAPI encryption failed to protect data")
+	}
+}

--- a/internal/edgeagent/edgedirs/doc.go
+++ b/internal/edgeagent/edgedirs/doc.go
@@ -1,0 +1,14 @@
+// Package edgedirs 定义 edge agent 部署目录约定（ADR-033 I2）。
+//
+// 这是跨 binary 共享的路径 source of truth：
+//   - cmd/ongrid-edge（worker.exe / linux edge）的数据目录
+//   - cmd/ongrid-edge-supervisor（supervisor.exe）的 binary / 数据目录
+//
+// 历史：原 cmd/ongrid-edge/paths_{linux,windows}.go 在本包建立前就存在
+// （issue #3 build tag 骨架）。MVP-2 时 paths_*.go 迁移到 import 本包。
+// 新代码（supervisor / worker 心跳写端）一律用本包。
+package edgedirs
+
+// 跨平台行为：每个平台专属文件（edgedirs_{linux,windows}.go）定义自己的
+// BinDir / DataDir / PluginWorkDir / StageDir 常量。本文件不包含任何
+// 平台相关定义，仅作包文档。

--- a/internal/edgeagent/edgedirs/doc.go
+++ b/internal/edgeagent/edgedirs/doc.go
@@ -1,11 +1,9 @@
-// Package edgedirs 定义 edge agent 部署目录约定（ADR-033 I2）。
+// Package edgedirs 定义 edge agent 部署目录约定。
 //
 // 这是跨 binary 共享的路径 source of truth：
 //   - cmd/ongrid-edge（worker.exe / linux edge）的数据目录
 //   - cmd/ongrid-edge-supervisor（supervisor.exe）的 binary / 数据目录
 //
-// 历史：原 cmd/ongrid-edge/paths_{linux,windows}.go 在本包建立前就存在
-// （issue #3 build tag 骨架）。MVP-2 时 paths_*.go 迁移到 import 本包。
 // 新代码（supervisor / worker 心跳写端）一律用本包。
 package edgedirs
 

--- a/internal/edgeagent/edgedirs/edgedirs_linux.go
+++ b/internal/edgeagent/edgedirs/edgedirs_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package edgedirs
+
+// Linux 部署目录约定（FHS / ADR-024）。
+//
+// 注：Linux edge 没有 supervisor.exe（ADR-033 U3 是 Windows 专属）。
+// 本文件仅为 cmd/ongrid-edge 未来 import 提供对称 API，supervisor 包
+// 不会用到。
+const (
+	BinDir        = `/usr/local/bin`
+	DataDir       = `/var/lib/ongrid-edge`
+	PluginWorkDir = `/var/lib/ongrid-edge/plugins`
+	StageDir      = `/var/lib/ongrid-edge/.upgrade`
+)

--- a/internal/edgeagent/edgedirs/edgedirs_linux.go
+++ b/internal/edgeagent/edgedirs/edgedirs_linux.go
@@ -2,9 +2,9 @@
 
 package edgedirs
 
-// Linux 部署目录约定（FHS / ADR-024）。
+// Linux 部署目录约定（FHS）。
 //
-// 注：Linux edge 没有 supervisor.exe（ADR-033 U3 是 Windows 专属）。
+// 注：Linux edge 没有 supervisor.exe（supervisor 是 Windows 专属）。
 // 本文件仅为 cmd/ongrid-edge 未来 import 提供对称 API，supervisor 包
 // 不会用到。
 const (

--- a/internal/edgeagent/edgedirs/edgedirs_windows.go
+++ b/internal/edgeagent/edgedirs/edgedirs_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package edgedirs
+
+// Windows 部署目录约定（ADR-033 I2）。
+//
+//   - binary → C:\Program Files\ongrid-edge\bin\
+//   - data   → C:\ProgramData\ongrid-edge\
+//
+// ProgramData 是 Windows Service 标准数据目录，NetworkService 可写
+// （ADR-036 P4 默认服务账户）。
+const (
+	BinDir       = `C:\Program Files\ongrid-edge\bin`
+	DataDir      = `C:\ProgramData\ongrid-edge`
+	PluginWorkDir = `C:\ProgramData\ongrid-edge\plugins`
+	StageDir     = `C:\ProgramData\ongrid-edge\upgrade`
+)
+
+// HealthFile 是 worker.exe 与 supervisor.exe 之间的 health.json IPC 文件
+// 路径（ADR-033 U3）。
+const HealthFile = DataDir + `\health.json`
+
+// WorkerBinary 是 worker.exe 在 BinDir 下的文件名。
+const WorkerBinary = "ongrid-edge-worker.exe"

--- a/internal/edgeagent/edgedirs/edgedirs_windows.go
+++ b/internal/edgeagent/edgedirs/edgedirs_windows.go
@@ -2,13 +2,12 @@
 
 package edgedirs
 
-// Windows 部署目录约定（ADR-033 I2）。
+// Windows 部署目录约定。
 //
 //   - binary → C:\Program Files\ongrid-edge\bin\
 //   - data   → C:\ProgramData\ongrid-edge\
 //
-// ProgramData 是 Windows Service 标准数据目录，NetworkService 可写
-// （ADR-036 P4 默认服务账户）。
+// ProgramData 是 Windows Service 标准数据目录，NetworkService 可写。
 const (
 	BinDir       = `C:\Program Files\ongrid-edge\bin`
 	DataDir      = `C:\ProgramData\ongrid-edge`
@@ -16,8 +15,7 @@ const (
 	StageDir     = `C:\ProgramData\ongrid-edge\upgrade`
 )
 
-// HealthFile 是 worker.exe 与 supervisor.exe 之间的 health.json IPC 文件
-// 路径（ADR-033 U3）。
+// HealthFile 是 worker.exe 与 supervisor.exe 之间的 health.json IPC 文件路径。
 const HealthFile = DataDir + `\health.json`
 
 // WorkerBinary 是 worker.exe 在 BinDir 下的文件名。

--- a/internal/edgeagent/host_files/handlers.go
+++ b/internal/edgeagent/host_files/handlers.go
@@ -43,13 +43,11 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -686,21 +684,8 @@ func runStatOnePath(_ context.Context, sb *SandboxConfig, path string) tunnel.St
 		typ = "dir"
 	}
 
-	// Owner/group via syscall.Stat_t — works on Linux + Darwin;
-	// `sys, ok := li.Sys().(*syscall.Stat_t)` is the canonical idiom.
-	var owner, group string
-	if st, ok := li.Sys().(*syscall.Stat_t); ok {
-		if u, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10)); err == nil {
-			owner = u.Username
-		} else {
-			owner = strconv.FormatUint(uint64(st.Uid), 10)
-		}
-		if g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10)); err == nil {
-			group = g.Name
-		} else {
-			group = strconv.FormatUint(uint64(st.Gid), 10)
-		}
-	}
+	// Owner/group — resolved per-GOOS in owner_{unix,windows}.go.
+	owner, group := fileOwner(li)
 
 	// Atime is OS-specific in syscall.Stat_t. fileTimes() resolves it
 	// per-GOOS so the handler stays portable.

--- a/internal/edgeagent/host_files/owner_unix.go
+++ b/internal/edgeagent/host_files/owner_unix.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package host_files
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// fileOwner extracts owner/group names from FileInfo on Unix-like
+// systems (Linux + Darwin). Uses syscall.Stat_t to get uid/gid, then
+// resolves to names via os/user. Falls back to numeric string when
+// LookupId fails (common in scratch containers without /etc/passwd).
+//
+// Windows uses ACL/SID for ownership (fundamentally different from
+// uid/gid); see owner_windows.go for the MVP-1 stub that returns
+// empty strings.
+func fileOwner(fi os.FileInfo) (owner, group string) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if u, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10)); err == nil {
+			owner = u.Username
+		} else {
+			owner = strconv.FormatUint(uint64(st.Uid), 10)
+		}
+		if g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10)); err == nil {
+			group = g.Name
+		} else {
+			group = strconv.FormatUint(uint64(st.Gid), 10)
+		}
+	}
+	return owner, group
+}

--- a/internal/edgeagent/host_files/owner_unix.go
+++ b/internal/edgeagent/host_files/owner_unix.go
@@ -15,8 +15,8 @@ import (
 // LookupId fails (common in scratch containers without /etc/passwd).
 //
 // Windows uses ACL/SID for ownership (fundamentally different from
-// uid/gid); see owner_windows.go for the MVP-1 stub that returns
-// empty strings.
+// uid/gid); see owner_windows.go for the stub that returns
+// empty strings until a Windows skill needs this data.
 func fileOwner(fi os.FileInfo) (owner, group string) {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
 		if u, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10)); err == nil {

--- a/internal/edgeagent/host_files/owner_windows.go
+++ b/internal/edgeagent/host_files/owner_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package host_files
+
+import "os"
+
+// fileOwner is a stub on Windows. Windows uses ACLs/SIDs for file
+// ownership (not uid/gid), and resolving SID → account name requires
+// heavier Win32 API calls (LookupAccountSid). For MVP-1 the host_files
+// response omits owner/group on Windows — full support is deferred
+// until a Windows skill actually needs this data (YAGNI).
+func fileOwner(_ os.FileInfo) (owner, group string) {
+	return "", ""
+}

--- a/internal/edgeagent/host_files/owner_windows.go
+++ b/internal/edgeagent/host_files/owner_windows.go
@@ -6,9 +6,9 @@ import "os"
 
 // fileOwner is a stub on Windows. Windows uses ACLs/SIDs for file
 // ownership (not uid/gid), and resolving SID → account name requires
-// heavier Win32 API calls (LookupAccountSid). For MVP-1 the host_files
+// heavier Win32 API calls (LookupAccountSid). The host_files
 // response omits owner/group on Windows — full support is deferred
-// until a Windows skill actually needs this data (YAGNI).
+// until a Windows skill actually needs this data.
 func fileOwner(_ os.FileInfo) (owner, group string) {
 	return "", ""
 }

--- a/internal/edgeagent/host_files/times_windows.go
+++ b/internal/edgeagent/host_files/times_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package host_files
+
+import (
+	"os"
+	"time"
+)
+
+// fileTimes returns mtime and atime for the given FileInfo on Windows.
+// Windows file timestamps use a different syscall
+// (windows.Win32FileAttributeData) than Unix syscall.Stat_t. For MVP-1
+// we return mtime for both fields — accurate atime resolution on
+// Windows is deferred until a skill needs it (YAGNI). handlers.go
+// treats atime as optional metadata, so this stub keeps the handler
+// compiling without altering its control flow.
+func fileTimes(fi os.FileInfo) (time.Time, time.Time) {
+	mtime := fi.ModTime().UTC()
+	return mtime, mtime
+}

--- a/internal/edgeagent/host_files/times_windows.go
+++ b/internal/edgeagent/host_files/times_windows.go
@@ -9,9 +9,9 @@ import (
 
 // fileTimes returns mtime and atime for the given FileInfo on Windows.
 // Windows file timestamps use a different syscall
-// (windows.Win32FileAttributeData) than Unix syscall.Stat_t. For MVP-1
-// we return mtime for both fields — accurate atime resolution on
-// Windows is deferred until a skill needs it (YAGNI). handlers.go
+// (windows.Win32FileAttributeData) than Unix syscall.Stat_t.
+// We return mtime for both fields — accurate atime resolution on
+// Windows is deferred until a skill needs it. handlers.go
 // treats atime as optional metadata, so this stub keeps the handler
 // compiling without altering its control flow.
 func fileTimes(fi os.FileInfo) (time.Time, time.Time) {

--- a/internal/edgeagent/install/acl_windows.go
+++ b/internal/edgeagent/install/acl_windows.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ACL 验证：DPAPI CRYPTPROTECT_LOCAL_MACHINE scope 绑定到机器级 SystemCredential，
+// 同机器上任何 LocalSystem / NetworkService 进程都能解密。这意味着 DPAPI 本身
+// 不替代文件 ACL——必须配合文件系统 ACL 限制非 System/Administrators 身份的读访问。
+//
+// 目标 ACL（secrets.enc + 父目录）：
+//   - NT AUTHORITY\SYSTEM:(F)        — supervisor / worker 跑在 LocalSystem，需要 Read + Write + Delete（rotate）
+//   - BUILTIN\Administrators:(F)     — 管理员运维访问（rotate / uninstall）
+//   - 移除 BUILTIN\Users / Everyone / Authenticated Users 的所有 ACE
+//
+// 用 icacls.exe（Windows 内置命令）而非 raw syscall：
+//   - 标准做法，可审计（icacls 输出人类可读）
+//   - 错误信息清晰
+//   - 避免 SECURITY_DESCRIPTOR 手工构造的复杂度
+
+// ApplySecretACL 应用 secrets.enc 的 ACL：仅 SYSTEM + Administrators 有 Full Control。
+//
+// 操作：
+//  1. /inheritance:r  — 移除从父目录继承的 ACE
+//  2. /grant:r         — 替换为指定 ACE（非合并）
+//
+// 注意：(F) Full Control 是必要的——supervisor（SYSTEM 身份）需要 Write + Delete
+// 来执行 Rotate（rename tmp → secrets.enc 会用 Delete 旧文件）。
+func ApplySecretACL(path string) error {
+	// icacls 在路径参数上接受正斜杠或反斜杠，但路径含空格时需要 quote。
+	// 用 filepath.Clean 规范化（去 trailing slash 等）。
+	clean := filepath.Clean(path)
+	cmd := exec.Command("icacls", clean,
+		"/inheritance:r",
+		"/grant:r",
+		"NT AUTHORITY\\SYSTEM:(F)",
+		"BUILTIN\\Administrators:(F)",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("icacls apply ACL on %s: %w (output: %s)", clean, err, out)
+	}
+	return nil
+}
+
+// VerifySecretACL 验证 secrets.enc 的 ACL 符合预期。
+//
+// 读 icacls 输出，确认：
+//   - SYSTEM 有 Full Control 权限（含或不含 inherit 标记）
+//   - Administrators 有 Full Control 权限
+//   - 不含 Users / Everyone / Authenticated Users 组（防普通用户读）
+//
+// 注意：这是"独立检查点"——即使 ApplySecretACL 成功，也要读回来验证。
+// 防止 GPO / AV / 其他工具在 apply 后修改 ACL。
+//
+// 匹配策略：按行扫描，每行检查是否同时含 principal 关键字 + (F)。
+// 这样兼容 icacls 各种 inherit 标记格式（(I)(F) / (OI)(CI)(F) / (F)）。
+func VerifySecretACL(path string) error {
+	clean := filepath.Clean(path)
+	out, err := exec.Command("icacls", clean).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("icacls verify on %s: %w (output: %s)", clean, err, out)
+	}
+	output := string(out)
+
+	// 按行检查 SYSTEM + Administrators 是否有 (F)
+	if !hasAceWithPerm(output, "NT AUTHORITY\\SYSTEM:", "(F)") {
+		return fmt.Errorf("verify ACL: SYSTEM:(F) missing on %s (output: %s)", clean, output)
+	}
+	if !hasAceWithPerm(output, "BUILTIN\\Administrators:", "(F)") {
+		return fmt.Errorf("verify ACL: Administrators:(F) missing on %s (output: %s)", clean, output)
+	}
+	// 必须不出现 Users / Everyone / Authenticated Users（任何权限位）
+	for _, forbidden := range []string{"BUILTIN\\Users:", "Everyone:", "Authenticated Users:"} {
+		if strings.Contains(output, forbidden) {
+			return fmt.Errorf("verify ACL: forbidden ACE %q present on %s (output: %s)", forbidden, clean, output)
+		}
+	}
+	return nil
+}
+
+// hasAceWithPerm 检查 icacls 输出中是否存在某 principal 行且该行含指定权限位。
+// 行内同时含 principal 关键字和权限位（如 (F)）即视为匹配。
+func hasAceWithPerm(output, principal, perm string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, principal) && strings.Contains(line, perm) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/edgeagent/install/acl_windows.go
+++ b/internal/edgeagent/install/acl_windows.go
@@ -4,6 +4,7 @@ package install
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -14,14 +15,47 @@ import (
 // 不替代文件 ACL——必须配合文件系统 ACL 限制非 System/Administrators 身份的读访问。
 //
 // 目标 ACL（secrets.enc + 父目录）：
-//   - NT AUTHORITY\SYSTEM:(F)        — supervisor / worker 跑在 LocalSystem，需要 Read + Write + Delete（rotate）
-//   - BUILTIN\Administrators:(F)     — 管理员运维访问（rotate / uninstall）
+//   - NT AUTHORITY\SYSTEM:(F)        — supervisor / worker 跑在 LocalSystem
+//   - BUILTIN\Administrators:(F)     — 管理员运维访问
 //   - 移除 BUILTIN\Users / Everyone / Authenticated Users 的所有 ACE
 //
 // 用 icacls.exe（Windows 内置命令）而非 raw syscall：
 //   - 标准做法，可审计（icacls 输出人类可读）
 //   - 错误信息清晰
 //   - 避免 SECURITY_DESCRIPTOR 手工构造的复杂度
+//
+// icacls 错误信息 sanitize 策略：
+//   - error message 只保留 exit code + 简短原因，不暴露 icacls 完整输出
+//   - 完整输出在开发期可见（test 跑 icacls），生产日志不记录（避免泄露路径/SID）
+
+// icaclsNotFoundError 表示 icacls.exe 不在 PATH 中（如 Windows Server Core 精简镜像）。
+// 这种环境下无法应用 ACL，调用方必须中止 install（不降级到无 ACL 状态）。
+var icaclsNotFoundError = fmt.Errorf("icacls.exe not found in PATH — cannot apply ACL, install aborted (Windows Server Core 精简镜像可能移除了 icacls)")
+
+// requireIcacls 在入口检查 icacls 可用性，避免后续命令失败时错误信息不清晰。
+func requireIcacls() error {
+	if _, err := exec.LookPath("icacls"); err != nil {
+		return icaclsNotFoundError
+	}
+	return nil
+}
+
+// sanitizeIcaclsOutput 从 icacls 输出中提取关键错误信息，去除路径前缀和 SID 详情。
+// 用于 error message，避免泄露完整路径/ACL 配置到生产日志。
+func sanitizeIcaclsOutput(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	// 取最后一行（通常是 "Successfully processed N files" 或错误摘要）
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	last := strings.TrimSpace(lines[len(lines)-1])
+	// 截断超长输出
+	if len(last) > 200 {
+		last = last[:200] + "..."
+	}
+	return last
+}
 
 // ApplySecretACL 应用 secrets.enc 的 ACL：仅 SYSTEM + Administrators 有 Full Control。
 //
@@ -32,8 +66,9 @@ import (
 // 注意：(F) Full Control 是必要的——supervisor（SYSTEM 身份）需要 Write + Delete
 // 来执行 Rotate（rename tmp → secrets.enc 会用 Delete 旧文件）。
 func ApplySecretACL(path string) error {
-	// icacls 在路径参数上接受正斜杠或反斜杠，但路径含空格时需要 quote。
-	// 用 filepath.Clean 规范化（去 trailing slash 等）。
+	if err := requireIcacls(); err != nil {
+		return err
+	}
 	clean := filepath.Clean(path)
 	cmd := exec.Command("icacls", clean,
 		"/inheritance:r",
@@ -41,44 +76,116 @@ func ApplySecretACL(path string) error {
 		"NT AUTHORITY\\SYSTEM:(F)",
 		"BUILTIN\\Administrators:(F)",
 	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("icacls apply ACL on %s: %w (output: %s)", clean, err, out)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("icacls apply on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
 	}
 	return nil
 }
 
 // VerifySecretACL 验证 secrets.enc 的 ACL 符合预期。
 //
-// 读 icacls 输出，确认：
-//   - SYSTEM 有 Full Control 权限（含或不含 inherit 标记）
-//   - Administrators 有 Full Control 权限
-//   - 不含 Users / Everyone / Authenticated Users 组（防普通用户读）
+// 检查：
+//   - SYSTEM 行含 (F)
+//   - Administrators 行含 (F)
+//   - 不含 Users / Everyone / Authenticated Users
 //
-// 注意：这是"独立检查点"——即使 ApplySecretACL 成功，也要读回来验证。
+// 这是"独立检查点"——即使 ApplySecretACL 成功，也要读回来验证。
 // 防止 GPO / AV / 其他工具在 apply 后修改 ACL。
-//
-// 匹配策略：按行扫描，每行检查是否同时含 principal 关键字 + (F)。
-// 这样兼容 icacls 各种 inherit 标记格式（(I)(F) / (OI)(CI)(F) / (F)）。
 func VerifySecretACL(path string) error {
+	if err := requireIcacls(); err != nil {
+		return err
+	}
 	clean := filepath.Clean(path)
 	out, err := exec.Command("icacls", clean).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("icacls verify on %s: %w (output: %s)", clean, err, out)
+		return fmt.Errorf("icacls verify on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
 	}
 	output := string(out)
 
-	// 按行检查 SYSTEM + Administrators 是否有 (F)
 	if !hasAceWithPerm(output, "NT AUTHORITY\\SYSTEM:", "(F)") {
-		return fmt.Errorf("verify ACL: SYSTEM:(F) missing on %s (output: %s)", clean, output)
+		return fmt.Errorf("verify ACL: SYSTEM:(F) missing on %s", clean)
 	}
 	if !hasAceWithPerm(output, "BUILTIN\\Administrators:", "(F)") {
-		return fmt.Errorf("verify ACL: Administrators:(F) missing on %s (output: %s)", clean, output)
+		return fmt.Errorf("verify ACL: Administrators:(F) missing on %s", clean)
 	}
-	// 必须不出现 Users / Everyone / Authenticated Users（任何权限位）
 	for _, forbidden := range []string{"BUILTIN\\Users:", "Everyone:", "Authenticated Users:"} {
 		if strings.Contains(output, forbidden) {
-			return fmt.Errorf("verify ACL: forbidden ACE %q present on %s (output: %s)", forbidden, clean, output)
+			return fmt.Errorf("verify ACL: forbidden ACE %q present on %s", forbidden, clean)
 		}
+	}
+	return nil
+}
+
+// ApplyDirACL 应用目录的 ACL，使用 (OI)(CI) 容器继承标记让子文件/子目录自动继承。
+//
+// 与 ApplySecretACL 区别：
+//   - 目录用 (OI)(CI)(F) — Object Inherit + Container Inherit + Full Control
+//   - secrets.enc 用 (F) — 仅文件本身
+//
+// 调用 EnsureSecureDir 而非直接调用此函数（EnsureSecureDir 含 MkdirAll + 验证）。
+func ApplyDirACL(dir string) error {
+	if err := requireIcacls(); err != nil {
+		return err
+	}
+	clean := filepath.Clean(dir)
+	cmd := exec.Command("icacls", clean,
+		"/inheritance:r",
+		"/grant:r",
+		"NT AUTHORITY\\SYSTEM:(OI)(CI)(F)",
+		"BUILTIN\\Administrators:(OI)(CI)(F)",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("icacls apply dir ACL on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
+	}
+	return nil
+}
+
+// VerifyDirACL 验证目录 ACL 符合预期（与 VerifySecretACL 类似，但允许 inherit 标记）。
+func VerifyDirACL(dir string) error {
+	if err := requireIcacls(); err != nil {
+		return err
+	}
+	clean := filepath.Clean(dir)
+	out, err := exec.Command("icacls", clean).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("icacls verify dir on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
+	}
+	output := string(out)
+
+	if !hasAceWithPerm(output, "NT AUTHORITY\\SYSTEM:", "(F)") {
+		return fmt.Errorf("verify dir ACL: SYSTEM:(F) missing on %s", clean)
+	}
+	if !hasAceWithPerm(output, "BUILTIN\\Administrators:", "(F)") {
+		return fmt.Errorf("verify dir ACL: Administrators:(F) missing on %s", clean)
+	}
+	for _, forbidden := range []string{"BUILTIN\\Users:", "Everyone:", "Authenticated Users:"} {
+		if strings.Contains(output, forbidden) {
+			return fmt.Errorf("verify dir ACL: forbidden ACE %q present on %s", forbidden, clean)
+		}
+	}
+	return nil
+}
+
+// EnsureSecureDir 确保 dir 存在且 ACL 受限（仅 SYSTEM + Administrators）。
+//
+// 流程：
+//  1. MkdirAll(dir) — 创建目录（如已存在是 noop）
+//  2. ApplyDirACL(dir) — 强制刷新 ACL（idempotent）
+//  3. VerifyDirACL(dir) — 读回来验证
+//
+// 调用时机：Install 流程开始前（写 secrets.enc 之前）确保父目录受限，
+// 这样 secrets.enc 即使继承父目录 ACL 也只对 SYSTEM+Admins 可读。
+func EnsureSecureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := ApplyDirACL(dir); err != nil {
+		return fmt.Errorf("apply dir ACL: %w", err)
+	}
+	if err := VerifyDirACL(dir); err != nil {
+		return fmt.Errorf("verify dir ACL: %w", err)
 	}
 	return nil
 }

--- a/internal/edgeagent/install/acl_windows_test.go
+++ b/internal/edgeagent/install/acl_windows_test.go
@@ -1,0 +1,107 @@
+//go:build windows
+
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withNoopACL 把 ACL apply/verify 函数替换为 noop，t.Cleanup 还原。
+//
+// 用途：DPAPI round-trip 测试不需要触发真实 ACL（ACL 会让后续 WriteFile / Remove
+// 在普通用户身份下失败）。ACL 行为在 TestApplySecretACL_* / TestVerifySecretACL_*
+// 单独验证（需 Administrator 身份）。
+func withNoopACL(t *testing.T) {
+	t.Helper()
+	origApply, origVerify := applySecretACLFn, verifySecretACLFn
+	applySecretACLFn = func(string) error { return nil }
+	verifySecretACLFn = func(string) error { return nil }
+	t.Cleanup(func() {
+		applySecretACLFn, verifySecretACLFn = origApply, origVerify
+	})
+}
+
+// isAdmin 通过 net session 命令探测当前进程是否以 elevated Administrator 身份运行。
+// net session 在非 admin 时返回非零 exit code。
+func isAdmin() bool {
+	cmd := exec.Command("net", "session")
+	return cmd.Run() == nil
+}
+
+// TestApplySecretACL_RestrictsToSystemAndAdmins 验证 ApplySecretACL 后：
+//   - SYSTEM:(F) 出现在 icacls 输出
+//   - Administrators:(F) 出现
+//   - BUILTIN\Users 不出现
+//
+// 需要 Administrator 身份（icacls 修改 ACL 需要文件所有权或 SeTakeOwnershipPrivilege）。
+func TestApplySecretACL_RestrictsToSystemAndAdmins(t *testing.T) {
+	if !isAdmin() {
+		t.Skip("requires Administrator (icacls modify needs elevated token)")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.enc")
+	if err := os.WriteFile(path, []byte("dummy"), 0600); err != nil {
+		t.Fatalf("setup: write file: %v", err)
+	}
+
+	if err := ApplySecretACL(path); err != nil {
+		t.Fatalf("ApplySecretACL: %v", err)
+	}
+
+	out, err := exec.Command("icacls", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("icacls read: %v (output: %s)", err, out)
+	}
+	output := string(out)
+
+	if !strings.Contains(output, "NT AUTHORITY\\SYSTEM:(F)") {
+		t.Errorf("SYSTEM:(F) missing in ACL: %s", output)
+	}
+	if !strings.Contains(output, "BUILTIN\\Administrators:(F)") {
+		t.Errorf("Administrators:(F) missing in ACL: %s", output)
+	}
+	if strings.Contains(output, "BUILTIN\\Users:") {
+		t.Errorf("forbidden Users ACE present: %s", output)
+	}
+}
+
+// TestVerifySecretACL_DetectsMissingSystem 验证 VerifySecretACL 能检出 SYSTEM ACE 缺失。
+//
+// 不需要 Administrator：用 t.TempDir 默认 ACL（含 SYSTEM:(I)(F)）→ 通过；
+// 然后测一个不存在的路径 → icacls 失败 → VerifySecretACL 报错。
+// 完整的 forbidden ACE 检测在 TestApplySecretACL_RestrictsToSystemAndAdmins（admin-only）覆盖。
+func TestVerifySecretACL_DetectsMissingSystem(t *testing.T) {
+	// 不存在的路径 → icacls 命令本身失败
+	missing := filepath.Join(t.TempDir(), "no-such-file.enc")
+	err := VerifySecretACL(missing)
+	if err == nil {
+		t.Fatal("VerifySecretACL should fail on non-existent path")
+	}
+}
+
+// TestVerifySecretACL_PassesAfterApply 验证 ApplySecretACL + VerifySecretACL 端到端闭环。
+//
+// 需要 Administrator 身份（ApplySecretACL 修改 ACL 需要 elevated token）。
+func TestVerifySecretACL_PassesAfterApply(t *testing.T) {
+	if !isAdmin() {
+		t.Skip("requires Administrator (ApplySecretACL needs elevated token)")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.enc")
+	if err := os.WriteFile(path, []byte("dummy"), 0600); err != nil {
+		t.Fatalf("setup: write file: %v", err)
+	}
+
+	if err := ApplySecretACL(path); err != nil {
+		t.Fatalf("ApplySecretACL: %v", err)
+	}
+	if err := VerifySecretACL(path); err != nil {
+		t.Errorf("VerifySecretACL after Apply should pass, got: %v", err)
+	}
+}

--- a/internal/edgeagent/install/acl_windows_test.go
+++ b/internal/edgeagent/install/acl_windows_test.go
@@ -3,6 +3,7 @@
 package install
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -103,5 +104,175 @@ func TestVerifySecretACL_PassesAfterApply(t *testing.T) {
 	}
 	if err := VerifySecretACL(path); err != nil {
 		t.Errorf("VerifySecretACL after Apply should pass, got: %v", err)
+	}
+}
+
+// --- ACL flow integration tests ---
+//
+// 这组测试验证 Install/Rotate 真的调用了 ACL 函数（不全部 noop），且调用顺序正确。
+// 补 withNoopACL 之外的盲区：withNoopACL 让 Install/Rotate 测试跳过 ACL，
+// 这些测试用 spy 记录调用顺序，确保 ACL 步骤确实在流程里。
+
+// aclSpy 记录 ACL 函数调用顺序，可注入错误。
+type aclSpy struct {
+	calls     []string
+	applyErr  error
+	verifyErr error
+	ensureErr error
+}
+
+// install 替换包级 ACL var 函数为 spy，t.Cleanup 自动还原。
+func (s *aclSpy) install(t *testing.T) {
+	t.Helper()
+	origEnsure, origApply, origVerify := ensureSecureDirFn, applySecretACLFn, verifySecretACLFn
+	ensureSecureDirFn = func(dir string) error {
+		s.calls = append(s.calls, "ensure:"+dir)
+		return s.ensureErr
+	}
+	applySecretACLFn = func(path string) error {
+		s.calls = append(s.calls, "apply:"+path)
+		return s.applyErr
+	}
+	verifySecretACLFn = func(path string) error {
+		s.calls = append(s.calls, "verify:"+path)
+		return s.verifyErr
+	}
+	t.Cleanup(func() {
+		ensureSecureDirFn, applySecretACLFn, verifySecretACLFn = origEnsure, origApply, origVerify
+	})
+}
+
+// TestInstall_ACLFlowOrder 验证 Install 调用 ACL 函数顺序：ensure → apply → verify。
+// round-trip 验证（ReadFile + Unprotect）发生在 ACL 之后。
+func TestInstall_ACLFlowOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path).(*WindowsSecretStore)
+
+	spy := &aclSpy{}
+	spy.install(t)
+
+	if err := ss.Install([]byte("test_token_order")); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// 前 3 个调用应为 ensure → apply → verify
+	want := []string{
+		"ensure:" + dir,
+		"apply:" + path,
+		"verify:" + path,
+	}
+	if len(spy.calls) < len(want) {
+		t.Fatalf("expected at least %d calls, got %d: %v", len(want), len(spy.calls), spy.calls)
+	}
+	for i, w := range want {
+		if spy.calls[i] != w {
+			t.Errorf("call[%d] = %q, want %q (full: %v)", i, spy.calls[i], w, spy.calls)
+		}
+	}
+}
+
+// TestInstall_ApplyErr_CleansUpFile 验证 apply 失败时清理 secrets.enc。
+func TestInstall_ApplyErr_CleansUpFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path).(*WindowsSecretStore)
+
+	spy := &aclSpy{applyErr: fmt.Errorf("simulated icacls failure")}
+	spy.install(t)
+
+	if err := ss.Install([]byte("token")); err == nil {
+		t.Fatal("Install should fail when apply fails")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("secrets.enc should be removed on apply failure, got err: %v", err)
+	}
+}
+
+// TestInstall_VerifyErr_CleansUpFile 验证 verify 失败时清理 secrets.enc。
+func TestInstall_VerifyErr_CleansUpFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path).(*WindowsSecretStore)
+
+	spy := &aclSpy{verifyErr: fmt.Errorf("simulated verify failure")}
+	spy.install(t)
+
+	if err := ss.Install([]byte("token")); err == nil {
+		t.Fatal("Install should fail when verify fails")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("secrets.enc should be removed on verify failure, got err: %v", err)
+	}
+}
+
+// TestRotate_ACLFlowOrder 验证 Rotate 调用顺序：ensure → apply(tmp) → verify(final)。
+// 注意 tmp 名随机（os.CreateTemp），所以 apply 调用的路径是动态的。
+func TestRotate_ACLFlowOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path).(*WindowsSecretStore)
+
+	// 先 Install 初始化（用 spy 但允许全通过）
+	initSpy := &aclSpy{}
+	initSpy.install(t)
+	if err := ss.Install([]byte("init")); err != nil {
+		t.Fatalf("Install init: %v", err)
+	}
+
+	// 重新装 spy（清空 calls）
+	spy := &aclSpy{}
+	spy.install(t)
+
+	if err := ss.Rotate([]byte("rotated")); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// 第一个调用必须是 ensure:dir
+	if len(spy.calls) == 0 || spy.calls[0] != "ensure:"+dir {
+		t.Fatalf("call[0] = %q, want ensure:%s", spy.calls, dir)
+	}
+	// 必须有 apply:...（tmp 路径，动态）和 verify:path
+	foundApply, foundVerify := false, false
+	for _, c := range spy.calls {
+		if strings.HasPrefix(c, "apply:") {
+			foundApply = true
+			// apply 的路径必须不是 final path（应该是 tmp）
+			if c == "apply:"+path {
+				t.Errorf("apply should be on tmp path, got final path: %s", c)
+			}
+		}
+		if c == "verify:"+path {
+			foundVerify = true
+		}
+	}
+	if !foundApply {
+		t.Errorf("apply on tmp not called: %v", spy.calls)
+	}
+	if !foundVerify {
+		t.Errorf("verify on final path not called: %v", spy.calls)
+	}
+}
+
+// TestRotate_VerifyErr_NoErrorReturned 验证 Rotate verify 失败时返回 nil
+// （因为 rename 后新 token 已生效，返回 error 会让调用方误以为可重试）。
+func TestRotate_VerifyErr_NoErrorReturned(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path).(*WindowsSecretStore)
+
+	// 先 Install
+	initSpy := &aclSpy{}
+	initSpy.install(t)
+	if err := ss.Install([]byte("init")); err != nil {
+		t.Fatalf("Install init: %v", err)
+	}
+
+	// Rotate with verify failing — should NOT return error
+	spy := &aclSpy{verifyErr: fmt.Errorf("simulated post-rename ACL drift")}
+	spy.install(t)
+
+	if err := ss.Rotate([]byte("rotated")); err != nil {
+		t.Errorf("Rotate should swallow verify error (new token already in effect), got: %v", err)
 	}
 }

--- a/internal/edgeagent/install/doc.go
+++ b/internal/edgeagent/install/doc.go
@@ -1,0 +1,16 @@
+// Package install 提供 Windows edge agent 的安装/卸载抽象。
+//
+// 将 runInstall 的 3 个正交关注点拆为独立接口（ADR-037 A2 CR4,
+// MVP-3 #18-1 深化 pass）：
+//
+//   - SecretStore: DPAPI 加密的凭证文件（secrets.enc）
+//   - ServiceController: Windows Service 生命周期（sc.exe 包装）
+//   - EnvWriter: 服务注册表 Environment 字段（REG_MULTI_SZ）
+//
+// 接口定义在 interfaces.go（无 build tag，跨平台可见）。
+// 具体实现按平台分文件：*_windows.go 为真实实现，
+// install_other.go 为非 Windows stub（返回 ErrUnsupportedPlatform）。
+//
+// 这使得 manager（Linux）可以引用 install 包的符号而不编译失败，
+// 与 dpapi / edgedirs 包的跨平台模式一致。
+package install

--- a/internal/edgeagent/install/doc.go
+++ b/internal/edgeagent/install/doc.go
@@ -1,7 +1,6 @@
 // Package install 提供 Windows edge agent 的安装/卸载抽象。
 //
-// 将 runInstall 的 3 个正交关注点拆为独立接口（ADR-037 A2 CR4,
-// MVP-3 #18-1 深化 pass）：
+// 将 runInstall 的 3 个正交关注点拆为独立接口：
 //
 //   - SecretStore: DPAPI 加密的凭证文件（secrets.enc）
 //   - ServiceController: Windows Service 生命周期（sc.exe 包装）

--- a/internal/edgeagent/install/env_windows.go
+++ b/internal/edgeagent/install/env_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// RegistryEnvWriter 是 EnvWriter 的 Windows 实现，
+// 通过注册表写服务 Environment 字段（REG_MULTI_SZ）。
+type RegistryEnvWriter struct {
+	regPath string
+}
+
+// NewEnvWriter 创建注册表 EnvWriter。
+// regPath 是服务注册表路径（如 `SYSTEM\CurrentControlSet\Services\ongrid-edge`）。
+func NewEnvWriter(regPath string) EnvWriter {
+	return &RegistryEnvWriter{regPath: regPath}
+}
+
+// Write 写入 KEY=VALUE 多字符串到注册表 Environment 字段。
+// 在 ServiceController.Create 之后调用（服务键此时已存在）。
+func (w *RegistryEnvWriter) Write(pairs []string) error {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, w.regPath,
+		registry.SET_VALUE|registry.QUERY_VALUE)
+	if err != nil {
+		return fmt.Errorf("open service registry key: %w", err)
+	}
+	defer key.Close()
+
+	if err := key.SetStringsValue("Environment", pairs); err != nil {
+		return fmt.Errorf("set Environment MultiString: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/install_other.go
+++ b/internal/edgeagent/install/install_other.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+// 非 Windows stub：所有方法返回 ErrUnsupportedPlatform。
+// 这使得 manager（Linux）可以引用 install 包的符号而不编译失败。
+
+package install
+
+// unsupportedSecretStore 是非 Windows 平台的 SecretStore stub。
+type unsupportedSecretStore struct{}
+
+// NewSecretStore 在非 Windows 平台返回 stub 实现。
+func NewSecretStore(_ string) SecretStore {
+	return unsupportedSecretStore{}
+}
+
+func (unsupportedSecretStore) Install(_ []byte) error { return ErrUnsupportedPlatform }
+func (unsupportedSecretStore) Rotate(_ []byte) error  { return ErrUnsupportedPlatform }
+func (unsupportedSecretStore) Remove() error           { return ErrUnsupportedPlatform }
+
+// unsupportedServiceController 是非 Windows 平台的 ServiceController stub。
+type unsupportedServiceController struct{}
+
+// NewServiceController 在非 Windows 平台返回 stub 实现。
+func NewServiceController(_ string) ServiceController {
+	return unsupportedServiceController{}
+}
+
+func (unsupportedServiceController) Create(_ string) error                  { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) ConfigureRecovery() error              { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) ConfigureDefenderExclusion() error     { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Start() error                          { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Stop() error                           { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Delete() error                         { return ErrUnsupportedPlatform }
+
+// unsupportedEnvWriter 是非 Windows 平台的 EnvWriter stub。
+type unsupportedEnvWriter struct{}
+
+// NewEnvWriter 在非 Windows 平台返回 stub 实现。
+func NewEnvWriter(_ string) EnvWriter {
+	return unsupportedEnvWriter{}
+}
+
+func (unsupportedEnvWriter) Write(_ []string) error { return ErrUnsupportedPlatform }

--- a/internal/edgeagent/install/install_windows_test.go
+++ b/internal/edgeagent/install/install_windows_test.go
@@ -1,0 +1,154 @@
+//go:build windows
+
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWindowsSecretStore_Install_CreatesValidFile 验证 Install 创建合法 DPAPI 加密文件 + round-trip。
+func TestWindowsSecretStore_Install_CreatesValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	token := []byte("ed_bk_test_token_abc123")
+
+	ss := NewSecretStore(path)
+	if err := ss.Install(token); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// 文件应存在且非空
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("secrets.enc is empty")
+	}
+}
+
+// TestWindowsSecretStore_Install_OverwritesExisting 验证写入覆盖已有文件。
+func TestWindowsSecretStore_Install_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	// 先写 token1
+	if err := ss.Install([]byte("token1")); err != nil {
+		t.Fatalf("first Install failed: %v", err)
+	}
+	// 再写 token2
+	if err := ss.Install([]byte("token2")); err != nil {
+		t.Fatalf("second Install failed: %v", err)
+	}
+	// 验证文件内容对应 token2：如果 token1 仍匹配则说明覆盖失败
+	// （无法直接验证 round-trip 因为 Install 内部已验证，这里间接验证：
+	//   如果文件没更新，第二次 Install 的 round-trip 会用旧密文 → mismatch → error）
+	// 所以只要第二次 Install 不报错就说明覆盖成功
+}
+
+// TestWindowsSecretStore_Remove_DeletesFile 验证 Remove 删除文件。
+func TestWindowsSecretStore_Remove_DeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	if err := ss.Install([]byte("token")); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if err := ss.Remove(); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should not exist after Remove, got err: %v", err)
+	}
+}
+
+// TestWindowsSecretStore_Remove_NonExistentNoError 验证 Remove 不存在的文件不报错。
+func TestWindowsSecretStore_Remove_NonExistentNoError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.enc")
+	ss := NewSecretStore(path)
+
+	if err := ss.Remove(); err != nil {
+		t.Errorf("Remove non-existent file should not error, got: %v", err)
+	}
+}
+
+// TestWindowsSecretStore_Install_WrongTokenRoundTrip 验证不同 token 产生不同密文。
+func TestWindowsSecretStore_Install_WrongTokenRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	// 写 token1
+	if err := ss.Install([]byte("correct_token")); err != nil {
+		t.Fatalf("Install correct_token failed: %v", err)
+	}
+	// 再写 token2（覆盖）
+	if err := ss.Install([]byte("wrong_token")); err != nil {
+		t.Fatalf("Install wrong_token failed: %v", err)
+	}
+	// 如果覆盖失败，第二次 Install 的 round-trip 会验证到旧密文 → mismatch → error
+	// 所以只要第二次 Install 不报错就说明覆盖成功
+}
+
+// --- Rotate tests (#16 D4 tmp→rename) ---
+
+// TestWindowsSecretStore_Rotate_ReplacesToken 验证 Rotate 原子替换文件内容。
+func TestWindowsSecretStore_Rotate_ReplacesToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	token1 := []byte("original-cred-value")
+	token2 := []byte("rotated-cred-value")
+
+	ss := NewSecretStore(path)
+	if err := ss.Install(token1); err != nil {
+		t.Fatalf("Install token1: %v", err)
+	}
+
+	// 记录旧文件修改时间
+	infoBefore, _ := os.Stat(path)
+
+	if err := ss.Rotate(token2); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// 验证文件存在且非空
+	infoAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("file not found after Rotate: %v", err)
+	}
+	if infoAfter.Size() == 0 {
+		t.Error("secrets.enc is empty after Rotate")
+	}
+
+	// 验证 tmp 文件已被清理
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("tmp file should not exist after Rotate, got err: %v", err)
+	}
+
+	// 验证文件确实被更新（修改时间不同）
+	if !infoAfter.ModTime().After(infoBefore.ModTime()) {
+		t.Error("file ModTime not updated after Rotate")
+	}
+}
+
+// TestWindowsSecretStore_Rotate_OnNonExistentFile 验证 Rotate 对不存在的文件也能工作
+// （os.Rename 会创建目标文件）。
+func TestWindowsSecretStore_Rotate_OnNonExistentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+
+	ss := NewSecretStore(path)
+	if err := ss.Rotate([]byte("fresh-cred")); err != nil {
+		t.Fatalf("Rotate on non-existent file: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file should exist after Rotate: %v", err)
+	}
+}

--- a/internal/edgeagent/install/install_windows_test.go
+++ b/internal/edgeagent/install/install_windows_test.go
@@ -104,7 +104,7 @@ func TestWindowsSecretStore_Install_WrongTokenRoundTrip(t *testing.T) {
 	// 所以只要第二次 Install 不报错就说明覆盖成功
 }
 
-// --- Rotate tests (#16 D4 tmp→rename) ---
+// --- Rotate tests ---
 
 // TestWindowsSecretStore_Rotate_ReplacesToken 验证 Rotate 原子替换文件内容。
 func TestWindowsSecretStore_Rotate_ReplacesToken(t *testing.T) {

--- a/internal/edgeagent/install/install_windows_test.go
+++ b/internal/edgeagent/install/install_windows_test.go
@@ -8,8 +8,14 @@ import (
 	"testing"
 )
 
+// 这个测试文件验证 DPAPI round-trip 逻辑（加密 → 写文件 → 读回 → 解密 → 比较）。
+// ACL 行为（icacls apply/verify）在 acl_windows_test.go 单独验证，需要 Administrator
+// 身份（生产 supervisor 以 SYSTEM 跑，测试环境普通用户跑不动）。
+// 所有测试用 withNoopACL 跳过 ACL apply/verify，专注 round-trip 正确性。
+
 // TestWindowsSecretStore_Install_CreatesValidFile 验证 Install 创建合法 DPAPI 加密文件 + round-trip。
 func TestWindowsSecretStore_Install_CreatesValidFile(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 	token := []byte("ed_bk_test_token_abc123")
@@ -31,6 +37,7 @@ func TestWindowsSecretStore_Install_CreatesValidFile(t *testing.T) {
 
 // TestWindowsSecretStore_Install_OverwritesExisting 验证写入覆盖已有文件。
 func TestWindowsSecretStore_Install_OverwritesExisting(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 	ss := NewSecretStore(path)
@@ -51,6 +58,7 @@ func TestWindowsSecretStore_Install_OverwritesExisting(t *testing.T) {
 
 // TestWindowsSecretStore_Remove_DeletesFile 验证 Remove 删除文件。
 func TestWindowsSecretStore_Remove_DeletesFile(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 	ss := NewSecretStore(path)
@@ -79,6 +87,7 @@ func TestWindowsSecretStore_Remove_NonExistentNoError(t *testing.T) {
 
 // TestWindowsSecretStore_Install_WrongTokenRoundTrip 验证不同 token 产生不同密文。
 func TestWindowsSecretStore_Install_WrongTokenRoundTrip(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 	ss := NewSecretStore(path)
@@ -99,6 +108,7 @@ func TestWindowsSecretStore_Install_WrongTokenRoundTrip(t *testing.T) {
 
 // TestWindowsSecretStore_Rotate_ReplacesToken 验证 Rotate 原子替换文件内容。
 func TestWindowsSecretStore_Rotate_ReplacesToken(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 	token1 := []byte("original-cred-value")
@@ -140,6 +150,7 @@ func TestWindowsSecretStore_Rotate_ReplacesToken(t *testing.T) {
 // TestWindowsSecretStore_Rotate_OnNonExistentFile 验证 Rotate 对不存在的文件也能工作
 // （os.Rename 会创建目标文件）。
 func TestWindowsSecretStore_Rotate_OnNonExistentFile(t *testing.T) {
+	withNoopACL(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secrets.enc")
 

--- a/internal/edgeagent/install/interfaces.go
+++ b/internal/edgeagent/install/interfaces.go
@@ -1,0 +1,74 @@
+// interfaces.go 定义安装/卸载流程的 3 个核心接口。
+//
+// 设计原则（MVP-3 #18-1）：
+//   - YAGNI：仅定义 install + uninstall 流程当前所需方法，0 投机方法
+//   - 编排顺序由调用方（runInstall orchestrator）决定，接口不规定顺序
+//   - 每个方法是一个可独立测试的 seam
+
+package install
+
+import "errors"
+
+// ErrUnsupportedPlatform 表示当前平台不支持安装操作（仅 Windows 可用）。
+// 非 Windows 构建中所有方法返回此错误。
+var ErrUnsupportedPlatform = errors.New("install: unsupported platform (Windows only)")
+
+// SecretStore 管理 DPAPI 加密的凭证文件（secrets.enc）。
+//
+// Install 内部执行完整流程：DPAPI 加密 → 写文件 → round-trip 验证。
+// 验证失败时 Install 自行删除文件（保持调用前状态）。
+//
+// #16 token rotation 将通过组合 Install + 文件 backup/restore 实现，
+// 不需要独立的 Rotate 方法（YAGNI — 等语义明确再加）。
+type SecretStore interface {
+	// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+	// 失败时文件应处于调用前状态（不存在或旧内容）。
+	Install(token []byte) error
+
+	// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
+	// 流程：DPAPI 加密新 token → 写 tmp 文件 → rename 覆盖 → round-trip 验证。
+	// 失败时旧文件保持不变。
+	Rotate(token []byte) error
+
+	// Remove 删除 secrets.enc（用于 --uninstall）。
+	Remove() error
+}
+
+// ServiceController 管理 Windows Service 生命周期（sc.exe 包装）。
+//
+// Create 与 Start 分离：orchestrator 需在两者之间插入 EnvWriter.Write
+// （服务启动前必须有环境变量）。
+//
+// #21 supervisor 自升级：ConfigureRecovery 配置 SCM failure action（service.go
+// 的 samesession=false 设计依赖此配置）；ConfigureDefenderExclusion 为 ongrid
+// 目录添加 Defender exclusion（W3 加固，减少 AV 干扰 rename-aside）。
+type ServiceController interface {
+	// Create 注册 Windows 服务（sc.exe create）。
+	Create(binPath string) error
+
+	// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+	// reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
+	// service.go 的 return false, 0（samesession=false）依赖此配置触发 SCM 重启。
+	ConfigureRecovery() error
+
+	// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
+	//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+	// 第三方 AV 或 Defender 已禁用时静默失败（返回 error 但调用方仅 warn）。
+	ConfigureDefenderExclusion() error
+
+	// Start 启动已注册的服务（sc.exe start）。
+	Start() error
+
+	// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+	Stop() error
+
+	// Delete 删除服务（sc.exe delete）。
+	Delete() error
+}
+
+// EnvWriter 管理服务注册表 Environment 字段（REG_MULTI_SZ）。
+type EnvWriter interface {
+	// Write 写入 KEY=VALUE 多字符串到注册表 Environment 字段。
+	// 在 ServiceController.Create 之后、Start 之前调用。
+	Write(pairs []string) error
+}

--- a/internal/edgeagent/install/interfaces.go
+++ b/internal/edgeagent/install/interfaces.go
@@ -1,6 +1,6 @@
 // interfaces.go 定义安装/卸载流程的 3 个核心接口。
 //
-// 设计原则（MVP-3 #18-1）：
+// 设计原则：
 //   - YAGNI：仅定义 install + uninstall 流程当前所需方法，0 投机方法
 //   - 编排顺序由调用方（runInstall orchestrator）决定，接口不规定顺序
 //   - 每个方法是一个可独立测试的 seam
@@ -15,18 +15,15 @@ var ErrUnsupportedPlatform = errors.New("install: unsupported platform (Windows 
 
 // SecretStore 管理 DPAPI 加密的凭证文件（secrets.enc）。
 //
-// Install 内部执行完整流程：DPAPI 加密 → 写文件 → round-trip 验证。
-// 验证失败时 Install 自行删除文件（保持调用前状态）。
-//
-// #16 token rotation 将通过组合 Install + 文件 backup/restore 实现，
-// 不需要独立的 Rotate 方法（YAGNI — 等语义明确再加）。
+// Install 内部执行完整流程：DPAPI 加密 → 写文件 → ACL 应用 → round-trip 验证。
+// 失败时文件应处于调用前状态（不存在或旧内容）。
 type SecretStore interface {
-	// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+	// Install 加密 token 并写入 secrets.enc，含 ACL 应用 + round-trip 验证。
 	// 失败时文件应处于调用前状态（不存在或旧内容）。
 	Install(token []byte) error
 
-	// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
-	// 流程：DPAPI 加密新 token → 写 tmp 文件 → rename 覆盖 → round-trip 验证。
+	// Rotate 原子地替换 secrets.enc 中的 token。
+	// 流程：DPAPI 加密新 token → 写 tmp 文件（随机名）→ apply ACL → rename 覆盖 → round-trip 验证。
 	// 失败时旧文件保持不变。
 	Rotate(token []byte) error
 
@@ -38,28 +35,23 @@ type SecretStore interface {
 //
 // Create 与 Start 分离：orchestrator 需在两者之间插入 EnvWriter.Write
 // （服务启动前必须有环境变量）。
-//
-// #21 supervisor 自升级：ConfigureRecovery 配置 SCM failure action（service.go
-// 的 samesession=false 设计依赖此配置）；ConfigureDefenderExclusion 为 ongrid
-// 目录添加 Defender exclusion（W3 加固，减少 AV 干扰 rename-aside）。
 type ServiceController interface {
 	// Create 注册 Windows 服务（sc.exe create）。
 	Create(binPath string) error
 
-	// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+	// ConfigureRecovery 配置 SCM failure recovery action。
 	// reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
-	// service.go 的 return false, 0（samesession=false）依赖此配置触发 SCM 重启。
 	ConfigureRecovery() error
 
-	// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
-	//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+	// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion。
+	// 仅在 Windows Server with Defender 时生效；
 	// 第三方 AV 或 Defender 已禁用时静默失败（返回 error 但调用方仅 warn）。
 	ConfigureDefenderExclusion() error
 
 	// Start 启动已注册的服务（sc.exe start）。
 	Start() error
 
-	// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+	// Stop 停止服务（sc.exe stop），仅忽略"服务未启动/不存在"预期错误。
 	Stop() error
 
 	// Delete 删除服务（sc.exe delete）。

--- a/internal/edgeagent/install/secrets_windows.go
+++ b/internal/edgeagent/install/secrets_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package install
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// WindowsSecretStore 是 SecretStore 的 Windows 实现，
+// 使用 DPAPI CryptProtectData 加密凭证（ADR-037 A2 CR4）。
+type WindowsSecretStore struct {
+	path string
+}
+
+// NewSecretStore 创建 Windows DPAPI SecretStore。
+// secretsPath 是 secrets.enc 的完整路径。
+func NewSecretStore(secretsPath string) SecretStore {
+	return &WindowsSecretStore{path: secretsPath}
+}
+
+// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+//
+// 流程：
+//  1. dpapi.Protect(token) → 加密
+//  2. os.WriteFile(path, encrypted, 0600)
+//  3. 读回 + dpapi.Unprotect → 验证 round-trip
+//  4. 验证失败时删除文件（保持调用前状态）
+//
+// token 的 []byte 副本清零由调用方负责（defer zeroBytes）。
+func (s *WindowsSecretStore) Install(token []byte) error {
+	encrypted, err := dpapi.Protect(token)
+	if err != nil {
+		return fmt.Errorf("dpapi encrypt token: %w", err)
+	}
+	if err := os.WriteFile(s.path, encrypted, 0600); err != nil {
+		return fmt.Errorf("write secrets.enc: %w", err)
+	}
+	// round-trip 验证
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("read secrets.enc for verify: %w", err)
+	}
+	decrypted, err := dpapi.Unprotect(data)
+	if err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("decrypt secrets.enc for verify: %w", err)
+	}
+	if !bytes.Equal(decrypted, token) {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("secrets.enc round-trip mismatch")
+	}
+	return nil
+}
+
+// Remove 删除 secrets.enc。不存在时不报错。
+func (s *WindowsSecretStore) Remove() error {
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove secrets.enc: %w", err)
+	}
+	return nil
+}
+
+// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
+//
+// 流程：
+//  1. dpapi.Protect(newToken) → 加密
+//  2. 写入 tmp 文件（path + ".tmp"）
+//  3. round-trip 验证 tmp 文件
+//  4. os.Rename(tmp, path) — Windows 上 ReplaceFile/os.Rename 是原子操作
+//  5. 验证失败或任何错误 → 删除 tmp，旧文件不受影响
+//
+// 轮转过程中进程崩溃：tmp 文件残留，secrets.enc 保持旧内容不受影响。
+func (s *WindowsSecretStore) Rotate(token []byte) error {
+	encrypted, err := dpapi.Protect(token)
+	if err != nil {
+		return fmt.Errorf("dpapi encrypt token: %w", err)
+	}
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, encrypted, 0600); err != nil {
+		return fmt.Errorf("write tmp secrets: %w", err)
+	}
+	// round-trip 验证 tmp 文件
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("read tmp secrets for verify: %w", err)
+	}
+	decrypted, err := dpapi.Unprotect(data)
+	if err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("decrypt tmp secrets for verify: %w", err)
+	}
+	if !bytes.Equal(decrypted, token) {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("tmp secrets round-trip mismatch")
+	}
+	// 原子替换：os.Rename 在 Windows 上等价于 MoveFileEx(MOVEFILE_REPLACE_EXISTING)
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("rename tmp to secrets.enc: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/secrets_windows.go
+++ b/internal/edgeagent/install/secrets_windows.go
@@ -16,19 +16,29 @@ type WindowsSecretStore struct {
 	path string
 }
 
+// 包级 var 间接调用 ACL 函数，便于测试 mock（生产环境 supervisor 以 SYSTEM 身份
+// 运行，普通用户测试无法通过 ApplySecretACL 后的 WriteFile；用 var 间接让测试
+// 替换为 noop，ACL 行为在 acl_windows_test.go 单独验证）。
+var (
+	applySecretACLFn  = ApplySecretACL
+	verifySecretACLFn = VerifySecretACL
+)
+
 // NewSecretStore 创建 Windows DPAPI SecretStore。
 // secretsPath 是 secrets.enc 的完整路径。
 func NewSecretStore(secretsPath string) SecretStore {
 	return &WindowsSecretStore{path: secretsPath}
 }
 
-// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+// Install 加密 token 并写入 secrets.enc，含 round-trip 验证 + ACL 应用。
 //
 // 流程：
 //  1. dpapi.Protect(token) → 加密
 //  2. os.WriteFile(path, encrypted, 0600)
 //  3. 读回 + dpapi.Unprotect → 验证 round-trip
-//  4. 验证失败时删除文件（保持调用前状态）
+//  4. ApplySecretACL → 限制 SYSTEM + Administrators 可读
+//  5. VerifySecretACL → 读 ACL 回来验证
+//  6. 任何步骤失败时删除文件（保持调用前状态）
 //
 // token 的 []byte 副本清零由调用方负责（defer zeroBytes）。
 func (s *WindowsSecretStore) Install(token []byte) error {
@@ -54,6 +64,15 @@ func (s *WindowsSecretStore) Install(token []byte) error {
 		_ = os.Remove(s.path)
 		return fmt.Errorf("secrets.enc round-trip mismatch")
 	}
+	// ACL 应用 + 验证（DPAPI 不替代文件 ACL）
+	if err := applySecretACLFn(s.path); err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("apply ACL: %w", err)
+	}
+	if err := verifySecretACLFn(s.path); err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("verify ACL: %w", err)
+	}
 	return nil
 }
 
@@ -71,8 +90,10 @@ func (s *WindowsSecretStore) Remove() error {
 //  1. dpapi.Protect(newToken) → 加密
 //  2. 写入 tmp 文件（path + ".tmp"）
 //  3. round-trip 验证 tmp 文件
-//  4. os.Rename(tmp, path) — Windows 上 ReplaceFile/os.Rename 是原子操作
-//  5. 验证失败或任何错误 → 删除 tmp，旧文件不受影响
+//  4. ApplySecretACL + VerifySecretACL on tmp（先限制 tmp 权限）
+//  5. os.Rename(tmp, path) — Windows 上 ReplaceFile/os.Rename 是原子操作
+//       rename 时 ACL 随文件迁移（不继承目标目录）
+//  6. 验证失败或任何错误 → 删除 tmp，旧文件不受影响
 //
 // 轮转过程中进程崩溃：tmp 文件残留，secrets.enc 保持旧内容不受影响。
 func (s *WindowsSecretStore) Rotate(token []byte) error {
@@ -99,10 +120,19 @@ func (s *WindowsSecretStore) Rotate(token []byte) error {
 		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("tmp secrets round-trip mismatch")
 	}
+	// 先对 tmp 应用 ACL（rename 时 ACL 随文件迁移）
+	if err := applySecretACLFn(tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("apply ACL on tmp: %w", err)
+	}
 	// 原子替换：os.Rename 在 Windows 上等价于 MoveFileEx(MOVEFILE_REPLACE_EXISTING)
 	if err := os.Rename(tmpPath, s.path); err != nil {
 		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("rename tmp to secrets.enc: %w", err)
+	}
+	// rename 后再 verify（防 GPO / AV 干扰）
+	if err := verifySecretACLFn(s.path); err != nil {
+		return fmt.Errorf("verify ACL after rotate: %w", err)
 	}
 	return nil
 }

--- a/internal/edgeagent/install/secrets_windows.go
+++ b/internal/edgeagent/install/secrets_windows.go
@@ -5,13 +5,15 @@ package install
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
 )
 
 // WindowsSecretStore 是 SecretStore 的 Windows 实现，
-// 使用 DPAPI CryptProtectData 加密凭证（ADR-037 A2 CR4）。
+// 使用 DPAPI CryptProtectData 加密凭证。
 type WindowsSecretStore struct {
 	path string
 }
@@ -20,6 +22,7 @@ type WindowsSecretStore struct {
 // 运行，普通用户测试无法通过 ApplySecretACL 后的 WriteFile；用 var 间接让测试
 // 替换为 noop，ACL 行为在 acl_windows_test.go 单独验证）。
 var (
+	ensureSecureDirFn  = EnsureSecureDir
 	applySecretACLFn  = ApplySecretACL
 	verifySecretACLFn = VerifySecretACL
 )
@@ -30,48 +33,54 @@ func NewSecretStore(secretsPath string) SecretStore {
 	return &WindowsSecretStore{path: secretsPath}
 }
 
-// Install 加密 token 并写入 secrets.enc，含 round-trip 验证 + ACL 应用。
+// Install 加密 token 并写入 secrets.enc，含 ACL 应用 + round-trip 验证。
 //
 // 流程：
-//  1. dpapi.Protect(token) → 加密
-//  2. os.WriteFile(path, encrypted, 0600)
-//  3. 读回 + dpapi.Unprotect → 验证 round-trip
-//  4. ApplySecretACL → 限制 SYSTEM + Administrators 可读
-//  5. VerifySecretACL → 读 ACL 回来验证
-//  6. 任何步骤失败时删除文件（保持调用前状态）
+//  1. EnsureSecureDir(parent) — 父目录受限为 SYSTEM+Admins，子文件自动继承
+//  2. dpapi.Protect(token) → 加密
+//  3. os.WriteFile — 文件继承父目录 ACL（出生即受限，无明文窗口）
+//  4. ApplySecretACL — 显式 /inheritance:r 防父目录被改后影响
+//  5. VerifySecretACL — 读回 ACL 验证
+//  6. ReadFile + dpapi.Unprotect → round-trip 验证
+//  7. 失败时清理（暴露 Remove 错误，不静默吞掉）
 //
-// token 的 []byte 副本清零由调用方负责（defer zeroBytes）。
+// token 的 []byte 副本清零由调用方负责。
 func (s *WindowsSecretStore) Install(token []byte) error {
+	dir := filepath.Dir(s.path)
+	if err := ensureSecureDirFn(dir); err != nil {
+		return fmt.Errorf("secure parent dir: %w", err)
+	}
 	encrypted, err := dpapi.Protect(token)
 	if err != nil {
 		return fmt.Errorf("dpapi encrypt token: %w", err)
 	}
-	if err := os.WriteFile(s.path, encrypted, 0600); err != nil {
+	if err := os.WriteFile(s.path, encrypted, 0o600); err != nil {
 		return fmt.Errorf("write secrets.enc: %w", err)
 	}
-	// round-trip 验证
+	// 立即 ApplySecretACL 缩小明文窗口：文件继承父目录 ACL 后即使没这步也受限，
+	// 这步是 belt-and-suspenders（防 GPO 在 EnsureSecureDir 后改父目录）。
+	if err := applySecretACLFn(s.path); err != nil {
+		cleanupErr := os.Remove(s.path)
+		return fmt.Errorf("apply ACL: %w (cleanup: %v)", err, cleanupErr)
+	}
+	if err := verifySecretACLFn(s.path); err != nil {
+		cleanupErr := os.Remove(s.path)
+		return fmt.Errorf("verify ACL: %w (cleanup: %v)", err, cleanupErr)
+	}
+	// round-trip 验证（ACL 已限制，普通用户即使能 round-trip 也需要 SYSTEM 身份）
 	data, err := os.ReadFile(s.path)
 	if err != nil {
-		_ = os.Remove(s.path)
-		return fmt.Errorf("read secrets.enc for verify: %w", err)
+		cleanupErr := os.Remove(s.path)
+		return fmt.Errorf("read secrets.enc for verify: %w (cleanup: %v)", err, cleanupErr)
 	}
 	decrypted, err := dpapi.Unprotect(data)
 	if err != nil {
-		_ = os.Remove(s.path)
-		return fmt.Errorf("decrypt secrets.enc for verify: %w", err)
+		cleanupErr := os.Remove(s.path)
+		return fmt.Errorf("decrypt secrets.enc for verify: %w (cleanup: %v)", err, cleanupErr)
 	}
 	if !bytes.Equal(decrypted, token) {
-		_ = os.Remove(s.path)
-		return fmt.Errorf("secrets.enc round-trip mismatch")
-	}
-	// ACL 应用 + 验证（DPAPI 不替代文件 ACL）
-	if err := applySecretACLFn(s.path); err != nil {
-		_ = os.Remove(s.path)
-		return fmt.Errorf("apply ACL: %w", err)
-	}
-	if err := verifySecretACLFn(s.path); err != nil {
-		_ = os.Remove(s.path)
-		return fmt.Errorf("verify ACL: %w", err)
+		cleanupErr := os.Remove(s.path)
+		return fmt.Errorf("secrets.enc round-trip mismatch (cleanup: %v)", cleanupErr)
 	}
 	return nil
 }
@@ -84,55 +93,77 @@ func (s *WindowsSecretStore) Remove() error {
 	return nil
 }
 
-// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
+// Rotate 原子地替换 secrets.enc 中的 token。
 //
 // 流程：
-//  1. dpapi.Protect(newToken) → 加密
-//  2. 写入 tmp 文件（path + ".tmp"）
-//  3. round-trip 验证 tmp 文件
-//  4. ApplySecretACL + VerifySecretACL on tmp（先限制 tmp 权限）
-//  5. os.Rename(tmp, path) — Windows 上 ReplaceFile/os.Rename 是原子操作
-//       rename 时 ACL 随文件迁移（不继承目标目录）
-//  6. 验证失败或任何错误 → 删除 tmp，旧文件不受影响
+//  1. EnsureSecureDir(parent) — 父目录受限（idempotent，首次后幂等）
+//  2. dpapi.Protect(token) → 加密
+//  3. os.CreateTemp(dir, "secrets-*.tmp") — 随机 tmp 名（防并发竞态），
+//     继承父目录 ACL（无明文窗口）
+//  4. Write encrypted to tmp + Close
+//  5. ApplySecretACL(tmpPath) — 显式 /inheritance:r
+//  6. ReadFile + dpapi.Unprotect → round-trip 验证
+//  7. os.Rename(tmpPath, s.path) — 原子替换（MoveFileEx REPLACE_EXISTING）
+//  8. VerifySecretACL(s.path) — 失败时仅 warn（rename 后新 token 已生效，
+//     返回 error 会让调用方误以为可重试，实际旧 token 已被覆盖）
 //
 // 轮转过程中进程崩溃：tmp 文件残留，secrets.enc 保持旧内容不受影响。
 func (s *WindowsSecretStore) Rotate(token []byte) error {
+	dir := filepath.Dir(s.path)
+	if err := ensureSecureDirFn(dir); err != nil {
+		return fmt.Errorf("secure parent dir: %w", err)
+	}
 	encrypted, err := dpapi.Protect(token)
 	if err != nil {
 		return fmt.Errorf("dpapi encrypt token: %w", err)
 	}
-	tmpPath := s.path + ".tmp"
-	if err := os.WriteFile(tmpPath, encrypted, 0600); err != nil {
+	// 随机 tmp 名（防并发竞态）+ 继承父目录 ACL（无明文窗口）
+	f, err := os.CreateTemp(dir, "secrets-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp secrets: %w", err)
+	}
+	tmpPath := f.Name()
+	defer func() {
+		// 兜底清理：如果函数在 Rename 之前 return，tmp 文件应被删除
+		if _, statErr := os.Stat(tmpPath); statErr == nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := f.Write(encrypted); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("write tmp secrets: %w", err)
 	}
-	// round-trip 验证 tmp 文件
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close tmp secrets: %w", err)
+	}
+	// 显式 ApplySecretACL（防 GPO 改父目录后影响）
+	if err := applySecretACLFn(tmpPath); err != nil {
+		return fmt.Errorf("apply ACL on tmp: %w", err)
+	}
+	// round-trip 验证
 	data, err := os.ReadFile(tmpPath)
 	if err != nil {
-		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("read tmp secrets for verify: %w", err)
 	}
 	decrypted, err := dpapi.Unprotect(data)
 	if err != nil {
-		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("decrypt tmp secrets for verify: %w", err)
 	}
 	if !bytes.Equal(decrypted, token) {
-		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("tmp secrets round-trip mismatch")
-	}
-	// 先对 tmp 应用 ACL（rename 时 ACL 随文件迁移）
-	if err := applySecretACLFn(tmpPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("apply ACL on tmp: %w", err)
 	}
 	// 原子替换：os.Rename 在 Windows 上等价于 MoveFileEx(MOVEFILE_REPLACE_EXISTING)
 	if err := os.Rename(tmpPath, s.path); err != nil {
-		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
 		return fmt.Errorf("rename tmp to secrets.enc: %w", err)
 	}
-	// rename 后再 verify（防 GPO / AV 干扰）
+	// rename 后 tmpPath 已不存在，清空 defer 兜底
+	tmpPath = ""
+	// rename 后 verify（防 GPO / AV 在 rename 后修改 ACL）
+	// 注意：失败时仅 warn，因为新 token 已经生效。返回 error 会让调用方误以为
+	// 可重试 Rotate，实际旧 token 已被覆盖，重试会再生成新密文。
 	if err := verifySecretACLFn(s.path); err != nil {
-		return fmt.Errorf("verify ACL after rotate: %w", err)
+		slog.Warn("verify ACL after rotate failed (new token already in effect, manual remediation needed)",
+			"path", s.path, "err", err)
 	}
 	return nil
 }

--- a/internal/edgeagent/install/service_windows.go
+++ b/internal/edgeagent/install/service_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+)
+
+// SCServiceController 是 ServiceController 的 Windows 实现，
+// 通过 sc.exe 管理 Windows Service 生命周期。
+type SCServiceController struct {
+	name string
+}
+
+// NewServiceController 创建 sc.exe ServiceController。
+// serviceName 是 Windows Service 名称（如 "ongrid-edge"）。
+func NewServiceController(serviceName string) ServiceController {
+	return &SCServiceController{name: serviceName}
+}
+
+// Create 注册 Windows 服务（sc.exe create）。
+func (sc *SCServiceController) Create(binPath string) error {
+	cmd := exec.Command("sc.exe", "create", sc.name,
+		"binPath=", binPath,
+		"start=", "auto",
+		"DisplayName=", "Ongrid Edge Agent",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe create: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+// reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
+// service.go Execute 返回 (false, 1)（samesession=false + 非 0 exitCode）时 SCM 按此配置重启。
+// 3 次/24h 上限后停止，等价于"立即停止"行为。
+func (sc *SCServiceController) ConfigureRecovery() error {
+	cmd := exec.Command("sc.exe", "failure", sc.name,
+		"reset=", "86400",
+		"actions=", "restart/60000/restart/60000/restart/60000",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe failure: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
+//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+// 第三方 AV 或 Defender 已禁用时返回 error，调用方仅 warn 不阻断。
+//
+// 参数格式：PowerShell Add-MpPreference 的 -ExclusionPath 接受字符串数组，
+// 必须用逗号分隔（"-ExclusionPath A,B"），不能重复同名参数
+// （"-ExclusionPath A -ExclusionPath B" 会报 ParameterAlreadyBound）。
+func (sc *SCServiceController) ConfigureDefenderExclusion() error {
+	ps := buildDefenderExclusionCmd(edgedirs.BinDir, edgedirs.DataDir)
+	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive",
+		"-Command", ps).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Add-MpPreference: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// buildDefenderExclusionCmd 生成 Add-MpPreference 命令字符串。
+// 提取为独立纯函数以便单元测试验证参数格式（防止 ParameterAlreadyBound 回归）。
+func buildDefenderExclusionCmd(binDir, dataDir string) string {
+	return fmt.Sprintf(
+		`Add-MpPreference -ExclusionPath "%s","%s" -ErrorAction SilentlyContinue`,
+		binDir, dataDir,
+	)
+}
+
+// Start 启动已注册的服务（sc.exe start）。
+func (sc *SCServiceController) Start() error {
+	cmd := exec.Command("sc.exe", "start", sc.name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe start: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+func (sc *SCServiceController) Stop() error {
+	cmd := exec.Command("sc.exe", "stop", sc.name)
+	_ = cmd.Run() // 忽略所有错误（服务可能未运行）
+	return nil
+}
+
+// Delete 删除服务（sc.exe delete）。
+func (sc *SCServiceController) Delete() error {
+	cmd := exec.Command("sc.exe", "delete", sc.name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe delete: %w (output: %s)", err, out)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/service_windows.go
+++ b/internal/edgeagent/install/service_windows.go
@@ -84,10 +84,25 @@ func (sc *SCServiceController) Start() error {
 	return nil
 }
 
-// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+// Stop 停止服务（sc.exe stop），仅忽略"服务未启动/不存在"预期错误。
+// 其他错误（权限不足、SCM 不可达、命令缺失等）返回给调用方处理。
+//
+// sc.exe exit codes（Windows SDK）：
+//   - 0 = SUCCESS
+//   - 1060 = ERROR_SERVICE_DOES_NOT_EXIST（服务未注册）
+//   - 1062 = ERROR_SERVICE_NOT_ACTIVE（服务未启动）
 func (sc *SCServiceController) Stop() error {
 	cmd := exec.Command("sc.exe", "stop", sc.name)
-	_ = cmd.Run() // 忽略所有错误（服务可能未运行）
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code := exitErr.ExitCode()
+			if code == 1060 || code == 1062 {
+				return nil
+			}
+		}
+		return fmt.Errorf("sc.exe stop: %w (output: %s)", err, out)
+	}
 	return nil
 }
 

--- a/internal/edgeagent/install/service_windows.go
+++ b/internal/edgeagent/install/service_windows.go
@@ -34,7 +34,7 @@ func (sc *SCServiceController) Create(binPath string) error {
 	return nil
 }
 
-// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+// ConfigureRecovery 配置 SCM failure recovery action。
 // reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
 // service.go Execute 返回 (false, 1)（samesession=false + 非 0 exitCode）时 SCM 按此配置重启。
 // 3 次/24h 上限后停止，等价于"立即停止"行为。
@@ -49,8 +49,8 @@ func (sc *SCServiceController) ConfigureRecovery() error {
 	return nil
 }
 
-// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
-//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion。
+// 仅在 Windows Server with Defender 时生效；
 // 第三方 AV 或 Defender 已禁用时返回 error，调用方仅 warn 不阻断。
 //
 // 参数格式：PowerShell Add-MpPreference 的 -ExclusionPath 接受字符串数组，

--- a/internal/edgeagent/install/service_windows_test.go
+++ b/internal/edgeagent/install/service_windows_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDefenderExclusionCmd_SingleParamName 验证 -ExclusionPath 参数名只出现一次。
+// 回归防护：旧代码用 `-ExclusionPath A -ExclusionPath B` 会导致 PowerShell
+// ParameterAlreadyBound 错误（#21 dogfood 2026-07-16 发现）。
+func TestBuildDefenderExclusionCmd_SingleParamName(t *testing.T) {
+	cmd := buildDefenderExclusionCmd(`C:\bin`, `C:\data`)
+	if count := strings.Count(cmd, "-ExclusionPath"); count != 1 {
+		t.Errorf("-ExclusionPath should appear exactly once, got %d (cmd: %s)", count, cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_CommaSeparated 验证两个路径用逗号分隔。
+// PowerShell 数组参数语法：`-ParamName "val1","val2"`。
+func TestBuildDefenderExclusionCmd_CommaSeparated(t *testing.T) {
+	binDir := `C:\Program Files\ongrid-edge\bin`
+	dataDir := `C:\ProgramData\ongrid-edge`
+	cmd := buildDefenderExclusionCmd(binDir, dataDir)
+
+	if !strings.Contains(cmd, `"`+binDir+`","`+dataDir+`"`) {
+		t.Errorf("expected comma-separated paths in command, got: %s", cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_BothPathsPresent 验证两个目录都出现在命令中。
+func TestBuildDefenderExclusionCmd_BothPathsPresent(t *testing.T) {
+	binDir := `C:\test\bin`
+	dataDir := `C:\test\data`
+	cmd := buildDefenderExclusionCmd(binDir, dataDir)
+
+	if !strings.Contains(cmd, binDir) {
+		t.Errorf("binDir missing from command: %s", cmd)
+	}
+	if !strings.Contains(cmd, dataDir) {
+		t.Errorf("dataDir missing from command: %s", cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_AddMpPreferencePresent 验证命令前缀正确。
+func TestBuildDefenderExclusionCmd_AddMpPreferencePresent(t *testing.T) {
+	cmd := buildDefenderExclusionCmd(`C:\a`, `C:\b`)
+	if !strings.HasPrefix(cmd, "Add-MpPreference ") {
+		t.Errorf("command should start with Add-MpPreference, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "-ErrorAction SilentlyContinue") {
+		t.Errorf("command should contain -ErrorAction SilentlyContinue, got: %s", cmd)
+	}
+}

--- a/internal/edgeagent/install/service_windows_test.go
+++ b/internal/edgeagent/install/service_windows_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestBuildDefenderExclusionCmd_SingleParamName 验证 -ExclusionPath 参数名只出现一次。
 // 回归防护：旧代码用 `-ExclusionPath A -ExclusionPath B` 会导致 PowerShell
-// ParameterAlreadyBound 错误（#21 dogfood 2026-07-16 发现）。
+// ParameterAlreadyBound 错误。
 func TestBuildDefenderExclusionCmd_SingleParamName(t *testing.T) {
 	cmd := buildDefenderExclusionCmd(`C:\bin`, `C:\data`)
 	if count := strings.Count(cmd, "-ExclusionPath"); count != 1 {


### PR DESCRIPTION
Windows edge agent platform foundation. Adds 5 new packages only — no changes to existing files, zero merge conflicts with upstream.

## Scope (this PR)

- `internal/edgeagent/dpapi`: DPAPI `CRYPTPROTECT_LOCAL_MACHINE` encryption with round-trip verification
- `internal/edgeagent/edgedirs`: Windows platform directory abstraction (`BinDir` / `DataDir` / `PluginWorkDir` / `StageDir`)
- `internal/edgeagent/install`: supervisor `--install` entry point split into `SecretStore` / `ServiceController` / `EnvWriter` interfaces, using
`sc.exe` to manage Windows Service lifecycle
- `internal/edgeagent/config`: secrets.enc loading + token rotation period check (90-day default)
- `internal/edgeagent/host_files`: platform split (`owner_windows` / `owner_unix` / `times_windows`)

## Scope Clarification — Cannot Produce Windows Edge Alone

**This PR alone does not produce a runnable Windows Edge.** It only introduces platform primitives:

- `dpapi` / `edgedirs` / `install` packages are foundation libraries with no consumers yet
- No `cmd/ongrid-edge` Windows binary wiring in this PR

Each package is independently testable but cannot be installed as a complete Edge until follow-up PRs integrate them. Reviewers can verify package-level
correctness (DPAPI round-trip, ACL apply/verify, Service lifecycle) without needing end-to-end Windows install.

## Security Model

- **DPAPI scope**: `CRYPTPROTECT_LOCAL_MACHINE` binds ciphertext to machine-level SystemCredential. LocalSystem and NetworkService can decrypt; copy to
other machine cannot.
- **File ACL**: DPAPI does NOT replace file ACL. `acl_windows.go` applies icacls restrictions to `secrets.enc` (SYSTEM + Administrators Full Control) and
parent directory (with `(OI)(CI)` container inheritance). `VerifySecretACL` reads ACL back to detect post-apply drift.
- **Window minimization**: `Install` / `Rotate` apply ACL immediately after file write to shrink plaintext-readable window.
- **Atomic rotate**: `Rotate` uses `os.CreateTemp` for random tmp name (avoids concurrency race), applies ACL before rename, then atomic `os.Rename`
(Windows `MoveFileEx` with `REPLACE_EXISTING`).
- **Post-rename verify**: If ACL drifts after rename (GPO / AV interference), `Rotate` logs warning but returns nil — new token is already in effect,
returning error would mislead caller into retrying.

## CI

- `ci-windows-cross.yml` (this PR): `GOOS=windows` cross-build + vet + test-binary compile for the 4 Windows subpackages (`dpapi` / `edgedirs` /
`install` / `config`).
- Existing `ci.yml`: Linux full test + vet continues to gate this PR.

## Verification

- `GOOS=linux go build ./...` — full repo builds clean
- `GOOS=windows go build ./internal/edgeagent/{config,dpapi,edgedirs,install,host_files}/...` — Windows packages compile clean
- Unit tests: `dpapi` + `install` + `config` pass; `install` includes 5 ACL flow tests verifying `ensure → apply → verify` call order

## Notes for reviewers

The packages here are not yet wired into `cmd/ongrid-edge/main.go`. Follow-up PRs will introduce the supervisor binary and worker integration. This
staged rollout mirrors how Linux edge grew its platform abstractions.
- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md