### PR TITLE
feat(edge/windows): Windows Service supervisor + upgrade state machine

### DIFF
--- a/.github/workflows/ci-windows-cross.yml
+++ b/.github/workflows/ci-windows-cross.yml
@@ -43,16 +43,21 @@ jobs:
         env:
           GOOS: windows
           GOARCH: amd64
-        # 只编译 PR1 scope 的 4 个 Windows 子包
-        run: go build ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+        # 4 个 Windows 子包（PR1 scope）+ 两个最终交付入口二进制——
+        # 仅最终命令依赖图或 Windows build tags 下才暴露的编译错误
+        # 必须在 PR CI 阶段被发现
+        run: |
+          go build ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+          go build ./cmd/ongrid-edge ./cmd/ongrid-edge-supervisor
 
       - name: go vet (GOOS=windows)
         env:
           GOOS: windows
           GOARCH: amd64
         run: |
-          # vet 只跑 Windows 子包（避免 Linux-only 文件的误报）
+          # vet 覆盖 Windows 子包 + 两个最终交付入口（避免 Linux-only 文件的误报）
           go vet ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+          go vet ./cmd/ongrid-edge ./cmd/ongrid-edge-supervisor
 
       - name: go test (GOOS=windows, no-cgo)
         env:

--- a/cmd/ongrid-edge-supervisor/env_windows.go
+++ b/cmd/ongrid-edge-supervisor/env_windows.go
@@ -1,0 +1,37 @@
+// env_windows.go — read the service Environment registry field directly.
+// Companion to mergedServiceEnv in worker.go: Windows SCM's promise of
+// "service Environment field = process env" leaks under fork/exec of a
+// different binary (supervisor.exe spawning worker.exe). Reading the
+// field from the registry bypasses the SCM corner case and feeds the
+// pairs into exec.Cmd.Env explicitly.
+
+//go:build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows/registry"
+)
+
+// serviceRegKeyPath is the HKLM path to the ongrid-edge service entry.
+// Kept in sync with install_windows.go; duplicate literal avoids a
+// shared const across the install / worker split.
+const envRegKeyPath = `SYSTEM\CurrentControlSet\Services\` + serviceName
+
+// readServiceEnvField reads the service Environment multi-string value
+// from the registry. Returns the raw pairs (each "KEY=VALUE"), or an
+// empty slice + error if the field is absent / unreadable. Callers
+// should treat any error as "fall back to os.Environ" — this is a
+// best-effort correctness path, not a hard requirement.
+func readServiceEnvField() ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, envRegKeyPath, registry.QUERY_VALUE|registry.READ)
+	if err != nil {
+		return nil, err
+	}
+	defer k.Close()
+	values, _, err := k.GetStringsValue("Environment")
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}

--- a/cmd/ongrid-edge-supervisor/install_windows.go
+++ b/cmd/ongrid-edge-supervisor/install_windows.go
@@ -1,0 +1,291 @@
+// install_windows.go 实现 supervisor.exe --install / --uninstall 子命令
+//。
+// --install --token <X> --cloud-addr <X> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>]:
+//   1. DPAPI CryptProtectData(token) → secrets.enc
+//   2. 验证 CryptUnprotectData(secrets.enc) 能还原
+//   3. 清零明文 token 内存
+//   4. sc.exe create → 启动服务
+//   5. 写注册表 Environment MultiString（cloud_addr / access_key / collector_mode / plugin_*_dir）
+// --uninstall:
+//   1. sc.exe stop + delete（注册表 Environment 字段随服务键一起清除）
+//   2. 删除 secrets.enc
+// 安全：明文 token 仅在 CLI flag 时刻存在于内存，加密后立即清零。
+// 不写日志/临时文件。Go string 不可变（无法真正清零 argv），但 []byte 可以。
+// 注：access_key 暂以明文存于 Environment（与 R4 现状一致； 仅要求 SECRET_KEY
+// 走 DPAPI，ACCESS_KEY 在现有  服务中也是明文环境变量）。
+//  深化：runInstall 从 66 行单体函数拆为 ≤30 行 orchestrator，
+// 3 个正交关注点委托给 install 包接口（SecretStore / ServiceController / EnvWriter）。
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+// secretsFileName 是 DPAPI 加密的 token 文件名。
+const secretsFileName = "secrets.enc"
+
+// serviceRegKeyPath 是 Windows Service 注册表路径（HKLM 前缀由 registry.OpenKey 自动加）。
+const serviceRegKeyPath = `SYSTEM\CurrentControlSet\Services\` + serviceName
+
+// installOptions 是 --install 子命令接收的所有参数。
+type installOptions struct {
+	// Token 是 broker SECRET_KEY（DPAPI 加密后存 secrets.enc）。必需。
+	Token string
+	// CloudAddr 是 frontier broker 地址（host:port）。必需。
+	CloudAddr string
+	// AccessKey 是 broker ACCESS_KEY（明文存服务 Environment）。必需。
+	AccessKey string
+	// CollectorMode 是 node_* 采集模式（off / all），默认 off。
+	CollectorMode string
+	// PluginBinDir / PluginWorkDir 可选，缺省由 edgedirs 默认值决定。
+	PluginBinDir  string
+	PluginWorkDir string
+	// TLSCAFile 是 frontier TLS CA 证书路径（PEM）。可选；空 = plaintext。
+	// 当 frontier 启用 TLS时必需。
+	TLSCAFile string
+	// TLSServerName 是 TLS SNI / 证书 CN。可选；当 TLSCAFile 非空且
+	// CloudAddr 是 IP 字面量时必需（Go TLS 需要显式 ServerName）。
+	TLSServerName string
+	// ScrapeConfigFile 是 worker metrics plugin 加载的 scrape.yaml 路径
+	// （ONGRID_EDGE_SCRAPE_CONFIG_FILE env）。可选；空 = Validate 填
+	// edgedirs.DataDir/scrape.yaml 默认值。
+	// 必需场景：collector_mode=auto 且有自定义 metrics 需 scrape。
+	// 缺失会导致 worker 用 embedded baseline 只 scrape windows_exporter，
+	// 自定义 metrics 全断（NSSM→supervisor 切换功能回退，修复）。
+	ScrapeConfigFile string
+}
+
+// Validate 校验必需字段并应用默认值。
+func (o *installOptions) Validate() error {
+	if o.Token == "" {
+		return fmt.Errorf("--token <X> is required")
+	}
+	if o.CloudAddr == "" {
+		return fmt.Errorf("--cloud-addr <host:port> is required")
+	}
+	if o.AccessKey == "" {
+		return fmt.Errorf("--access-key <X> is required")
+	}
+	if o.CollectorMode == "" {
+		o.CollectorMode = "off"
+	}
+	if o.PluginBinDir == "" {
+		o.PluginBinDir = edgedirs.BinDir
+	}
+	if o.PluginWorkDir == "" {
+		o.PluginWorkDir = edgedirs.PluginWorkDir
+	}
+	if o.ScrapeConfigFile == "" {
+		o.ScrapeConfigFile = filepath.Join(edgedirs.DataDir, "scrape.yaml")
+	}
+	// TLSCAFile 非空时校验文件存在（ca.pem validation）。
+	// 缺失会导致 install 成功但 worker tunnel dial 必失败（"force closed"），
+	// 排查成本高 — install 时 fail-fast。
+	if o.TLSCAFile != "" {
+		if _, err := os.Stat(o.TLSCAFile); err != nil {
+			return fmt.Errorf("--tls-ca-file %q: %w", o.TLSCAFile, err)
+		}
+	}
+	return nil
+}
+
+// envPairs 返回写入服务 Environment 字段的 KEY=VALUE 多字符串数组。
+// 顺序固定，便于人工排查与重装比对。
+// TLS env vars 只在用户显式提供 --tls-ca-file / --tls-server-name 时
+// 写入。缺失会导致 frontier TLS 连接失败（"force closed"）—
+// 必须传 --tls-ca-file C:/ongrid-edge/ca.pem。
+func (o *installOptions) envPairs() []string {
+	pairs := []string{
+		"ONGRID_EDGE_CLOUD_ADDR=" + o.CloudAddr,
+		"ONGRID_EDGE_ACCESS_KEY=" + o.AccessKey,
+		// SECRET_KEY 由 secrets.enc 提供（DPAPI），不写入 Environment
+		"ONGRID_EDGE_COLLECTOR_MODE=" + o.CollectorMode,
+		"ONGRID_EDGE_PLUGIN_BIN_DIR=" + o.PluginBinDir,
+		"ONGRID_EDGE_PLUGIN_WORK_DIR=" + o.PluginWorkDir,
+		// secrets.enc 路径（让 worker main.go 知道从哪加载 DPAPI token）
+		"ONGRID_EDGE_SECRETS_FILE=" + filepath.Join(edgedirs.DataDir, secretsFileName),
+		// scrape.yaml 路径（worker metrics plugin 加载自定义 scrape targets；
+		// 缺失会让 worker 用 embedded baseline 只 scrape windows_exporter）
+		"ONGRID_EDGE_SCRAPE_CONFIG_FILE=" + o.ScrapeConfigFile,
+	}
+	if o.TLSCAFile != "" {
+		pairs = append(pairs, "ONGRID_EDGE_TLS_CA_FILE="+o.TLSCAFile)
+		// TLS 锚点：记录"本机安装时启用过 TLS"。worker 侧据此在 CA 配置丢失时
+		// fail-closed（拒绝明文降级拨号）而非静默回退明文 — 凭证通道不允许无感降级。
+		pairs = append(pairs, "ONGRID_EDGE_TLS_REQUIRED=1")
+	}
+	if o.TLSServerName != "" {
+		pairs = append(pairs, "ONGRID_EDGE_TLS_SERVER_NAME="+o.TLSServerName)
+	}
+	return pairs
+}
+
+// secureUpgradeDir 是 runInstall 的升级目录加固测试缝：生产路径指向
+// install.EnsureSecureDir（真实 icacls ACL），测试注入 no-op / sentinel 错误
+// 避免触碰真实 ProgramData 路径（与 install 包 ensureSecureDirFn 缝模式一致）。
+var secureUpgradeDir = install.EnsureSecureDir
+
+// runInstall 执行 --install 流程，编排接口的调用顺序。
+// 编排顺序：
+//  1. SecretStore.Install — DPAPI 加密 + round-trip 验证（内部自清理）
+//  2. ServiceController.Create — sc.exe create（失败时回滚凭证）
+//  3. ServiceController.ConfigureDefenderExclusion — Add-MpPreference
+//  4. ServiceController.ConfigureRecovery — sc.exe failure（失败即中止：
+//     recovery 承载 supervisor crash 自恢复契约，缺失则安装不可信）
+//  5. EnvWriter.Write — registry Environment（失败不回滚服务）
+//  6. ServiceController.Start — sc.exe start（失败即报错：自动化部署必须
+//     收到真实退出码；不回滚已创建服务，保留现场供 SCM/nssm 排障）
+func runInstall(
+	log *slog.Logger, opts installOptions,
+	ss install.SecretStore, sc install.ServiceController, ew install.EnvWriter,
+) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	// 将 token 转为 []byte 一次，全链路复用，defer 清零
+	// Go string 不可变（argv 残留到进程退出），但 []byte 副本可以清零
+	tokenBytes := []byte(opts.Token)
+	defer zeroBytes(tokenBytes)
+
+	// 确保 data 目录存在
+	if err := os.MkdirAll(edgedirs.DataDir, 0755); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	// StageDir / PluginWorkDir 是升级链路的信任根：升级 bundle 无签名，完整性
+	// 依赖目录 ACL（ProgramData 默认 ACL 允许 Users 创建文件）。必须显式收紧 —
+	// 目录已存在时（迁移安装 / 旧版残留）ApplyDirACL 的继承标记也会刷新既有
+	// 子树的继承 ACE，防止旧宽松 ACL 存活。
+	for _, dir := range []string{edgedirs.StageDir, opts.PluginWorkDir} {
+		if err := secureUpgradeDir(dir); err != nil {
+			return fmt.Errorf("secure dir %s: %w", dir, err)
+		}
+	}
+
+	// 1. 凭证（DPAPI 加密 + 验证；失败时 Install 内部自清理）
+	if err := ss.Install(tokenBytes); err != nil {
+		return err
+	}
+
+	// 2. 服务注册（失败时回滚凭证；`_ =` 丢弃回滚删除的次要错误 —
+	// 主错误已确定，secrets.enc 残留可由重装或 --uninstall 清理）
+	exePath, err := os.Executable()
+	if err != nil {
+		_ = ss.Remove()
+		return fmt.Errorf("resolve executable path: %w", err)
+	}
+	if err := sc.Create(exePath); err != nil {
+		_ = ss.Remove()
+		return fmt.Errorf("create service: %w", err)
+	}
+
+	// 3. Defender exclusion
+	if err := sc.ConfigureDefenderExclusion(); err != nil {
+		log.Warn("failed to configure Windows Defender exclusion (non-fatal; AV may interfere with supervisor self-swap)",
+			slog.String("err", err.Error()))
+	}
+
+	// 4. SCM failure recovery（+ failureflag — 失败即中止安装；
+	//    service.go samesession=false + supervisor self-swap exit(0) 依赖此配置触发 SCM restart，
+	//    配置缺失时服务不具备自恢复能力，交付它等同于假成功）
+	if err := sc.ConfigureRecovery(); err != nil {
+		return fmt.Errorf("configure SCM failure recovery: %w", err)
+	}
+
+	// 5. 环境配置（失败不回滚服务 — 由调用方决定是否 --uninstall）
+	if err := ew.Write(opts.envPairs()); err != nil {
+		log.Warn("service created but failed to set Environment; manual cleanup needed",
+			slog.String("err", err.Error()))
+		return fmt.Errorf("write service Environment: %w", err)
+	}
+
+	// 6. 启动（失败即返回错误——"install completed" 只允许在服务真正运行后出现；
+	//    不回滚已创建的服务，保留现场供排障，--install 幂等可重跑）
+	if err := sc.Start(); err != nil {
+		return fmt.Errorf("start service: %w", err)
+	}
+
+	log.Info("install completed",
+		slog.String("binary", exePath),
+		slog.String("cloud_addr", opts.CloudAddr))
+	return nil
+}
+
+// runUninstall 执行 --uninstall 流程。
+func runUninstall(log *slog.Logger, sc install.ServiceController, ss install.SecretStore) error {
+	// 1. 停止服务（忽略 "服务未运行" 错误）
+	_ = sc.Stop()
+
+	// 2. 删除服务（注册表 Environment 字段随服务键一起删除）
+	if err := sc.Delete(); err != nil {
+		return err
+	}
+
+	// 3. 删除 secrets.enc
+	if err := ss.Remove(); err != nil {
+		log.Warn("failed to remove secrets.enc", slog.String("err", err.Error()))
+	}
+
+	log.Info("uninstall completed")
+	return nil
+}
+
+// zeroBytes 清零 byte slice（SecureString cleanup）。
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// parseInstallOptions 从 args 中提取所有 --install 子命令参数。
+// 支持两种格式：--flag <VALUE> 和 --flag=<VALUE>。
+func parseInstallOptions(args []string) installOptions {
+	var opts installOptions
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		// 提取 --flag 或 --flag=VALUE
+		flag, inlineVal, hasInline := strings.Cut(a, "=")
+		// 取值：优先 inline，否则看下一个 arg
+		getValue := func() string {
+			if hasInline {
+				return inlineVal
+			}
+			if i+1 < len(args) {
+				i++
+				return args[i]
+			}
+			return ""
+		}
+		switch flag {
+		case "--token":
+			opts.Token = getValue()
+		case "--cloud-addr":
+			opts.CloudAddr = getValue()
+		case "--access-key":
+			opts.AccessKey = getValue()
+		case "--collector-mode":
+			opts.CollectorMode = getValue()
+		case "--plugin-bin-dir":
+			opts.PluginBinDir = getValue()
+		case "--plugin-work-dir":
+			opts.PluginWorkDir = getValue()
+		case "--tls-ca-file":
+			opts.TLSCAFile = getValue()
+		case "--tls-server-name":
+			opts.TLSServerName = getValue()
+		case "--scrape-config-file":
+			opts.ScrapeConfigFile = getValue()
+		}
+	}
+	return opts
+}

--- a/cmd/ongrid-edge-supervisor/install_windows_test.go
+++ b/cmd/ongrid-edge-supervisor/install_windows_test.go
@@ -1,0 +1,756 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+// TestZeroBytes_ClearsContent 验证 zeroBytes 清零内容。
+func TestZeroBytes_ClearsContent(t *testing.T) {
+	cases := [][]byte{
+		[]byte("secret"),
+		[]byte("ed_bk_token_123"),
+		{0xFF, 0xAA, 0x55, 0x00},
+		{},
+	}
+	for i, b := range cases {
+		original := make([]byte, len(b))
+		copy(original, b)
+		zeroBytes(b)
+		for j, v := range b {
+			if v != 0 {
+				t.Errorf("case %d byte %d = %d (0x%02X), want 0 (original was 0x%02X)",
+					i, j, v, v, original[j])
+			}
+		}
+	}
+}
+
+// TestParseInstallOptions_ExtractsAllFields 验证所有参数解析。
+func TestParseInstallOptions_ExtractsAllFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want installOptions
+	}{
+		{
+			"all_flags_space",
+			[]string{"--token", "tok", "--cloud-addr", "1.2.3.4:40012", "--access-key", "ak123", "--collector-mode", "all", "--plugin-bin-dir", "C:\\bin", "--plugin-work-dir", "C:\\data"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123", CollectorMode: "all", PluginBinDir: "C:\\bin", PluginWorkDir: "C:\\data"},
+		},
+		{
+			"all_flags_equals",
+			[]string{"--token=tok", "--cloud-addr=1.2.3.4:40012", "--access-key=ak123"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123"},
+		},
+		{
+			"mixed_inline_and_space",
+			[]string{"--token=tok", "--cloud-addr", "1.2.3.4:40012", "--access-key=ak123"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123"},
+		},
+		{
+			"empty_args",
+			[]string{},
+			installOptions{},
+		},
+		{
+			"missing_value_at_end",
+			[]string{"--token"},
+			installOptions{}, // Token 仍为空（缺值）
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseInstallOptions(tc.args)
+			if got != tc.want {
+				t.Errorf("parseInstallOptions(%v)\n  got  = %+v\n  want = %+v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInstallOptions_Validate 验证 Validate 校验必需字段并填默认值。
+func TestInstallOptions_Validate(t *testing.T) {
+	t.Run("missing_token", func(t *testing.T) {
+		o := installOptions{CloudAddr: "1.2.3.4:40012", AccessKey: "ak"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing token")
+		}
+	})
+	t.Run("missing_cloud_addr", func(t *testing.T) {
+		o := installOptions{Token: "tok", AccessKey: "ak"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing cloud_addr")
+		}
+	})
+	t.Run("missing_access_key", func(t *testing.T) {
+		o := installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing access_key")
+		}
+	})
+	t.Run("applies_defaults", func(t *testing.T) {
+		o := installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak"}
+		if err := o.Validate(); err != nil {
+			t.Fatalf("Validate failed: %v", err)
+		}
+		if o.CollectorMode != "off" {
+			t.Errorf("default CollectorMode = %q, want off", o.CollectorMode)
+		}
+		if o.PluginBinDir == "" {
+			t.Error("default PluginBinDir should be set")
+		}
+		if o.PluginWorkDir == "" {
+			t.Error("default PluginWorkDir should be set")
+		}
+	})
+	t.Run("tls_ca_file_not_exist_rejected", func(t *testing.T) {
+		o := installOptions{
+			Token:     "tok",
+			CloudAddr: "1.2.3.4:40012",
+			AccessKey: "ak",
+			TLSCAFile: `Z:\nonexistent\path\ca.pem`,
+		}
+		err := o.Validate()
+		if err == nil {
+			t.Fatal("expected error for nonexistent TLSCAFile")
+		}
+	})
+	t.Run("tls_ca_file_exist_accepted", func(t *testing.T) {
+		tmp := t.TempDir()
+		caFile := filepath.Join(tmp, "ca.pem")
+		if err := os.WriteFile(caFile, []byte("dummy"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		o := installOptions{
+			Token:     "tok",
+			CloudAddr: "1.2.3.4:40012",
+			AccessKey: "ak",
+			TLSCAFile: caFile,
+		}
+		if err := o.Validate(); err != nil {
+			t.Errorf("Validate should pass when TLSCAFile exists: %v", err)
+		}
+	})
+	t.Run("tls_ca_file_empty_not_checked", func(t *testing.T) {
+		o := installOptions{
+			Token:     "tok",
+			CloudAddr: "1.2.3.4:40012",
+			AccessKey: "ak",
+			// TLSCAFile 留空 — 不校验（plaintext 模式）
+		}
+		if err := o.Validate(); err != nil {
+			t.Errorf("Validate should pass when TLSCAFile is empty: %v", err)
+		}
+	})
+}
+
+// TestInstallOptions_EnvPairs 验证 envPairs 输出格式正确。
+func TestInstallOptions_EnvPairs(t *testing.T) {
+	o := installOptions{
+		Token:         "tok",
+		CloudAddr:     "1.2.3.4:40012",
+		AccessKey:     "ak123",
+		CollectorMode: "off",
+		PluginBinDir:  `C:\bin`,
+		PluginWorkDir: `C:\data`,
+	}
+	pairs := o.envPairs()
+	if len(pairs) != 7 {
+		t.Fatalf("envPairs len = %d, want 7 (含 SCRAPE_CONFIG_FILE, 修复)", len(pairs))
+	}
+	// 必须含 ACCESS_KEY 明文（不加密）
+	foundAccessKey := false
+	for _, p := range pairs {
+		if p == "ONGRID_EDGE_ACCESS_KEY=ak123" {
+			foundAccessKey = true
+		}
+	}
+	if !foundAccessKey {
+		t.Error("envPairs missing ONGRID_EDGE_ACCESS_KEY")
+	}
+	// 必须含 SECRETS_FILE 路径（让 worker 知道从哪加载 DPAPI token）
+	foundSecretsFile := false
+	for _, p := range pairs {
+		if strings.HasPrefix(p, "ONGRID_EDGE_SECRETS_FILE=") {
+			foundSecretsFile = true
+		}
+	}
+	if !foundSecretsFile {
+		t.Error("envPairs missing ONGRID_EDGE_SECRETS_FILE")
+	}
+	// 不应含 SECRET_KEY 明文（仅 secrets.enc 提供）
+	for _, p := range pairs {
+		if strings.HasPrefix(p, "ONGRID_EDGE_SECRET_KEY=") {
+			t.Errorf("SECRET_KEY should NOT be in Environment (DPAPI only): %s", p)
+		}
+	}
+	// 默认无 TLS env（用户未传 --tls-ca-file）
+	for _, p := range pairs {
+		if strings.HasPrefix(p, "ONGRID_EDGE_TLS_") {
+			t.Errorf("TLS env should NOT be set without --tls-ca-file: %s", p)
+		}
+	}
+}
+
+// TestInstallOptions_TLSEnvPairs 验证 --tls-ca-file / --tls-server-name
+// 透传到 service Environment。启用 TLS 时必需，缺失会导致
+// worker tunnel dial 失败（"force closed"）。
+func TestInstallOptions_TLSEnvPairs(t *testing.T) {
+	o := installOptions{
+		Token:         "tok",
+		CloudAddr:     "broker.example.com:16667",
+		AccessKey:     "ak123",
+		TLSCAFile:     `C:\ongrid-edge\ca.pem`,
+		TLSServerName: "broker.example.com",
+	}
+	pairs := o.envPairs()
+
+	wantCA := false
+	wantSN := false
+	wantRequired := false
+	for _, p := range pairs {
+		if p == "ONGRID_EDGE_TLS_CA_FILE=C:\\ongrid-edge\\ca.pem" {
+			wantCA = true
+		}
+		if p == "ONGRID_EDGE_TLS_SERVER_NAME=broker.example.com" {
+			wantSN = true
+		}
+		if p == "ONGRID_EDGE_TLS_REQUIRED=1" {
+			wantRequired = true
+		}
+	}
+	if !wantCA {
+		t.Errorf("envPairs missing ONGRID_EDGE_TLS_CA_FILE; got %v", pairs)
+	}
+	if !wantSN {
+		t.Errorf("envPairs missing ONGRID_EDGE_TLS_SERVER_NAME; got %v", pairs)
+	}
+	// TLS 锚点：安装时启用 TLS 必须同时落 ONGRID_EDGE_TLS_REQUIRED=1，
+	// worker 侧据此在 CA 配置丢失时拒绝明文降级。
+	if !wantRequired {
+		t.Errorf("envPairs missing ONGRID_EDGE_TLS_REQUIRED=1; got %v", pairs)
+	}
+
+	// 未启用 TLS 时不得写入 TLS_REQUIRED（否则 worker 无 CA 也会 fail-closed）。
+	noTLS := installOptions{
+		Token:         "tok",
+		CloudAddr:     "broker.example.com:16667",
+		AccessKey:     "ak123",
+		CollectorMode: "off",
+		PluginBinDir:  `C:\bin`,
+		PluginWorkDir: `C:\data`,
+	}
+	for _, p := range noTLS.envPairs() {
+		if strings.HasPrefix(p, "ONGRID_EDGE_TLS_REQUIRED=") {
+			t.Errorf("TLS_REQUIRED must not be set without --tls-ca-file; got %q", p)
+		}
+	}
+}
+
+// TestEnvPairs_IncludesScrapeConfig 验证 envPairs 含 ONGRID_EDGE_SCRAPE_CONFIG_FILE
+// （worker 找不到 scrape.yaml 时会退回 embedded baseline
+// 只 scrape windows_exporter，自定义 metrics 全断）。
+func TestEnvPairs_IncludesScrapeConfig(t *testing.T) {
+	o := installOptions{
+		Token:            "tok",
+		CloudAddr:        "1.2.3.4:40012",
+		AccessKey:        "ak123",
+		CollectorMode:    "off",
+		PluginBinDir:     `C:\bin`,
+		PluginWorkDir:    `C:\data`,
+		ScrapeConfigFile: `C:\ProgramData\ongrid-edge\scrape.yaml`,
+	}
+	pairs := o.envPairs()
+	found := false
+	for _, p := range pairs {
+		if p == "ONGRID_EDGE_SCRAPE_CONFIG_FILE=C:\\ProgramData\\ongrid-edge\\scrape.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("envPairs missing ONGRID_EDGE_SCRAPE_CONFIG_FILE; got %v", pairs)
+	}
+}
+
+// TestValidate_DefaultsScrapeConfigFile 验证 Validate 在 ScrapeConfigFile 空时
+// 填 edgedirs.DataDir/scrape.yaml 默认值（与 PLUGIN_WORK_DIR 默认值模式一致）。
+func TestValidate_DefaultsScrapeConfigFile(t *testing.T) {
+	o := installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak"}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if o.ScrapeConfigFile == "" {
+		t.Error("Validate should default ScrapeConfigFile (was empty)")
+	}
+}
+
+// TestParseInstallOptions_ScrapeConfigFlag 验证 --scrape-config-file 解析（同时支持
+// space 和 = 两种形式，对齐其它 --flag 模式）。
+func TestParseInstallOptions_ScrapeConfigFlag(t *testing.T) {
+	t.Run("space form", func(t *testing.T) {
+		opts := parseInstallOptions([]string{"--scrape-config-file", `C:\custom\scrape.yaml`})
+		if opts.ScrapeConfigFile != `C:\custom\scrape.yaml` {
+			t.Errorf("ScrapeConfigFile = %q; want C:\\custom\\scrape.yaml", opts.ScrapeConfigFile)
+		}
+	})
+	t.Run("equals form", func(t *testing.T) {
+		opts := parseInstallOptions([]string{"--scrape-config-file=C:/x/scrape.yaml"})
+		if opts.ScrapeConfigFile != "C:/x/scrape.yaml" {
+			t.Errorf("ScrapeConfigFile = %q; want C:/x/scrape.yaml", opts.ScrapeConfigFile)
+		}
+	})
+}
+
+// TestParseInstallOptions_TLSFlags 验证 --tls-ca-file / --tls-server-name
+// 同时支持 --flag <value> 和 --flag=<value> 两种形式。
+func TestParseInstallOptions_TLSFlags(t *testing.T) {
+	t.Run("space form", func(t *testing.T) {
+		opts := parseInstallOptions([]string{
+			"--token", "tok",
+			"--cloud-addr", "1.2.3.4:40012",
+			"--access-key", "ak",
+			"--tls-ca-file", `C:\ca.pem`,
+			"--tls-server-name", "frontier.example.com",
+		})
+		if opts.TLSCAFile != `C:\ca.pem` {
+			t.Errorf("TLSCAFile = %q; want C:\\ca.pem", opts.TLSCAFile)
+		}
+		if opts.TLSServerName != "frontier.example.com" {
+			t.Errorf("TLSServerName = %q; want frontier.example.com", opts.TLSServerName)
+		}
+	})
+	t.Run("equals form", func(t *testing.T) {
+		opts := parseInstallOptions([]string{
+			"--token=tok",
+			"--cloud-addr=1.2.3.4:40012",
+			"--access-key=ak",
+			"--tls-ca-file=C:/ca.pem",
+			"--tls-server-name=frontier.example.com",
+		})
+		if opts.TLSCAFile != "C:/ca.pem" {
+			t.Errorf("TLSCAFile = %q; want C:/ca.pem", opts.TLSCAFile)
+		}
+		if opts.TLSServerName != "frontier.example.com" {
+			t.Errorf("TLSServerName = %q; want frontier.example.com", opts.TLSServerName)
+		}
+	})
+}
+
+// TestMain 将 runInstall 的目录加固缝替换为 no-op：orchestrator 用例关注
+// 编排顺序，不应触碰真实 ProgramData 的 ACL（加固步骤本身由
+// TestRunInstall_SecureDir* 专项覆盖，此处关闭不降低覆盖）。
+func TestMain(m *testing.M) {
+	secureUpgradeDir = func(string) error { return nil }
+	os.Exit(m.Run())
+}
+
+// ---------------------------------------------------------------------------
+// Mock 实现（用于 runInstall orchestrator 测试）
+// ---------------------------------------------------------------------------
+
+// errDPAPI / errSC / errReg / errStart 是测试用的 sentinel 错误。
+var (
+	errDPAPI = fmt.Errorf("mock: dpapi failure")
+	errSC    = fmt.Errorf("mock: sc.exe failure")
+	errReg   = fmt.Errorf("mock: registry failure")
+	errStart = fmt.Errorf("mock: sc.exe start failure")
+)
+
+// 编译时断言：mock 类型实现 install 包接口。
+var (
+	_ install.SecretStore       = (*mockSecretStore)(nil)
+	_ install.ServiceController = (*mockServiceController)(nil)
+	_ install.EnvWriter         = (*mockEnvWriter)(nil)
+)
+
+// mockSecretStore 实现 install.SecretStore。
+type mockSecretStore struct {
+	installErr error
+	removeErr  error
+	installed  []byte
+	removeCall int
+}
+
+func (m *mockSecretStore) Install(token []byte) error {
+	if m.installErr != nil {
+		return m.installErr
+	}
+	m.installed = append([]byte(nil), token...)
+	return nil
+}
+
+func (m *mockSecretStore) Rotate(token []byte) error {
+	if m.installErr != nil {
+		return m.installErr
+	}
+	m.installed = append([]byte(nil), token...)
+	return nil
+}
+
+func (m *mockSecretStore) Remove() error {
+	m.removeCall++
+	if m.removeErr != nil {
+		return m.removeErr
+	}
+	return nil
+}
+
+// mockServiceController 实现 install.ServiceController。
+type mockServiceController struct {
+	createErr            error
+	recoveryErr          error
+	defenderExclusionErr error
+	startErr             error
+	stopErr              error
+	deleteErr            error
+	created              string
+	recoveryConfigured   bool
+	defenderConfigured   bool
+	started              bool
+	stopped              bool
+	deleted              bool
+}
+
+func (m *mockServiceController) Create(binPath string) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = binPath
+	return nil
+}
+
+func (m *mockServiceController) ConfigureRecovery() error {
+	if m.recoveryErr != nil {
+		return m.recoveryErr
+	}
+	m.recoveryConfigured = true
+	return nil
+}
+
+func (m *mockServiceController) ConfigureDefenderExclusion() error {
+	if m.defenderExclusionErr != nil {
+		return m.defenderExclusionErr
+	}
+	m.defenderConfigured = true
+	return nil
+}
+
+func (m *mockServiceController) Start() error {
+	if m.startErr != nil {
+		return m.startErr
+	}
+	m.started = true
+	return nil
+}
+
+func (m *mockServiceController) Stop() error {
+	m.stopped = true
+	if m.stopErr != nil {
+		return m.stopErr
+	}
+	return nil
+}
+
+func (m *mockServiceController) Delete() error {
+	m.deleted = true
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	return nil
+}
+
+// mockEnvWriter 实现 install.EnvWriter。
+type mockEnvWriter struct {
+	writeErr error
+	written  []string
+}
+
+func (m *mockEnvWriter) Write(pairs []string) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	m.written = pairs
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// runInstall orchestrator 测试（4 错误路径 + happy path）
+// ---------------------------------------------------------------------------
+
+// validInstallOptions 返回通过 Validate 的 installOptions。
+func validInstallOptions() installOptions {
+	return installOptions{
+		Token:         "test_token_abc123",
+		CloudAddr:     "1.2.3.4:40012",
+		AccessKey:     "ak_test",
+		CollectorMode: "off",
+		PluginBinDir:  `C:\bin`,
+		PluginWorkDir: `C:\data`,
+	}
+}
+
+// TestRunInstall_DPAPIFailure 验证 DPAPI 加密失败时 install 中止，不创建服务。
+func TestRunInstall_DPAPIFailure(t *testing.T) {
+	ss := &mockSecretStore{installErr: errDPAPI}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for DPAPI failure, got nil")
+	}
+
+	// 服务不应被创建
+	if sc.created != "" {
+		t.Errorf("service should not be created, got binPath=%s", sc.created)
+	}
+	// Environment 不应被写
+	if ew.written != nil {
+		t.Error("Environment should not be written")
+	}
+	// Remove 不应被调用（Install 内部自清理，orchestrator 不介入）
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should not be called, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_SCCreateFailure 验证 sc.exe create 失败时回滚 secrets.enc。
+func TestRunInstall_SCCreateFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{createErr: errSC}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for sc.exe create failure, got nil")
+	}
+
+	// Remove 应被调用（回滚 secrets）
+	if ss.removeCall != 1 {
+		t.Errorf("Remove should be called once for rollback, got %d calls", ss.removeCall)
+	}
+	// Environment 不应被写
+	if ew.written != nil {
+		t.Error("Environment should not be written after sc.exe create failure")
+	}
+	// Start 不应被调用
+	if sc.started {
+		t.Error("Start should not be called")
+	}
+}
+
+// TestRunInstall_RegistryFailure 验证 registry 失败时报错但不回滚服务。
+func TestRunInstall_RegistryFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{writeErr: errReg}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for registry failure, got nil")
+	}
+
+	// Remove 不应被调用（服务已创建，不回滚）
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called for registry failure, got %d calls", ss.removeCall)
+	}
+	// 服务应已创建
+	if sc.created == "" {
+		t.Error("service should be created before registry write")
+	}
+	// Start 不应被调用
+	if sc.started {
+		t.Error("Start should not be called after registry failure")
+	}
+}
+
+// TestRunInstall_SCStartFailure 验证 sc.exe start 失败时返回错误（fail-fast：
+// 自动化部署必须收到失败信号而非假成功），且不回滚已创建的服务（保留 SCM/
+// nssm 排障现场，--install 幂等可重跑）。
+func TestRunInstall_SCStartFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{startErr: errStart}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for sc.exe start failure, got nil")
+	}
+
+	// 服务应已创建 + Environment 已写（失败发生在最后一步）
+	if sc.created == "" {
+		t.Error("service should be created")
+	}
+	if ew.written == nil {
+		t.Error("Environment should be written")
+	}
+	// 不回滚：Remove 不应被调用，服务保留现场
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called for start failure, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_Success 验证 happy path：全部步骤成功执行。
+func TestRunInstall_Success(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 所有步骤应执行
+	if len(ss.installed) == 0 {
+		t.Error("token should be installed")
+	}
+	if sc.created == "" {
+		t.Error("service should be created")
+	}
+	if !sc.recoveryConfigured {
+		t.Error("SCM failure recovery should be configured")
+	}
+	if !sc.defenderConfigured {
+		t.Error("Defender exclusion should be configured")
+	}
+	if !sc.started {
+		t.Error("service should be started")
+	}
+	if ew.written == nil {
+		t.Error("Environment should be written")
+	}
+	// Remove 不应被调用
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called on success, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_DefenderExclusionFailure_NonFatal 验证 Defender exclusion 失败不阻断 install。
+func TestRunInstall_DefenderExclusionFailure_NonFatal(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{
+		defenderExclusionErr: fmt.Errorf("mock: Add-MpPreference failed"),
+	}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("Defender exclusion 失败不应阻断 install： %v", err)
+	}
+	// 后续步骤应继续
+	if !sc.recoveryConfigured {
+		t.Error("ConfigureRecovery 应在 Defender 失败后继续执行")
+	}
+	if !sc.started {
+		t.Error("Start 应在 Defender 失败后继续执行")
+	}
+}
+
+// TestRunInstall_RecoveryFailure 验证 ConfigureRecovery 失败时 install 立即中止
+// （fail-fast：recovery 承载 supervisor crash 自恢复契约，缺失即安装不可信），
+// 后续 Environment 写入与 Start 均不执行；不回滚已创建的服务。
+func TestRunInstall_RecoveryFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{
+		recoveryErr: fmt.Errorf("mock: sc.exe failure failed"),
+	}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for ConfigureRecovery failure, got nil")
+	}
+	if !sc.defenderConfigured {
+		t.Error("Defender exclusion 应已配置（在 Recovery 之前）")
+	}
+	if ew.written != nil {
+		t.Error("Environment 不应在 Recovery 失败后写入")
+	}
+	if sc.started {
+		t.Error("Start 不应在 Recovery 失败后执行")
+	}
+	// 不回滚：Remove 不应被调用
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called for recovery failure, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_SecureDirFailure 验证目录加固失败时 install 立即中止，
+// 不进入凭证 / 服务注册步骤（fail-closed：ACL 不可信则拒绝安装）。
+func TestRunInstall_SecureDirFailure(t *testing.T) {
+	errSecure := fmt.Errorf("mock: icacls failure")
+	orig := secureUpgradeDir
+	secureUpgradeDir = func(dir string) error { return errSecure }
+	defer func() { secureUpgradeDir = orig }()
+
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for secure dir failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "secure dir") {
+		t.Errorf("error should mention secure dir, got: %v", err)
+	}
+	if ss.installed != nil {
+		t.Error("credentials should not be installed before dir hardening succeeds")
+	}
+	if sc.created != "" {
+		t.Error("service should not be created before dir hardening succeeds")
+	}
+}
+
+// TestRunInstall_SecuresStageAndPluginDirs 验证加固对象是 StageDir 与
+// PluginWorkDir（升级链路的信任根），且在凭证安装之前执行。
+func TestRunInstall_SecuresStageAndPluginDirs(t *testing.T) {
+	var secured []string
+	orig := secureUpgradeDir
+	secureUpgradeDir = func(dir string) error {
+		secured = append(secured, dir)
+		return nil
+	}
+	defer func() { secureUpgradeDir = orig }()
+
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	opts := validInstallOptions()
+	if err := runInstall(log, opts, ss, sc, ew); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{edgedirs.StageDir, opts.PluginWorkDir}
+	if len(secured) != len(want) {
+		t.Fatalf("secured dirs = %v, want %v", secured, want)
+	}
+	for i, d := range want {
+		if secured[i] != d {
+			t.Errorf("secured[%d] = %q, want %q", i, secured[i], d)
+		}
+	}
+	if ss.installed == nil {
+		t.Error("credentials should be installed after dirs are secured")
+	}
+}

--- a/cmd/ongrid-edge-supervisor/main.go
+++ b/cmd/ongrid-edge-supervisor/main.go
@@ -1,0 +1,122 @@
+// Command ongrid-edge-supervisor 是 Windows 版 Edge Agent 的 supervisor 进程
+//。
+//  职责：
+//   - Windows Service 入口（golang.org/x/sys/windows/svc）
+//   - 启动 + 监控 worker.exe（cmd/ongrid-edge 编译产物）
+//   - 健康感知（health.json 文件 IPC，30s 心跳窗口）
+//
+//   - ✅ --install / --uninstall 子命令 + DPAPI 加密 token
+//   - ✅ token 90 天轮转检查（edge 端）
+//   - ❌ bundle upgrade staging + swap + rollback
+// 整个包 //go:build windows（Linux 不编译，对称 cmdpolicy 的 //go:build linux）。
+// health 逻辑在 internal/edgeagent/supervisorhealth 包，跨平台可测。
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows/svc"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+const serviceName = "ongrid-edge"
+
+// version 是编译期版本号（Makefile -ldflags "-X main.version=v$(VERSION)" 注入）。
+// SupervisorSelfSwap.smokeTestVersion 跑 `supervisor.exe.new --version` 验证
+// binary 可执行 + 版本非空。
+var version = "dev"
+
+func main() {
+	// Windows Service 模式下 os.Stderr 写入 invalid handle 返回 error，
+	// io.MultiWriter 遇到第一个 writer 失败就 short-circuit 不写后续 writer。
+	// 因此 logFile 必须排在 os.Stderr 之前，确保文件一定拿到日志。
+	_ = os.MkdirAll(edgedirs.DataDir, 0o755)
+	logFile, logErr := os.OpenFile(filepath.Join(edgedirs.DataDir, "supervisor.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	var w io.Writer = os.Stderr
+	if logErr == nil {
+		w = io.MultiWriter(logFile, os.Stderr)
+	}
+	log := slog.New(slog.NewJSONHandler(w, nil))
+
+	// --install / --uninstall 子命令
+	if len(os.Args) >= 2 {
+		switch os.Args[1] {
+		case "--install":
+			opts := parseInstallOptions(os.Args[2:])
+			if err := opts.Validate(); err != nil {
+				log.Error("--install 参数错误", "err", err)
+				fmt.Fprintf(os.Stderr, "Usage: ongrid-edge-supervisor.exe --install --token <X> --cloud-addr <host:port> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>] [--scrape-config-file <P>] [--tls-ca-file <P>] [--tls-server-name <X>]\n")
+				os.Exit(2)
+			}
+			if err := runInstall(log, opts,
+				install.NewSecretStore(filepath.Join(edgedirs.DataDir, secretsFileName)),
+				install.NewServiceController(serviceName),
+				install.NewEnvWriter(serviceRegKeyPath),
+			); err != nil {
+				log.Error("install failed", "err", err)
+				os.Exit(1)
+			}
+			return
+		case "--uninstall":
+			if err := runUninstall(log,
+				install.NewServiceController(serviceName),
+				install.NewSecretStore(filepath.Join(edgedirs.DataDir, secretsFileName)),
+			); err != nil {
+				log.Error("uninstall failed", "err", err)
+				os.Exit(1)
+			}
+			return
+		case "--version", "-v":
+			fmt.Fprintf(os.Stdout, "ongrid-edge-supervisor %s\n", version)
+			return
+		case "--upgrade":
+			//   trigger：写 sentinel + os.Exit(0) 让 SCM 重启
+			// supervisor → BootCheck 检测 sentinel → SupervisorSelfSwap。
+			// 见 upgrade_windows.go runUpgrade 文档。
+			if err := runUpgrade(log, edgedirs.StageDir); err != nil {
+				log.Error("--upgrade failed", "err", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		case "--help", "-h":
+			fmt.Fprintf(os.Stdout, "Usage:\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe --install --token <X> --cloud-addr <host:port> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>] [--scrape-config-file <P>] [--tls-ca-file <P>] [--tls-server-name <X>]\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe --uninstall\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe --upgrade  (write sentinel + exit; SCM restart triggers SelfSwap)\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe (run as Windows Service)\n")
+			return
+		}
+	}
+
+	isSvc, err := svc.IsWindowsService()
+	if err != nil {
+		log.Error("detect windows service context failed", "err", err)
+		os.Exit(1)
+	}
+
+	if !isSvc {
+		// 开发调试模式：直接跑 worker（不通过 SCM）。
+		log.Info("running in interactive mode; starting worker directly (dev mode)")
+		if err := runWorkerOnly(log); err != nil {
+			log.Error("interactive worker exited with error", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	h := &serviceHandler{log: log}
+	if err := svc.Run(serviceName, h); err != nil {
+		log.Error("service Run failed", "err", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/ongrid-edge-supervisor/service.go
+++ b/cmd/ongrid-edge-supervisor/service.go
@@ -1,0 +1,124 @@
+// service.go 实现 Windows Service 的 svc.Handler 接口。
+// serviceHandler.Execute 是 SCM 调用的入口：
+//   - 启动 worker supervisor goroutine（superviseWorker）
+//   - 接受 Stop / Shutdown 请求，优雅取消 ctx，等 worker 退出
+//   - worker supervisor 异常退出 → 服务停止 + 报告错误码（依赖 SCM recovery action 重启）
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+	"golang.org/x/sys/windows/svc"
+)
+
+// serviceHandler 实现 svc.Handler。
+type serviceHandler struct {
+	log *slog.Logger
+}
+
+// Execute 是 SCM 调用的服务主循环。返回 (samesession, exitCode)：
+//   - samesession=true 表示非致命错误，SCM 不重启（用于 graceful shutdown）
+//   - samesession=false 表示需要 SCM 介入（按 recovery action 决定是否重启）
+//
+// worker 挂了 supervisor 自动重启（superviseWorker 内部循环），只有
+// supervisor 自身循环异常退出才返回 samesession=false。
+// Upgrade boot hooks：
+//  1. maybeRollbackOnBoot — 先回滚未健康的升级（上次 swap 后 worker 没活过 180s）
+//  2. maybeApplyOnBoot — 再 apply 残留的 pending bundle（断电恢复）
+func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
+	status <- svc.Status{State: svc.StartPending, Accepts: 0}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// upgrade boot hook：rollback 不健康升级 → apply 残留 pending bundle
+	// → supervisor self-swap
+	m := upgrademachine.NewMachine(
+		edgedirs.StageDir, edgedirs.BinDir,
+		h.log, &windowsProcessController{},
+	)
+	// stage 目录 ACL 运行期门控（fail-closed）：升级 bundle 无签名，完整性
+	// 依赖 StageDir 的 ACL（install 时已收紧）。树级校验（VerifyTreeACL）：
+	// 顶层目录 ACL 正确不代表子项正确——pending / incoming / 哨兵文件的
+	// DACL 可被持 WRITE_DAC 的主体事后放宽，消费前逐项复验。校验失败只
+	// 关闭升级消费，不影响 rollback。
+	m.SetStageDirGuard(func() error {
+		return install.VerifyTreeACL(edgedirs.StageDir)
+	})
+	if err := m.BootCheck(ctx); err != nil {
+		if errors.Is(err, upgrademachine.ErrSupervisorRestartSoon) {
+			// supervisor self-swap 完成 — 必须在 worker goroutine 启动前退出，
+			// 让 SCM 按 recovery action 重启加载新 supervisor.exe。
+			// exitCode=1（非 0）让 SCM 视为 failure → 触发 restart action；
+			// exitCode=0 会被视为"正常停止"→ SCM 不 restart。
+			// crash-equivalent exit：不手动发 StopPending/Stopped。
+			// Go svc wrapper（vendor/.../svc/service.go:276）在 handler return 后
+			// 用返回的 exitCode 发唯一一个 Stopped → SCM 收到 Win32ExitCode=1 →
+			// 走 crash-equivalent 快速检测路径。手动发 Stopped 会先锁定
+			// Win32ExitCode=0（wrapper 初始 ec.errno=0，vendor service.go:238），
+			// 导致 SCM 走 non-crash 慢路径（~3m45s 才 restart， 实测）。
+			h.log.Info("supervisor self-swap done; exiting for SCM restart")
+			return false, 1 // samesession=false + 非0 exitCode → SCM restart
+		}
+		h.log.Error("upgrade: BootCheck failed", "err", err)
+		// 不中止启动 — rollback/apply 失败不阻塞 supervisor 运行
+	}
+
+	workerExit := make(chan error, 1)
+	go func() {
+		workerExit <- superviseWorker(ctx, h.log, m)
+	}()
+
+	// 报告 Running，声明只接受 Stop / Shutdown（不处理 Pause/Continue）。
+	status <- svc.Status{
+		State:   svc.Running,
+		Accepts: svc.AcceptStop | svc.AcceptShutdown,
+	}
+
+	for {
+		select {
+		case cr := <-req:
+			switch cr.Cmd {
+			case svc.Interrogate:
+				// SCM 周期性 ping 检查服务存活，回显当前状态。
+				status <- cr.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				h.log.Info("service stop requested", "cmd", cr.Cmd)
+				status <- svc.Status{State: svc.StopPending, Accepts: 0}
+				cancel()
+				if err := <-workerExit; err != nil {
+					h.log.Error("worker supervisor exit on stop", "err", err)
+				}
+				status <- svc.Status{State: svc.Stopped, Accepts: 0}
+				return false, 0
+			default:
+				h.log.Warn("unsupported service command", "cmd", cr.Cmd)
+			}
+		case err := <-workerExit:
+			// superviseWorker 返回 ErrSupervisorRestartSoon = supervisor self-swap 完成。
+			// 返回 false, 1 让 SCM 视为 failure → 触发 recovery restart 加载新 supervisor.exe。
+			// crash-equivalent exit：同 BootCheck 路径，不手动发 Stopped。
+			// 手动发会锁定 Win32ExitCode=0 → SCM non-crash 慢路径。
+			// 让 wrapper 用 return exitCode=1 发唯一 Stopped → Win32ExitCode=1 → 快速 restart。
+			if errors.Is(err, upgrademachine.ErrSupervisorRestartSoon) {
+				h.log.Info("supervisor self-swap done (worker path); exiting for SCM restart")
+				return false, 1
+			}
+			// worker supervisor 异常退出（ctx 未取消）= 真异常。
+			if ctx.Err() != nil {
+				return false, 0
+			}
+			h.log.Error("worker supervisor unexpected exit", "err", err)
+			status <- svc.Status{State: svc.Stopped, Accepts: 0}
+			return false, 1
+		}
+	}
+}

--- a/cmd/ongrid-edge-supervisor/upgrade_windows.go
+++ b/cmd/ongrid-edge-supervisor/upgrade_windows.go
@@ -1,0 +1,103 @@
+// upgrade_windows.go 定义 Windows 专属的进程控制器 + 升级超时常量。
+// 升级编排逻辑（applyAndSwap、maybeApply/maybeRollback、watchUpgradeHealth、
+// rollbackAndMark、checkPendingUpgrade）已移至 upgrademachine.Machine。
+// 本文件仅保留 Windows 平台的 taskkill 实现和超时常量。
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// upgradeWatchTimeout 是 swap 后等待新 worker register_edge 成功的窗口。
+// 超过此时间 healthy_marker 仍未匹配 → rollback（对称 Linux 180s watchdog）。
+const upgradeWatchTimeout = 180 * time.Second
+
+// upgradePollInterval 是 Machine.HealthPoll 轮询 IsUpgradeHealthy 的间隔
+// （HealthPoll redesign：HealthCheck → HealthPoll，仅 polling 不再持 timer）。
+const upgradePollInterval = 5 * time.Second
+
+// windowsProcessController 实现 upgrademachine.ProcessController 接口。
+// 用 Windows taskkill 终止进程树和按镜像名杀进程。
+type windowsProcessController struct{}
+
+// taskkillExe 返回 taskkill.exe 的绝对路径（%SystemRoot%\System32）。
+// supervisor 以 SYSTEM 运行并继承系统 PATH；第三方软件注入的用户可写目录
+// 若在 PATH 中，相对名解析会以 LocalSystem 执行被劫持的副本。
+func taskkillExe() (string, error) {
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = os.Getenv("windir")
+	}
+	if root == "" {
+		return "", fmt.Errorf("SystemRoot environment variable not set; cannot resolve taskkill.exe")
+	}
+	p := filepath.Join(root, "System32", "taskkill.exe")
+	if _, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("taskkill.exe not found at %s: %w", p, err)
+	}
+	return p, nil
+}
+
+// KillTree 用 taskkill /T /F /PID 终止 pid 及其所有子进程
+// （windows_exporter / promtail 等），释放 .exe 文件锁。
+// 进程已退出时 taskkill 返回非零退出码，调用方应忽略错误（幂等）。
+func (windowsProcessController) KillTree(pid int) error {
+	exe, err := taskkillExe()
+	if err != nil {
+		return err
+	}
+	return exec.Command(exe, "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}
+
+// KillByImage 用 taskkill /F /IM <name> 按镜像名杀进程。
+// 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
+// orphaned（reparented to PID 1），KillTree 无法触达。
+// 幂等：进程不存在时 taskkill 返回非零，调用方忽略。
+//
+// 系统镜像黑名单兜底：kill 按镜像名全局匹配，
+// 与调用方白名单（KillManifestExes）互为异源防线 — 此层挡所有调用点的
+// 系统关键进程误杀/恶意杀，命中即显式拒绝（不静默跳过）。
+func (windowsProcessController) KillByImage(name string) error {
+	if upgrademachine.IsProtectedSystemImage(name) {
+		return fmt.Errorf("refusing to kill protected system image %q", name)
+	}
+	exe, err := taskkillExe()
+	if err != nil {
+		return err
+	}
+	return exec.Command(exe, "/F", "/IM", name).Run()
+}
+
+// runUpgrade 写 supervisor_upgrade.pending sentinel 触发 SCM 重启升级流程。
+// 端到端流程（由调用方 os.Exit(0) + SCM recovery action 串联）：
+//  1. supervisor.exe --upgrade 调本函数写 sentinel + os.Exit(0)
+//  2. SCM 视 supervisor 进程退出，按 recovery action 重启
+//  3. 新 supervisor 启动 → serviceHandler.Execute → BootCheck 检测 sentinel
+//  4. BootCheck 触发 SupervisorSelfSwap → 完成 rename-aside 后返回
+//     ErrSupervisorRestartSoon → supervisor 再 exit(1) 让 SCM 再次 restart
+//  5. 最终加载新 supervisor.exe，升级闭环
+//
+// sentinel version 参数传空 —— applyOne 已 stage supervisor.exe.new 时
+// supervisor 的真实版本由 BootCheck 从 supervisor.exe.new 自身读取，
+// sentinel 内容非必要。
+// 幂等：WriteSupervisorUpgradePending 用 os.WriteFile 覆盖写，
+// 多次调用不报错（用于 --upgrade 重复触发场景）。
+func runUpgrade(log *slog.Logger, stageDir string) error {
+	log.Info("supervisor upgrade pending, exiting for SCM restart",
+		"stage_dir", stageDir)
+	if err := upgrademachine.WriteSupervisorUpgradePending(stageDir, ""); err != nil {
+		return fmt.Errorf("--upgrade write supervisor pending sentinel: %w", err)
+	}
+	return nil
+}

--- a/cmd/ongrid-edge-supervisor/upgrade_windows_test.go
+++ b/cmd/ongrid-edge-supervisor/upgrade_windows_test.go
@@ -1,0 +1,73 @@
+// upgrade_windows_test.go 测试 --upgrade 子命令的 sentinel 写入逻辑。
+// Seam：测 runUpgrade orchestrator（仿 runInstall 模式），不测 main ——
+// main 含 os.Exit(0) 不可测，且现有 install_windows_test.go 也是测 runInstall 而非 main。
+// 端到端流程：
+//   supervisor.exe --upgrade
+//     → runUpgrade 写 supervisor_upgrade.pending sentinel
+//     → os.Exit(0) 让进程退出
+//     → SCM 按 recovery action 重启 supervisor
+//     → serviceHandler.Execute → BootCheck 检测 sentinel
+//     → SupervisorSelfSwap 完成 → ErrSupervisorRestartSoon → exit(1) 让 SCM 再次 restart
+//     → 新 supervisor.exe 加载完成
+
+//go:build windows
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// TestRunUpgrade_WritesPendingSentinel 验证 runUpgrade 在 stageDir 下写
+// supervisor_upgrade.pending sentinel 文件。
+// 这是 --upgrade 子命令的唯一可观测副作用 —— 不验证 log 输出（log 是观察副作用，
+// 非行为契约），只验证 sentinel 落盘（这是 BootCheck 后续依赖的唯一信号）。
+func TestRunUpgrade_WritesPendingSentinel(t *testing.T) {
+	// 用 t.TempDir 隔离 stageDir —— 不污染 ProgramData。
+	// 注意：upgrademachine.WriteSupervisorUpgradePending 内部会 MkdirAll(stageDir)，
+	// 所以传入不存在的子目录也能工作（验证幂等的 stage 创建）。
+	stageDir := t.TempDir() + `\upgrade`
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := runUpgrade(log, stageDir); err != nil {
+		t.Fatalf("runUpgrade failed: %v", err)
+	}
+
+	// 断言 1：sentinel 文件存在
+	if !upgrademachine.IsSupervisorUpgradePending(stageDir) {
+		t.Fatal("supervisor_upgrade.pending sentinel not written")
+	}
+
+	// 断言 2：sentinel 路径与 upgrademachine 单一真相源一致（防 drift）
+	// （如果将来常量改了但 runUpgrade 用硬编码字符串，此断言会捕获）
+	sentinelPath := upgrademachine.SupervisorUpgradePendingPath(stageDir)
+	if _, err := os.Stat(sentinelPath); err != nil {
+		t.Fatalf("sentinel path mismatch (drift?): %v", err)
+	}
+}
+
+// TestRunUpgrade_IdempotentOverExistingSentinel 验证 runUpgrade 在 sentinel
+// 已存在时仍能成功（幂等）—— upgrademachine.WriteSupervisorUpgradePending 用
+// os.WriteFile 覆盖写，不应返回错误。
+// 场景：用户重复跑 supervisor.exe --upgrade（未触发 SCM restart 前），
+// 不应失败。
+func TestRunUpgrade_IdempotentOverExistingSentinel(t *testing.T) {
+	stageDir := t.TempDir() + `\upgrade`
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// 第一次写
+	if err := runUpgrade(log, stageDir); err != nil {
+		t.Fatalf("first runUpgrade failed: %v", err)
+	}
+	// 第二次写（sentinel 已存在）
+	if err := runUpgrade(log, stageDir); err != nil {
+		t.Fatalf("second runUpgrade failed (should be idempotent): %v", err)
+	}
+	if !upgrademachine.IsSupervisorUpgradePending(stageDir) {
+		t.Fatal("sentinel missing after second runUpgrade")
+	}
+}

--- a/cmd/ongrid-edge-supervisor/worker.go
+++ b/cmd/ongrid-edge-supervisor/worker.go
@@ -1,0 +1,566 @@
+// worker.go 实现 supervisor.exe 对 worker.exe 的启动 + 监控 + 心跳 watchdog
+// （仅做"崩溃重启 + 心跳超时 kill 重启"，bundle upgrade 流程由
+// upgrademachine 状态机驱动）。
+//
+// 健康感知走 health.json 文件 IPC：
+//   - worker 每 30s 写一次心跳
+//   - supervisor 每 30s 读 + 判断超时（90s 阈值，3× 心跳间隔）
+//   - 超时 → kill worker → superviseWorker 外层循环重启
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/supervisorhealth"
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// 部署路径常量统一在 internal/edgeagent/edgedirs 包，与 cmd/ongrid-edge
+// 共享。
+//
+// 重启间隔是 worker 异常退出后的固定等待时间。
+//
+//	不做指数退避（YAGNI）；后续如需要再加资源限制 / 指数退避。
+const (
+	restartDelay      = 5 * time.Second
+	workerKillTimeout = 10 * time.Second
+)
+
+// workerExe 返回 worker.exe 的绝对路径（edgedirs.BinDir + 文件名）。
+func workerExe() string {
+	return edgedirs.BinDir + `\` + edgedirs.WorkerBinary
+}
+
+// runWorkerOnly 是交互模式（非 Service）入口，直接启动 worker。
+// 用于开发调试（RDP 跑 supervisor.exe 看日志）。
+func runWorkerOnly(log *slog.Logger) error {
+	ctx, cancel := signalInterruptContext()
+	defer cancel()
+	m := upgrademachine.NewMachine(
+		edgedirs.StageDir, edgedirs.BinDir,
+		log, &windowsProcessController{},
+	)
+	return superviseWorker(ctx, log, m)
+}
+
+// signalInterruptContext 返回一个在 Ctrl+C 时 cancel 的 ctx。
+// 仅用于交互模式（runWorkerOnly）；服务模式由 SCM Stop 回调 cancel。
+func signalInterruptContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	go func() {
+		<-ch
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// superviseWorker 是 supervisor 主循环：启动 worker → 监控 → 异常退出则等待
+// restartDelay 后重启。ctx 取消时优雅停止 worker 并返回 ctx.Err。
+//
+// upgrade 集成：
+//
+//   - errUpgradeApplied → 跳过 restartDelay 立即重启 + 下一轮进入 upgrade watch
+//
+//   - rollback.done sentinel 存在 → 跳过 upgrade watch（避免死循环）
+//
+//   - watchDeadline 到期 + worker 已退出（空窗）→ RollbackAndMark（在文件锁
+//     释放后的空窗执行，rename 可成功）
+//
+//   - 超时回滚后若 supervisor 自升级待恢复（awaiting_health 哨兵），
+//     保留哨兵 + return ErrSupervisorRestartSoon → SCM 重启 → BootCheck 恢复 .old
+//
+// 设计要点：rollback 决策放在本函数循环顶部，而非 HealthPoll goroutine 内
+// 的 timer 触发。两个原因：
+//   - HealthPoll 若持 workerCtx，worker 崩溃连锁取消 workerCtx 时
+//     timer.C 分支永不触发 → RollbackAndMark 永不执行（crash loop 场景）。
+//   - worker 仍运行时调 RollbackAndMark → os.Rename 撞
+//     Windows image section 文件锁。
+//
+// 移到 superviseWorker 循环顶部（runWorkerOnce 返回 = worker.exe 已退出）后：
+// watchDeadline 由 superviseWorker 持有（免疫 workerCtx 连锁取消），且 worker.exe
+// 文件锁已释放（rename 可成功）。
+//
+// shouldRollbackAfterDeadline 是 superviseWorker 循环顶部 rollback 判定的纯函数
+// 抽象，抽出主要为可测性 — superviseWorker 本身需要起 worker 子进程
+// 无法在 unit test 跑，但 rollback 决策逻辑（4 条件 AND）可以独立验证。返回 true
+// 当且仅当：watchUpgrade 已激活 + watchDeadline 已武装 + 当前时刻已过 deadline +
+// 升级未确认健康（IsUpgradeHealthy=false）。superviseWorker 在 runWorkerOnce 返回
+// （= worker.exe 已退出空窗）时调用此函数判定是否触发 RollbackAndMark。
+func shouldRollbackAfterDeadline(stageDir string, watchUpgrade bool, watchDeadline, now time.Time) bool {
+	if !watchUpgrade || watchDeadline.IsZero() {
+		return false
+	}
+	if !now.After(watchDeadline) {
+		return false
+	}
+	return !upgrademachine.IsUpgradeHealthy(stageDir)
+}
+
+// maxRollbackRetries 是回滚失败告警阈值。连续失败达到此
+// 值时发恰好一次终态告警；重试本身不设上限（见 rollbackAlertDecision 注释）。
+const maxRollbackRetries = 3
+
+// rollbackAlertDecision 报告回滚失败后是否发终态告警，
+// 对称 shouldRollbackAfterDeadline 的纯函数先例：恰好 failures ==
+// maxRollbackRetries 时 true（恰好一次，防告警风暴），之前/之后均 false。
+//
+// 设计裁决：重试在 watch 保留期间**不设
+// 上限**——每轮循环顶空窗重试一次 RollbackAndMark（rename 幂等且廉价，AV/EDR
+// 持锁通常短暂，锁释放即自愈收敛）。曾评估的两个替代方案均劣：
+//   - 达上限停止重试：锁释放后也不自愈（skip 阻止后续 rename 尝试），
+//     纯 worker 升级场景（无 awaiting_health 哨兵）无任何机制重启 supervisor
+//     → BootCheck 年龄兜底不可达 → 永久振荡静默态
+//   - 达上限 exit(1) 换 SCM 重启上下文重试：锁永持时 4min 级 supervisor 重启
+//     循环，且 SCM recovery 配置可能有失败上限（服务最终停止，伤害扩大）
+//
+// 告警上报通道偏差：supervisor 进程无 manager RPC 客户端
+// （网络栈属 worker 进程），告警落地为调用点的 log.Error 结构化告警
+// （supervisor.log + Windows 事件日志采集链路可达）；未来加通道时决策
+// 语义不变，仅换上报动作。
+func rollbackAlertDecision(failures int) bool {
+	return failures == maxRollbackRetries
+}
+
+func superviseWorker(ctx context.Context, log *slog.Logger, m *upgrademachine.Machine) error {
+	// BootCheck 检测到 supervisor_selfswap_awaiting_health
+	// sentinel 时设 pendingHealthCheck=true → superviseWorker 启用 upgrade watch，
+	// 启 worker 后跑 HealthPoll 180s grace 确认健康（健康判定发生在 worker
+	// 实际启动后，避免在 worker 有机会写健康标记前误回滚）。
+	watchUpgrade := m.PendingHealthCheck()
+	// watchDeadline 是 upgrade watch 窗口的截止时刻。零值 = 未武装。
+	// 首次进入 watch 模式时武装（now + upgradeWatchTimeout），runWorkerOnce 读取
+	// 它在到期时 cancel worker，让本循环顶部在空窗判定 rollback。
+	var watchDeadline time.Time
+	if watchUpgrade {
+		log.Info("upgrade: watch armed from pendingHealthCheck (supervisor self-swap awaiting health)")
+	}
+	// rollbackFailures 是 RollbackAndMark 连续失败计数。
+	// 告警决策见 rollbackAlertDecision；回滚成功、watch 卸载、进入新升级周期
+	// （ErrApplied）时复位 — 每个升级窗口的告警预算独立。
+	var rollbackFailures int
+	for attempt := 0; ; attempt++ {
+		// rollback.done sentinel → 上次 rollback 过，本轮不 watch
+		if upgrademachine.RollbackDoneExists(edgedirs.StageDir) {
+			if watchUpgrade {
+				log.Info("upgrade: rollback.done sentinel present; disarming watch")
+				rollbackFailures = 0
+			}
+			watchUpgrade = false
+			watchDeadline = time.Time{}
+		}
+
+		// 武装 watchDeadline（首次进 watch 模式 / ErrApplied 重启后）
+		if watchUpgrade && watchDeadline.IsZero() {
+			watchDeadline = time.Now().Add(upgradeWatchTimeout)
+			log.Info("upgrade: watch deadline armed", "timeout", upgradeWatchTimeout, "deadline", watchDeadline)
+		}
+
+		err := runWorkerOnce(ctx, log, watchUpgrade, watchDeadline, m)
+
+		if errors.Is(err, upgrademachine.ErrApplied) {
+			// swap 完成 → 检查是否需要 supervisor 自升级
+			//（bundle 含 supervisor.exe 时 applyOne 写 pending sentinel）
+			if upgrademachine.IsSupervisorUpgradePending(edgedirs.StageDir) {
+				log.Info("supervisor self-swap pending; triggering rename-aside")
+				swapErr := m.SupervisorSelfSwap()
+				if errors.Is(swapErr, upgrademachine.ErrSupervisorRestartSoon) {
+					return swapErr // 让 service.go 触发 SCM restart 加载新 supervisor
+				}
+				if swapErr != nil {
+					log.Error("supervisor self-swap failed (worker continues with current supervisor; HealthPoll will catch version mismatch)",
+						"err", swapErr)
+				}
+			}
+			// 立即重启新 worker + 进入 upgrade watch；watchDeadline 下轮重新武装。
+			// 新升级周期 → 失败计数复位。
+			log.Info("upgrade applied; restarting worker without delay")
+			watchDeadline = time.Time{}
+			watchUpgrade = true
+			rollbackFailures = 0
+			continue
+		}
+
+		// runWorkerOnce 返回 = worker.exe 已退出
+		// 空窗。若 watch 窗口已到期 + 不健康 → 在此处 RollbackAndMark（worker.exe
+		// 文件锁已释放，os.Rename 不再撞 image section）。
+		//
+		// TOCTOU 不变式：shouldRollbackAfterDeadline 内部
+		// 读 IsUpgradeHealthy 与下面的 RollbackAndMark 写之间存在理论竞态窗口，
+		// 但 worker 已退出（runWorkerOnce 返回的先验条件）= 唯一可能写 healthy_marker
+		// 的进程已死 = 无并发 fs 写入 = TOCTOU 不可达。未来若加 manager RPC 远程写
+		// healthy_marker 的能力，此不变式需重新评估。
+		if shouldRollbackAfterDeadline(edgedirs.StageDir, watchUpgrade, watchDeadline, time.Now()) {
+			// 编排顺序约束：终止进程 → 等 worker 退出 → 回滚。
+			// 本块处于 runWorkerOnce 返回之后（worker.exe 已退出空窗，文件锁已释放），
+			// RollbackAndMark 是纯文件操作（upgrademachine.Rollback 无进程探测）—
+			// 「先杀后回滚」的顺序由本编排层保证；BootCheck 强制双恢复分支的
+			// KillByImage → RollbackAndMark 顺序由 dualrestore 测试锚定。
+			if rerr := m.RollbackAndMark(); rerr != nil {
+				// 回滚失败保留 watch 武装与哨兵，循环顶持续重试
+				// （不设上限，见 rollbackAlertDecision 注释的方案裁决）。达阈值告警
+				// 恰好一次；此后失败日志降频 Debug（每轮空窗一次，Error 会刷屏）。
+				rollbackFailures++
+				if rollbackAlertDecision(rollbackFailures) {
+					log.Error("ALERT: upgrade rollback keeps failing; manual intervention may be required",
+						"failures", rollbackFailures, "threshold", maxRollbackRetries, "err", rerr)
+				}
+				if rollbackFailures <= maxRollbackRetries {
+					log.Error("upgrade: rollback after deadline failed; will retry at loop top",
+						"err", rerr, "attempt", rollbackFailures)
+				} else {
+					log.Debug("upgrade: rollback retry still failing (degraded log)",
+						"err", rerr, "attempt", rollbackFailures)
+				}
+			} else if upgrademachine.IsSupervisorSelfSwapAwaitingHealth(edgedirs.StageDir) {
+				// 双恢复：worker 已回滚（先），supervisor 侧恢复
+				// 走 BootCheck 哨兵路径（后）— 保留 awaiting_health 哨兵不删，
+				// 它与 rollback.done 的组合 = "worker 已回滚、supervisor 待恢复"
+				// 中间态信号，BootCheck 步骤 1 检测后恢复 .old 并触发 SCM 重启。
+				// 断电安全：中间点断电后下次 BootCheck 到达同一恢复路径（幂等）。
+				log.Info("upgrade: worker rolled back; supervisor restore pending via BootCheck; exiting for SCM restart")
+				return upgrademachine.ErrSupervisorRestartSoon
+			} else {
+				// 纯 worker 升级超时（bundle 不含 supervisor.exe，无自恢复源）：
+				// 卸载 watch 即可。回滚已成功，失败计数复位。
+				watchUpgrade = false
+				watchDeadline = time.Time{}
+				rollbackFailures = 0
+			}
+		} else if watchUpgrade && !watchDeadline.IsZero() && time.Now().After(watchDeadline) {
+			// deadline 到了但 IsUpgradeHealthy=true → 升级成功，卸载 watch
+			log.Info("upgrade: watch deadline reached; upgrade healthy, disarming watch")
+			watchUpgrade = false
+			watchDeadline = time.Time{}
+			rollbackFailures = 0
+		}
+
+		if err != nil && ctx.Err() == nil {
+			log.Error("worker exited unexpectedly", "attempt", attempt, "err", err)
+		}
+
+		if ctx.Err() != nil {
+			log.Info("supervisor context cancelled; exiting worker loop")
+			return ctx.Err()
+		}
+
+		log.Info("restarting worker", "after", restartDelay, "attempt", attempt+1)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(restartDelay):
+		}
+	}
+}
+
+// runWorkerOnce 启动一次 worker.exe，阻塞等待其退出。
+// 退出原因有三：(1) worker 自己崩溃（Wait 返回 err）；(2) watchdog 发现心跳
+// 超时，cancel workerCtx → kill worker；(3) 父 ctx 取消（服务停止）。
+//
+// watchUpgrade=true 时，worker 启动后额外启动 upgrade watch goroutine
+// （HealthPoll polling healthy_marker，  去掉原 timer 分支）。
+// watchDeadline 到期时本函数 cancel worker，让 superviseWorker 循环顶部在
+// 空窗判定 rollback（worker.exe 文件锁已释放）。
+//
+// worker 退出后检测 pending upgrade（checkPendingUpgrade），有则 swap 并返回
+// errUpgradeApplied sentinel 让 superviseWorker 跳过 restartDelay。
+func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, watchDeadline time.Time, m *upgrademachine.Machine) error {
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	defer workerCancel()
+
+	// CommandContext 而非 exec.Command：Go 1.20+ 要求设了 cmd.Cancel 的命令
+	// 必须用 CommandContext 创建，否则 Start 返回
+	// "exec: command with a non-nil Cancel was not created with CommandContext"。
+	cmd := exec.CommandContext(workerCtx, workerExe())
+	// Explicitly construct worker env to dodge a Windows SCM corner case:
+	// service Environment registry field is injected into the service's
+	// own process env block, but worker subprocesses spawned via
+	// exec.Command (CreateProcess with NULL lpEnvironment) inherit the
+	// *current process* env — which on some Windows builds excludes
+	// service-specific pairs (root cause TBD; symptom: worker's
+	// ONGRID_EDGE_ACCESS_KEY comes through empty even though the field
+	// is set in HKLM\...\Services\ongrid-edge\Environment). Workaround:
+	// read the Environment multi-string straight from the registry and
+	// merge with os.Environ so the worker sees every pair the operator
+	// configured via supervisor.exe --install. .
+	cmd.Env = mergedServiceEnv()
+	// worker stdout/stderr 重定向到轮转日志文件（supervisor.log 已有自己的 sink）。
+	// Windows Service 进程无 console，nil inherit = 丢弃；改用 append-only file
+	// 让 worker 的 slog 输出可观测。
+	if workerStdout, err := openWorkerLog("worker-stdout.log"); err == nil {
+		cmd.Stdout = workerStdout
+		defer workerStdout.Close()
+	} else {
+		log.Warn("supervisor: open worker stdout log failed; falling back to discard", "err", err)
+		cmd.Stdout = nil
+	}
+	if workerStderr, err := openWorkerLog("worker-stderr.log"); err == nil {
+		cmd.Stderr = workerStderr
+		defer workerStderr.Close()
+	} else {
+		log.Warn("supervisor: open worker stderr log failed; falling back to discard", "err", err)
+		cmd.Stderr = nil
+	}
+
+	// Go 1.20+ CommandContext 自动 kill 进程当 ctx 取消；指定 Cancel 用优雅方式
+	// （taskkill /T 先 send Ctrl-Break，再 workerKillTimeout 后强制 kill）。
+	cmd.Cancel = func() error {
+		// taskkill /T /F 等于 SIGKILL 整个进程树（绝对路径防 PATH 劫持，
+		// 见 upgrade_windows.go taskkillExe）。
+		// 不做优雅停止（worker 收到 TerminateProcess 直接退出，状态由
+		// health.json + 启动时从 manager 重连 tunnel 恢复）。
+		exe, err := taskkillExe()
+		if err != nil {
+			return err
+		}
+		return exec.Command(exe, "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
+	}
+	cmd.WaitDelay = workerKillTimeout
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start worker %q: %w", workerExe(), err)
+	}
+
+	log.Info("worker started", "pid", cmd.Process.Pid, "path", workerExe())
+
+	workerPID := cmd.Process.Pid
+	wdErr := make(chan error, 1)
+	go func() {
+		wdErr <- watchHeartbeat(workerCtx, workerPID, log)
+	}()
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+	}()
+
+	// upgrade watch goroutine（仅 swap 后首次启动时活跃）。
+	// HealthPoll 仅 polling，无 timer / 无 RollbackAndMark —
+	// 超时判定移到 superviseWorker 循环顶部。
+	var uwErr chan error
+	if watchUpgrade {
+		uwErr = make(chan error, 1)
+		go func() {
+			uwErr <- m.HealthPoll(workerCtx, upgradePollInterval)
+		}()
+		log.Info("upgrade: HealthPoll activated", "poll_interval", upgradePollInterval, "deadline", watchDeadline)
+	}
+
+	// deadlineCh：watchDeadline 到期时触发 cancel workerCtx，让 waitErr 路径返回。
+	// superviseWorker 下一轮循环顶部在空窗（worker.exe 已退出）判定 rollback。
+	// 这是核心时序：deadline 由 superviseWorker 持有（免疫 workerCtx
+	// 连锁取消），rollback 在 worker 已退出时执行（无文件锁）。
+	//
+	// remaining<=0 边界：superviseWorker 重启 worker 时若
+	// watchDeadline 已过期（如 watchdog 触发 runWorkerOnce 返回耗时超过剩余窗口），
+	// 不能让 worker 无限运行等 watchdog 兜底 — 立即 cancel 让 superviseWorker
+	// 顶部 shouldRollbackAfterDeadline 在空窗判定。
+	var deadlineCh <-chan time.Time
+	deadlineAlreadyExpired := false
+	if watchUpgrade && !watchDeadline.IsZero() {
+		remaining := time.Until(watchDeadline)
+		if remaining > 0 {
+			deadlineCh = time.After(remaining)
+		} else {
+			// deadline 已过期：worker 启动前就超时 → 立即 cancel 让 waitErr 返回。
+			// 用 deferred cancel + continue-into-select 会让 worker 启动后立即被 kill。
+			// 简化：标记后启 worker 会让 cmd.Start 成功但 cmd.Wait 很快返回（taskkill）。
+			deadlineAlreadyExpired = true
+		}
+	}
+
+	// 边界处理：deadline 在 worker 启动前已过期 → 立即 cancel 让 waitErr 返回。
+	// superviseWorker 下一轮循环顶部在空窗判定 rollback。
+	if deadlineAlreadyExpired {
+		log.Warn("upgrade: watch deadline already expired at worker start; cancelling immediately")
+		workerCancel()
+	}
+
+	for {
+		select {
+		case err := <-waitErr:
+			// worker 自己挂了。watchdog goroutine 在 workerCtx cancel 后会返回 nil。
+			workerCancel()
+			<-wdErr
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// worker 退出后检测 pending upgrade
+			if uerr := m.CheckPending(ctx, workerPID); uerr != nil {
+				return uerr
+			}
+			if err != nil {
+				return fmt.Errorf("worker wait: %w", err)
+			}
+			return nil
+
+		case err := <-wdErr:
+			// watchdog 触发：kill worker → 等 Wait 返回。
+			if err != nil {
+				log.Error("watchdog killed worker", "reason", err, "pid", workerPID)
+			}
+			workerCancel()
+			<-waitErr
+			// watchdog kill 后也检测 pending upgrade
+			if uerr := m.CheckPending(ctx, workerPID); uerr != nil {
+				return uerr
+			}
+			return err
+
+		case err := <-uwErr:
+			// upgrade watch 结果（只处理一次，然后置 nil 防止重复 select）
+			uwErr = nil
+			if err == nil {
+				// healthy_marker 匹配 → cleanup + 清 sentinel 已完成，继续监控 worker。
+				// 健康已确认 → 解除超时定时器（通道引用
+				// 置空）。不置 nil 的话，残留定时器在健康确认后到期会误杀一次已确认
+				// 健康的 worker（真 bug：watchDeadline 与健康确认是独立时钟）。
+				deadlineCh = nil
+				continue
+			}
+			// workerCtx.Err（worker 先退出 / deadlineCh cancel / wdErr cancel）→
+			// 交给 waitErr/wdErr 路径处理，这里不返回。
+			log.Debug("upgrade HealthPoll ended with ctx error", "err", err)
+			continue
+
+		case <-deadlineCh:
+			// watchDeadline 到期：cancel worker 让 waitErr 路径返回。superviseWorker
+			// 循环顶部在空窗判定 rollback（worker 已退出，文件锁已释放）。本分支只触发一次。
+			log.Warn("upgrade: watch deadline fired; cancelling worker for superviseWorker rollback",
+				"deadline", watchDeadline)
+			deadlineCh = nil
+			workerCancel()
+			// 循环继续 — waitErr 会因 workerCtx cancel 触发 cmd.Cancel taskkill 而返回。
+		}
+	}
+}
+
+// watchHeartbeat 周期性读 health.json 判断 worker 心跳是否过期。
+// 发现过期 → 返回 error（触发外层 kill worker）。
+// workerCtx 取消时立即返回 nil（worker 已被外层 kill，不需要再报警）。
+//
+// startupGrace 是 worker 启动到首次写 health.json 的宽限时间（2× HeartbeatTimeout = 180s），
+// 超过此窗口 health.json 还未出现 → 视为 worker 启动失败。
+func watchHeartbeat(workerCtx context.Context, workerPID int, log *slog.Logger) error {
+	startupGrace := 2 * supervisorhealth.HeartbeatTimeout
+	startupDeadline := time.Now().Add(startupGrace)
+	ticker := time.NewTicker(supervisorhealth.HeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-workerCtx.Done():
+			return nil
+		case <-ticker.C:
+			h, err := supervisorhealth.Read(edgedirs.HealthFile)
+			if err != nil {
+				if supervisorhealth.IsNotExist(err) {
+					if time.Now().After(startupDeadline) {
+						return fmt.Errorf("worker (pid=%d) started but did not write health.json within %v", workerPID, startupGrace)
+					}
+					log.Info("health.json not yet written; worker still starting")
+					continue
+				}
+				log.Error("read health.json failed", "err", err)
+				continue
+			}
+
+			// PID race 检查：health.json 可能是上一个 worker 进程残留。
+			if h.WorkerPID != workerPID {
+				log.Warn("health.json PID mismatch; ignoring",
+					"expected", workerPID, "got", h.WorkerPID)
+				continue
+			}
+
+			if supervisorhealth.IsStale(h, time.Now(), supervisorhealth.HeartbeatTimeout) {
+				return fmt.Errorf("worker (pid=%d) heartbeat stale (last: %s)",
+					workerPID, h.LastHeartbeat.Format(time.RFC3339))
+			}
+		}
+	}
+}
+
+// openWorkerLog 打开 DataDir 下的 worker 日志文件（append 模式）。
+// 用于将 worker stdout/stderr 从 Windows Service nil-sink 救出来。
+// 失败时返回 error，调用方降级为 nil（= 丢弃）。
+func openWorkerLog(name string) (*os.File, error) {
+	path := edgedirs.DataDir + `\` + name
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+}
+
+// mergedServiceEnv returns an env slice suitable for exec.Cmd.Env that
+// merges the current process env with values read directly from the
+// service's Environment registry field.
+//
+// Why: Windows SCM injects the service Environment multi-string into the
+// service's own process env block at startup, and CreateProcess with a
+// NULL lpEnvironment inherits the parent's env. In theory a worker
+// subprocess spawned via exec.Command (no explicit Env) should see all
+// service-specific pairs. In practice some Windows builds skip the
+// injection for child processes whose binary path differs from the
+// service's registered BinaryPath (supervisor.exe vs worker.exe), so
+// the worker's ONGRID_EDGE_ACCESS_KEY comes through empty even though
+// the registry field is set (observed on real Windows Server hosts).
+//
+// Reading the field directly and merging is the surgical fix that keeps
+// operator-facing `supervisor.exe --install` UX unchanged. Failures
+// (registry access denied, field absent) silently fall back to
+// os.Environ — same behaviour as before this fix.
+//
+// serviceEnvReader / environFunc are package vars so tests can stub
+// them without spinning up a real registry entry.
+var (
+	serviceEnvReader = readServiceEnvField
+	environFunc      = os.Environ
+)
+
+func mergedServiceEnv() []string {
+	base := environFunc()
+	pairs, err := serviceEnvReader()
+	if err != nil || len(pairs) == 0 {
+		return base
+	}
+	// Build KEY=value map from base so service pairs can override without
+	// producing duplicates. Windows env is case-insensitive — fold keys
+	// to upper for the merge but preserve original case in the value.
+	merged := make(map[string]string, len(base)+len(pairs))
+	order := make([]string, 0, len(base)+len(pairs))
+	keyOf := func(kv string) string {
+		if k, _, found := strings.Cut(kv, "="); found {
+			return strings.ToUpper(k)
+		}
+		return strings.ToUpper(kv)
+	}
+	for _, kv := range base {
+		k := keyOf(kv)
+		if _, ok := merged[k]; !ok {
+			order = append(order, k)
+		}
+		merged[k] = kv
+	}
+	for _, kv := range pairs {
+		k := keyOf(kv)
+		if _, ok := merged[k]; !ok {
+			order = append(order, k)
+		}
+		merged[k] = kv
+	}
+	out := make([]string, 0, len(order))
+	for _, k := range order {
+		out = append(out, merged[k])
+	}
+	return out
+}

--- a/cmd/ongrid-edge-supervisor/worker_env_test.go
+++ b/cmd/ongrid-edge-supervisor/worker_env_test.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestMergedServiceEnv_DedupCaseInsensitive 验证 base env + service
+// Environment 字段合并 + 大小写去重（Windows env case-insensitive）。
+// service pair ONGRID_EDGE_ACCESS_KEY=new 应覆盖 base 中 lowercase 同名 pair，
+// 且最终输出不出现两条 ACCESS_KEY=。
+func TestMergedServiceEnv_DedupCaseInsensitive(t *testing.T) {
+	oldReader := serviceEnvReader
+	serviceEnvReader = func() ([]string, error) {
+		return []string{
+			"ONGRID_EDGE_ACCESS_KEY=new-value",
+			"ONGRID_EDGE_CLOUD_ADDR=frontier.example.com:16667",
+		}, nil
+	}
+	defer func() { serviceEnvReader = oldReader }()
+
+	oldEnviron := environFunc
+	environFunc = func() []string {
+		return []string{
+			"PATH=/usr/bin",
+			"ongrid_edge_access_key=old-value", // lowercase key, same env var
+			"SYSTEMROOT=C:\\Windows",
+		}
+	}
+	defer func() { environFunc = oldEnviron }()
+
+	got := mergedServiceEnv()
+
+	seen := make(map[string]string, len(got))
+	for _, kv := range got {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		seen[strings.ToUpper(k)] = v
+	}
+	if seen["ONGRID_EDGE_ACCESS_KEY"] != "new-value" {
+		t.Errorf("ACCESS_KEY = %q; want new-value (service should override base lowercase)", seen["ONGRID_EDGE_ACCESS_KEY"])
+	}
+	if seen["PATH"] != "/usr/bin" {
+		t.Errorf("PATH = %q; want /usr/bin (base preserved)", seen["PATH"])
+	}
+	if seen["ONGRID_EDGE_CLOUD_ADDR"] != "frontier.example.com:16667" {
+		t.Errorf("CLOUD_ADDR missing; got %v", seen)
+	}
+	// 无重复（case-insensitive）
+	upKeys := make([]string, 0, len(got))
+	for _, kv := range got {
+		k, _, _ := strings.Cut(kv, "=")
+		upKeys = append(upKeys, strings.ToUpper(k))
+	}
+	sort.Strings(upKeys)
+	for i := 1; i < len(upKeys); i++ {
+		if upKeys[i] == upKeys[i-1] {
+			t.Errorf("duplicate key in merged env: %s", upKeys[i])
+		}
+	}
+}
+
+// TestMergedServiceEnv_FallbackWhenRegistryFails 验证 registry 读
+// 失败时 fallback 到 os.Environ，行为与未加 fix 前一致。
+func TestMergedServiceEnv_FallbackWhenRegistryFails(t *testing.T) {
+	errFake := errors.New("fake registry error")
+	oldReader := serviceEnvReader
+	serviceEnvReader = func() ([]string, error) { return nil, errFake }
+	defer func() { serviceEnvReader = oldReader }()
+
+	oldEnviron := environFunc
+	environFunc = func() []string { return []string{"PATH=/usr/bin"} }
+	defer func() { environFunc = oldEnviron }()
+
+	got := mergedServiceEnv()
+	if len(got) != 1 || got[0] != "PATH=/usr/bin" {
+		t.Errorf("fallback did not return base env; got %v", got)
+	}
+}

--- a/cmd/ongrid-edge-supervisor/worker_test.go
+++ b/cmd/ongrid-edge-supervisor/worker_test.go
@@ -1,0 +1,145 @@
+// worker_test.go 测试 superviseWorker 循环顶部 rollback 决策逻辑（HealthPoll redesign）。
+// superviseWorker 本身需要起 worker.exe 子进程，无法在 unit test 跑；但 HealthPoll redesign
+// 的核心决策（watchDeadline 到期 + worker 退出 + 未健康 → RollbackAndMark）是 4 条件
+// AND 纯函数，抽出为 shouldRollbackAfterDeadline 在 worker.go。这里覆盖它的全部
+// 真值分支。
+// 重点场景：
+//   - worker crash loop：worker 在 watch 窗口内反复崩溃 → deadline 未到 → 不 rollback
+//     （避免过早回滚；deadline 到期后才触发）
+//   - 空窗 rollback（file lock fix）：deadline 到期 + worker 已退出 + 未健康 → rollback true
+
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// writeStageFile 写 path 下单个文件（自动 mkdir 父目录）。
+func writeStageFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o640); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeStageFiles 写 stageDir 下的 last_upgrade_ver 和 healthy_marker。
+// lastVer != marker 模拟升级未确认；两者相等模拟健康。marker="" 表示不写
+// healthy_marker 文件（模拟新 worker 还未 register）。
+func writeStageFiles(t *testing.T, stageDir, lastVer, marker string) {
+	t.Helper()
+	writeStageFile(t, filepath.Join(stageDir, upgrademachine.LastUpgradeVerFile), lastVer)
+	if marker == "" {
+		return
+	}
+	writeStageFile(t, filepath.Join(stageDir, upgrademachine.HealthyMarkerFile), marker)
+}
+
+// TestShouldRollbackAfterDeadline_ExceededAndUnhealthy 验证 HealthPoll redesign
+// 的核心断言：watchDeadline 已到 + worker 已退出（runWorkerOnce 已返回）+
+// 升级未确认健康 → shouldRollbackAfterDeadline 返回 true（触发 RollbackAndMark 在
+// superviseWorker 循环顶部空窗执行，worker.exe 文件锁已释放）。
+func TestShouldRollbackAfterDeadline_ExceededAndUnhealthy(t *testing.T) {
+	stageDir := t.TempDir()
+	// 未健康：lastVer != marker（worker 启动了但未 register 或 register 了但版本不匹配）
+	writeStageFiles(t, stageDir, "v9.9.9", "v9.9.8")
+
+	deadline := time.Now().Add(-1 * time.Second) // 1 秒前已到期
+	now := time.Now()
+
+	if !shouldRollbackAfterDeadline(stageDir, true, deadline, now) {
+		t.Error("expected rollback when watch active + deadline exceeded + unhealthy")
+	}
+}
+
+// TestShouldRollbackAfterDeadline_NotExceededInWatchWindow 验证 worker crash loop
+// 场景：worker 在 watch 窗口内反复崩溃（runWorkerOnce 多次返回），但 deadline 还没到 →
+// 不应过早 rollback。HealthPoll redesign 的关键不变式：watchDeadline 是 180s 总窗口，
+// 不因 worker 单次崩溃触发回滚。
+func TestShouldRollbackAfterDeadline_NotExceededInWatchWindow(t *testing.T) {
+	stageDir := t.TempDir()
+	// 未健康（worker 在 crash loop 中，从未 register）
+	writeStageFiles(t, stageDir, "v9.9.9", "")
+
+	deadline := time.Now().Add(120 * time.Second) // 还有 120s
+	now := time.Now()
+
+	if shouldRollbackAfterDeadline(stageDir, true, deadline, now) {
+		t.Error("rollback should NOT fire within watch window (worker crash loop scenario)")
+	}
+}
+
+// TestShouldRollbackAfterDeadline_HealthyAfterDeadline 验证 deadline 到期但升级
+// 已确认健康（HealthPoll 返回 nil 路径）→ 不 rollback，superviseWorker 走 "disarm
+// watch" 分支。
+func TestShouldRollbackAfterDeadline_HealthyAfterDeadline(t *testing.T) {
+	stageDir := t.TempDir()
+	// 健康：lastVer == marker
+	writeStageFiles(t, stageDir, "v9.9.9", "v9.9.9")
+
+	deadline := time.Now().Add(-1 * time.Second) // 已到期
+	now := time.Now()
+
+	if shouldRollbackAfterDeadline(stageDir, true, deadline, now) {
+		t.Error("rollback should NOT fire when upgrade healthy (even after deadline)")
+	}
+}
+
+// TestShouldRollbackAfterDeadline_WatchInactive 验证 watchUpgrade=false（普通路径
+// 或 rollback.done 已存在）→ 不 rollback，即使 deadline 似乎已到。
+func TestShouldRollbackAfterDeadline_WatchInactive(t *testing.T) {
+	stageDir := t.TempDir()
+	writeStageFiles(t, stageDir, "v9.9.9", "v9.9.8") // 不健康，但 watch 未激活
+
+	deadline := time.Now().Add(-1 * time.Second)
+	now := time.Now()
+
+	if shouldRollbackAfterDeadline(stageDir, false, deadline, now) {
+		t.Error("rollback should NOT fire when watchUpgrade=false")
+	}
+}
+
+// TestShouldRollbackAfterDeadline_DeadlineZero 验证 watchDeadline 零值（未武装）
+// → 不 rollback。防止 superviseWorker 初始化时的零值误触发。
+func TestShouldRollbackAfterDeadline_DeadlineZero(t *testing.T) {
+	stageDir := t.TempDir()
+	writeStageFiles(t, stageDir, "v9.9.9", "")
+
+	if shouldRollbackAfterDeadline(stageDir, true, time.Time{}, time.Now()) {
+		t.Error("rollback should NOT fire when watchDeadline is zero (not armed)")
+	}
+}
+
+// TestRollbackAlertDecision 验证回滚失败告警决策纯函数：
+// 恰好达阈值 → 告警一次；阈值前后 → 不告警（防告警风暴）。重试本身不设上限
+// （rollbackAlertDecision 注释中的方案裁决：skip 重试会导致锁释放后不自愈）。
+func TestRollbackAlertDecision(t *testing.T) {
+	tests := []struct {
+		name      string
+		failures  int
+		wantAlert bool
+	}{
+		{"首次失败不告警", 1, false},
+		{"阈值前不告警", maxRollbackRetries - 1, false},
+		{"恰好达阈值告警一次", maxRollbackRetries, true},
+		{"超阈值不重复告警", maxRollbackRetries + 1, false},
+		{"远超阈值不告警", maxRollbackRetries * 10, false},
+		{"零值（首轮调用前）不告警", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rollbackAlertDecision(tt.failures); got != tt.wantAlert {
+				t.Errorf("rollbackAlertDecision(%d) = %v, want %v", tt.failures, got, tt.wantAlert)
+			}
+		})
+	}
+}

--- a/cmd/ongrid-edge/capabilities_linux.go
+++ b/cmd/ongrid-edge/capabilities_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package main
+
+import (
+	"log/slog"
+
+	edgebash "github.com/ongridio/ongrid/internal/edgeagent/bash"
+	edgehostfiles "github.com/ongridio/ongrid/internal/edgeagent/host_files"
+	edgerestartservice "github.com/ongridio/ongrid/internal/edgeagent/restart_service"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+// registerEdgeCapabilities registers the platform-specific edge capability
+// handlers with the tunnel client. Linux side: host_files / restart_service
+// / bash. The Windows counterpart (capabilities_windows.go) registers
+// host_files only — bash and restart_service depend on cmdpolicy/systemd,
+// which are Linux-only.
+//
+// All Register calls are soft-fail: the edge keeps booting and the
+// operator sees a warning in the log when a capability is disabled. A
+// single failing skill must not take down the whole agent.
+func registerEdgeCapabilities(client tunnel.Client, log *slog.Logger) {
+	if err := edgehostfiles.Register(client, log); err != nil {
+		log.Warn("host_files register failed; capability disabled", slog.Any("err", err))
+	}
+	if err := edgerestartservice.Register(client, log); err != nil {
+		log.Warn("restart_service register failed; capability disabled", slog.Any("err", err))
+	}
+	if err := edgebash.Register(client, log); err != nil {
+		log.Warn("bash register failed; capability disabled", slog.Any("err", err))
+	}
+}

--- a/cmd/ongrid-edge/capabilities_windows.go
+++ b/cmd/ongrid-edge/capabilities_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"log/slog"
+
+	edgehostfiles "github.com/ongridio/ongrid/internal/edgeagent/host_files"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+// registerEdgeCapabilities registers the platform-specific edge capability
+// handlers with the tunnel client. Windows: host_files only (the package
+// itself is cross-platform after the build-tag split).
+//
+// bash / restart_service are Linux-only (cmdpolicy/systemctl) and are not
+// ported to Windows. Windows-native equivalents are future work and need
+// a PowerShell subprocess framework.
+//
+// All Register calls are soft-fail: the edge keeps booting and the
+// operator sees a warning in the log when a capability is disabled.
+func registerEdgeCapabilities(client tunnel.Client, log *slog.Logger) {
+	if err := edgehostfiles.Register(client, log); err != nil {
+		log.Warn("host_files register failed; capability disabled", slog.Any("err", err))
+	}
+}

--- a/cmd/ongrid-edge/health_writer_other.go
+++ b/cmd/ongrid-edge/health_writer_other.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+// health_writer_other.go: stub for non-Windows platforms. A Linux edge has
+// no supervisor.exe parent and needs no health.json IPC.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+)
+
+// startHeartbeatWriter is a no-op on non-Windows platforms (no supervisor
+// is monitoring the process).
+func startHeartbeatWriter(_ context.Context, _ *slog.Logger) error {
+	return nil
+}

--- a/cmd/ongrid-edge/health_writer_windows.go
+++ b/cmd/ongrid-edge/health_writer_windows.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+// health_writer_windows.go: worker.exe writes a heartbeat to health.json
+// every HeartbeatInterval so supervisor.exe can monitor this process.
+//
+// This file is compiled on Windows only. Other platforms use the no-op
+// stub in health_writer_other.go (a Linux edge has no supervisor parent).
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/supervisorhealth"
+)
+
+// startHeartbeatWriter periodically writes health.json. It returns nil
+// immediately when ctx is cancelled (no stopping state is written; the
+// supervisor learns about worker exit via cmd.Wait).
+//
+// A failed write is logged but not returned as an error: a lost heartbeat
+// makes the supervisor watchdog kill this process after HeartbeatTimeout,
+// which is the intended fail-safe behavior.
+func startHeartbeatWriter(ctx context.Context, log *slog.Logger) error {
+	pid := os.Getpid()
+	startedAt := time.Now()
+
+	// Write the starting state immediately so the supervisor sees the
+	// worker early.
+	h := supervisorhealth.Health{
+		Version:       supervisorhealth.HealthSchemaVersion,
+		WorkerPID:     pid,
+		StartedAt:     startedAt,
+		LastHeartbeat: time.Now(),
+		Status:        supervisorhealth.StatusStarting,
+	}
+	writeHeartbeat(h, log)
+
+	// Move to healthy.
+	h.Status = supervisorhealth.StatusHealthy
+	writeHeartbeat(h, log)
+
+	ticker := time.NewTicker(supervisorhealth.HeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			h.LastHeartbeat = time.Now()
+			writeHeartbeat(h, log)
+		}
+	}
+}
+
+func writeHeartbeat(h supervisorhealth.Health, log *slog.Logger) {
+	if err := supervisorhealth.Write(edgedirs.HealthFile, h); err != nil {
+		log.Error("heartbeat write failed", "path", edgedirs.HealthFile, "err", err)
+	}
+}

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -29,10 +29,9 @@ import (
 	"github.com/ongridio/ongrid/internal/pkg/prom"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 
-	edgebash "github.com/ongridio/ongrid/internal/edgeagent/bash"
 	edgebiz "github.com/ongridio/ongrid/internal/edgeagent/biz"
 	edgecollector "github.com/ongridio/ongrid/internal/edgeagent/collector"
-	edgehostfiles "github.com/ongridio/ongrid/internal/edgeagent/host_files"
+	edgeconfig "github.com/ongridio/ongrid/internal/edgeagent/config"
 	edgek8s "github.com/ongridio/ongrid/internal/edgeagent/k8s"
 	edgeoperator "github.com/ongridio/ongrid/internal/edgeagent/operator"
 	edgeplugins "github.com/ongridio/ongrid/internal/edgeagent/plugins"
@@ -43,7 +42,6 @@ import (
 	edgepluginmetrics "github.com/ongridio/ongrid/internal/edgeagent/plugins/metrics"
 	edgepluginprocmetrics "github.com/ongridio/ongrid/internal/edgeagent/plugins/procmetrics"
 	edgeplugintraces "github.com/ongridio/ongrid/internal/edgeagent/plugins/traces"
-	edgerestartservice "github.com/ongridio/ongrid/internal/edgeagent/restart_service"
 	edgesvc "github.com/ongridio/ongrid/internal/edgeagent/service"
 	edgestreamrouter "github.com/ongridio/ongrid/internal/edgeagent/streamrouter"
 	edgewebshell "github.com/ongridio/ongrid/internal/edgeagent/webshell"
@@ -116,6 +114,26 @@ func main() {
 		slog.String("version", version),
 	)
 
+	// Load the DPAPI-encrypted broker token. Prefer secrets.enc; fall
+	// back to the env var when the file is missing or fails to decrypt.
+	secretsPath := cfg.Edge.SecretsFile
+	if secretsPath == "" {
+		secretsPath = defaultSecretsFile()
+	}
+	if secretsPath != "" {
+		if token, err := edgeconfig.LoadSecrets(secretsPath); err == nil {
+			cfg.Edge.SecretKey = token
+			log.Info("loaded broker token from secrets.enc",
+				slog.String("path", secretsPath))
+		} else {
+			// A missing file is the normal pre-install state (the env
+			// var is used); a decrypt failure is not.
+			log.Warn("secrets.enc load failed, using env var fallback",
+				slog.String("path", secretsPath),
+				slog.String("err", err.Error()))
+		}
+	}
+
 	rootCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 	if handled, err := runK8sDataPlaneMode(rootCtx, strings.TrimSpace(os.Getenv("ONGRID_EDGE_MODE")), log); handled {
@@ -137,16 +155,24 @@ func main() {
 
 	// Tunnel client.
 	client := tunnel.NewClient(tunnel.ClientConfig{
-		CloudAddr: cfg.Edge.CloudAddr,
-		AccessKey: cfg.Edge.AccessKey,
-		SecretKey: cfg.Edge.SecretKey,
-		Log:       log,
+		CloudAddr:     cfg.Edge.CloudAddr,
+		AccessKey:     cfg.Edge.AccessKey,
+		SecretKey:     cfg.Edge.SecretKey,
+		TLSCAFile:     cfg.Edge.TLSCAFile,
+		TLSServerName: cfg.Edge.TLSServerName,
+		TLSRequired:   cfg.Edge.TLSRequired,
+		Log:           log,
 	})
 
 	eg, egCtx := errgroup.WithContext(rootCtx)
 	if isK8sController(k8sInfo) && strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")) != "" {
 		eg.Go(func() error { return runK8sTelemetryConfigSync(egCtx, cfg, k8sInfo, log) })
 	}
+
+	// Heartbeat writer (Windows only, no-op stub on Linux) so
+	// supervisor.exe can monitor this worker process via the
+	// health.json IPC.
+	eg.Go(func() error { return startHeartbeatWriter(egCtx, log) })
 
 	// Build the collector based on configured mode.
 	collector, scraperRunner, err := buildCollector(egCtx, cfg, log, eg)
@@ -158,37 +184,14 @@ func main() {
 
 	edgesvc.RegisterWithCollector(client, collector, log)
 
-	// host_files plugin (PR-8 + PR-N of): register the three
-	// filesystem inspection handlers (find_large_files / du_summary /
-	// stat_file). Real shell-out gated by SandboxConfig — failure to
-	// validate the sandbox (no allowed paths, missing find/du in PATH)
-	// is non-fatal: the edge boots without the host_files capability
-	// and operators see the warning in the journal.
+	// Platform-specific capabilities (host_files / restart_service /
+	// bash on Linux; host_files only on Windows — see
+	// capabilities_{linux,windows}.go). All Register calls are
+	// soft-fail: the edge boots and the operator sees a warning in the
+	// log when a capability is disabled. Kubernetes controllers skip
+	// host handlers; node-mode agents and standalone hosts keep them.
 	if k8sInfo == nil || isK8sNode(k8sInfo) {
-		if err := edgehostfiles.Register(client, log); err != nil {
-			log.Warn("host_files register failed; capability disabled", slog.Any("err", err))
-		}
-
-		// restart_service plugin (/ first MUTATING skill).
-		// Mocked posture in PR-7: handler returns Mocked=true without
-		// shelling out. SandboxConfig.Validate enforces a non-empty
-		// allow-list; on failure we boot without the capability so the
-		// edge can still scrape metrics / read files.
-		if err := edgerestartservice.Register(client, log); err != nil {
-			log.Warn("restart_service register failed; capability disabled", slog.Any("err", err))
-		}
-
-		// bash skill: generic read-only shell-execution gated by
-		// internal/edgeagent/cmdpolicy. The cmdpolicy package owns the
-		// rules (binary classes / arg matchers / path + network
-		// allowlists); this Register call wires the cmdpolicy.Sandbox to
-		// the host_files path validator and installs the handler. Boot
-		// continues on any soft failure (operator yaml override parse
-		// error, missing binaries) — cmdpolicy.Sandbox.Decide just
-		// rejects calls cleanly with a Reason the LLM can read.
-		if err := edgebash.Register(client, log); err != nil {
-			log.Warn("bash register failed; capability disabled", slog.Any("err", err))
-		}
+		registerEdgeCapabilities(client, log)
 		operatorLog := log.With(slog.String("comp", "operator"))
 		edgeoperator.Register(client, operatorLog)
 
@@ -212,12 +215,13 @@ func main() {
 		)
 	}
 
-	// UpgradeStageDir defaults to the systemd-install layout
-	// /var/lib/ongrid-edge/.upgrade. Empty disables agent_upgrade entirely
-	// (dev / non-systemd); set OVERRIDE via env to relocate for tests.
+	// UpgradeStageDir defaults to the platform-specific staging
+	// directory (see paths_{linux,windows}.go). Empty disables
+	// agent_upgrade entirely (dev / non-systemd); set OVERRIDE via env
+	// to relocate for tests.
 	stageDir := os.Getenv("ONGRID_EDGE_UPGRADE_STAGE_DIR")
 	if stageDir == "" {
-		stageDir = "/var/lib/ongrid-edge/.upgrade"
+		stageDir = defaultStageDir()
 	}
 	agent := edgebiz.NewAgent(client, collector, edgebiz.Config{
 		MetricsInterval:          cfg.Edge.CollectorInterval,
@@ -228,6 +232,7 @@ func main() {
 		UpgradeStageDir:          stageDir,
 		PacketCaptureDir:         envOr("ONGRID_PACKET_CAPTURE_DIR", "/var/lib/ongrid-edge/pcap"),
 	}, log)
+
 	if isK8sController(k8sInfo) {
 		inventoryInterval := parseDurationEnv("ONGRID_K8S_INVENTORY_INTERVAL", 10*time.Minute)
 		inventoryWatch := parseBoolEnv("ONGRID_K8S_INVENTORY_WATCH", true)
@@ -310,8 +315,8 @@ func main() {
 		// goroutine (in-process) or supervised subprocess. Kubernetes
 		// controllers do not run this host-oriented plugin set; node-mode
 		// DaemonSet agents keep it so they can reuse edge host capability.
-		pluginBinDir := envOr("ONGRID_EDGE_PLUGIN_BIN_DIR", "/usr/local/lib/ongrid-edge")
-		pluginWorkDir := envOr("ONGRID_EDGE_PLUGIN_WORK_DIR", "/var/lib/ongrid-edge/plugins")
+		pluginBinDir := envOr("ONGRID_EDGE_PLUGIN_BIN_DIR", defaultPluginBinDir())
+		pluginWorkDir := envOr("ONGRID_EDGE_PLUGIN_WORK_DIR", defaultPluginWorkDir())
 		pluginLog := log.With(slog.String("comp", "plugins"))
 
 		var registered []edgeplugins.Plugin

--- a/cmd/ongrid-edge/paths_linux.go
+++ b/cmd/ongrid-edge/paths_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package main
+
+// Linux default path constants (created by install.sh). The Windows
+// counterparts live in paths_windows.go. These were extracted from the
+// hardcoded paths in main.go as part of the platform split via build
+// tags: main.go only calls defaultXxx() and is unaware of the OS.
+
+// defaultPluginBinDir is the fallback when ONGRID_EDGE_PLUGIN_BIN_DIR is
+// unset. Points at the install directory of subprocess binaries
+// (node_exporter / otelcol / ...).
+func defaultPluginBinDir() string { return "/usr/local/lib/ongrid-edge" }
+
+// defaultPluginWorkDir is the fallback when ONGRID_EDGE_PLUGIN_WORK_DIR is
+// unset. Working directory for subprocesses (state files / pid files /
+// scratch output).
+func defaultPluginWorkDir() string { return "/var/lib/ongrid-edge/plugins" }
+
+// defaultStageDir is the fallback when ONGRID_EDGE_UPGRADE_STAGE_DIR is
+// unset. Staging directory for bundle upgrades.
+func defaultStageDir() string { return "/var/lib/ongrid-edge/.upgrade" }
+
+// defaultSecretsFile returns the default path of the DPAPI-encrypted
+// secrets.enc. There is no DPAPI on Linux, so it returns an empty string
+// (secrets.enc is never loaded).
+func defaultSecretsFile() string { return "" }

--- a/cmd/ongrid-edge/paths_windows.go
+++ b/cmd/ongrid-edge/paths_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package main
+
+// Windows default path constants. The directories are created by the
+// supervisor.exe --install subcommand.
+//
+// Layout:
+//   - binary → C:\Program Files\ongrid-edge\bin\
+//   - data   → C:\ProgramData\ongrid-edge\
+//
+// ProgramData is the standard data directory for Windows services and is
+// writable by the service account running the edge.
+
+func defaultPluginBinDir() string { return `C:\Program Files\ongrid-edge\bin` }
+
+func defaultPluginWorkDir() string { return `C:\ProgramData\ongrid-edge\plugins` }
+
+func defaultStageDir() string { return `C:\ProgramData\ongrid-edge\upgrade` }
+
+// defaultSecretsFile returns the default path of the DPAPI-encrypted
+// secrets.enc, placed under ProgramData (writable by the service account).
+func defaultSecretsFile() string { return `C:\ProgramData\ongrid-edge\secrets.enc` }

--- a/internal/edgeagent/bash/handlers.go
+++ b/internal/edgeagent/bash/handlers.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package bash registers the edge-side handler for MethodBashExec
 // (internal/pkg/tunnel/bash.go). The handler is a thin shim over
 // cmdpolicy.Sandbox: parse the wire request, call sandbox.Exec,

--- a/internal/edgeagent/bash/handlers_test.go
+++ b/internal/edgeagent/bash/handlers_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package bash
 
 import (

--- a/internal/edgeagent/cmdpolicy/parse.go
+++ b/internal/edgeagent/cmdpolicy/parse.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (

--- a/internal/edgeagent/cmdpolicy/parse_test.go
+++ b/internal/edgeagent/cmdpolicy/parse_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (
@@ -43,8 +45,8 @@ func TestSplitPipes_ForbiddenChars(t *testing.T) {
 		"echo a &",
 		"diff <(ls) <(ls)",
 		"echo ${HOME}",
-		"echo |",      // empty trailing segment
-		"| ps",        // empty leading segment
+		"echo |",       // empty trailing segment
+		"| ps",         // empty leading segment
 		`echo "unterm`, // unterminated quote
 		`echo \`,       // trailing backslash
 	}

--- a/internal/edgeagent/cmdpolicy/policy.go
+++ b/internal/edgeagent/cmdpolicy/policy.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (
@@ -35,11 +37,11 @@ const (
 // counts. Operators extend via LoadFromYAML.
 func DefaultReadOnly() *Policy {
 	p := &Policy{
-		bins:        map[string]*BinaryPolicy{},
-		StdoutCap:   defaultStdoutCap,
-		StderrCap:   defaultStderrCap,
-		Timeout:     defaultTimeout,
-		MaxArgs:     defaultMaxArgs,
+		bins:      map[string]*BinaryPolicy{},
+		StdoutCap: defaultStdoutCap,
+		StderrCap: defaultStderrCap,
+		Timeout:   defaultTimeout,
+		MaxArgs:   defaultMaxArgs,
 		PathAllowlist: []string{
 			"/var", "/opt", "/home", "/tmp", "/srv", "/data",
 		},
@@ -552,11 +554,11 @@ func discoverBin(name string) string {
 // to add / replace; everything else is taken from base.
 type yamlPolicy struct {
 	Binaries []struct {
-		Name             string         `yaml:"name"`
-		Class            string         `yaml:"class"`
-		ReadOnlyMatchers []yamlMatcher  `yaml:"read_only_matchers"`
-		WriteMatchers    []yamlMatcher  `yaml:"write_matchers"`
-		DeniedArgs       []string       `yaml:"denied_args"`
+		Name             string        `yaml:"name"`
+		Class            string        `yaml:"class"`
+		ReadOnlyMatchers []yamlMatcher `yaml:"read_only_matchers"`
+		WriteMatchers    []yamlMatcher `yaml:"write_matchers"`
+		DeniedArgs       []string      `yaml:"denied_args"`
 	} `yaml:"binaries"`
 	NetworkHostAllowlist []string `yaml:"network_host_allowlist"`
 	StdoutCapBytes       int      `yaml:"stdout_cap_bytes"`

--- a/internal/edgeagent/cmdpolicy/policy_test.go
+++ b/internal/edgeagent/cmdpolicy/policy_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (

--- a/internal/edgeagent/cmdpolicy/sandbox.go
+++ b/internal/edgeagent/cmdpolicy/sandbox.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (

--- a/internal/edgeagent/cmdpolicy/sandbox_test.go
+++ b/internal/edgeagent/cmdpolicy/sandbox_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cmdpolicy
 
 import (

--- a/internal/edgeagent/cmdpolicy/types.go
+++ b/internal/edgeagent/cmdpolicy/types.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package cmdpolicy is the policy + sandbox layer that gates which
 // shell commands the edge will execute on behalf of an LLM-driven tool
 // (currently the bash skill — internal/edgeagent/bash). The policy is

--- a/internal/edgeagent/host_files/sandbox_test.go
+++ b/internal/edgeagent/host_files/sandbox_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package host_files
 
 import (

--- a/internal/edgeagent/install/acl_windows.go
+++ b/internal/edgeagent/install/acl_windows.go
@@ -4,40 +4,64 @@ package install
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // ACL 验证：DPAPI CRYPTPROTECT_LOCAL_MACHINE scope 绑定到机器级 SystemCredential，
 // 同机器上任何 LocalSystem / NetworkService 进程都能解密。这意味着 DPAPI 本身
 // 不替代文件 ACL——必须配合文件系统 ACL 限制非 System/Administrators 身份的读访问。
 //
-// 目标 ACL（secrets.enc + 父目录）：
-//   - NT AUTHORITY\SYSTEM:(F)        — supervisor / worker 跑在 LocalSystem
-//   - BUILTIN\Administrators:(F)     — 管理员运维访问
-//   - 移除 BUILTIN\Users / Everyone / Authenticated Users 的所有 ACE
+// 目标 ACL（secrets.enc + 受管目录）：
+//   - NT AUTHORITY\SYSTEM (S-1-5-18)        — supervisor / worker 跑在 LocalSystem
+//   - BUILTIN\Administrators (S-1-5-32-544) — 管理员运维访问
+//   - 不允许任何其他 trustee 的 ACE
 //
-// 用 icacls.exe（Windows 内置命令）而非 raw syscall：
-//   - 标准做法，可审计（icacls 输出人类可读）
-//   - 错误信息清晰
-//   - 避免 SECURITY_DESCRIPTOR 手工构造的复杂度
+// 实现策略：
+//   - Apply 用 icacls.exe（内置命令，可审计），grant 目标用 SID 而非账户名
+//     （`*S-1-5-18`），免疫非英文系统上账户名的本地化差异
+//   - Verify 用 GetNamedSecurityInfo 原生 API 逐 ACE 读出 trustee SID，做
+//     正向白名单校验：每个 ACE 的 SID 必须 ∈ {SYSTEM, Administrators}。
+//     黑名单式检查（只查 Users/Everyone 等通配组）检不出预植的具体用户 ACE
 //
-// icacls 错误信息 sanitize 策略：
-//   - error message 只保留 exit code + 简短原因，不暴露 icacls 完整输出
-//   - 完整输出在开发期可见（test 跑 icacls），生产日志不记录（避免泄露路径/SID）
+// 路径安全：所有系统工具（icacls）用 %SystemRoot%\System32 绝对路径调用。
+// SYSTEM 服务继承系统 PATH，第三方软件常向其中注入用户可写目录 — 相对名
+// 解析会让 icacls 以 LocalSystem 执行被劫持的副本。
 
-// icaclsNotFoundError 表示 icacls.exe 不在 PATH 中（如 Windows Server Core 精简镜像）。
-// 这种环境下无法应用 ACL，调用方必须中止 install（不降级到无 ACL 状态）。
-var icaclsNotFoundError = fmt.Errorf("icacls.exe not found in PATH — cannot apply ACL, install aborted (Windows Server Core 精简镜像可能移除了 icacls)")
+// 允许的 trustee SID（本地化无关的稳定标识）。
+const (
+	sidSYSTEM = "S-1-5-18"     // NT AUTHORITY\SYSTEM
+	sidAdmins = "S-1-5-32-544" // BUILTIN\Administrators
 
-// requireIcacls 在入口检查 icacls 可用性，避免后续命令失败时错误信息不清晰。
-func requireIcacls() error {
-	if _, err := exec.LookPath("icacls"); err != nil {
-		return icaclsNotFoundError
+	// fileAllAccess = FILE_ALL_ACCESS（icacls 显示为 (F)）。
+	fileAllAccess = 0x001F01FF
+)
+
+// archiveDirFn 是 EnsureSecureDir 归档预植目录的测试缝（生产 = os.Rename）。
+var archiveDirFn = os.Rename
+
+// systemTool 返回系统工具的绝对路径（%SystemRoot%\System32\<name>）。
+// 绝对路径解析是硬要求：见文件头注释的 PATH 劫持说明。
+func systemTool(name string) (string, error) {
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = os.Getenv("windir")
 	}
-	return nil
+	if root == "" {
+		return "", fmt.Errorf("SystemRoot environment variable not set; cannot resolve %s", name)
+	}
+	p := filepath.Join(root, "System32", name)
+	if _, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("system tool %s not found at %s: %w", name, p, err)
+	}
+	return p, nil
 }
 
 // sanitizeIcaclsOutput 从 icacls 输出中提取关键错误信息，去除路径前缀和 SID 详情。
@@ -57,64 +81,58 @@ func sanitizeIcaclsOutput(out []byte) string {
 	return last
 }
 
+// icaclsPath 返回 icacls.exe 的绝对路径（Server Core 精简镜像可能缺失）。
+func icaclsPath() (string, error) {
+	return systemTool("icacls.exe")
+}
+
+// runIcacls 执行 icacls 并返回 CombinedOutput / error。
+func runIcacls(args ...string) ([]byte, error) {
+	exe, err := icaclsPath()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(exe, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("icacls %s failed (exit %v): %s",
+			strings.Join(redactPaths(args), " "), err, sanitizeIcaclsOutput(out))
+	}
+	return out, nil
+}
+
+// redactPaths 把参数列表中的绝对路径替换为 <path>（错误信息防泄露）。
+func redactPaths(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if filepath.IsAbs(a) {
+			out[i] = "<path>"
+		} else {
+			out[i] = a
+		}
+	}
+	return out
+}
+
 // ApplySecretACL 应用 secrets.enc 的 ACL：仅 SYSTEM + Administrators 有 Full Control。
 //
 // 操作：
 //  1. /inheritance:r  — 移除从父目录继承的 ACE
-//  2. /grant:r         — 替换为指定 ACE（非合并）
+//  2. /grant:r        — 替换为指定 ACE（非合并）
+//
+// grant 目标用 SID（`*S-1-5-18`）而非账户名：icacls 的 /grant 接受 SID，
+// 且不受系统语言/locale 影响账户名翻译。
 //
 // 注意：(F) Full Control 是必要的——supervisor（SYSTEM 身份）需要 Write + Delete
 // 来执行 Rotate（rename tmp → secrets.enc 会用 Delete 旧文件）。
 func ApplySecretACL(path string) error {
-	if err := requireIcacls(); err != nil {
-		return err
-	}
-	clean := filepath.Clean(path)
-	cmd := exec.Command("icacls", clean,
+	_, err := runIcacls(filepath.Clean(path),
 		"/inheritance:r",
 		"/grant:r",
-		"NT AUTHORITY\\SYSTEM:(F)",
-		"BUILTIN\\Administrators:(F)",
+		"*"+sidSYSTEM+":(F)",
+		"*"+sidAdmins+":(F)",
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("icacls apply on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
-	}
-	return nil
-}
-
-// VerifySecretACL 验证 secrets.enc 的 ACL 符合预期。
-//
-// 检查：
-//   - SYSTEM 行含 (F)
-//   - Administrators 行含 (F)
-//   - 不含 Users / Everyone / Authenticated Users
-//
-// 这是"独立检查点"——即使 ApplySecretACL 成功，也要读回来验证。
-// 防止 GPO / AV / 其他工具在 apply 后修改 ACL。
-func VerifySecretACL(path string) error {
-	if err := requireIcacls(); err != nil {
-		return err
-	}
-	clean := filepath.Clean(path)
-	out, err := exec.Command("icacls", clean).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("icacls verify on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
-	}
-	output := string(out)
-
-	if !hasAceWithPerm(output, "NT AUTHORITY\\SYSTEM:", "(F)") {
-		return fmt.Errorf("verify ACL: SYSTEM:(F) missing on %s", clean)
-	}
-	if !hasAceWithPerm(output, "BUILTIN\\Administrators:", "(F)") {
-		return fmt.Errorf("verify ACL: Administrators:(F) missing on %s", clean)
-	}
-	for _, forbidden := range []string{"BUILTIN\\Users:", "Everyone:", "Authenticated Users:"} {
-		if strings.Contains(output, forbidden) {
-			return fmt.Errorf("verify ACL: forbidden ACE %q present on %s", forbidden, clean)
-		}
-	}
-	return nil
+	return err
 }
 
 // ApplyDirACL 应用目录的 ACL，使用 (OI)(CI) 容器继承标记让子文件/子目录自动继承。
@@ -123,80 +141,145 @@ func VerifySecretACL(path string) error {
 //   - 目录用 (OI)(CI)(F) — Object Inherit + Container Inherit + Full Control
 //   - secrets.enc 用 (F) — 仅文件本身
 //
+// 局限：/inheritance:r 只移除继承 ACE，不清除已存在的显式 ACE。预植目录
+// （攻击者在 install 前创建并给自己授予显式 ACE）由 EnsureSecureDir 的
+// 归档重建路径处理，不依赖本函数。
+//
 // 调用 EnsureSecureDir 而非直接调用此函数（EnsureSecureDir 含 MkdirAll + 验证）。
 func ApplyDirACL(dir string) error {
-	if err := requireIcacls(); err != nil {
-		return err
-	}
-	clean := filepath.Clean(dir)
-	cmd := exec.Command("icacls", clean,
+	_, err := runIcacls(filepath.Clean(dir),
 		"/inheritance:r",
 		"/grant:r",
-		"NT AUTHORITY\\SYSTEM:(OI)(CI)(F)",
-		"BUILTIN\\Administrators:(OI)(CI)(F)",
+		"*"+sidSYSTEM+":(OI)(CI)(F)",
+		"*"+sidAdmins+":(OI)(CI)(F)",
 	)
-	out, err := cmd.CombinedOutput()
+	return err
+}
+
+// verifyACLStrict 验证 path 的 DACL 符合正向白名单：
+//   - 必须存在 SYSTEM 与 Administrators 的 allow-full ACE
+//   - 不包含任何其他 trustee 的 ACE（具体用户、预植显式 ACE、deny ACE 全部 fail）
+//
+// 用 GetNamedSecurityInfo 原生 API（不经 icacls 文本输出）：
+//   - SID 级比较，免疫非英文系统上 icacls 输出的账户名本地化
+//   - 黑名单式检查检不出"陌生 SID"，正向白名单才闭合预植面
+func verifyACLStrict(path string) error {
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
 	if err != nil {
-		return fmt.Errorf("icacls apply dir ACL on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
+		return fmt.Errorf("read DACL of %s: %w", filepath.Base(path), err)
+	}
+	dacl, present, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("get DACL of %s: %w", filepath.Base(path), err)
+	}
+	if !present || dacl == nil {
+		return fmt.Errorf("no DACL present on %s (unrestricted access)", filepath.Base(path))
+	}
+
+	seenSYSTEM, seenAdmins := false, false
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			return fmt.Errorf("read ACE %d of %s: %w", i, filepath.Base(path), err)
+		}
+		// SID 紧跟 ACE 头部（SidStart 字段即 SID 首字节；deny ACE 布局相同）。
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		full := ace.Mask&fileAllAccess == fileAllAccess
+		switch sid.String() {
+		case sidSYSTEM:
+			if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || !full {
+				return fmt.Errorf("SYSTEM ACE on %s is not allow-full", filepath.Base(path))
+			}
+			seenSYSTEM = true
+		case sidAdmins:
+			if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || !full {
+				return fmt.Errorf("Administrators ACE on %s is not allow-full", filepath.Base(path))
+			}
+			seenAdmins = true
+		default:
+			return fmt.Errorf("unexpected ACE trustee on %s (allowlist: SYSTEM, Administrators only)",
+				filepath.Base(path))
+		}
+	}
+	if !seenSYSTEM || !seenAdmins {
+		return fmt.Errorf("missing required ACE on %s (need SYSTEM + Administrators allow-full)", filepath.Base(path))
 	}
 	return nil
 }
 
-// VerifyDirACL 验证目录 ACL 符合预期（与 VerifySecretACL 类似，但允许 inherit 标记）。
-func VerifyDirACL(dir string) error {
-	if err := requireIcacls(); err != nil {
-		return err
-	}
-	clean := filepath.Clean(dir)
-	out, err := exec.Command("icacls", clean).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("icacls verify dir on %s failed (exit %v): %s", clean, err, sanitizeIcaclsOutput(out))
-	}
-	output := string(out)
+// VerifySecretACL 验证 secrets.enc 的 ACL 符合预期（正向白名单，见 verifyACLStrict）。
+//
+// 这是"独立检查点"——即使 ApplySecretACL 成功，也要读回来验证。
+// 防止 GPO / AV / 其他工具在 apply 后修改 ACL。
+func VerifySecretACL(path string) error {
+	return verifyACLStrict(filepath.Clean(path))
+}
 
-	if !hasAceWithPerm(output, "NT AUTHORITY\\SYSTEM:", "(F)") {
-		return fmt.Errorf("verify dir ACL: SYSTEM:(F) missing on %s", clean)
+// VerifyDirACL 验证目录 ACL 符合预期（正向白名单，见 verifyACLStrict）。
+func VerifyDirACL(dir string) error {
+	return verifyACLStrict(filepath.Clean(dir))
+}
+
+// VerifyTreeACL 验证 root 目录及其现有子树内每个条目的 DACL 都是严格白名单。
+//
+// 运行期门控用（stage 目录消费前）：顶层目录 ACL 正确不代表子项正确——
+// 子项（pending / incoming / 哨兵文件）的 DACL 可被持 WRITE_DAC 的主体事后
+// 放宽，消费前逐项复验才闭合。只校验已存在的条目。
+func VerifyTreeACL(root string) error {
+	clean := filepath.Clean(root)
+	if err := verifyACLStrict(clean); err != nil {
+		return fmt.Errorf("root: %w", err)
 	}
-	if !hasAceWithPerm(output, "BUILTIN\\Administrators:", "(F)") {
-		return fmt.Errorf("verify dir ACL: Administrators:(F) missing on %s", clean)
-	}
-	for _, forbidden := range []string{"BUILTIN\\Users:", "Everyone:", "Authenticated Users:"} {
-		if strings.Contains(output, forbidden) {
-			return fmt.Errorf("verify dir ACL: forbidden ACE %q present on %s", forbidden, clean)
+	return filepath.WalkDir(clean, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-	}
-	return nil
+		if p == clean {
+			return nil
+		}
+		return verifyACLStrict(p)
+	})
 }
 
 // EnsureSecureDir 确保 dir 存在且 ACL 受限（仅 SYSTEM + Administrators）。
 //
 // 流程：
-//  1. MkdirAll(dir) — 创建目录（如已存在是 noop）
-//  2. ApplyDirACL(dir) — 强制刷新 ACL（idempotent）
-//  3. VerifyDirACL(dir) — 读回来验证
+//  1. dir 已存在时先严格验证：通过 = 保留（幂等重装不动数据）；
+//     不通过 = 视为不可信（可能是 install 前预植的目录——/inheritance:r
+//     清不掉显式 ACE），归档改名后全新重建。全新创建的目录不含任何
+//     显式 ACE，只有我们授予的两条。
+//  2. MkdirAll(dir) — 创建目录（如已存在是 noop）
+//  3. ApplyDirACL(dir) — 刷新 ACL（幂等）
+//  4. VerifyDirACL(dir) — 读回来验证（fail-closed）
+//
+// 归档产物 <dir>.preexisting-<unix-ts> 保留在磁盘上（不删除数据），
+// 其 ACL 不受控但路径已脱离信任根。
 //
 // 调用时机：Install 流程开始前（写 secrets.enc 之前）确保父目录受限，
 // 这样 secrets.enc 即使继承父目录 ACL 也只对 SYSTEM+Admins 可读。
 func EnsureSecureDir(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("mkdir %s: %w", dir, err)
+	clean := filepath.Clean(dir)
+	if fi, err := os.Stat(clean); err == nil {
+		if !fi.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", clean)
+		}
+		if err := verifyACLStrict(clean); err != nil {
+			arch := fmt.Sprintf("%s.preexisting-%d", clean, time.Now().Unix())
+			if err := archiveDirFn(clean, arch); err != nil {
+				return fmt.Errorf("dir %s has untrusted ACL (refusing to reuse; likely pre-planted): archive to %s failed: %w", clean, arch, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", clean, err)
 	}
-	if err := ApplyDirACL(dir); err != nil {
+	if err := os.MkdirAll(clean, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", clean, err)
+	}
+	if err := ApplyDirACL(clean); err != nil {
 		return fmt.Errorf("apply dir ACL: %w", err)
 	}
-	if err := VerifyDirACL(dir); err != nil {
+	if err := VerifyDirACL(clean); err != nil {
 		return fmt.Errorf("verify dir ACL: %w", err)
 	}
 	return nil
-}
-
-// hasAceWithPerm 检查 icacls 输出中是否存在某 principal 行且该行含指定权限位。
-// 行内同时含 principal 关键字和权限位（如 (F)）即视为匹配。
-func hasAceWithPerm(output, principal, perm string) bool {
-	for _, line := range strings.Split(output, "\n") {
-		if strings.Contains(line, principal) && strings.Contains(line, perm) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/edgeagent/install/acl_windows_test.go
+++ b/internal/edgeagent/install/acl_windows_test.go
@@ -33,10 +33,10 @@ func isAdmin() bool {
 	return cmd.Run() == nil
 }
 
-// TestApplySecretACL_RestrictsToSystemAndAdmins 验证 ApplySecretACL 后：
-//   - SYSTEM:(F) 出现在 icacls 输出
-//   - Administrators:(F) 出现
-//   - BUILTIN\Users 不出现
+// TestApplySecretACL_RestrictsToSystemAndAdmins 验证 ApplySecretACL 后
+// DACL 是严格白名单（SYSTEM + Administrators allow-full，无其他 trustee）。
+// 用 VerifySecretACL（原生 API / SID 级）而非 icacls 文本输出做断言 —
+// 文本输出里的账户名会随系统语言本地化，断言不可靠。
 //
 // 需要 Administrator 身份（icacls 修改 ACL 需要文件所有权或 SeTakeOwnershipPrivilege）。
 func TestApplySecretACL_RestrictsToSystemAndAdmins(t *testing.T) {
@@ -53,21 +53,116 @@ func TestApplySecretACL_RestrictsToSystemAndAdmins(t *testing.T) {
 	if err := ApplySecretACL(path); err != nil {
 		t.Fatalf("ApplySecretACL: %v", err)
 	}
+	if err := VerifySecretACL(path); err != nil {
+		t.Errorf("VerifySecretACL after Apply should pass (strict whitelist), got: %v", err)
+	}
+}
 
-	out, err := exec.Command("icacls", path).CombinedOutput()
-	if err != nil {
-		t.Fatalf("icacls read: %v (output: %s)", err, out)
-	}
-	output := string(out)
+// --- 正向白名单（strict verify）---
 
-	if !strings.Contains(output, "NT AUTHORITY\\SYSTEM:(F)") {
-		t.Errorf("SYSTEM:(F) missing in ACL: %s", output)
+// TestVerifyDirACL_RejectsDefaultTempACL 验证正向白名单语义（无需 admin）：
+// t.TempDir 的默认 ACL 含当前用户等额外 trustee → 必须拒绝。
+// 黑名单式检查（只查 Users/Everyone）检不出这种"具体用户 ACE"，
+// 这正是预植目录攻击（install 前给自己授予显式 ACE）的形态。
+func TestVerifyDirACL_RejectsDefaultTempACL(t *testing.T) {
+	if err := VerifyDirACL(t.TempDir()); err == nil {
+		t.Fatal("VerifyDirACL should reject default TempDir ACL (extra trustees present)")
 	}
-	if !strings.Contains(output, "BUILTIN\\Administrators:(F)") {
-		t.Errorf("Administrators:(F) missing in ACL: %s", output)
+}
+
+// TestVerifyTreeACL_MissingRoot 验证 root 不存在时显式报错（fail-closed）。
+func TestVerifyTreeACL_MissingRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir")
+	if err := VerifyTreeACL(missing); err == nil {
+		t.Fatal("VerifyTreeACL should fail on non-existent root")
 	}
-	if strings.Contains(output, "BUILTIN\\Users:") {
-		t.Errorf("forbidden Users ACE present: %s", output)
+}
+
+// TestVerifyTreeACL_PassesAfterApplyDirACL 验证 ApplyDirACL 后整棵子树
+// （子目录 + 文件，经 (OI)(CI) 继承）通过严格白名单。需要 Administrator。
+func TestVerifyTreeACL_PassesAfterApplyDirACL(t *testing.T) {
+	if !isAdmin() {
+		t.Skip("requires Administrator")
+	}
+	root := t.TempDir()
+	sub := filepath.Join(root, "incoming")
+	if err := os.MkdirAll(sub, 0o750); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pending"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+	if err := ApplyDirACL(root); err != nil {
+		t.Fatalf("ApplyDirACL: %v", err)
+	}
+	if err := VerifyTreeACL(root); err != nil {
+		t.Errorf("VerifyTreeACL after ApplyDirACL should pass for inherited subtree, got: %v", err)
+	}
+}
+
+// --- EnsureSecureDir 归档重建（预植目录防御）---
+
+// TestEnsureSecureDir_ArchivesPrePlantedInsecureDir 验证：已存在但 ACL
+// 不合规的目录（模拟 install 前预植）被归档改名，原位全新重建且新目录
+// 无预植内容、ACL 严格通过。需要 Administrator（ApplyDirACL + 归档后的访问）。
+func TestEnsureSecureDir_ArchivesPrePlantedInsecureDir(t *testing.T) {
+	if !isAdmin() {
+		t.Skip("requires Administrator")
+	}
+	base := t.TempDir()
+	dir := filepath.Join(base, "upgrade")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir pre-planted: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "attacker-file"), []byte("evil"), 0o644); err != nil {
+		t.Fatalf("write pre-planted file: %v", err)
+	}
+
+	if err := EnsureSecureDir(dir); err != nil {
+		t.Fatalf("EnsureSecureDir: %v", err)
+	}
+
+	// 新目录不含预植内容
+	if _, err := os.Stat(filepath.Join(dir, "attacker-file")); !os.IsNotExist(err) {
+		t.Errorf("pre-planted file must not survive into the rebuilt dir, got err: %v", err)
+	}
+	// 归档产物存在且包含预植文件（数据保留，路径脱离信任根）
+	archives, err := filepath.Glob(filepath.Join(base, "upgrade.preexisting-*"))
+	if err != nil || len(archives) != 1 {
+		t.Fatalf("expected exactly one archive, got %v (err: %v)", archives, err)
+	}
+	if _, err := os.Stat(filepath.Join(archives[0], "attacker-file")); err != nil {
+		t.Errorf("archive should retain pre-planted file: %v", err)
+	}
+	// 重建后的目录 ACL 严格通过
+	if err := VerifyDirACL(dir); err != nil {
+		t.Errorf("rebuilt dir should pass strict whitelist, got: %v", err)
+	}
+}
+
+// TestEnsureSecureDir_IdempotentKeepsSecureDir 验证幂等重入：已合规目录
+// 不归档、内容保留。需要 Administrator。
+func TestEnsureSecureDir_IdempotentKeepsSecureDir(t *testing.T) {
+	if !isAdmin() {
+		t.Skip("requires Administrator")
+	}
+	base := t.TempDir()
+	dir := filepath.Join(base, "data")
+	if err := EnsureSecureDir(dir); err != nil {
+		t.Fatalf("first EnsureSecureDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secrets.enc"), []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	if err := EnsureSecureDir(dir); err != nil {
+		t.Fatalf("second EnsureSecureDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "secrets.enc")); err != nil {
+		t.Errorf("existing content must survive idempotent re-run: %v", err)
+	}
+	archives, _ := filepath.Glob(filepath.Join(base, "data.preexisting-*"))
+	if len(archives) != 0 {
+		t.Errorf("secure dir must not be archived on re-run, got: %v", archives)
 	}
 }
 

--- a/internal/edgeagent/install/service_windows.go
+++ b/internal/edgeagent/install/service_windows.go
@@ -4,7 +4,9 @@ package install
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
 )
@@ -21,9 +23,35 @@ func NewServiceController(serviceName string) ServiceController {
 	return &SCServiceController{name: serviceName}
 }
 
+// scExe 返回 sc.exe 的绝对路径（PATH 劫持防护，见 acl_windows.go 注释）。
+func scExe() (string, error) {
+	return systemTool("sc.exe")
+}
+
+// powerShellExe 返回 powershell.exe 的绝对路径（PATH 劫持防护）。
+// powershell.exe 不在 System32 根目录，而在 WindowsPowerShell\v1.0 子目录。
+func powerShellExe() (string, error) {
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = os.Getenv("windir")
+	}
+	if root == "" {
+		return "", fmt.Errorf("SystemRoot environment variable not set; cannot resolve powershell.exe")
+	}
+	p := filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	if _, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("powershell.exe not found at %s: %w", p, err)
+	}
+	return p, nil
+}
+
 // Create 注册 Windows 服务（sc.exe create）。
 func (sc *SCServiceController) Create(binPath string) error {
-	cmd := exec.Command("sc.exe", "create", sc.name,
+	exe, err := scExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "create", sc.name,
 		"binPath=", binPath,
 		"start=", "auto",
 		"DisplayName=", "Ongrid Edge Agent",
@@ -39,7 +67,11 @@ func (sc *SCServiceController) Create(binPath string) error {
 // service.go Execute 返回 (false, 1)（samesession=false + 非 0 exitCode）时 SCM 按此配置重启。
 // 3 次/24h 上限后停止，等价于"立即停止"行为。
 func (sc *SCServiceController) ConfigureRecovery() error {
-	cmd := exec.Command("sc.exe", "failure", sc.name,
+	exe, err := scExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "failure", sc.name,
 		"reset=", "86400",
 		"actions=", "restart/60000/restart/60000/restart/60000",
 	)
@@ -57,8 +89,12 @@ func (sc *SCServiceController) ConfigureRecovery() error {
 // 必须用逗号分隔（"-ExclusionPath A,B"），不能重复同名参数
 // （"-ExclusionPath A -ExclusionPath B" 会报 ParameterAlreadyBound）。
 func (sc *SCServiceController) ConfigureDefenderExclusion() error {
+	exe, err := powerShellExe()
+	if err != nil {
+		return err
+	}
 	ps := buildDefenderExclusionCmd(edgedirs.BinDir, edgedirs.DataDir)
-	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive",
+	out, err := exec.Command(exe, "-NoProfile", "-NonInteractive",
 		"-Command", ps).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Add-MpPreference: %w (output: %s)", err, out)
@@ -77,7 +113,11 @@ func buildDefenderExclusionCmd(binDir, dataDir string) string {
 
 // Start 启动已注册的服务（sc.exe start）。
 func (sc *SCServiceController) Start() error {
-	cmd := exec.Command("sc.exe", "start", sc.name)
+	exe, err := scExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "start", sc.name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sc.exe start: %w (output: %s)", err, out)
 	}
@@ -92,7 +132,11 @@ func (sc *SCServiceController) Start() error {
 //   - 1060 = ERROR_SERVICE_DOES_NOT_EXIST（服务未注册）
 //   - 1062 = ERROR_SERVICE_NOT_ACTIVE（服务未启动）
 func (sc *SCServiceController) Stop() error {
-	cmd := exec.Command("sc.exe", "stop", sc.name)
+	exe, err := scExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "stop", sc.name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -108,7 +152,11 @@ func (sc *SCServiceController) Stop() error {
 
 // Delete 删除服务（sc.exe delete）。
 func (sc *SCServiceController) Delete() error {
-	cmd := exec.Command("sc.exe", "delete", sc.name)
+	exe, err := scExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "delete", sc.name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sc.exe delete: %w (output: %s)", err, out)
 	}

--- a/internal/edgeagent/restart_service/handlers.go
+++ b/internal/edgeagent/restart_service/handlers.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package restart_service registers the edge-side handler for
 // MethodRestartService — the first mutating skill in ongrid (
 // double-sign / mutating class). The manager-side

--- a/internal/edgeagent/restart_service/handlers_test.go
+++ b/internal/edgeagent/restart_service/handlers_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package restart_service
 
 import (

--- a/internal/edgeagent/supervisorhealth/health.go
+++ b/internal/edgeagent/supervisorhealth/health.go
@@ -1,0 +1,128 @@
+// Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
+// health.json 文件 IPC。
+// worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
+// 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启。
+// 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 Linux CI 跑。
+package supervisorhealth
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// HealthSchemaVersion 是 health.json schema 的当前版本。
+// 字段增删或语义变更时 +1，supervisor 读到不兼容版本应拒绝启动 worker。
+const HealthSchemaVersion = 1
+
+// HeartbeatInterval 是 worker.exe 写心跳的频率。
+const HeartbeatInterval = 30 * time.Second
+
+// HeartbeatTimeout 是 supervisor.exe 视为 worker 卡死的阈值。
+// 设为 3× HeartbeatInterval 给 GC / 临时文件锁 / antivirus 扫描留 margin，
+// 避免误杀健康 worker。
+const HeartbeatTimeout = 90 * time.Second
+
+// Status 枚举 worker 自报的健康状态。supervisor 主要靠 LastHeartbeat 时间戳
+// 做超时判断；Status 是辅助信号（如 worker 启动中但还没就绪）。
+type Status string
+
+const (
+	// StatusStarting 表示 worker 进程已启动但 skill dispatcher 未就绪。
+	StatusStarting Status = "starting"
+	// StatusHealthy 表示 worker 正常运行。
+	StatusHealthy Status = "healthy"
+	// StatusDegraded 表示 worker 自报部分 skill 不可用（如 windows_exporter 挂了）。
+	//  supervisor 不对 degraded 做特殊处理，仅记录。
+	StatusDegraded Status = "degraded"
+)
+
+// Health 是 health.json 文件的 schema。worker 写，supervisor 读。
+// 字段对齐 ：worker_pid 用于 supervisor 检测 PID race（旧 worker
+// 崩溃后新 worker 复用 PID 槽位但 started_at 不同）；started_at 与
+// last_heartbeat 都是 RFC3339 纳秒精度。
+type Health struct {
+	Version       int       `json:"version"`
+	WorkerPID     int       `json:"worker_pid"`
+	StartedAt     time.Time `json:"started_at"`
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+	Status        Status    `json:"status"`
+}
+
+// Write 原子地写入 health.json：先写到同目录的临时文件，再 rename 覆盖。
+// 原子写避免 supervisor 读到半写入的 JSON（Windows 上 rename 是原子的，
+// 同分区下 NTFS保证原子性）。
+func Write(path string, h Health) error {
+	buf, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal health: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	// 同目录临时文件保证 rename 是同分区原子操作（跨分区 rename 退化成 copy+unlink）。
+	tmp, err := os.CreateTemp(dir, ".health-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			// cleanup 路径：tmp 文件已写坏或 rename 失败，删除残留。
+			// 错误丢弃是刻意的（cleanup 失败无处理手段，下次 CreateTemp 会冲突触发上层报错）。
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(buf); err != nil {
+		// Write 失败后 Close 错误丢弃（已经被 write 错误掩盖，无诊断价值）。
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
+	}
+	cleanup = false
+	return nil
+}
+
+// Read 读取 health.json 并反序列化。文件不存在时返回包装 fs.ErrNotExist 的错误。
+func Read(path string) (Health, error) {
+	var h Health
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return h, fmt.Errorf("read %s: %w", path, err)
+	}
+	// 提前 trim BOM（有些编辑器在 Windows 自动加 BOM，会让 encoding/json 报错）。
+	buf = bytes.TrimPrefix(buf, []byte("\xef\xbb\xbf"))
+	if err := json.Unmarshal(buf, &h); err != nil {
+		return h, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+	return h, nil
+}
+
+// IsStale 判断心跳是否过期：now - LastHeartbeat > timeout。
+// 边界恰好等于 timeout 视为未过期（属于"最后的有效时刻"）。
+// 错误的判断由调用方做（文件不存在 ≠ worker 卡死，可能是首次启动）。
+func IsStale(h Health, now time.Time, timeout time.Duration) bool {
+	return now.Sub(h.LastHeartbeat) > timeout
+}
+
+// IsNotExist 报告错误链中是否包含 fs.ErrNotExist。supervisor 用这个区分
+// "health.json 还没写"（worker 启动中，等待）vs "health.json 损坏"（告警）。
+func IsNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/edgeagent/supervisorhealth/health_test.go
+++ b/internal/edgeagent/supervisorhealth/health_test.go
@@ -1,0 +1,137 @@
+// Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
+// health.json 文件 IPC。
+// worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
+// 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启。
+// 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 Linux CI 跑。
+package supervisorhealth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWrite_Then_Read_RoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+
+	want := Health{
+		Version:       HealthSchemaVersion,
+		WorkerPID:     12345,
+		StartedAt:     time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC),
+		LastHeartbeat: time.Date(2026, 7, 12, 10, 0, 30, 0, time.UTC),
+		Status:        StatusHealthy,
+	}
+
+	if err := Write(path, want); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestRead_NotExist_Returns_Error(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := Read(filepath.Join(dir, "missing.json"))
+	if err == nil {
+		t.Fatal("Read should fail for missing file")
+	}
+}
+
+func TestRead_InvalidJSON_Returns_Error(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("setup WriteFile failed: %v", err)
+	}
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("Read should fail for invalid JSON")
+	}
+}
+
+func TestWrite_Overwrite_Existing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+
+	first := Health{Version: 1, WorkerPID: 1, Status: StatusStarting}
+	if err := Write(path, first); err != nil {
+		t.Fatalf("first Write failed: %v", err)
+	}
+	second := Health{Version: 1, WorkerPID: 2, Status: StatusHealthy}
+	if err := Write(path, second); err != nil {
+		t.Fatalf("second Write failed: %v", err)
+	}
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if got.WorkerPID != 2 || got.Status != StatusHealthy {
+		t.Errorf("overwrite failed: got %+v, want PID=2 Status=healthy", got)
+	}
+}
+
+func TestIsStale_FreshHeartbeat_False(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	h := Health{LastHeartbeat: now.Add(-10 * time.Second)}
+	if IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be false for 10s-old heartbeat (within 90s window)")
+	}
+}
+
+func TestIsStale_ExpiredHeartbeat_True(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	h := Health{LastHeartbeat: now.Add(-120 * time.Second)} // 120s > 90s
+	if !IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be true for 120s-old heartbeat (beyond 90s window)")
+	}
+}
+
+func TestIsStale_Boundary_ExactlyAtTimeout_True(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	// 超时判断用 > 比较：恰好等于 timeout 视为未超时（边界属于"最后的有效时刻"）
+	h := Health{LastHeartbeat: now.Add(-HeartbeatTimeout)}
+	if IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be false at exactly timeout boundary (>)")
+	}
+	h2 := Health{LastHeartbeat: now.Add(-(HeartbeatTimeout + time.Second))}
+	if !IsStale(h2, now, HeartbeatTimeout) {
+		t.Error("IsStale should be true 1s past timeout boundary")
+	}
+}
+
+func TestWrite_PermissionDenied_Returns_Error(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits behave differently on Windows; covered by a Windows runner")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, permission test unreliable")
+	}
+	dir := t.TempDir()
+	readOnlyDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0o500); err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	err := Write(filepath.Join(readOnlyDir, "health.json"), Health{Version: 1})
+	if err == nil {
+		t.Fatal("Write should fail on read-only directory")
+	}
+}

--- a/internal/edgeagent/upgradebundle/doc.go
+++ b/internal/edgeagent/upgradebundle/doc.go
@@ -1,0 +1,14 @@
+// Package upgradebundle 实现 worker 侧的 bundle 下载与健康标记写入。
+// 职责分工（对称 supervisor 侧的 upgrademachine 包）：
+//   - upgradebundle（本包，worker 侧）— 下载 bundle 到 incoming/ + 写 healthy_marker
+//   - upgrademachine（supervisor 侧）— swap + rollback + 状态机编排 + IPC 常量单一真相源
+//
+// 文件系统 IPC（常量定义在 upgrademachine 包，两侧共享引用）：
+//
+//	<StageDir>/incoming/MANIFEST.txt — 存在 = pending upgrade 触发器
+//	<StageDir>/incoming/VERSION     — bundle 版本号
+//	<StageDir>/healthy_marker       — register_edge 成功后写的版本号
+//	<StageDir>/rollback.done        — rollback 完成 sentinel（本包负责清理）
+//
+// 本包纯 Go（无 Windows 专属依赖），Linux CI 可测。
+package upgradebundle

--- a/internal/edgeagent/upgradebundle/download.go
+++ b/internal/edgeagent/upgradebundle/download.go
@@ -1,0 +1,259 @@
+// download.go 实现 worker 侧的 bundle 下载 + sha256 校验 + 解压。
+// 对称 Linux 侧 biz/handleFetchPackage，但作为独立纯函数 API（不绑定 Agent 结构体），
+// 可被 Windows worker / 测试 / RPC handler 直接调用。
+// 流程（all-or-nothing，任何步骤失败都清理残留）：
+//  1. 校验输入（URL 协议、sha256 格式）
+//  2. 清理旧残留（incoming/ + incoming.tar.gz）
+//  3. 流式下载 → incoming.tar.gz（边下边算 sha256）
+//  4. sha256 校验（不信任下载内容）
+//  5. 解压 → incoming/（拒绝路径逃逸、symlink、超限）
+//  6. 删 tarball（只保留解压后的树）
+//  7. 验证 incoming/MANIFEST.txt（per-file sha256 all-or-nothing）
+// 成功后 incoming/MANIFEST.txt 存在 = 触发器就绪，supervisor 检测到此文件 → swap。
+
+package upgradebundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// maxBundleBytes 限制接受的最大 bundle 大小（解压后）。
+// 对称 biz/upgrade_package.go 的 maxBundleBytes（1 GB）。
+const maxBundleBytes = 1024 * 1024 * 1024
+
+// downloadTimeout 是单次下载的最大时长。
+const downloadTimeout = 45 * time.Minute
+
+// bundleTarballName 是下载暂存的 tarball 文件名（解压后删除）。
+const bundleTarballName = "incoming.tar.gz"
+
+// DownloadBundle 从 downloadURL 下载 .tar.gz bundle，校验 sha256，解压到
+// stageDir/incoming/，并验证 MANIFEST.txt 中每个文件的 sha256。
+// 返回 (下载字节数, manifest 文件数, error)。
+// 成功后 stageDir/incoming/MANIFEST.txt 存在（= pending upgrade 触发器）。
+// 任何步骤失败时清理所有残留文件（tarball + incoming/），不留半成品。
+// ctx 用于请求级取消（RPC 超时、客户端断开）。内部用 downloadTimeout
+// 作为上限封顶，避免慢网络无限挂起。ctx.Done() 触发时 HTTP 请求中止。
+// client 为 nil 时使用 http.DefaultClient。调用方可注入跳过 TLS 验证的
+// client（私有部署自签名 nginx 场景，对称 biz.bundleDownloadClient）。
+//
+// 函数内 `_ =` 清理调用（删 tarball / incoming/ / sentinel）：均位于主错误
+// 即将返回或幂等重置的路径上，清理失败无独立处理手段且下次调用入口会再次
+// 幂等清理，故显式丢弃。
+func DownloadBundle(ctx context.Context, client *http.Client, downloadURL, expectedSHA, stageDir string) (int64, int, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// 1. 校验输入。
+	expectedSHA = strings.ToLower(strings.TrimSpace(expectedSHA))
+	if len(expectedSHA) != 64 {
+		return 0, 0, fmt.Errorf("download_bundle: sha256 must be 64 hex chars (got %d)", len(expectedSHA))
+	}
+	for _, c := range expectedSHA {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return 0, 0, fmt.Errorf("download_bundle: sha256 not lower-hex")
+		}
+	}
+	url := strings.TrimSpace(downloadURL)
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return 0, 0, fmt.Errorf("download_bundle: url must be http(s)")
+	}
+
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return 0, 0, fmt.Errorf("download_bundle: mkdir stage: %w", err)
+	}
+
+	tarballPath := filepath.Join(stageDir, bundleTarballName)
+	incomingPath := filepath.Join(stageDir, upgrademachine.IncomingDirName)
+
+	// 2. 清理旧残留（幂等）。含 rollback.done sentinel：
+	// 上次 rollback 残留的 sentinel 必须在新升级下载前清掉，否则 superviseWorker
+	//（cmd/ongrid-edge-supervisor/worker.go:80）检测到 sentinel → watchUpgrade=false
+	// → 跳过新升级的 health watch → 坏 bundle 不触发 rollback → brick。
+	// edge 自治清理（而非 manager RPC），因为 manager 是远程进程不持有 edge 本地文件系统。
+	_ = os.Remove(tarballPath)
+	_ = os.RemoveAll(incomingPath)
+	_ = DeleteRollbackSentinel(stageDir)
+
+	// 3-4. 下载 + sha256 校验。
+	n, err := downloadAndVerify(ctx, client, url, expectedSHA, tarballPath)
+	if err != nil {
+		_ = os.Remove(tarballPath)
+		return 0, 0, fmt.Errorf("download_bundle: %w", err)
+	}
+
+	// 5. 解压 → incoming/。
+	if err := extractTarGz(tarballPath, incomingPath); err != nil {
+		_ = os.Remove(tarballPath)
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: extract: %w", err)
+	}
+
+	// 6. 删 tarball（只保留解压后的树）。
+	_ = os.Remove(tarballPath)
+
+	// 7. 验证 MANIFEST.txt（per-file sha256 all-or-nothing）。
+	manifestPath := filepath.Join(incomingPath, upgrademachine.ManifestFileName)
+	entries, err := upgrademachine.ParseManifest(manifestPath)
+	if err != nil {
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: manifest parse: %w", err)
+	}
+	if err := upgrademachine.VerifyAll(incomingPath, entries); err != nil {
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: manifest verify: %w", err)
+	}
+
+	return n, len(entries), nil
+}
+
+// downloadAndVerify 流式下载 url 到 out，边下边算 sha256，校验后返回字节数。
+// 失败时删除 out 文件。ctx 用上层 RPC 的 context（可取消），内部用
+// downloadTimeout 封顶防止慢网络无限挂起。
+//
+// 各失败分支的 `_ = f.Close()` / `_ = os.Remove(out)`：主错误已确定并即将
+// 返回，cleanup 的次要错误无独立处理手段（文件句柄随进程回收，残留 out 由
+// 下次 DownloadBundle 入口的幂等清理删除），故显式丢弃。
+func downloadAndVerify(ctx context.Context, client *http.Client, url, expectedSHA, out string) (int64, error) {
+	// downloadTimeout 作为上限封顶；ctx 自身的 deadline 可能更短（RPC 超时）。
+	dlCtx, cancel := context.WithTimeout(ctx, downloadTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(dlCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build req: %w", err)
+	}
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return 0, fmt.Errorf("get: %w", err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("get: status %d", httpResp.StatusCode)
+	}
+
+	f, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return 0, fmt.Errorf("open: %w", err)
+	}
+	hasher := sha256.New()
+	n, err := io.Copy(io.MultiWriter(f, hasher), io.LimitReader(httpResp.Body, maxBundleBytes+1))
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("stream: %w", err)
+	}
+	if n > maxBundleBytes {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("bundle too large (%d > %d)", n, maxBundleBytes)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("sync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("close: %w", err)
+	}
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != expectedSHA {
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("sha256 mismatch (got %s, want %s)", got, expectedSHA)
+	}
+	return n, nil
+}
+
+// extractTarGz 解压 src（.tar.gz）到 dst。
+// 安全措施：拒绝路径逃逸（zip-slip）、symlink/hardlink、超限总大小。
+func extractTarGz(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return fmt.Errorf("mkdir dst: %w", err)
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("abs dst: %w", err)
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		// 只接受普通文件和目录（拒绝 symlink/hardlink/device）。
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeDir:
+		default:
+			return fmt.Errorf("disallowed tar entry type %v in %q", hdr.Typeflag, hdr.Name)
+		}
+		cleaned := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(cleaned, "/") || strings.Contains(cleaned, "..") {
+			return fmt.Errorf("disallowed tar path %q (escapes archive root)", hdr.Name)
+		}
+		target := filepath.Join(absDst, cleaned)
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("abs target: %w", err)
+		}
+		if !upgrademachine.EqualFoldPrefix(absTarget, absDst+string(os.PathSeparator)) && !strings.EqualFold(absTarget, absDst) {
+			return fmt.Errorf("target %q escapes %q", absTarget, absDst)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("mkdir parent of %s: %w", target, err)
+		}
+		w, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+			os.FileMode(hdr.Mode)&0o755)
+		if err != nil {
+			return fmt.Errorf("open out %s: %w", target, err)
+		}
+		n, err := io.Copy(w, io.LimitReader(tr, maxBundleBytes-totalBytes+1))
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", target, err)
+		}
+		totalBytes += n
+		if totalBytes > maxBundleBytes {
+			return fmt.Errorf("extracted size exceeded %d bytes", maxBundleBytes)
+		}
+	}
+	return nil
+}

--- a/internal/edgeagent/upgradebundle/download_test.go
+++ b/internal/edgeagent/upgradebundle/download_test.go
@@ -1,0 +1,336 @@
+package upgradebundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeBundle 构造一个合法的 .tar.gz bundle 字节流。
+// 文件映射：name → content。自动生成对应的 MANIFEST.txt（每行
+// `<sha256> <mode> <src> <dest>` 格式）。
+func makeBundle(t *testing.T, files map[string]string, includeManifest bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	var manifestLines []string
+
+	// 先写普通文件
+	for name, content := range files {
+		h := sha256.Sum256([]byte(content))
+		sha := hex.EncodeToString(h[:])
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+		// manifest 行：sha / mode / src(incoming 相对) / dest(绝对路径占位)
+		manifestLines = append(manifestLines, fmt.Sprintf("%s 0755 %s /usr/local/bin/%s", sha, name, name))
+	}
+
+	if includeManifest {
+		manifest := strings.Join(manifestLines, "\n") + "\n"
+		if err := tw.WriteHeader(&tar.Header{
+			Name: "MANIFEST.txt",
+			Mode: 0644,
+			Size: int64(len(manifest)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(manifest)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// bundleSHA256 计算 bundle 字节流的 sha256（供 DownloadBundle 的 expectedSHA 参数用）。
+func bundleSHA256(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// TestDownloadBundle_Success 验证完整正常路径：
+// 下载 → sha256 校验 → 解压 → manifest 验证 → incoming/MANIFEST.txt 就绪。
+func TestDownloadBundle_Success(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{
+		"worker": "fake binary content",
+	}, true)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	expectedSHA := bundleSHA256(bundleData)
+
+	n, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, expectedSHA, dir)
+	if err != nil {
+		t.Fatalf("DownloadBundle: %v", err)
+	}
+	if n != int64(len(bundleData)) {
+		t.Errorf("bytes = %d, want %d", n, len(bundleData))
+	}
+
+	// 触发器就绪：incoming/MANIFEST.txt 存在
+	manifestPath := filepath.Join(dir, "incoming", "MANIFEST.txt")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("MANIFEST.txt should exist at %s: %v", manifestPath, err)
+	}
+
+	// tarball 应被删除（只保留解压后的文件）
+	if _, err := os.Stat(filepath.Join(dir, "incoming.tar.gz")); !os.IsNotExist(err) {
+		t.Error("incoming.tar.gz should be removed after extract")
+	}
+}
+
+// TestDownloadBundle_SHA256Mismatch 验证 sha256 不匹配时报错 + 清理。
+func TestDownloadBundle_SHA256Mismatch(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{"worker": "x"}, true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		"0000000000000000000000000000000000000000000000000000000000000000", dir)
+	if err == nil {
+		t.Fatal("expected sha mismatch error")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error should mention sha256 mismatch, got: %v", err)
+	}
+
+	// tarball 应被删除
+	if _, err := os.Stat(filepath.Join(dir, "incoming.tar.gz")); !os.IsNotExist(err) {
+		t.Error("tarball should be removed on sha mismatch")
+	}
+	// incoming/ 不应存在（sha 校验在解压前）
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should not exist when sha fails before extract")
+	}
+}
+
+// TestDownloadBundle_BadURL 验证非 http(s) URL 被拒绝。
+func TestDownloadBundle_BadURL(t *testing.T) {
+	dir := t.TempDir()
+	// 传合法 sha256 格式，确保报错来自 URL 校验而非 sha
+	validSHA := hex.EncodeToString(make([]byte, 32))
+	_, _, err := DownloadBundle(context.Background(), http.DefaultClient, "ftp://example.com/bundle.tar.gz",
+		validSHA, dir)
+	if err == nil || !strings.Contains(err.Error(), "must be http(s)") {
+		t.Errorf("expected URL protocol error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_BadSHAFormat 验证 sha256 格式校验。
+func TestDownloadBundle_BadSHAFormat(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), http.DefaultClient, "http://example.com/x",
+		"tooshort", dir)
+	if err == nil || !strings.Contains(err.Error(), "sha256 must be 64") {
+		t.Errorf("expected sha format error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_HTTP404 验证 HTTP 错误状态码。
+func TestDownloadBundle_HTTP404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256([]byte("x")), dir)
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Errorf("expected HTTP 404 error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_ManifestVerifyFail 验证 manifest per-file sha 不匹配时报错。
+// 构造一个 MANIFEST.txt 声明的 sha 与实际文件不符的 bundle。
+func TestDownloadBundle_ManifestVerifyFail(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// 写一个内容固定的文件
+	content := []byte("real content")
+	tw.WriteHeader(&tar.Header{Name: "worker", Mode: 0644, Size: int64(len(content))})
+	tw.Write(content)
+
+	// MANIFEST.txt 声明一个错误的 sha
+	badManifest := fmt.Sprintf("%s 0755 worker /usr/local/bin/worker\n",
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	tw.WriteHeader(&tar.Header{Name: "MANIFEST.txt", Mode: 0644, Size: int64(len(badManifest))})
+	tw.Write([]byte(badManifest))
+
+	tw.Close()
+	gz.Close()
+	bundleData := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, bundleSHA256(bundleData), dir)
+	if err == nil {
+		t.Fatal("expected manifest verify error")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Errorf("error should mention manifest, got: %v", err)
+	}
+
+	// 失败后 incoming/ 应被清理
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should be cleaned up after manifest verify failure")
+	}
+}
+
+// TestDownloadBundle_CleansStaleIncoming 验证下载前清理旧残留（幂等）。
+func TestDownloadBundle_CleansStaleIncoming(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{"worker": "new"}, true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	// 放一个旧的 incoming/ 目录 + 旧 tarball
+	oldIncoming := filepath.Join(dir, "incoming")
+	os.MkdirAll(oldIncoming, 0o750)
+	os.WriteFile(filepath.Join(oldIncoming, "MANIFEST.txt"), []byte("stale"), 0o640)
+	os.WriteFile(filepath.Join(dir, "incoming.tar.gz"), []byte("stale"), 0o640)
+
+	expectedSHA := bundleSHA256(bundleData)
+	if _, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, expectedSHA, dir); err != nil {
+		t.Fatalf("DownloadBundle: %v", err)
+	}
+
+	// 旧 MANIFEST.txt 应被新内容覆盖
+	got, _ := os.ReadFile(filepath.Join(oldIncoming, "MANIFEST.txt"))
+	if strings.Contains(string(got), "stale") {
+		t.Error("stale MANIFEST.txt should be replaced")
+	}
+}
+
+// TestDownloadBundle_ClearsRollbackSentinel 验证下载前清理 rollback.done sentinel。
+// rollback 后 supervisor 写 rollback.done → 下次升级 DownloadBundle 必须清理，
+// 否则 superviseWorker（worker.go:80）检测到 sentinel → watchUpgrade=false → 跳过
+// 新升级的 health watch → 坏 bundle 不触发 rollback → brick。
+func TestDownloadBundle_ClearsRollbackSentinel(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{"worker": "new"}, true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	// 模拟上次 rollback 残留的 sentinel
+	sentinelPath := filepath.Join(dir, RollbackDoneFile)
+	if err := os.WriteFile(sentinelPath, []byte("done\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSHA := bundleSHA256(bundleData)
+	if _, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, expectedSHA, dir); err != nil {
+		t.Fatalf("DownloadBundle: %v", err)
+	}
+
+	// rollback.done 必须被清理
+	if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+		t.Error("rollback.done sentinel should be removed before download ()")
+	}
+}
+
+// TestDownloadBundle_RejectsPathEscape 验证 tar 条目含 ../ 时解压被拒绝。
+func TestDownloadBundle_RejectsPathEscape(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	tw.WriteHeader(&tar.Header{Name: "../escape.txt", Mode: 0644, Size: 1})
+	tw.Write([]byte("x"))
+	tw.Close()
+	gz.Close()
+	evilBundle := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(evilBundle)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256(evilBundle), dir)
+	if err == nil {
+		t.Fatal("expected path escape rejection")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Errorf("error should mention escape, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should be cleaned after path escape rejection")
+	}
+}
+
+// TestDownloadBundle_RejectsSymlink 验证 tar 条目含 symlink 时被拒绝。
+func TestDownloadBundle_RejectsSymlink(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	tw.WriteHeader(&tar.Header{
+		Name:     "evil",
+		Linkname: "/etc/passwd",
+		Typeflag: tar.TypeSymlink,
+	})
+	tw.Close()
+	gz.Close()
+	symlinkBundle := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(symlinkBundle)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256(symlinkBundle), dir)
+	if err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "disallowed tar entry type") {
+		t.Errorf("error should mention disallowed type, got: %v", err)
+	}
+}

--- a/internal/edgeagent/upgradebundle/health.go
+++ b/internal/edgeagent/upgradebundle/health.go
@@ -1,0 +1,59 @@
+// health.go 实现 worker 侧的健康标记 + rollback sentinel 管理。
+// 常量引用 upgrademachine 包（单一真相源），消除跨包 drift。
+
+package upgradebundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// HealthyMarkerFile 是 register_edge 成功后写的版本号文件名。
+// 引用 upgrademachine.HealthyMarkerFile（单一真相源）。
+const HealthyMarkerFile = upgrademachine.HealthyMarkerFile
+
+// RollbackDoneFile 是 rollback 完成后的 sentinel 文件名。
+// 引用 upgrademachine.RollbackDoneFile（单一真相源）。
+const RollbackDoneFile = upgrademachine.RollbackDoneFile
+
+// WriteHealthyMarker 在 register_edge 成功后写 <stageDir>/healthy_marker。
+// 内容 = version + "\n"。supervisor 的 Machine.HealthPoll 检测到此文件
+// 内容匹配 last_upgrade_ver 时判定升级成功。
+// 空 version 时跳过（不报错）— 适配 dev 模式或未配 AgentVersion 的场景。
+// stageDir 不存在时自动创建。
+func WriteHealthyMarker(stageDir, version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil
+	}
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	path := filepath.Join(stageDir, HealthyMarkerFile)
+	if err := os.WriteFile(path, []byte(version+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write healthy_marker: %w", err)
+	}
+	return nil
+}
+
+// DeleteRollbackSentinel 删除 <stageDir>/rollback.done sentinel 文件。
+// DownloadBundle 步骤 2（download.go 清理旧残留段）自动调用此函数，
+// 保证新升级下载前清掉上次 rollback 留下的 sentinel —— 否则 superviseWorker
+// （cmd/ongrid-edge-supervisor/worker.go:80）检测到 rollback.done → watchUpgrade=false
+// → 跳过新升级的 health watch → 坏 bundle 不触发 rollback → brick。
+// 设计说明：原  注释承诺 "manager 推送入口" 清理，但代码考古证明 manager
+// 是远程进程（部署在 manager），不持有 edge 本地 stageDir → 物理上无法直接删文件。
+// 真实架构是 manager 通过 fetch_package RPC 触发 edge 的 DownloadBundle，
+// 因此清理责任归 edge 自治（与 incoming/ + tarball 清理同构）。
+// 幂等：文件不存在时返回 nil（首次升级或已清理）。
+func DeleteRollbackSentinel(stageDir string) error {
+	path := filepath.Join(stageDir, RollbackDoneFile)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove rollback.done: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/upgradebundle/health_test.go
+++ b/internal/edgeagent/upgradebundle/health_test.go
@@ -1,0 +1,89 @@
+package upgradebundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteHealthyMarker_WritesVersion 验证正常路径：写 healthy_marker 文件，
+// 内容 = version + "\n"，权限 0640。
+func TestWriteHealthyMarker_WritesVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteHealthyMarker: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, HealthyMarkerFile))
+	if err != nil {
+		t.Fatalf("read healthy_marker: %v", err)
+	}
+	if string(got) != "v0.7.50\n" {
+		t.Errorf("healthy_marker = %q, want %q", got, "v0.7.50\n")
+	}
+}
+
+// TestWriteHealthyMarker_EmptyVersion 验证空版本号幂等跳过（不报错、不写文件）。
+func TestWriteHealthyMarker_EmptyVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, ""); err != nil {
+		t.Fatalf("empty version should not error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should not be written for empty version")
+	}
+}
+
+// TestWriteHealthyMarker_CreatesDir 验证 stage dir 不存在时自动创建。
+func TestWriteHealthyMarker_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "upgrade")
+
+	if err := WriteHealthyMarker(dir, "v1.0.0"); err != nil {
+		t.Fatalf("should create nested dir: %v", err)
+	}
+}
+
+// TestWriteHealthyMarker_OverwritesExisting 验证幂等覆盖（多次 register_edge 场景）。
+func TestWriteHealthyMarker_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, "v0.7.49"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHealthyMarker(dir, "v0.7.50"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, HealthyMarkerFile))
+	if string(got) != "v0.7.50\n" {
+		t.Errorf("after overwrite = %q, want %q", got, "v0.7.50\n")
+	}
+}
+
+// TestDeleteRollbackSentinel_RemovesExisting 验证存在时删除。
+func TestDeleteRollbackSentinel_RemovesExisting(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, RollbackDoneFile)
+	if err := os.WriteFile(sentinel, []byte("done\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteRollbackSentinel(dir); err != nil {
+		t.Fatalf("DeleteRollbackSentinel: %v", err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("rollback.done should be removed")
+	}
+}
+
+// TestDeleteRollbackSentinel_Idempotent 验证不存在时幂等（不报错）。
+func TestDeleteRollbackSentinel_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// rollback.done 不存在
+
+	if err := DeleteRollbackSentinel(dir); err != nil {
+		t.Fatalf("should not error when sentinel missing: %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply.go
+++ b/internal/edgeagent/upgrademachine/apply.go
@@ -1,0 +1,205 @@
+// apply.go 实现 bundle swap 算法。
+//
+// 对称 Linux apply-pending-upgrade.sh 的 bundle apply 模式：
+//  1. 预检：验证所有 src 的 sha256（all-or-nothing，半换比不换更糟）
+//  2. 对每条 entry：
+//     a. 如果 dest 存在 → copy(dest, dest.previous)（备份）
+//     b. copy(src, dest.new)（暂存到 dest 同目录，保证同卷原子 rename）
+//     c. rename(dest.new, dest)（原子替换）
+//
+// Windows 特殊考虑：
+//   - os.Rename 在同目录下是原子的（底层 MoveFileExW + MOVEFILE_REPLACE_EXISTING）
+//   - copy 到 dest.new 而非直接 rename src→dest，因为 incoming/ 和 dest 可能跨卷
+//   - 残留 dest.new（上次崩溃）在步骤 b 被覆盖，幂等
+//
+// context 约定例外：ApplyBundle 操作本地文件系统（秒级），
+// 是原子事务语义（all-or-nothing），中途取消比跑完更危险（半 swap 状态）。
+// 取消检查由编排层 Machine.Apply 在入口处完成（ctx.Err guard），
+// 进入 ApplyBundle 后操作不可取消。故不接收 context.Context 参数。
+
+package upgrademachine
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ApplyResult 记录 swap 结果，供调用方决策（日志 + 是否触发 rollback）。
+type ApplyResult struct {
+	Swapped  []string // 成功 swap 的 dest 路径
+	BackedUp []string // 创建的 .previous 备份路径
+	Staged   []string // supervisor.exe.new 暂存路径（未 rename，等 SupervisorSelfSwap）
+}
+
+// ApplyBundle 执行 MANIFEST 中所有条目的 swap。
+//
+// 预检阶段（VerifyAll）失败时立即返回，不触碰任何 dest 文件。
+// swap 阶段中单条 entry 失败时执行失败自恢复：对本次已备份的
+// 全部条目（BackedUp 集合，含未及改名的）逆序恢复 + 清理 supervisor 暂存文件
+// 与升级哨兵，然后返回 error。恢复集必须含未换条目 — 残留 .previous 与合法
+// 备份同形，会阻断/污染下次 apply。
+//
+// stageDir 用于写 supervisor_upgrade.pending sentinel。
+// 当 entry.Dest 是 supervisor.exe 时，只 stage .new + 写 sentinel，不 rename。
+// log 用于 renameWithAVRetry 的 AV 重试日志（nil 时重试静默，仍重试）。
+func ApplyBundle(stageDir, incomingDir string, log *slog.Logger, entries []ManifestEntry) (*ApplyResult, error) {
+	// 预检：所有 src 的 sha 必须验证通过
+	if err := VerifyAll(incomingDir, entries); err != nil {
+		return nil, fmt.Errorf("pre-verify aborted: %w", err)
+	}
+
+	result := &ApplyResult{}
+	for _, e := range entries {
+		if err := applyOne(stageDir, incomingDir, log, e, result); err != nil {
+			recErr := recoverFailedApply(stageDir, result)
+			if recErr != nil {
+				return result, fmt.Errorf("swap %s: %w (recovery failed: %w)", e.Src, err, recErr)
+			}
+			return result, fmt.Errorf("swap %s: %w (recovered %d backups, supervisor staging cleaned)",
+				e.Src, err, len(result.BackedUp))
+		}
+	}
+	return result, nil
+}
+
+// recoverFailedApply 是 apply 失败自恢复。
+//
+// 幂等性：BackedUp 条目 rename 回原路径 — 已改名条目 = 恢复旧版本，未及改名
+// 条目 = 同内容原地替换；rename 语义与 Rollback 一致（同目录原子替换）。
+// 恢复失败不静默：返回 error（调用方把它与原始 swap 错误一起传播，残留态由
+// 下次 apply 入口的收敛兜底）。
+func recoverFailedApply(stageDir string, result *ApplyResult) error {
+	var errs []error
+	// 逆序恢复已备份全集（含未及改名条目 — 它们的 .previous 同样是残留物）
+	for i := len(result.BackedUp) - 1; i >= 0; i-- {
+		prevPath := result.BackedUp[i]
+		target := strings.TrimSuffix(prevPath, PreviousSuffix)
+		if err := os.Rename(prevPath, target); err != nil {
+			errs = append(errs, fmt.Errorf("restore %s: %w", prevPath, err))
+		}
+	}
+	// 清理 supervisor 暂存 .new + pending 哨兵 — 失败 bundle 不得在下次启动
+	// 越权触发 supervisor self-swap（swap 的是本轮 stage 的 .new，非受控状态）
+	if err := cleanupSupervisorStaging(stageDir, result.Staged...); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// isSupervisorBinary 判断 dest 是否指向 supervisor.exe。
+// applyOne 用此决定走 stage-only 路径还是标准 swap 路径。
+// EqualFold：与 KillManifestExes / destBaseAllowed 比较语义统一 —
+// 区分大小写比较会被大小写变体绕过 supervisor 保护（走标准 swap 路径撞 image 锁）。
+func isSupervisorBinary(dest string) bool {
+	return strings.EqualFold(destBase(dest), SupervisorBinaryName)
+}
+
+// applyOne 执行单条 entry 的 swap：backup → stage → atomic rename。
+//
+// supervisor.exe special-case：运行中的 supervisor.exe 无法被
+// 原子 rename（image loader 持有 image section）。改为只 stage .new + 写
+// pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。
+func applyOne(stageDir, incomingDir string, log *slog.Logger, e ManifestEntry, result *ApplyResult) error {
+	srcPath := filepath.Join(incomingDir, e.Src)
+	destDir := filepath.Dir(e.Dest)
+
+	// 确保 dest 父目录存在（首次安装路径可能不存在）
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir dest dir %s: %w", destDir, err)
+	}
+
+	// supervisor.exe special-case：stage .new + 写 pending sentinel，不 backup / rename
+	if isSupervisorBinary(e.Dest) {
+		newPath := e.Dest + ".new"
+		if err := copyFile(srcPath, newPath); err != nil {
+			return fmt.Errorf("supervisor stage to %s: %w", newPath, err)
+		}
+		if e.Mode != "" {
+			_ = os.Chmod(newPath, parseMode(e.Mode))
+		}
+		if err := WriteSupervisorUpgradePending(stageDir, ""); err != nil {
+			return fmt.Errorf("write supervisor pending sentinel: %w", err)
+		}
+		result.Staged = append(result.Staged, newPath)
+		return nil
+	}
+
+	// 备份：dest 存在 → copy(dest, dest.previous)
+	if _, err := os.Stat(e.Dest); err == nil {
+		prevPath := e.Dest + PreviousSuffix
+		if err := copyFile(e.Dest, prevPath); err != nil {
+			return fmt.Errorf("backup to %s: %w", prevPath, err)
+		}
+		result.BackedUp = append(result.BackedUp, prevPath)
+	}
+
+	// 暂存：copy(src, dest.new) — 同目录保证后续 rename 原子
+	newPath := e.Dest + ".new"
+	if err := copyFile(srcPath, newPath); err != nil {
+		return fmt.Errorf("stage to %s: %w", newPath, err)
+	}
+
+	// 应用 mode（Windows 上仅 read-only bit 有效，但保持语义一致）
+	if e.Mode != "" {
+		_ = os.Chmod(newPath, parseMode(e.Mode)) // 失败不阻断（Windows 忽略）
+	}
+
+	// 原子替换：rename(dest.new, dest) — 同目录 = 同卷，原子。
+	// 走 renameWithAVRetry（与 SupervisorSelfSwap 同一容错标准）：KillTree/
+	// KillByImage 后 AV/EDR 可能仍短暂持有 dest 句柄，裸 rename 会瞬时失败。
+	if err := renameWithAVRetry(newPath, e.Dest, log); err != nil {
+		_ = os.Remove(newPath) // best-effort 清理暂存文件；rename 已失败，清理失败也无处理手段
+		return fmt.Errorf("rename %s → %s: %w", newPath, e.Dest, err)
+	}
+
+	result.Swapped = append(result.Swapped, e.Dest)
+	return nil
+}
+
+// copyFile 是 src → dst 的完整拷贝（内容 + 权限）。
+// 不用 os.Rename 是因为 src 和 dst 可能跨卷（incoming/ 在 ProgramData，
+// dest 在 Program Files）。
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat src: %w", err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("create dst: %w", err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return fmt.Errorf("copy: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("close dst: %w", err)
+	}
+	return nil
+}
+
+// parseMode 将 "0755" 等字符串转为 os.FileMode。
+func parseMode(s string) os.FileMode {
+	var m uint32
+	for _, c := range s {
+		if c >= '0' && c <= '7' {
+			m = m<<3 | uint32(c-'0')
+		}
+	}
+	return os.FileMode(m)
+}

--- a/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
+++ b/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
@@ -1,0 +1,330 @@
+// apply_cycle_windows_test.go — kill 后文件锁释放时序的反馈循环测试（Windows-only）。
+//
+// 复现核心场景：worker 退出后 plugin 进程 orphaned → .exe 文件锁 →
+// ApplyBundle rename 失败（Access denied）。
+//
+// 本测试不模拟 orphaned 路径（PID 1 reparenting 是内核行为，无法用 Go 模拟），
+// 而是直接测试核心时序问题：
+//   1. 启动 promtail.exe（持有自身 .exe 文件锁）
+//   2. taskkill /F /IM promtail.exe（windowsProcessController.KillByImage）
+//   3. 立即 ApplyBundle rename promtail.exe
+//   4. 验证 rename 是否成功（若失败则 bug 复现）
+//
+// 如果 taskkill 返回后文件锁未及时释放（race condition），本测试会 Access denied。
+//
+// 这是 Phase 1 的 tight feedback loop：秒级、deterministic、agent-runnable。
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sleeperOnce 保证 sleeper.exe 只编译一次（所有 subtests 共用）。
+var (
+	sleeperOnce sync.Once
+	sleeperPath string
+	sleeperErr  error
+)
+
+// buildSleeper 编译 sleeper_main.go → sleeper.exe，所有测试共用。
+// 首次调用 ~3-5s，后续调用 0s（cache 在 t.TempDir 外的固定路径）。
+func buildSleeper(t *testing.T) string {
+	t.Helper()
+	sleeperOnce.Do(func() {
+		out := filepath.Join(os.TempDir(), "ongrid-sleeper.exe")
+		src := filepath.Join("testdata", "sleeper_main.go")
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			sleeperErr = fmt.Errorf("go build sleeper: %w\noutput: %s", err, out)
+			return
+		}
+		sleeperPath = out
+	})
+	if sleeperErr != nil {
+		t.Fatal(sleeperErr)
+	}
+	return sleeperPath
+}
+
+// realWindowsPC 是真实的 Windows ProcessController（taskkill 实现）。
+// 对称 cmd/ongrid-edge-supervisor/upgrade_windows.go 的 windowsProcessController，
+// 但放在测试包中避免循环依赖（cmd/ 不能被 import）。
+type realWindowsPC struct{}
+
+func (realWindowsPC) KillTree(pid int) error {
+	return exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}
+
+func (realWindowsPC) KillByImage(name string) error {
+	return exec.Command("taskkill", "/F", "/IM", name).Run()
+}
+
+// copyFileExe / appendMarker / copyStream 已提取到 dummy_helper_test.go（跨平台共用）。
+
+// TestKillByImageReleaseTiming 是 kill-锁释放反馈循环的核心验证：
+// KillByImage 返回后立即尝试 ApplyBundle rename .exe → 是否 Access denied。
+//
+// 失败（t.Errorf "BUG REPRODUCED"）= 文件锁未及时释放的根因确认。
+// 成功 = 当前实现（KillManifestExes）在测试场景下工作正常。
+func TestKillByImageReleaseTiming(t *testing.T) {
+	sleeper := buildSleeper(t)
+
+	// 铺地板：dest 目录有 promtail.exe（旧版本）
+	destDir := t.TempDir()
+	destExe := filepath.Join(destDir, "promtail.exe")
+	copyFileExe(t, sleeper, destExe)
+	appendMarker(t, destExe, "OLD-VERSION\n")
+
+	// 启动 destExe（持有自身 .exe 文件锁）
+	cmd := exec.Command(destExe)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start plugin: %v", err)
+	}
+	t.Logf("plugin started pid=%d", cmd.Process.Pid)
+	// 测试结束确保清理
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// 短暂等待进程完全启动（加载 image、初始化）
+	time.Sleep(200 * time.Millisecond)
+
+	// 铺地板：incoming/ 有新版本 promtail.exe
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	if err := os.MkdirAll(incoming, 0o755); err != nil {
+		t.Fatalf("mkdir incoming: %v", err)
+	}
+	srcExe := filepath.Join(incoming, "promtail.exe")
+	copyFileExe(t, sleeper, srcExe)
+	appendMarker(t, srcExe, "NEW-VERSION\n")
+
+	// 写 MANIFEST.txt
+	sha := shaFile(t, srcExe)
+	manifestLine := sha + " 0755 promtail.exe " + destExe + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifestLine)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v0.9.1-test\n")
+
+	// 准备 Machine（PID=0 跳过 KillTree；KillManifestExes 会触发）
+	m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+
+	start := time.Now()
+	err := m.Apply(context.Background(), 0)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("BUG REPRODUCED: Machine.Apply failed after KillByImage (elapsed=%v): %v",
+			elapsed, err)
+		// 尝试找出实际释放延迟
+		probeReleaseDelay(t, destExe, srcExe)
+		return
+	}
+
+	t.Logf("Apply succeeded in %v — KillByImage 释放了文件锁（测试场景无 race）", elapsed)
+
+	// 验证 swap 完成状态
+	got, _ := os.ReadFile(destExe)
+	if !strings.Contains(string(got), "NEW-VERSION") {
+		t.Errorf("dest content = %q, want contains NEW-VERSION", got)
+	}
+}
+
+// probeReleaseDelay 在 bug 复现时探测 taskkill 后的实际文件锁释放延迟。
+// 不是测试断言，而是诊断输出。
+func probeReleaseDelay(t *testing.T, destExe, srcExe string) {
+	t.Helper()
+	t.Logf("--- probing file lock release delay ---")
+	newPath := destExe + ".new"
+	for _, delay := range []time.Duration{
+		10 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+	} {
+		time.Sleep(delay)
+		// 重新 stage
+		copyFileExe(t, srcExe, newPath)
+		err := os.Rename(newPath, destExe)
+		if err == nil {
+			t.Logf("rename succeeded after cumulative delay ~%v: %v", delay, err)
+			return
+		}
+		t.Logf("  after %v: %v", delay, err)
+	}
+	t.Logf("rename never succeeded within probe window — promtail.exe 仍被持有")
+}
+
+// shaFile 计算文件 sha256 hex（用于 MANIFEST.txt 行）。
+func shaFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestKillByImageRelease_MultiCycle 是 kill-锁释放的核心验收测试：
+// 连续 10 次升级循环，每次都启动 promtail.exe → KillByImage → rename。
+// 验收标准：所有循环成功，无残留进程。
+//
+// 若任一循环失败（Access denied）= bug 复现，记录循环号 + 错误。
+func TestKillByImageRelease_MultiCycle(t *testing.T) {
+	sleeper := buildSleeper(t)
+	const cycles = 10
+
+	// 复用同一个 destDir 模拟生产场景（文件锁可能累积）
+	destDir := t.TempDir()
+	destExe := filepath.Join(destDir, "promtail.exe")
+	copyFileExe(t, sleeper, destExe)
+	appendMarker(t, destExe, "BASE\n")
+
+	var runningPIDs []int
+	defer func() {
+		// 测试结束清理所有可能残留的进程
+		for _, pid := range runningPIDs {
+			_ = exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run()
+		}
+	}()
+
+	for i := 0; i < cycles; i++ {
+		// 启动当前 destExe（持有 .exe 锁）
+		cmd := exec.Command(destExe)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("cycle %d: start plugin: %v", i, err)
+		}
+		runningPIDs = append(runningPIDs, cmd.Process.Pid)
+		time.Sleep(100 * time.Millisecond) // 等待进程完全加载
+
+		// 准备 incoming（每轮内容不同 — version marker）
+		stageDir := t.TempDir()
+		incoming := filepath.Join(stageDir, IncomingDirName)
+		if err := os.MkdirAll(incoming, 0o755); err != nil {
+			t.Fatalf("cycle %d: mkdir incoming: %v", i, err)
+		}
+		srcExe := filepath.Join(incoming, "promtail.exe")
+		copyFileExe(t, sleeper, srcExe)
+		appendMarker(t, srcExe, fmt.Sprintf("CYCLE-%d\n", i))
+
+		sha := shaFile(t, srcExe)
+		writeTestFile(t, filepath.Join(incoming, ManifestFileName),
+			sha+" 0755 promtail.exe "+destExe+"\n")
+		writeTestFile(t, filepath.Join(incoming, VersionFileName),
+			fmt.Sprintf("v0.9.%d\n", i+1))
+
+		m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+		start := time.Now()
+		err := m.Apply(context.Background(), 0)
+		elapsed := time.Since(start)
+		t.Logf("cycle %d: Apply elapsed=%v err=%v", i, elapsed, err)
+		if err != nil {
+			t.Errorf("BUG REPRODUCED at cycle %d (elapsed=%v): %v", i, elapsed, err)
+			return
+		}
+
+		// 等待 cmd 完全退出（taskkill 后 Process.Wait 应立即返回）
+		_ = cmd.Wait()
+		runningPIDs = runningPIDs[:len(runningPIDs)-1] // pop
+
+		// 验证内容已替换
+		got, _ := os.ReadFile(destExe)
+		want := fmt.Sprintf("CYCLE-%d", i)
+		if !strings.Contains(string(got), want) {
+			t.Errorf("cycle %d: dest content = %q, want contains %q", i, got, want)
+		}
+	}
+	t.Logf("All %d cycles succeeded", cycles)
+}
+
+// TestKillByImageRelease_ParallelChildren 模拟更接近生产的环境：
+// 主进程启动多个子进程（模拟 windows_exporter + 其他 plugin），
+// 验证 KillManifestExes 能否一次性杀光所有 .exe 持有者。
+func TestKillByImageRelease_ParallelChildren(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping parallel test in short mode")
+	}
+	sleeper := buildSleeper(t)
+
+	// 准备两个不同的 .exe（promtail.exe + otelcol-contrib.exe）
+	destDir := t.TempDir()
+	destA := filepath.Join(destDir, "promtail.exe")
+	destB := filepath.Join(destDir, "otelcol-contrib.exe")
+	copyFileExe(t, sleeper, destA)
+	copyFileExe(t, sleeper, destB)
+	appendMarker(t, destA, "OLD-A\n")
+	appendMarker(t, destB, "OLD-B\n")
+
+	// 同时启动两个进程（都持有各自的 .exe 锁）
+	cmdA := exec.Command(destA)
+	cmdB := exec.Command(destB)
+	if err := cmdA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	if err := cmdB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer func() {
+		_ = cmdA.Process.Kill()
+		_ = cmdB.Process.Kill()
+		_, _ = cmdA.Process.Wait()
+		_, _ = cmdB.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	// 准备 incoming（含两条 MANIFEST 条目）
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	os.MkdirAll(incoming, 0o755)
+
+	srcA := filepath.Join(incoming, "promtail.exe")
+	srcB := filepath.Join(incoming, "otelcol-contrib.exe")
+	copyFileExe(t, sleeper, srcA)
+	copyFileExe(t, sleeper, srcB)
+	appendMarker(t, srcA, "NEW-A\n")
+	appendMarker(t, srcB, "NEW-B\n")
+
+	shaA := shaFile(t, srcA)
+	shaB := shaFile(t, srcB)
+	manifest := shaA + " 0755 promtail.exe " + destA + "\n" +
+		shaB + " 0755 otelcol-contrib.exe " + destB + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifest)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v1.0.0-parallel\n")
+
+	m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+	start := time.Now()
+	err := m.Apply(context.Background(), 0)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Errorf("BUG REPRODUCED in parallel scenario (elapsed=%v): %v", elapsed, err)
+		return
+	}
+	t.Logf("Parallel Apply succeeded in %v", elapsed)
+
+	gotA, _ := os.ReadFile(destA)
+	gotB, _ := os.ReadFile(destB)
+	if !strings.Contains(string(gotA), "NEW-A") {
+		t.Errorf("destA = %q, want NEW-A", gotA)
+	}
+	if !strings.Contains(string(gotB), "NEW-B") {
+		t.Errorf("destB = %q, want NEW-B", gotB)
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/apply_supervisor_test.go
@@ -1,0 +1,138 @@
+// apply_supervisor_test.go 测试  applyOne 的 supervisor special-case。
+// supervisor dest 不能走标准 backup → stage → rename 路径（Windows 锁定
+// 运行中的 .exe）。applyOne 检测 supervisor dest → 只 stage .new + 写
+// pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。
+
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestApplyBundle_SupervisorDest_StageOnly 验证 supervisor dest 走 special-case。
+func TestApplyBundle_SupervisorDest_StageOnly(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 下已有运行中 supervisor.exe（旧版本）
+	writeTestFile(t, filepath.Join(dest, SupervisorBinaryName), "old-supervisor")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "new-supervisor"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	// supervisor dest 应被 Staged，不是 Swapped
+	if len(result.Swapped) != 0 {
+		t.Errorf("supervisor dest 不应被 swap，got Swapped=%v", result.Swapped)
+	}
+	if len(result.Staged) != 1 {
+		t.Fatalf("expected 1 staged, got %d (%v)", len(result.Staged), result.Staged)
+	}
+	stagedPath := filepath.Join(dest, SupervisorBinaryName+".new")
+	if result.Staged[0] != stagedPath {
+		t.Errorf("staged[0] = %q, want %q", result.Staged[0], stagedPath)
+	}
+
+	// supervisor.exe（原文件）应未被改动
+	got, _ := os.ReadFile(filepath.Join(dest, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 不应被改动，got %q", got)
+	}
+
+	// .new 应存在且内容是新版本
+	got, _ = os.ReadFile(stagedPath)
+	if string(got) != "new-supervisor" {
+		t.Errorf("supervisor.exe.new content = %q, want %q", got, "new-supervisor")
+	}
+
+	// pending sentinel 应被写入
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("supervisor_upgrade.pending sentinel 应被写入")
+	}
+
+	// 不应有 .previous 备份（supervisor 路径跳过 backup）
+	if _, err := os.Stat(filepath.Join(dest, SupervisorBinaryName+PreviousSuffix)); !os.IsNotExist(err) {
+		t.Errorf("supervisor 路径不应创建 .previous 备份")
+	}
+}
+
+// TestApplyBundle_SupervisorMixedWithWorker 验证同一 bundle 中 supervisor +
+// worker 混合时各自走正确路径。
+func TestApplyBundle_SupervisorMixedWithWorker(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dest, SupervisorBinaryName), "old-supervisor")
+	writeTestFile(t, filepath.Join(dest, WorkerBinaryName), "old-worker")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "new-supervisor"},
+		{WorkerBinaryName, WorkerBinaryName, "new-worker"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	// worker 走 swap，supervisor 走 stage
+	if len(result.Swapped) != 1 || len(result.Staged) != 1 {
+		t.Fatalf("expected Swapped=1 + Staged=1, got Swapped=%d Staged=%d",
+			len(result.Swapped), len(result.Staged))
+	}
+
+	// worker.exe 应是新版本
+	got, _ := os.ReadFile(filepath.Join(dest, WorkerBinaryName))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe = %q, want new-worker", got)
+	}
+
+	// supervisor.exe 应保持旧版本（未被 swap）
+	got, _ = os.ReadFile(filepath.Join(dest, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应保持旧版本，got %q", got)
+	}
+
+	// pending sentinel 存在
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被写入")
+	}
+}
+
+// TestApplyBundle_SupervisorDest_NoOldExe 验证 supervisor dest 不存在时仍 stage。
+// 场景：首次安装 / brick 后 supervisor.exe 缺失。
+func TestApplyBundle_SupervisorDest_NoOldExe(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 下无 supervisor.exe（首次或 brick 后恢复）
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "fresh-supervisor"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	if len(result.Staged) != 1 {
+		t.Fatalf("expected 1 staged, got %d", len(result.Staged))
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, SupervisorBinaryName+".new"))
+	if string(got) != "fresh-supervisor" {
+		t.Errorf("supervisor.exe.new = %q, want fresh-supervisor", got)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被写入")
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply_test.go
+++ b/internal/edgeagent/upgrademachine/apply_test.go
@@ -1,0 +1,235 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildFakeBundle 创建一个完整的 fake bundle：incoming/ 下有 MANIFEST.txt
+// + 若干 src 文件。destDir 模拟部署目标目录（已有旧版本文件）。
+// 返回 (incomingDir, destDir, entries)。
+func buildFakeBundle(t *testing.T, incomingDir, destDir string,
+	files []struct{ Src, Dest, Content string }) []ManifestEntry {
+	t.Helper()
+
+	// 写 src 文件 + 计算 sha
+	var lines []string
+	for _, f := range files {
+		sha := writeTestFile(t, filepath.Join(incomingDir, f.Src), f.Content)
+		lines = append(lines, sha+" 0755 "+f.Src+" "+filepath.Join(destDir, f.Dest))
+	}
+	// 写 MANIFEST.txt
+	writeManifest(t, filepath.Join(incomingDir, ManifestFileName), lines)
+
+	// 解析回来（验证 round-trip）
+	entries, err := ParseManifest(filepath.Join(incomingDir, ManifestFileName))
+	if err != nil {
+		t.Fatalf("ParseManifest after build: %v", err)
+	}
+	return entries
+}
+
+func TestApplyBundle_AllSwapped(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 先放旧版本文件
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "old-worker")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe"), "old-exporter")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new-worker"},
+		{"exporter.exe", "exporter.exe", "new-exporter"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+	if len(result.Swapped) != 2 {
+		t.Fatalf("expected 2 swapped, got %d", len(result.Swapped))
+	}
+
+	// 验证新内容
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe content = %q, want %q", got, "new-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(dest, "exporter.exe"))
+	if string(got) != "new-exporter" {
+		t.Errorf("exporter.exe content = %q, want %q", got, "new-exporter")
+	}
+
+	// 验证 .previous 备份存在且内容是旧版本
+	got, _ = os.ReadFile(filepath.Join(dest, "worker.exe.previous"))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe.previous content = %q, want %q", got, "old-worker")
+	}
+}
+
+func TestApplyBundle_DestNotExists_NoBackup(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 目录存在但目标文件不存在（首次安装路径）
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"new.exe", "new.exe", "fresh-install"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+	if len(result.Swapped) != 1 {
+		t.Fatalf("expected 1 swapped, got %d", len(result.Swapped))
+	}
+	if len(result.BackedUp) != 0 {
+		t.Fatalf("expected 0 backed up (dest didn't exist), got %d", len(result.BackedUp))
+	}
+
+	// 不应该有 .previous 文件
+	if _, err := os.Stat(filepath.Join(dest, "new.exe.previous")); !os.IsNotExist(err) {
+		t.Errorf("should not have .previous when dest didn't exist")
+	}
+}
+
+func TestApplyBundle_SHAVerifyFails_AbortsAll(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 旧文件
+	oldContent := "old-worker"
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), oldContent)
+
+	// 先创建 incoming 目录 + src 文件
+	writeTestFile(t, filepath.Join(incoming, "worker.exe"), "new-worker")
+	// 故意写错误 sha 到 MANIFEST
+	writeManifest(t, filepath.Join(incoming, ManifestFileName), []string{
+		"0000000000000000000000000000000000000000000000000000000000000000 0755 worker.exe " + filepath.Join(dest, "worker.exe"),
+	})
+	entries, err := ParseManifest(filepath.Join(incoming, ManifestFileName))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+
+	_, err = ApplyBundle(stageDir, incoming, nil, entries)
+	if err == nil {
+		t.Fatal("expected error for SHA mismatch")
+	}
+
+	// 验证旧文件未被改动
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != oldContent {
+		t.Errorf("dest should be unchanged after SHA failure, got %q", got)
+	}
+}
+
+func TestApplyBundle_Idempotent_DestNewExists(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 模拟上次 swap 中途失败：dest.new 已存在但 dest 未替换
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "old-worker")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.new"), "new-worker-from-crash")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new-worker"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle should handle leftover .new: %v", err)
+	}
+	if len(result.Swapped) != 1 {
+		t.Fatalf("expected 1 swapped, got %d", len(result.Swapped))
+	}
+
+	// 验证最终文件是新版本
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe content = %q, want %q", got, "new-worker")
+	}
+	// .new 应该被清理（被 rename 掉了）
+	if _, err := os.Stat(filepath.Join(dest, "worker.exe.new")); !os.IsNotExist(err) {
+		t.Errorf(".new should be gone after successful swap")
+	}
+}
+
+// TestApplyBundle_Failure_RestoresAllBackups 验证：apply 中途
+// 失败时对本次已备份全集（BackedUp，含已改名条目）逆序恢复，并清理 supervisor
+// 暂存 .new 与 pending 哨兵（防下次启动越权 self-swap）。
+//
+// 失败注入：exporter.exe 预置为目录 → backup 阶段 copyFile(io.Copy 读目录) 必败。
+// 条目顺序：supervisor（stage .new + 写哨兵）→ worker（成功 swap）→ exporter（失败）。
+func TestApplyBundle_Failure_RestoresAllBackups(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 旧版本文件
+	writeTestFile(t, filepath.Join(dest, SupervisorBinaryName), "old-supervisor")
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "old-worker")
+	// exporter.exe 是目录（backup 失败注入点）
+	if err := os.Mkdir(filepath.Join(dest, "exporter.exe"), 0o755); err != nil {
+		t.Fatalf("mkdir obstacle: %v", err)
+	}
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "new-supervisor"},
+		{"worker.exe", "worker.exe", "new-worker"},
+		{"exporter.exe", "exporter.exe", "new-exporter"},
+	})
+
+	_, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err == nil {
+		t.Fatal("expected ApplyBundle to fail on obstacle entry")
+	}
+
+	// 恢复集 = BackedUp 全集：已换的 worker.exe 必须恢复为旧版本
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe = %q, want %q (restored)", got, "old-worker")
+	}
+	// 磁盘无残留备份
+	if _, statErr := os.Stat(filepath.Join(dest, "worker.exe.previous")); !os.IsNotExist(statErr) {
+		t.Errorf("worker.exe.previous must be consumed by recovery, stat err = %v", statErr)
+	}
+	// supervisor.exe 未被 swap，仍为旧版本
+	got, _ = os.ReadFile(filepath.Join(dest, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe = %q, want %q (untouched)", got, "old-supervisor")
+	}
+	// supervisor 暂存 .new 与 pending 哨兵必须清理（防越权 self-swap）
+	if _, statErr := os.Stat(filepath.Join(dest, SupervisorBinaryName+".new")); !os.IsNotExist(statErr) {
+		t.Errorf("staged .new must be cleaned by recovery, stat err = %v", statErr)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("supervisor_upgrade.pending sentinel must be cleaned by recovery")
+	}
+}
+
+func TestApplyBundle_CreatesDestDir(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := filepath.Join(t.TempDir(), "deploy")
+
+	// dest 目录不存在 — ApplyBundle 应该创建
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"app.exe", "app.exe", "content"},
+	})
+
+	_, err := ApplyBundle(stageDir, incoming, nil, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle should create dest dir: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dest, "app.exe"))
+	if string(got) != "content" {
+		t.Errorf("app.exe content = %q", got)
+	}
+}

--- a/internal/edgeagent/upgrademachine/bootcheck_dualrestore_test.go
+++ b/internal/edgeagent/upgrademachine/bootcheck_dualrestore_test.go
@@ -1,0 +1,497 @@
+// bootcheck_dualrestore_test.go 测试：
+// 健康超时双恢复 BootCheck 化 + awaiting_health 哨兵总年龄上限。
+//
+// 覆盖 BootCheck 步骤 1 的三个新语义：
+//   - 中间态恢复：rollback.done + awaiting_health 共存 = worker 已回滚、supervisor
+//     待恢复（superviseWorker 超时路径保留哨兵 + SCM 重启后到达这里）
+//   - 年龄上限：awaiting_health 哨兵 mtime 年龄超上限 → 强制双恢复（先 worker
+//     后 supervisor），彻底解决坏 supervisor 崩溃循环中每轮重启重新武装定时器、回滚
+//     永不触发的漏洞
+//   - healthy 残留哨兵：年龄超限但升级已确认健康 → 只清残留哨兵，不误回滚
+//
+// 断电中间态用预置文件组合模拟（同 converge_test.go 模式）；年龄用 os.Chtimes 预置 mtime。
+
+package upgrademachine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// setMtime 把文件 atime/mtime 预置到指定时刻（模拟哨兵的武装时刻）。
+func setMtime(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes %s: %v", path, err)
+	}
+}
+
+// --- awaiting_health 年龄超上限 → 强制双恢复 ---
+
+// TestBootCheck_AwaitingHealthAgeExceeded_ForcesDualRollback 验证核心场景：
+// 坏 supervisor 崩溃循环（每轮 SCM 重启重新武装 HealthPoll 定时器，180s deadline
+// 永不到达）→ awaiting_health 哨兵 mtime（= selfswap 武装时刻，无人重写）随时间
+// 累积超过上限 → BootCheck 强制双恢复：先 worker（.previous 回滚）后 supervisor
+// （.old 改名回），返回 ErrSupervisorRestartSoon 让 SCM 自然重启加载旧 supervisor。
+//
+// 断言契约（磁盘终态 + 哨兵终态，不测内部调用序列）：
+//   - 返回 ErrSupervisorRestartSoon（SCM restart 加载恢复后的旧 supervisor）
+//   - worker.exe 内容 = 旧版（.previous 已恢复且清空）
+//   - supervisor.exe 内容 = 旧版（.old 已恢复）；.old / .discard 均不存在
+//   - awaiting_health 哨兵已清；rollback.done 已写（worker 回滚权威标记）
+//   - PendingHealthCheck = false（不再 arm）
+func TestBootCheck_AwaitingHealthAgeExceeded_ForcesDualRollback(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 worker 双版本 + supervisor 双版本（断电中间态文件组合）
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-bad-worker")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "good-old-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor")
+	writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+	// 铺哨兵：awaiting_health 武装于 2h 前（超过 1h 上限）；meta 已写、健康标记缺失
+	agingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+	writeTestFile(t, agingPath, "awaiting")
+	setMtime(t, agingPath, time.Now().Add(-2*time.Hour))
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v0.9.4")
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	m.awaitingHealthMaxAge = 1 * time.Hour
+
+	err := m.BootCheck(context.Background())
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon（强制双恢复后 SCM restart），got %v", err)
+	}
+
+	// worker 已回滚（先恢复）
+	got, rerr := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if rerr != nil || string(got) != "good-old-worker" {
+		t.Errorf("worker.exe 应回滚到旧版，got %q (err=%v)", got, rerr)
+	}
+	if _, err := os.Stat(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix)); !os.IsNotExist(err) {
+		t.Errorf(".previous 应已恢复清空（err=%v）", err)
+	}
+	// supervisor 已恢复（后恢复）
+	got, rerr = os.ReadFile(supervisorPath)
+	if rerr != nil || string(got) != "good-old-supervisor" {
+		t.Errorf("supervisor.exe 应恢复为旧版，got %q (err=%v)", got, rerr)
+	}
+	if _, err := os.Stat(supervisorPath + ".old"); !os.IsNotExist(err) {
+		t.Errorf(".old 应已被 rename 走（err=%v）", err)
+	}
+	if _, err := os.Stat(supervisorPath + supervisorDiscardSuffix); !os.IsNotExist(err) {
+		t.Errorf(".discard（新 exe aside 残留）应被清理（err=%v）", err)
+	}
+	// 哨兵终态
+	if IsSupervisorSelfSwapAwaitingHealth(stageDir) {
+		t.Errorf("awaiting_health 哨兵应被清除")
+	}
+	if !RollbackDoneExists(stageDir) {
+		t.Errorf("rollback.done 应已写入（worker 回滚权威标记）")
+	}
+	if m.PendingHealthCheck() {
+		t.Errorf("PendingHealthCheck() 应为 false（已强制回滚，不再 arm）")
+	}
+	// 崩溃循环场景 orphan worker 持 worker.exe 锁会让 Rollback 失败 —
+	// 恢复前先 KillByImage 清 orphan（对称 BootCheck 步骤 5 的 KillByImage 先例）
+	if pc.killImageCalls.Load() != 1 || len(pc.killImageNames) != 1 ||
+		pc.killImageNames[0] != WorkerBinaryName {
+		t.Errorf("KillByImage(worker) 应被调用 1 次，got calls=%d names=%v",
+			pc.killImageCalls.Load(), pc.killImageNames)
+	}
+}
+
+// TestBootCheck_AwaitingHealthAgeFresh_ArmsHealthPoll_NoRollback 验证年龄未超上限时
+// 保持 awaiting-health 语义：arm HealthPoll 180s grace，不提前回滚。
+func TestBootCheck_AwaitingHealthAgeFresh_ArmsHealthPoll_NoRollback(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor")
+	writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+	agingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+	writeTestFile(t, agingPath, "awaiting")
+	setMtime(t, agingPath, time.Now().Add(-30*time.Minute)) // 新于 1h 上限
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v0.9.4")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	m.awaitingHealthMaxAge = 1 * time.Hour
+
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck 不应返回错误（arm 语义）： %v", err)
+	}
+
+	if !m.PendingHealthCheck() {
+		t.Errorf("PendingHealthCheck() 应为 true（awaiting-health 语义保留）")
+	}
+	// 无任何回滚/恢复发生
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe 不应被改动，got %q", got)
+	}
+	got, _ = os.ReadFile(supervisorPath)
+	if string(got) != "new-supervisor" {
+		t.Errorf("supervisor.exe 不应被改动，got %q", got)
+	}
+	if _, err := os.Stat(supervisorPath + ".old"); err != nil {
+		t.Errorf(".old 应存活（err=%v）", err)
+	}
+	if RollbackDoneExists(stageDir) {
+		t.Errorf("不应写 rollback.done")
+	}
+}
+
+// --- 中间态恢复：rollback.done + awaiting_health 共存 ---
+
+// TestBootCheck_RollbackDonePlusAwaiting_RestoresSupervisorOnly 验证双恢复的
+// 中间态信号：superviseWorker 超时路径已完成 worker 回滚（rollback.done 已写）并
+// 保留 awaiting_health 哨兵 + SCM 重启 → BootCheck 检测组合态 → 只补 supervisor
+// 侧恢复（.old 改名回），返回 ErrSupervisorRestartSoon。
+//
+// 断电推演：中间点（worker 已回滚 / supervisor 未恢复）不留版本混合态 — 任意点
+// 断电后下次 BootCheck 都到达同一恢复路径（rollback.done + awaiting 组合幂等）。
+func TestBootCheck_RollbackDonePlusAwaiting_RestoresSupervisorOnly(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// worker 已回滚（superviseWorker 上辈子完成）：旧版 + 无 .previous
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "good-old-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor")
+	writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+	// rollback.done + awaiting_health 共存（superviseWorker 超时路径的落盘终态）。
+	//  mtime 判据：真中间态 rollback.done 必晚于 awaiting（先武装 180s 超时
+	// 后才写 rollback.done），锚定真序防判据误伤。
+	writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+	agingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+	writeTestFile(t, agingPath, "awaiting")
+	now := time.Now()
+	setMtime(t, agingPath, now.Add(-35*time.Minute))
+	setMtime(t, filepath.Join(stageDir, RollbackDoneFile), now.Add(-30*time.Minute))
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	m.awaitingHealthMaxAge = 1 * time.Hour
+
+	err := m.BootCheck(context.Background())
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon（supervisor 侧恢复 + SCM restart），got %v", err)
+	}
+
+	// supervisor 恢复为旧版；aside 残留清理
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil || string(got) != "good-old-supervisor" {
+		t.Errorf("supervisor.exe 应恢复为旧版，got %q (err=%v)", got, rerr)
+	}
+	if _, err := os.Stat(supervisorPath + ".old"); !os.IsNotExist(err) {
+		t.Errorf(".old 应已被 rename 走（err=%v）", err)
+	}
+	if _, err := os.Stat(supervisorPath + supervisorDiscardSuffix); !os.IsNotExist(err) {
+		t.Errorf(".discard 应被清理（err=%v）", err)
+	}
+	// worker 不再动（已回滚）
+	got, _ = os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "good-old-worker" {
+		t.Errorf("worker.exe 不应被改动，got %q", got)
+	}
+	// awaiting_health 已清；不再 arm
+	if IsSupervisorSelfSwapAwaitingHealth(stageDir) {
+		t.Errorf("awaiting_health 哨兵应被清除")
+	}
+	if m.PendingHealthCheck() {
+		t.Errorf("PendingHealthCheck() 应为 false")
+	}
+}
+
+// TestBootCheck_RollbackDonePlusAwaiting_NoOld_ClearsSentinelAndContinues 验证
+// 中间态但 .old 缺失（如健康路径清理已跑、仅哨兵删除失败的自愈场景）：无处恢复 →
+// 只清残留哨兵，正常继续启动（不 restart）。
+func TestBootCheck_RollbackDonePlusAwaiting_NoOld_ClearsSentinelAndContinues(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "good-old-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "supervisor-current") // 无 .old
+
+	writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+	//  mtime 判据：锚定真序（rollback.done 晚于 awaiting），否则同秒写入顺序不定
+	setMtime(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), time.Now().Add(-35*time.Minute))
+	setMtime(t, filepath.Join(stageDir, RollbackDoneFile), time.Now().Add(-30*time.Minute))
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+
+	err := m.BootCheck(context.Background())
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("无 .old 可恢复时不应触发 SCM restart")
+	}
+	if err != nil {
+		t.Fatalf("BootCheck 应干净返回 nil： %v", err)
+	}
+
+	if IsSupervisorSelfSwapAwaitingHealth(stageDir) {
+		t.Errorf("残留 awaiting_health 哨兵应被清除（自愈）")
+	}
+	got, _ := os.ReadFile(supervisorPath)
+	if string(got) != "supervisor-current" {
+		t.Errorf("supervisor.exe 不应被改动，got %q", got)
+	}
+	if m.PendingHealthCheck() {
+		t.Errorf("PendingHealthCheck() 应为 false")
+	}
+}
+
+// TestBootCheck_RollbackDonePlusAwaiting_BrickState_RestoresWithoutAside 验证
+// brick 态双恢复边界：supervisor.exe 缺失（如恢复趟 rename aside 后断电）+ .old
+// 存在 + rollback.done + awaiting_health 共存 → restoreSupervisorFromOld 跳过
+// aside（无 exe 可挪）直接 .old rename 回，锚定该 Stat 分支防未来重构回归。
+func TestBootCheck_RollbackDonePlusAwaiting_BrickState_RestoresWithoutAside(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "good-old-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	// brick 态：supervisor.exe 缺失，仅 .old 存在
+	writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+	writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+	//  mtime 判据：锚定真序（rollback.done 晚于 awaiting），否则同秒写入顺序不定
+	setMtime(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), time.Now().Add(-35*time.Minute))
+	setMtime(t, filepath.Join(stageDir, RollbackDoneFile), time.Now().Add(-30*time.Minute))
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+
+	// 注意：此场景步骤 4 brick recovery 与步骤 1 中间态恢复都会尝试 rename 回，
+	// 无论哪个执行，磁盘终态一致（幂等）。断言终态即可。
+	err := m.BootCheck(context.Background())
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon（supervisor 恢复 + SCM restart），got %v", err)
+	}
+
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil || string(got) != "good-old-supervisor" {
+		t.Errorf("supervisor.exe 应恢复为旧版，got %q (err=%v)", got, rerr)
+	}
+	if _, serr := os.Stat(supervisorPath + ".old"); !os.IsNotExist(serr) {
+		t.Errorf(".old 应已被 rename 走（err=%v）", serr)
+	}
+	if _, derr := os.Stat(supervisorPath + supervisorDiscardSuffix); !os.IsNotExist(derr) {
+		t.Errorf(".discard 不应被创建（无 aside 需要，err=%v）", derr)
+	}
+}
+
+// --- healthy 残留哨兵：不误回滚 ---
+
+// TestBootCheck_AwaitingHealthAgeExceededButHealthy_ClearsStaleSentinel 验证：
+// HealthPoll 成功路径清 awaiting_health 失败（best-effort）+ 长期运行后重启 →
+// 哨兵年龄超限但升级已确认健康 → 只清残留哨兵，绝不回滚健康升级。
+func TestBootCheck_AwaitingHealthAgeExceededButHealthy_ClearsStaleSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-healthy-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor")
+	writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+	agingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+	writeTestFile(t, agingPath, "awaiting")
+	setMtime(t, agingPath, time.Now().Add(-48*time.Hour)) // 远超上限
+	// 健康已确认：healthy_marker == last_upgrade_ver
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v0.9.4")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v0.9.4")
+	WriteSupervisorUpgradeApplied(stageDir, "v0.9.4")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	m.awaitingHealthMaxAge = 1 * time.Hour
+
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck 应干净返回 nil： %v", err)
+	}
+
+	if IsSupervisorSelfSwapAwaitingHealth(stageDir) {
+		t.Errorf("残留哨兵应被清除")
+	}
+	// 健康升级不回滚：双 binary 均保持新版
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "new-healthy-worker" {
+		t.Errorf("健康升级的 worker 不应被回滚，got %q", got)
+	}
+	got, _ = os.ReadFile(supervisorPath)
+	if string(got) != "new-supervisor" {
+		t.Errorf("健康升级的 supervisor 不应被回滚，got %q", got)
+	}
+	// applied + 健康态 → 步骤 3 backstop 清 .old（幂等语义保留）
+	if _, err := os.Stat(supervisorPath + ".old"); !os.IsNotExist(err) {
+		t.Errorf(".old 应被步骤 3 backstop 清理（err=%v）", err)
+	}
+	if RollbackDoneExists(stageDir) {
+		t.Errorf("不应写 rollback.done")
+	}
+	if m.PendingHealthCheck() {
+		t.Errorf("PendingHealthCheck() 应为 false（升级已结束）")
+	}
+}
+
+// --- 年龄判定边界 ---
+
+// TestAwaitingHealthAgeExceeded_Boundary 验证年龄判定纯语义：
+// 超限是严格大于（恰好等于不触发）；哨兵缺失返回 false（防御）。
+func TestAwaitingHealthAgeExceeded_Boundary(t *testing.T) {
+	stageDir := t.TempDir()
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	m.awaitingHealthMaxAge = 1 * time.Hour
+	now := time.Now()
+
+	// 哨兵缺失 → false
+	if m.awaitingHealthAgeExceeded(now) {
+		t.Errorf("哨兵缺失时应返回 false")
+	}
+
+	agingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+	writeTestFile(t, agingPath, "awaiting")
+
+	// 恰好等于上限 → 不超限（严格大于）
+	setMtime(t, agingPath, now.Add(-1*time.Hour))
+	if m.awaitingHealthAgeExceeded(now) {
+		t.Errorf("年龄恰好等于上限不应触发（严格大于语义）")
+	}
+	// 超过上限 → true
+	setMtime(t, agingPath, now.Add(-1*time.Hour-1*time.Minute))
+	if !m.awaitingHealthAgeExceeded(now) {
+		t.Errorf("年龄超过上限应触发")
+	}
+}
+
+// --- 共存分支 mtime 顺序判据 ---
+
+// TestBootCheck_Coexistence_MtimeOrderDiscriminates 验证：rollback.done 与
+// awaiting_health 共存只看共存会误伤 — 实机现场是 7 天前旧周期
+// rollback.done 残留 + 本周期 SelfSwap 刚写的 awaiting_health 同形假阳性，
+// 把健康的刚 selfswap supervisor 误回滚成旧版。
+//
+// 判据：真中间态时序 = 先武装（写 awaiting_health）→ 健康超时 → 写 rollback.done，
+// 故 rollback.done.mtime 必严格晚于 awaiting_health.mtime；早于/相等 = stale
+// rollback.done 残留（清哨兵，按 awaiting-only 语义继续，不回滚）。
+func TestBootCheck_Coexistence_MtimeOrderDiscriminates(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		// 哨兵 mtime 偏移（相对 now，负值=过去）
+		rollbackDoneOffset time.Duration
+		awaitingOffset     time.Duration
+		wantRestore        bool // true = 真中间态（双恢复 supervisor）
+	}{
+		{
+			name:               "真中间态：rollback.done 晚于 awaiting → 双恢复",
+			rollbackDoneOffset: -30 * time.Minute,
+			awaitingOffset:     -35 * time.Minute,
+			wantRestore:        true,
+		},
+		{
+			name:               "stale：rollback.done 早于 awaiting（前周期残留现场）→ 不回滚",
+			rollbackDoneOffset: -7 * 24 * time.Hour,
+			awaitingOffset:     -30 * time.Minute,
+			wantRestore:        false,
+		},
+		{
+			name:               "边界：mtime 相等 → stale（真中间态两哨兵至少隔 180s 不可能相等）",
+			rollbackDoneOffset: -30 * time.Minute,
+			awaitingOffset:     -30 * time.Minute,
+			wantRestore:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stageDir := t.TempDir()
+			binDir := t.TempDir()
+
+			// 刚 selfswap 的健康新版组合：supervisor 新版 + .old 备份，worker 新版
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-worker")
+			supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+			writeTestFile(t, supervisorPath, "new-supervisor")
+			writeTestFile(t, supervisorPath+".old", "good-old-supervisor")
+
+			writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+			awaitingPath := filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+			writeTestFile(t, awaitingPath, "awaiting")
+			setMtime(t, filepath.Join(stageDir, RollbackDoneFile), now.Add(tc.rollbackDoneOffset))
+			setMtime(t, awaitingPath, now.Add(tc.awaitingOffset))
+
+			m := NewMachine(stageDir, binDir, testLogger(), nil)
+			m.selfPathResolver = func() (string, error) {
+				return supervisorPath, nil
+			}
+			m.awaitingHealthMaxAge = 1 * time.Hour // awaiting 均新鲜 → 不会走强制双恢复分支
+
+			err := m.BootCheck(context.Background())
+
+			if tc.wantRestore {
+				// 真中间态：补 supervisor 恢复 + SCM restart（既有语义不变）
+				if !errors.Is(err, ErrSupervisorRestartSoon) {
+					t.Fatalf("期望 ErrSupervisorRestartSoon（真中间态双恢复），got %v", err)
+				}
+				got, rerr := os.ReadFile(supervisorPath)
+				if rerr != nil || string(got) != "good-old-supervisor" {
+					t.Errorf("supervisor.exe 应恢复为旧版，got %q (err=%v)", got, rerr)
+				}
+				if m.PendingHealthCheck() {
+					t.Errorf("真中间态不应 arm HealthPoll")
+				}
+			} else {
+				// stale：不回滚刚 selfswap 的健康 supervisor，清残留哨兵，
+				// 按 awaiting-only 语义 arm HealthPoll（awaiting-health）
+				if err != nil {
+					t.Fatalf("stale 组合不应触发错误/重启： %v", err)
+				}
+				got, rerr := os.ReadFile(supervisorPath)
+				if rerr != nil || string(got) != "new-supervisor" {
+					t.Errorf("健康的新版 supervisor 不应被回滚，got %q (err=%v)", got, rerr)
+				}
+				if _, serr := os.Stat(supervisorPath + ".old"); serr != nil {
+					t.Errorf(".old 应存活（升级仍在健康确认中，err=%v）", serr)
+				}
+				if RollbackDoneExists(stageDir) {
+					t.Errorf("stale rollback.done 应被清除")
+				}
+				if !IsSupervisorSelfSwapAwaitingHealth(stageDir) {
+					t.Errorf("awaiting_health 应保留（awaiting-health 生命周期右端点在 HealthPoll）")
+				}
+				if !m.PendingHealthCheck() {
+					t.Errorf("stale 清除后应按 awaiting-only 语义 arm HealthPoll（awaiting-health）")
+				}
+			}
+		})
+	}
+}

--- a/internal/edgeagent/upgrademachine/bootcheck_stale_applied_test.go
+++ b/internal/edgeagent/upgrademachine/bootcheck_stale_applied_test.go
@@ -1,0 +1,203 @@
+// bootcheck_stale_applied_test.go 测试 BootCheck 步骤 3 的  孤儿
+// pending 清理遇跨周期混叠（stale applied + 新周期 pending）不得误清。
+//
+// 与 （rollbackDoneAfterAwaitingHealth）同族的 mtime 顺序判据：
+// 真孤儿时序 = Apply 先写 pending → SelfSwap 后写 applied，故
+// pending.mtime 必早于 applied.mtime；新周期= 上周期 SelfSwap
+// 写 applied → SCM restart → 新 Apply 写 pending，故 pending.mtime 必晚于
+// applied.mtime（跨 restart ≥ 秒级）。早于/相等 = 孤儿（清）；严格晚于 =
+// 新周期（不清，留给步骤 5 SelfSwap 正常消费）。
+//
+// 断电中间态用预置文件组合模拟（同 / 模式）；mtime 用 setMtime 锚定真序。
+
+package upgrademachine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBootCheck_OrphanPendingMtimeOrder 验证：applied + pending 共存时
+// 步骤 3 用 mtime 顺序区分孤儿与新周期 — 实机现场是上周期 applied 残留 +
+// 本周期 Apply 刚写的 pending 同形假阳性，无条件清会把新周期 pending 误删，
+// 步骤 5 SelfSwap 不触发，supervisor.exe.new 永久残留（本轮升级丢失）。
+func TestBootCheck_OrphanPendingMtimeOrder(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name          string
+		appliedOffset time.Duration
+		pendingOffset time.Duration
+		wantRestart   bool // true = 新周期：不误清，步骤 5 SelfSwap 触发
+	}{
+		{
+			name:          "新周期：pending 晚于 applied（跨周期新升级）→ 不清，SelfSwap 触发",
+			appliedOffset: -10 * time.Minute,
+			pendingOffset: -1 * time.Minute,
+			wantRestart:   true,
+		},
+		{
+			name:          "真孤儿：pending 早于 applied（断电窗口）→ 清理，不触发 SelfSwap",
+			appliedOffset: -1 * time.Minute,
+			pendingOffset: -10 * time.Minute,
+			wantRestart:   false,
+		},
+		{
+			name:          "边界：mtime 相等 → 判孤儿（真孤儿两哨兵至少隔一次 SelfSwap 不可能相等，相等=stale 语义一致）",
+			appliedOffset: -10 * time.Minute,
+			pendingOffset: -10 * time.Minute,
+			wantRestart:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dummy := buildDummy(t)
+			stageDir := t.TempDir()
+			binDir := t.TempDir()
+
+			// 铺 supervisor.exe（已是新版 — 上次 swap 成功，/ 共同前置）
+			supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+			copyFileExe(t, dummy, supervisorPath)
+			appendMarker(t, supervisorPath, "CURRENT-SUPERVISOR\n")
+			// 铺 .old 备份（上周期 swap step 1 残留）
+			copyFileExe(t, dummy, supervisorPath+".old")
+
+			// 铺 applied + pending 哨兵，锚定 mtime 真序（对称  测试）
+			appliedPath := SupervisorUpgradeAppliedPath(stageDir)
+			pendingPath := SupervisorUpgradePendingPath(stageDir)
+			writeTestFile(t, appliedPath, "applied")
+			writeTestFile(t, pendingPath, "pending")
+			setMtime(t, appliedPath, now.Add(tc.appliedOffset))
+			setMtime(t, pendingPath, now.Add(tc.pendingOffset))
+
+			// 新周期场景：.new 已 stage（本周期 Apply 刚写的，等步骤 5 消费）
+			if tc.wantRestart {
+				copyFileExe(t, dummy, supervisorPath+".new")
+				appendMarker(t, supervisorPath+".new", "NEW-SUPERVISOR\n")
+			}
+
+			m := NewMachine(stageDir, binDir, testLogger(), nil)
+			m.selfPathResolver = func() (string, error) {
+				return supervisorPath, nil
+			}
+
+			err := m.BootCheck(context.Background())
+
+			if tc.wantRestart {
+				// 新周期：pending 不被误清 → 步骤 5 SelfSwap 消费 .new
+				if !errors.Is(err, ErrSupervisorRestartSoon) {
+					t.Fatalf("期望 ErrSupervisorRestartSoon（SelfSwap 应触发），got %v", err)
+				}
+				got, rerr := os.ReadFile(supervisorPath)
+				if rerr != nil || !contains(got, "NEW-SUPERVISOR") {
+					t.Errorf("supervisor.exe 应已被 .new 换新，got %q (err=%v)", got, rerr)
+				}
+				if _, serr := os.Stat(supervisorPath + ".new"); !os.IsNotExist(serr) {
+					t.Errorf(".new 应被 SelfSwap 消费（err=%v）", serr)
+				}
+				// SelfSwap step 3 写了新 applied（swap 成功的佐证）；
+				// stale applied 已被步骤 3 先行删除（新写的 mtime 更晚）
+				if !IsSupervisorUpgradeApplied(stageDir) {
+					t.Errorf("SelfSwap 完成后应写新 applied sentinel")
+				}
+			} else {
+				// 孤儿：pending 被清 + 不触发 SelfSwap
+				if err != nil {
+					t.Fatalf("孤儿组合应干净返回 nil： %v", err)
+				}
+				if IsSupervisorUpgradePending(stageDir) {
+					t.Errorf("孤儿 pending 应被清理（孤儿判定语义不变）")
+				}
+				// 步骤 3 删 applied 后无人重写（不走 SelfSwap）
+				if IsSupervisorUpgradeApplied(stageDir) {
+					t.Errorf("applied sentinel 应被删除（收尾语义保留）")
+				}
+				got, rerr := os.ReadFile(supervisorPath)
+				if rerr != nil || !contains(got, "CURRENT-SUPERVISOR") {
+					t.Errorf("supervisor.exe 不应被改动，got %q (err=%v)", got, rerr)
+				}
+			}
+		})
+	}
+}
+
+// TestBootCheck_RefeedWithStaleApplied 验证  票验收第 1 条的代码级等价：
+// 重投喂 bundle + applied 残留窗口的完整 BootCheck 时序 —
+// 步骤 2 Apply 写新 pending（mtime=now）→ 步骤 3 读到上周期 stale applied
+// （mtime 过去）→ 不误清 → 步骤 5 SelfSwap 正常触发，.new 被消费无残留。
+//
+// 事故时序（修复前）：步骤 3 无条件清新周期 pending → 步骤 5 不触发 →
+// supervisor.exe.new 永久残留。
+func TestBootCheck_RefeedWithStaleApplied(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 当前 supervisor（旧版）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	copyFileExe(t, dummy, supervisorPath)
+	appendMarker(t, supervisorPath, "OLD-SUPERVISOR\n")
+
+	// 新投喂 bundle：incoming/ 新 supervisor + MANIFEST + VERSION
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	if err := os.MkdirAll(incoming, 0o755); err != nil {
+		t.Fatalf("mkdir incoming: %v", err)
+	}
+	srcExe := filepath.Join(incoming, SupervisorBinaryName)
+	copyFileExe(t, dummy, srcExe)
+	appendMarker(t, srcExe, "NEW-SUPERVISOR\n")
+	manifestLine := sha256Hex(t, srcExe) + " 0755 " + SupervisorBinaryName + " " + supervisorPath + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifestLine)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v0.9.4-test121\n")
+
+	// 上周期残留的 applied 哨兵（mtime 已过去 10 分钟）
+	appliedPath := SupervisorUpgradeAppliedPath(stageDir)
+	writeTestFile(t, appliedPath, "applied")
+	setMtime(t, appliedPath, time.Now().Add(-10*time.Minute))
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+
+	err := m.BootCheck(context.Background())
+
+	// 核心断言：SelfSwap 正常触发（新周期 pending 未被步骤 3 误清）
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon（重投喂 SelfSwap 应触发），got %v", err)
+	}
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil || !contains(got, "NEW-SUPERVISOR") {
+		t.Errorf("supervisor.exe 应被换新，got %q (err=%v)", got, rerr)
+	}
+	if _, serr := os.Stat(supervisorPath + ".new"); !os.IsNotExist(serr) {
+		t.Errorf(".new 应被消费无残留（err=%v）", serr)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending 应被 SelfSwap 收尾清理")
+	}
+}
+
+// contains 是 strings.Contains 的字节切片便捷形式（测试断言用）。
+func contains(b []byte, sub string) bool {
+	return strings.Contains(string(b), sub)
+}
+
+// sha256Hex 计算文件 sha256 hex（跨平台 MANIFEST 行构造用；
+// apply_cycle_windows_test.go 的 shaFile 是 windows-only）。
+func sha256Hex(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
@@ -1,0 +1,363 @@
+// bootcheck_supervisor_test.go 测试  BootCheck 的 supervisor 自升级集成。
+// 覆盖步骤 3（applied sentinel 清理）/ 4（brick recovery）/ 5（pending →  KillByImage → self-swap）。
+
+package upgrademachine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- 步骤 3：applied sentinel 清理 ---
+
+func TestBootCheck_AppliedSentinel_CleansOldAndSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 .old 备份 + applied sentinel
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "old-supervisor-binary")
+	WriteSupervisorUpgradeApplied(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	err := m.BootCheck(context.Background())
+	if err != nil {
+		t.Fatalf("BootCheck 不应返回错误（applied 清理是非关键路径）： %v", err)
+	}
+
+	// .old 应被清理
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf(".old 应被清理（err=%v）", err)
+	}
+	// applied sentinel 应被删除
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应被删除")
+	}
+}
+
+// TestBootCheck_AppliedAndPendingCoexist_CleansBoth 验证  死循环场景 (d)：
+// WriteSupervisorUpgradeApplied 成功后 + 删 pending 前断电 → 下次 BootCheck 步骤 3
+// 命中（清 .old + 删 applied），但步骤 5 仍命中（pending 残留）→ 触发 SelfSwap。
+// 此时 supervisor.exe 已新版（上次 swap 成功），.new 不存在 → relocate 失败 →
+// SCM restart 死循环。
+// 加固（方案 A）：步骤 3 applied 分支顺带清孤儿 pending，断电窗口的不变量违反
+// 在 BootCheck 收尾阶段自动纠正。
+// 断言契约：
+//   - err == nil（不应触发步骤 5 SelfSwap）
+//   - .old 备份被清理
+//   - applied sentinel 被删
+//   - pending sentinel 被删（步骤 3 收尾时一并清孤儿状态）
+//   - supervisor.exe 未被改动（步骤 4 brick / 步骤 5 SelfSwap 都未触发）
+func TestBootCheck_AppliedAndPendingCoexist_CleansBoth(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 supervisor.exe（已是新版 — 上次 swap 成功）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor-binary-already-swapped")
+	// 铺 .old 备份（swap step 1 的残留）
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "pre-swap-supervisor-binary")
+	// 铺 applied + pending 共存（断电窗口：applied 已写、pending 未删）
+	WriteSupervisorUpgradeApplied(stageDir, "v0.9.2")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+	//  mtime 判据：锚定真序(断电窗口 = Apply 先写 pending、SelfSwap
+	// 后写 applied，两哨兵至少隔一次完整 SelfSwap），否则测试连续写入在
+	// mtime 粒度内顺序不定，新周期判据会把断电孤儿误判为新周期（对称
+	// 测试的同问题处理）。
+	setMtime(t, SupervisorUpgradePendingPath(stageDir), time.Now().Add(-2*time.Minute))
+	setMtime(t, SupervisorUpgradeAppliedPath(stageDir), time.Now().Add(-1*time.Minute))
+	// 注意：不铺 .new — 上次 swap 已 rename .new → supervisor.exe，.new 不存在
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+
+	err := m.BootCheck(context.Background())
+	// 关键断言 1：不应返回 ErrSupervisorRestartSoon（步骤 5 不应触发）
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("applied+pending 共存时不应触发 SelfSwap（死循环）： %v", err)
+	}
+	if err != nil {
+		t.Fatalf("BootCheck 应在清理后干净返回 nil： %v", err)
+	}
+
+	// 关键断言 2：.old 应被清理
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf(".old 应被清理（err=%v）", err)
+	}
+	// 关键断言 3：applied sentinel 应被删
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应被删除")
+	}
+	// 关键断言 4：pending sentinel 应被删（步骤 3 收尾时一并清孤儿状态）
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被删除（applied 已写，pending 是孤儿状态）")
+	}
+	// 断言 5：supervisor.exe 内容未被改动（步骤 4/5 都不应触发）
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil {
+		t.Fatalf("supervisor.exe 应存在： %v", rerr)
+	}
+	if string(got) != "new-supervisor-binary-already-swapped" {
+		t.Errorf("supervisor.exe 内容不应被改动，got %q", got)
+	}
+}
+
+// TestBootCheck_AppliedAwaitingHealth_PreservesOld 验证：
+// self-swap 写 applied 哨兵在健康确认之前，BootCheck 步骤 3 不得在此窗口删 .old —
+// 否则健康判定失败时 supervisor 永久停留坏新版（.old 是唯一回滚源，brick 兜底也依赖）。
+//
+// 状态模拟（self-swap 完成 + SCM 重启 + worker 尚未写 healthy_marker 的真机状态）：
+//   - supervisor.exe = 新版（swap 完成）+ .old = 好旧版
+//   - applied + awaiting_health 哨兵共存
+//   - last_upgrade_ver 已写、healthy_marker 缺失（待确认窗口）
+//
+// 期望：.old 存活；applied 哨兵清理语义保留（幂等）；supervisor.exe 不动。
+func TestBootCheck_AppliedAwaitingHealth_PreservesOld(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	writeTestFile(t, supervisorPath, "new-supervisor-maybe-bad")
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "good-old-supervisor")
+	WriteSupervisorUpgradeApplied(stageDir, "v0.9.3")
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+	// 待确认窗口：meta 已写、健康标记缺失
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v0.9.3")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+
+	// 核心断言：健康确认前 .old 绝不被删除
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf(".old 必须存活至健康确认（err=%v）", err)
+	}
+	// applied 哨兵清理语义保留（幂等收尾不因条件化而丢失）
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应被清理")
+	}
+	// supervisor.exe 不被改动（非 brick 态，步骤 4/5 不触发）
+	got, _ := os.ReadFile(supervisorPath)
+	if string(got) != "new-supervisor-maybe-bad" {
+		t.Errorf("supervisor.exe = %q, 不应被改动", got)
+	}
+	// awaiting-health 分支：awaiting_health 使 BootCheck 不 rollback（HealthPoll 接管）
+	if !m.PendingHealthCheck() {
+		t.Error("PendingHealthCheck() = false, want true")
+	}
+}
+
+// --- 步骤 4：brick recovery 边界 — resolver 失败时显式 log warn ---
+
+// TestIsSupervisorBrickState_ResolverFail_LogsWarnAndReturnsFalse 验证：
+// selfPathResolver 失败时，isSupervisorBrickState 必须显式 log warn（不静默返回 false），
+// 符合显式失败原则（不静默吞掉异常路径）。
+// 不 fail-fast：brick check 是启动期防御，resolver 失败时安全 fallback 是"不触发恢复"，
+// 避免误恢复破坏正常状态。
+// 断言三项行为契约（不耦合具体 message 文案）：
+//   - level=WARN（不是 INFO/ERROR）
+//   - message 含 "resolve self path failed" 子串（运维侧日志搜索 anchor）
+//   - err 字段透传 resolver 返回的原始错误（错误链完整，%w wrapping）
+func TestIsSupervisorBrickState_ResolverFail_LogsWarnAndReturnsFalse(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 注入唯一可识别的错误，验证 err chain 透传
+	resolverErr := errors.New("synthetic resolver failure sentinel-7f3a")
+
+	var buf bytes.Buffer
+	m := NewMachine(stageDir, binDir, testLoggerCapturing(&buf), nil)
+	m.selfPathResolver = func() (string, error) {
+		return "", resolverErr
+	}
+
+	got := m.isSupervisorBrickState()
+	if got {
+		t.Errorf("resolver 失败时应返回 false（不触发恢复），got true")
+	}
+
+	logOut := buf.String()
+	// 契约 1：level=WARN（testLoggerCapturing 已过滤 < WARN，但仍验证确实有输出且不是更高 level）
+	if !strings.Contains(logOut, "level=WARN") {
+		t.Errorf("期望 level=WARN，got:\n%s", logOut)
+	}
+	// 契约 2：message 含失败上下文 anchor（运维搜索用）
+	if !strings.Contains(logOut, "resolve self path failed") {
+		t.Errorf("期望 warn message 含 'resolve self path failed' anchor，got:\n%s", logOut)
+	}
+	// 契约 3：err 字段透传原始 resolver 错误（验证错误链完整，不是被吞或包装丢失）
+	if !strings.Contains(logOut, "synthetic resolver failure sentinel-7f3a") {
+		t.Errorf("期望 err 字段透传 resolver 错误，got:\n%s", logOut)
+	}
+}
+
+// --- 步骤 4：brick recovery 边界 — resolver 成功 + 文件状态 ---
+
+// TestBootCheck_BrickState_RestoresOldToSupervisor 验证 brick recovery 成功路径。
+func TestBootCheck_BrickState_RestoresOldToSupervisor(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// brick 状态：supervisor.exe 缺失 + .old 存在
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "rescued-supervisor-binary")
+	// supervisor.exe 不存在
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	err := m.BootCheck(context.Background())
+	if err != nil {
+		t.Fatalf("BootCheck brick recovery 不应失败： %v", err)
+	}
+
+	// supervisor.exe 应被恢复（.old rename 回来）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil {
+		t.Fatalf("supervisor.exe 应存在： %v", rerr)
+	}
+	if string(got) != "rescued-supervisor-binary" {
+		t.Errorf("supervisor.exe 内容 = %q, want rescued-supervisor-binary", got)
+	}
+	// .old 应不存在（已被 rename 走）
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf(".old 应不存在（err=%v）", err)
+	}
+}
+
+func TestBootCheck_NoBrickState_SupervisorExists(t *testing.T) {
+	// supervisor.exe 存在 + .old 不存在 → 非 brick 状态，不应触发恢复
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "current")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	// 不应 panic 或误恢复
+	_ = m.BootCheck(context.Background())
+
+	got, _ := os.ReadFile(filepath.Join(binDir, SupervisorBinaryName))
+	if string(got) != "current" {
+		t.Errorf("supervisor.exe 内容不应被改动，got %q", got)
+	}
+}
+
+// --- 步骤 5：pending sentinel →  KillByImage → self-swap ---
+
+func TestBootCheck_PendingSentinel_KillsWorkerBeforeSelfSwap(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 supervisor.exe + supervisor.exe.new（dummy binary）
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName))
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName+".new"))
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+
+	err := m.BootCheck(context.Background())
+
+	// 应返回 ErrSupervisorRestartSoon（self-swap 成功）
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
+	}
+
+	// KillByImage 应被调用，参数是 WorkerBinaryName
+	if pc.killImageCalls.Load() != 1 {
+		t.Errorf("KillByImage 应被调用 1 次，got %d", pc.killImageCalls.Load())
+	}
+	if len(pc.killImageNames) != 1 || pc.killImageNames[0] != WorkerBinaryName {
+		t.Errorf("KillByImage 参数应是 %q，got %v", WorkerBinaryName, pc.killImageNames)
+	}
+}
+
+func TestBootCheck_PendingSentinel_NilPC_SkipsKillButStillSelfSwap(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName))
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName+".new"))
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	// pc == nil（测试场景 / 无 worker 启动场景）
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+
+	err := m.BootCheck(context.Background())
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("nil pc 也应完成 self-swap，got %v", err)
+	}
+}
+
+// --- 步骤 5：self-swap 失败记录 lastErr 但不阻断 ---
+
+func TestBootCheck_SelfSwapFails_RecordsLastError(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 supervisor.exe（旧版本）+ supervisor.exe.new 是坏 binary（冒烟失败）
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "old-supervisor")
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName+".new"), "bad-binary")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+
+	err := m.BootCheck(context.Background())
+	// 冒烟失败不是 ErrSupervisorRestartSoon，应是普通 error
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Errorf("冒烟失败不应返回 ErrSupervisorRestartSoon")
+	}
+	if err == nil {
+		t.Errorf("冒烟失败应返回错误（lastErr）")
+	}
+
+	// KillByImage 仍被调用（在 self-swap 之前）
+	if pc.killImageCalls.Load() != 1 {
+		t.Errorf("KillByImage 应被调用，got %d", pc.killImageCalls.Load())
+	}
+
+	// supervisor.exe 应未被改动
+	got, _ := os.ReadFile(filepath.Join(binDir, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应保持旧版本，got %q", got)
+	}
+}

--- a/internal/edgeagent/upgrademachine/converge.go
+++ b/internal/edgeagent/upgrademachine/converge.go
@@ -1,0 +1,90 @@
+// converge.go 实现 apply 入口残留收敛。
+//
+// 语义依据：上次 apply 断电/失败留下的 .previous 残留与
+// 「合法备份」同形，且断电点若在 WriteUpgradeMeta 前，last_upgrade_ver 仍是
+// 旧值且匹配 healthy_marker（假阳性健康态）→ 回滚永不触发、CleanupPrevious
+// 不可达 → 拒绝语义 = 无出口死锁。故入口不拒绝，改为先幂等收敛（恢复旧版 +
+// 清理暂存物与陈旧哨兵）再继续本轮 apply。
+
+package upgrademachine
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConvergeResidualBackups 在 apply 入口收敛上次崩溃轮次的残留物：
+//
+//  1. Rollback 恢复 binDir 与各 entry dest 目录下的全部 *.previous（幂等：
+//     干净状态 = 0 个 no-op）；恢复集 = 遍历到的全部备份，含「备份后改名前」
+//     断电的未换条目
+//  2. 清理 supervisor 暂存 .new（entry dest 侧 + binDir 侧）与
+//     supervisor_upgrade.pending 哨兵 — 本轮 manifest 若含 supervisor 条目，
+//     applyOne 会重新 stage，清旧不碍新
+//  3. 清理 stale rollback.done — 残留会让 superviseWorker 对本轮新版本误卸载
+//     健康监视（正常流程由 edge DownloadBundle 步骤 2 删除，issue ；此处
+//     是 apply 侧的幂等兜底）
+//
+// 必须在 ValidateAllEntries 之后调用：dirs 集合源自 manifest 条目，未校验的
+// manifest 不得驱动任意目录的文件操作。必须在 kill 之后调用：恢复 rename
+// 可能撞运行中进程的 image 锁。
+//
+// 返回恢复的文件数。恢复失败返回 error（与 Rollback 同语义：整体失败可重试），
+// 清理失败聚合进同一 error。
+func ConvergeResidualBackups(stageDir, binDir string, entries []ManifestEntry) (int, error) {
+	dirs := dirSet(binDir, entries)
+
+	restored, err := Rollback(dirs)
+	if err != nil {
+		return restored, fmt.Errorf("converge residual backups: %w", err)
+	}
+
+	var errs []error
+	// supervisor 暂存 .new：entry dest 侧（applyOne 写）+ binDir 侧
+	// （SupervisorSelfSwap 重定位源，覆盖非 BinDir 安装路径场景）
+	newPaths := []string{filepath.Join(binDir, SupervisorBinaryName+".new")}
+	for _, e := range entries {
+		if isSupervisorBinary(e.Dest) {
+			newPaths = append(newPaths, e.Dest+".new")
+		}
+	}
+	if err := cleanupSupervisorStaging(stageDir, newPaths...); err != nil {
+		errs = append(errs, err)
+	}
+	if err := os.Remove(RollbackDonePath(stageDir)); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("remove stale rollback.done: %w", err))
+	}
+	return restored, errors.Join(errs...)
+}
+
+// cleanupSupervisorStaging 删除 supervisor 暂存 .new 集合 + pending 哨兵。
+// （apply 失败自恢复）与 D2（入口残留收敛）共用的清理原语。
+// 幂等：路径不存在视为成功。
+func cleanupSupervisorStaging(stageDir string, newPaths ...string) error {
+	var errs []error
+	for _, p := range newPaths {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("remove staged %s: %w", p, err))
+		}
+	}
+	if err := os.Remove(SupervisorUpgradePendingPath(stageDir)); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("remove supervisor pending sentinel: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+// dirSet 返回 binDir + 各 entry dest 目录的去重集合（Rollback 的遍历范围）。
+func dirSet(binDir string, entries []ManifestEntry) []string {
+	seen := map[string]bool{binDir: true}
+	dirs := []string{binDir}
+	for _, e := range entries {
+		d := filepath.Dir(e.Dest)
+		if !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	return dirs
+}

--- a/internal/edgeagent/upgrademachine/converge_test.go
+++ b/internal/edgeagent/upgrademachine/converge_test.go
@@ -1,0 +1,231 @@
+// converge_test.go 验证：apply 入口残留收敛。
+//
+// 断电组合态用预置文件组合模拟（测试决策：不引入故障注入框架）—
+// 每个用例对应一类断电死锁场景：
+//   - apply 半换断电 + 健康标记匹配旧值 → 回滚不可达死锁
+//   - 多条目半换断电（一条已换、一条备份未改名）
+//   - 备份后改名前断电 + supervisor 暂存残留（.new + pending 哨兵）
+//   - 健康标记假阳性（WriteUpgradeMeta 未达）+ supervisor 暂存残留 + 旧哨兵
+
+package upgrademachine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// convergeCase 是断电组合态表驱动用例。
+type convergeCase struct {
+	name string
+	// preset 在 binDir/stageDir 预置断电后的文件组合
+	preset func(t *testing.T, stageDir, binDir string)
+	// verify 断言收敛后的磁盘/哨兵终态
+	verify func(t *testing.T, stageDir, binDir string, restored int, err error)
+}
+
+var convergeCases = []convergeCase{
+	{
+		name: "半换断电_健康标记匹配旧值死锁态",
+		preset: func(t *testing.T, stageDir, binDir string) {
+			// apply 在 worker swap 后、WriteUpgradeMeta 前断电：
+			// last_upgrade_ver 仍是上一健康版本 V1，healthy_marker=V1 →
+			// IsUpgradeHealthy=true → 回滚永不触发 + .previous 残留
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V2-broken")
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "V1-old")
+			writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "V1")
+			writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "V1")
+		},
+		verify: func(t *testing.T, stageDir, binDir string, restored int, err error) {
+			if err != nil {
+				t.Fatalf("converge: %v", err)
+			}
+			if restored != 1 {
+				t.Errorf("restored = %d, want 1", restored)
+			}
+			got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+			if string(got) != "V1-old" {
+				t.Errorf("worker.exe = %q, want %q (converged to old)", got, "V1-old")
+			}
+			if _, statErr := os.Stat(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix)); !os.IsNotExist(statErr) {
+				t.Errorf(".previous must be consumed")
+			}
+		},
+	},
+	{
+		name: "多条目半换断电_已换与未换并存",
+		preset: func(t *testing.T, stageDir, binDir string) {
+			// worker 已 swap（dest=V2），exporter 仅备份未改名（dest=V1）
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V2-worker")
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "V1-worker")
+			writeTestFile(t, filepath.Join(binDir, "windows_exporter.exe"), "V1-exporter")
+			writeTestFile(t, filepath.Join(binDir, "windows_exporter.exe"+PreviousSuffix), "V1-exporter")
+		},
+		verify: func(t *testing.T, stageDir, binDir string, restored int, err error) {
+			if err != nil {
+				t.Fatalf("converge: %v", err)
+			}
+			if restored != 2 {
+				t.Errorf("restored = %d, want 2", restored)
+			}
+			// 恢复集必须含未换条目（非仅已改名集）
+			for name, want := range map[string]string{
+				WorkerBinaryName:       "V1-worker",
+				"windows_exporter.exe": "V1-exporter",
+			} {
+				got, _ := os.ReadFile(filepath.Join(binDir, name))
+				if string(got) != want {
+					t.Errorf("%s = %q, want %q", name, got, want)
+				}
+				if _, statErr := os.Stat(filepath.Join(binDir, name+PreviousSuffix)); !os.IsNotExist(statErr) {
+					t.Errorf("%s.previous must be consumed", name)
+				}
+			}
+		},
+	},
+	{
+		name: "备份后改名前断电_supervisor暂存残留",
+		preset: func(t *testing.T, stageDir, binDir string) {
+			// worker 仅备份未改名 + supervisor .new 已 stage + pending 哨兵已写
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V1-worker")
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "V1-worker")
+			writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "V1-supervisor")
+			writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName+".new"), "V2-supervisor-stale")
+			writeTestFile(t, filepath.Join(stageDir, SupervisorUpgradePendingFile), "V2")
+		},
+		verify: func(t *testing.T, stageDir, binDir string, restored int, err error) {
+			if err != nil {
+				t.Fatalf("converge: %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix)); !os.IsNotExist(statErr) {
+				t.Errorf(".previous must be consumed")
+			}
+			// supervisor 暂存 .new + pending 哨兵必须清理（防越权 self-swap）
+			if _, statErr := os.Stat(filepath.Join(binDir, SupervisorBinaryName+".new")); !os.IsNotExist(statErr) {
+				t.Errorf("stale supervisor .new must be cleaned")
+			}
+			if IsSupervisorUpgradePending(stageDir) {
+				t.Errorf("pending sentinel must be cleaned")
+			}
+			// supervisor.exe 本体不动（rename-aside 是 self-swap 的职责，非收敛）
+			got, _ := os.ReadFile(filepath.Join(binDir, SupervisorBinaryName))
+			if string(got) != "V1-supervisor" {
+				t.Errorf("supervisor.exe = %q, want untouched %q", got, "V1-supervisor")
+			}
+		},
+	},
+	{
+		name: "健康标记假阳性_暂存残留_旧回滚哨兵",
+		preset: func(t *testing.T, stageDir, binDir string) {
+			// 健康标记假阳性态 + supervisor 暂存残留 + 前一周期回滚遗留 rollback.done
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V2-broken")
+			writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "V1-old")
+			writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "V1")
+			writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "V1")
+			writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "V1-supervisor")
+			writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName+".new"), "V2-supervisor-stale")
+			writeTestFile(t, filepath.Join(stageDir, SupervisorUpgradePendingFile), "V2")
+			writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+		},
+		verify: func(t *testing.T, stageDir, binDir string, restored int, err error) {
+			if err != nil {
+				t.Fatalf("converge: %v", err)
+			}
+			got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+			if string(got) != "V1-old" {
+				t.Errorf("worker.exe = %q, want %q", got, "V1-old")
+			}
+			if _, statErr := os.Stat(filepath.Join(binDir, SupervisorBinaryName+".new")); !os.IsNotExist(statErr) {
+				t.Errorf("stale supervisor .new must be cleaned")
+			}
+			if IsSupervisorUpgradePending(stageDir) {
+				t.Errorf("pending sentinel must be cleaned")
+			}
+			// 旧 rollback.done 必须清除 — 残留会让 superviseWorker 对本轮
+			// 新版本误卸载健康监视（upgrade watch 死锁的另一形态）
+			if RollbackDoneExists(stageDir) {
+				t.Errorf("stale rollback.done must be cleaned")
+			}
+		},
+	},
+}
+
+// TestConvergeResidualBackups_PowerLossStates 断电组合态表驱动。
+func TestConvergeResidualBackups_PowerLossStates(t *testing.T) {
+	for _, tc := range convergeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stageDir := t.TempDir()
+			binDir := t.TempDir()
+			tc.preset(t, stageDir, binDir)
+
+			// 入口收敛：entries 覆盖预置 dest（dest 目录去重后传入）
+			entries := []ManifestEntry{
+				{Src: WorkerBinaryName, Dest: filepath.Join(binDir, WorkerBinaryName)},
+				{Src: SupervisorBinaryName, Dest: filepath.Join(binDir, SupervisorBinaryName)},
+			}
+			restored, err := ConvergeResidualBackups(stageDir, binDir, entries)
+			tc.verify(t, stageDir, binDir, restored, err)
+		})
+	}
+}
+
+// TestConvergeResidualBackups_CleanState_NoOp 验证干净状态下收敛是零变动 no-op。
+func TestConvergeResidualBackups_CleanState_NoOp(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V1")
+
+	restored, err := ConvergeResidualBackups(stageDir, binDir, []ManifestEntry{
+		{Src: WorkerBinaryName, Dest: filepath.Join(binDir, WorkerBinaryName)},
+	})
+	if err != nil {
+		t.Fatalf("converge on clean state: %v", err)
+	}
+	if restored != 0 {
+		t.Errorf("restored = %d, want 0 on clean state", restored)
+	}
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "V1" {
+		t.Errorf("worker.exe = %q, must be untouched", got)
+	}
+}
+
+// TestMachineApply_ConvergesResidualThenApplies 验证半换断电死锁态经 Machine.Apply
+// 自动收敛：备份残留 + 健康标记匹配旧值 → 重新 apply 后自动回到可用路径。
+func TestMachineApply_ConvergesResidualThenApplies(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 预置死锁态：断电在 swap 后、WriteUpgradeMeta 前
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "V2-broken")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "V1-old")
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "V1")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "V1")
+
+	// 新 bundle v3
+	buildMachineBundle(t, stageDir, binDir, "v3", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "V3-worker"},
+	})
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.Apply(context.Background(), 0); err != nil {
+		t.Fatalf("Machine.Apply on residual state: %v", err)
+	}
+
+	// 新版本落地
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "V3-worker" {
+		t.Errorf("worker.exe = %q, want %q", got, "V3-worker")
+	}
+	// 关键断言：.previous 内容 = V1-old（收敛先行）。若无收敛，apply 会把
+	// V2-broken 备份成 .previous — 健康超时回滚将恢复到坏版本
+	got, _ = os.ReadFile(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix))
+	if string(got) != "V1-old" {
+		t.Errorf(".previous = %q, want %q (convergence must run before swap)", got, "V1-old")
+	}
+	// 版本元数据已更新为新 bundle
+	if v := readTrimmed(LastUpgradeVerPath(stageDir)); v != "v3" {
+		t.Errorf("last_upgrade_ver = %q, want v3", v)
+	}
+}

--- a/internal/edgeagent/upgrademachine/doc.go
+++ b/internal/edgeagent/upgrademachine/doc.go
@@ -1,0 +1,37 @@
+// Package upgrademachine 实现 supervisor.exe 的升级状态机深模块。
+// # 状态机
+// 升级状态机描述 worker 二进制文件的 swap → 健康确认 → 回滚 生命周期：
+//
+//	idle → pending → swapped → healthy
+//	                   └→ rolled_back → idle
+//
+// 状态定义：
+//   - StateIdle       — 无升级进行中（incoming/ 不存在，无 rollback.done）
+//   - StatePending    — incoming/MANIFEST.txt 存在（worker 下载了新 bundle，等待 swap）
+//   - StateSwapped    — 文件已替换，last_upgrade_ver 已写，等待健康确认
+//   - StateHealthy    — healthy_marker 匹配 last_upgrade_ver（新 worker register_edge 成功）
+//   - StateRolledBack — rollback.done 存在（旧版本已恢复，等待下次升级）
+//
+// # 状态转移触发
+//
+//	idle → pending       DownloadBundle（worker 侧 upgradebundle 包）
+//	pending → swapped    Machine.Apply / Machine.BootCheck
+//	swapped → healthy    Machine.HealthPoll（poll IsUpgradeHealthy）
+//	swapped → rolled_back superviseWorker 循环顶部 watchDeadline 超时 → Machine.RollbackAndMark（HealthPoll redesign）
+//	any → rolled_back    Machine.BootCheck（启动时检测不健康）
+//	rolled_back → idle   edge DownloadBundle 步骤 2 DeleteRollbackSentinel
+//
+// # 文件系统 IPC
+// supervisor 与 worker 通过 StageDir 下的文件通信（无 socket/pipe）：
+//
+//	<StageDir>/incoming/MANIFEST.txt  — pending 触发器
+//	<StageDir>/incoming/VERSION       — bundle 版本号
+//	<StageDir>/last_upgrade_ver       — 当前升级版本号
+//	<StageDir>/last_upgrade_at        — 升级时间戳
+//	<StageDir>/healthy_marker         — worker register_edge 成功后写的版本号
+//	<StageDir>/rollback.done          — rollback 完成哨兵
+//	<dest>.previous                   — swap 备份的旧文件
+//
+// 所有文件名常量定义在 ipc.go，是跨包单一真相源。
+// upgradebundle（worker 侧）和 cmd/（supervisor 侧）均引用本包的常量。
+package upgrademachine

--- a/internal/edgeagent/upgrademachine/dummy_helper_test.go
+++ b/internal/edgeagent/upgrademachine/dummy_helper_test.go
@@ -1,0 +1,78 @@
+// dummy_helper_test.go 提供 testdata/dummy_main.go 的跨平台编译 helper。
+// buildDummy 被 Windows 文件锁语义测试（running_exe_rename_windows_test.go）
+// 和 supervisor self-swap 测试（supervisor_selfswap_test.go）共用。
+// dummy.exe 支持：
+//   - 默认：sleep 60s（模拟运行中 supervisor.exe）
+//   - --version：输出 "ongrid-dummy v0.0.1" + exit 0（smokeTestVersion 验证用）
+//   - --self-rename <path>：自 rename + JSON 报告（rename 场景测试用）
+
+package upgrademachine
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	dummyOnce sync.Once
+	dummyPath string
+	dummyErr  error
+)
+
+// buildDummy 编译 dummy_main.go → dummy.exe，所有测试共用。
+// 首次调用 ~3-5s，后续 0s（cache 在 os.TempDir 固定路径）。
+func buildDummy(t *testing.T) string {
+	t.Helper()
+	dummyOnce.Do(func() {
+		out := filepath.Join(os.TempDir(), "ongrid-dummy.exe")
+		src := filepath.Join("testdata", "dummy_main.go")
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			dummyErr = fmt.Errorf("go build dummy: %w\noutput: %s", err, out)
+			return
+		}
+		dummyPath = out
+	})
+	if dummyErr != nil {
+		t.Fatal(dummyErr)
+	}
+	return dummyPath
+}
+
+// copyFileExe 复制 src → dst（用于铺地板，保留 src 的文件权限）。
+// 跨平台 — rename 和 self-swap 测试共用。
+func copyFileExe(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open src %s: %v", src, err)
+	}
+	defer in.Close()
+	info, _ := in.Stat()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		t.Fatalf("create dst %s: %v", dst, err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+}
+
+// appendMarker 在文件末尾追加 marker 字节，让 src 和 dest 内容不同（测试可区分版本）。
+func appendMarker(t *testing.T, path, marker string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append %s: %v", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(marker); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/extract_pending.go
+++ b/internal/edgeagent/upgrademachine/extract_pending.go
@@ -1,0 +1,187 @@
+// extract_pending.go — Windows 兼容层：解压 worker agent_upgrade RPC 下载的
+// pending tar.gz 到 incoming/。
+// 背景：Linux edge 由 systemd ExecStartPre（apply-pending-upgrade.sh）完成
+// pending → incoming 解压；Windows 无对等机制，由 supervisor CheckPending
+// 调用本文件函数完成。
+package upgrademachine
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PendingFileName 是 worker agent_upgrade RPC 下载的 bundle 文件名（tar.gz 内容，
+// 无 .tar.gz 后缀）。对称 biz/upgrade.go 的 final path。
+const PendingFileName = "pending"
+
+// PendingSHA256FileName 是 pending 的 sha256 companion 文件名。
+const PendingSHA256FileName = "pending.sha256"
+
+// maxExtractBytes 限制解压后总大小（1 GB，对称 upgradebundle.maxBundleBytes）。
+const maxExtractBytes = 1024 * 1024 * 1024
+
+// HasPendingBundle 报告 {stageDir}/pending 文件是否存在。
+// 用于区分"无 upgrade"和"pending tar.gz 未解压"两种状态。
+func HasPendingBundle(stageDir string) bool {
+	info, err := os.Stat(filepath.Join(stageDir, PendingFileName))
+	return err == nil && !info.IsDir()
+}
+
+// ExtractPendingBundle 解压 {stageDir}/pending（tar.gz）到 {stageDir}/incoming/，
+// 然后删除 pending + pending.sha256（防止重复解压触发 upgrade 死循环）。
+// 调用方：Machine.CheckPending 在 IsPending 返回 false 但 HasPendingBundle
+// 返回 true 时调用（Windows supervisor 路径）。
+//
+// 消费前先复核 pending 的 sha256 与 worker 下载时写的 companion 一致
+// （纵深：worker 侧下载时验过一次，supervisor 消费前再验一次 — 攻击者若
+// 只拿到 pending 的写权限而无 pending.sha256 的写权限即被拦）。复核失败
+// 或 companion 缺失 = fail-closed：删除 pending + sha（防死循环）并返回 error。
+func ExtractPendingBundle(stageDir string) error {
+	pendingPath := filepath.Join(stageDir, PendingFileName)
+	shaPath := filepath.Join(stageDir, PendingSHA256FileName)
+	incomingPath := IncomingDir(stageDir)
+
+	if err := verifyPendingSHA256(pendingPath, shaPath); err != nil {
+		// 完整性不可信的 pending 不得进入解压；删除防 CheckPending 死循环。
+		_ = os.Remove(pendingPath)
+		_ = os.Remove(shaPath)
+		return fmt.Errorf("verify pending: %w", err)
+	}
+
+	// 清理旧 incoming/ 残留（幂等）
+	_ = os.RemoveAll(incomingPath)
+
+	if err := extractTarGz(pendingPath, incomingPath); err != nil {
+		return fmt.Errorf("extract pending: %w", err)
+	}
+
+	// 解压成功后删除 pending + pending.sha256（防止 CheckPending 重复触发）
+	if err := os.Remove(pendingPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove pending: %w", err)
+	}
+	_ = os.Remove(shaPath)
+
+	return nil
+}
+
+// verifyPendingSHA256 计算 pending 文件的 sha256 并与 companion 文件内容比对。
+// companion 由 worker 侧下载链路写入（格式：64 位小写 hex + 换行，对称
+// biz/upgrade.go）。companion 缺失 = fail-closed（本 PR 起 worker 下载链路
+// 恒写该文件，缺失说明状态不完整）。
+func verifyPendingSHA256(pendingPath, shaPath string) error {
+	want, err := os.ReadFile(shaPath)
+	if err != nil {
+		return fmt.Errorf("read sha companion (missing = fail-closed): %w", err)
+	}
+	expected := strings.ToLower(strings.TrimSpace(string(want)))
+	if len(expected) != 64 {
+		return fmt.Errorf("sha companion malformed (want 64 hex chars, got %d)", len(expected))
+	}
+	f, err := os.Open(pendingPath)
+	if err != nil {
+		return fmt.Errorf("open pending: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash pending: %w", err)
+	}
+	if got := fmt.Sprintf("%x", h.Sum(nil)); got != expected {
+		return fmt.Errorf("checksum mismatch (want %s, got %s)", expected, got)
+	}
+	return nil
+}
+
+// extractTarGz 解压 src（.tar.gz）到 dst。
+// 安全措施：拒绝路径逃逸（zip-slip）、symlink/hardlink、超限总大小。
+// 逻辑对称 upgradebundle/download.go 的 extractTarGz（副本，避免循环依赖）。
+func extractTarGz(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return fmt.Errorf("mkdir dst: %w", err)
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("abs dst: %w", err)
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		// 只接受普通文件和目录（拒绝 symlink/hardlink/device）。
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeDir:
+		default:
+			return fmt.Errorf("disallowed tar entry type %v in %q", hdr.Typeflag, hdr.Name)
+		}
+		cleaned := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(cleaned, "/") || strings.Contains(cleaned, "..") {
+			return fmt.Errorf("disallowed tar path %q (escapes archive root)", hdr.Name)
+		}
+		target := filepath.Join(absDst, cleaned)
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("abs target: %w", err)
+		}
+		if !EqualFoldPrefix(absTarget, absDst+string(os.PathSeparator)) && !strings.EqualFold(absTarget, absDst) {
+			return fmt.Errorf("target %q escapes %q", absTarget, absDst)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("mkdir parent of %s: %w", target, err)
+		}
+		w, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+			os.FileMode(hdr.Mode)&0o755)
+		if err != nil {
+			return fmt.Errorf("open out %s: %w", target, err)
+		}
+		n, err := io.Copy(w, io.LimitReader(tr, maxExtractBytes-totalBytes+1))
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", target, err)
+		}
+		totalBytes += n
+		if totalBytes > maxExtractBytes {
+			return fmt.Errorf("extracted size exceeded %d bytes", maxExtractBytes)
+		}
+	}
+	return nil
+}
+
+// EqualFoldPrefix 报告 s 是否以 prefix 开头（大小写不敏感比较）。
+// 用于解压路径逃逸检测：Windows 路径比较是大小写不敏感语义，前缀判断若用
+// 区分大小写的 HasPrefix，dst 与 entry 以不同大小写拼写时检测会失效
+// （与 ensureWithinDir 的 EqualFold 语义对齐）。
+func EqualFoldPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(prefix, s[:len(prefix)])
+}

--- a/internal/edgeagent/upgrademachine/extract_pending_test.go
+++ b/internal/edgeagent/upgrademachine/extract_pending_test.go
@@ -1,0 +1,257 @@
+package upgrademachine
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeTarGz 创建一个包含给定文件的 .tar.gz 字节流。
+func makeTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatalf("write tar header %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write tar body %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// writePendingBundle 在 stageDir 下写入 pending（tar.gz）+ pending.sha256
+// （sha 与内容真实匹配，对称 worker 下载链路的写入格式）。
+func writePendingBundle(t *testing.T, stageDir string, files map[string]string) {
+	t.Helper()
+	writeRawPending(t, stageDir, makeTarGz(t, files))
+}
+
+// writeRawPending 写入原始 pending 字节 + 对应的真实 sha companion。
+func writeRawPending(t *testing.T, stageDir string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(stageDir, PendingFileName), data, 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	sha := fmt.Sprintf("%x\n", sum)
+	if err := os.WriteFile(filepath.Join(stageDir, PendingSHA256FileName), []byte(sha), 0o644); err != nil {
+		t.Fatalf("write pending.sha256: %v", err)
+	}
+}
+
+// --- HasPendingBundle ---
+
+func TestHasPendingBundle_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	if HasPendingBundle(dir) {
+		t.Error("expected false when pending does not exist")
+	}
+}
+
+func TestHasPendingBundle_Exists(t *testing.T) {
+	dir := t.TempDir()
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "stub"})
+	if !HasPendingBundle(dir) {
+		t.Error("expected true when pending exists")
+	}
+}
+
+// --- ExtractPendingBundle ---
+
+func TestExtractPendingBundle_Success(t *testing.T) {
+	dir := t.TempDir()
+	manifestContent := "abc123  0o755  worker.exe  C:\\bin\\worker.exe"
+	writePendingBundle(t, dir, map[string]string{
+		"MANIFEST.txt": manifestContent,
+		"VERSION":      "v0.9.3",
+	})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// 验证 incoming/MANIFEST.txt 存在且内容正确
+	manifestPath := ManifestPath(dir)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read extracted MANIFEST.txt: %v", err)
+	}
+	if string(data) != manifestContent {
+		t.Errorf("MANIFEST.txt content mismatch: got %q", string(data))
+	}
+
+	// 验证 incoming/VERSION 存在
+	versionPath := filepath.Join(dir, IncomingDirName, "VERSION")
+	if _, err := os.Stat(versionPath); err != nil {
+		t.Errorf("VERSION not extracted: %v", err)
+	}
+}
+
+func TestExtractPendingBundle_DeletesPendingAndSHA256(t *testing.T) {
+	dir := t.TempDir()
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "stub"})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// pending + pending.sha256 应被删除（防止重复解压）
+	if _, err := os.Stat(filepath.Join(dir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after extract, got err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, PendingSHA256FileName)); !os.IsNotExist(err) {
+		t.Errorf("pending.sha256 should be deleted after extract, got err: %v", err)
+	}
+}
+
+func TestExtractPendingBundle_BadGzip(t *testing.T) {
+	dir := t.TempDir()
+	// 写入损坏数据（不是合法 tar.gz，但 sha companion 真实匹配 —
+	// 确保失败来自解压层而非完整性复核层）
+	writeRawPending(t, dir, []byte("not a gzip"))
+
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error for bad gzip data")
+	}
+}
+
+func TestExtractPendingBundle_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	// 构造包含路径逃逸的 tar.gz
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	// 正常文件
+	tw.WriteHeader(&tar.Header{Name: "MANIFEST.txt", Mode: 0o644, Size: 4})
+	tw.Write([]byte("safe"))
+	// 恶意路径逃逸
+	tw.WriteHeader(&tar.Header{Name: "../escape.txt", Mode: 0o644, Size: 1})
+	tw.Write([]byte("X"))
+	tw.Close()
+	gz.Close()
+
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	sha := fmt.Sprintf("%x\n", sum)
+	if err := os.WriteFile(filepath.Join(dir, PendingSHA256FileName), []byte(sha), 0o644); err != nil {
+		t.Fatalf("write pending.sha256: %v", err)
+	}
+
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "..", "escape.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("escape file should not exist on disk")
+	}
+}
+
+func TestExtractPendingBundle_NoPendingFile(t *testing.T) {
+	dir := t.TempDir()
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error when pending file does not exist")
+	}
+}
+
+func TestExtractPendingBundle_OverwritesOldIncoming(t *testing.T) {
+	dir := t.TempDir()
+	// 先放旧 incoming/ 残留
+	oldFile := filepath.Join(dir, IncomingDirName, "stale.txt")
+	os.MkdirAll(filepath.Dir(oldFile), 0o755)
+	os.WriteFile(oldFile, []byte("stale"), 0o644)
+
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "fresh"})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// 旧文件应被清理
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Error("stale file in old incoming/ should be removed")
+	}
+}
+
+// --- pending.sha256 完整性复核 ---
+
+// TestExtractPendingBundle_SHA256Mismatch 验证 sha 不匹配时 fail-closed：
+// 拒绝解压 + 删除 pending / sha（防死循环）。
+func TestExtractPendingBundle_SHA256Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "stub"})
+	// 篡改 pending 内容（sha 不再匹配）
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), []byte("tampered"), 0o644); err != nil {
+		t.Fatalf("tamper pending: %v", err)
+	}
+
+	if err := ExtractPendingBundle(dir); err == nil {
+		t.Fatal("expected error on sha mismatch")
+	}
+	if _, err := os.Stat(filepath.Join(dir, PendingFileName)); !os.IsNotExist(err) {
+		t.Error("pending should be deleted after sha mismatch (prevent retry loop)")
+	}
+	if _, err := os.Stat(filepath.Join(dir, PendingSHA256FileName)); !os.IsNotExist(err) {
+		t.Error("pending.sha256 should be deleted after sha mismatch")
+	}
+	if _, err := os.Stat(filepath.Join(dir, IncomingDirName)); !os.IsNotExist(err) {
+		t.Error("incoming/ must not be created for tampered pending")
+	}
+}
+
+// TestExtractPendingBundle_MissingSHACompanion 验证 sha companion 缺失时
+// fail-closed（本 PR 起 worker 下载链路恒写该文件，缺失 = 状态不完整）。
+func TestExtractPendingBundle_MissingSHACompanion(t *testing.T) {
+	dir := t.TempDir()
+	data := makeTarGz(t, map[string]string{"MANIFEST.txt": "stub"})
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), data, 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+
+	if err := ExtractPendingBundle(dir); err == nil {
+		t.Fatal("expected error when sha companion is missing")
+	}
+	if _, err := os.Stat(filepath.Join(dir, PendingFileName)); !os.IsNotExist(err) {
+		t.Error("pending should be deleted when sha companion is missing")
+	}
+}
+
+// TestVerifyPendingSHA256_Success 单元级：正确 sha 通过、大写 hex 容忍。
+func TestVerifyPendingSHA256_Success(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("payload")
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), data, 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	upper := strings.ToUpper(fmt.Sprintf("%x", sum))
+	if err := os.WriteFile(filepath.Join(dir, PendingSHA256FileName), []byte(upper+"\n"), 0o644); err != nil {
+		t.Fatalf("write sha: %v", err)
+	}
+	if err := verifyPendingSHA256(filepath.Join(dir, PendingFileName), filepath.Join(dir, PendingSHA256FileName)); err != nil {
+		t.Fatalf("verifyPendingSHA256 should accept matching (upper-case) sha: %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/health.go
+++ b/internal/edgeagent/upgrademachine/health.go
@@ -1,0 +1,108 @@
+// health.go 管理升级版本元数据文件 + 状态检测函数。
+// 所有文件名常量引用本包 ipc.go（单一真相源）。
+// 健康判定：last_upgrade_ver == healthy_marker → 升级成功
+// rollback 触发：last_upgrade_ver 存在但 healthy_marker 不匹配 → 回滚
+// context 约定例外：WriteUpgradeMeta / ClearPending / WriteRollbackDone
+// 操作本地文件系统（毫秒级），WriteUpgradeMeta 删 healthy_marker 是关键步骤
+// （不删 → watchdog 永不触发 rollback）。取消检查由编排层 Machine 入口完成。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// IsPending 检查是否有 pending upgrade（incoming/MANIFEST.txt 存在）。
+func IsPending(stageDir string) bool {
+	_, err := os.Stat(ManifestPath(stageDir))
+	return err == nil
+}
+
+// IsUpgradeHealthy 判断最近一次 upgrade 是否被确认为健康。
+// 条件：last_upgrade_ver 存在 AND healthy_marker 内容匹配。
+func IsUpgradeHealthy(stageDir string) bool {
+	lastVer := readTrimmed(LastUpgradeVerPath(stageDir))
+	if lastVer == "" {
+		return false // 从未升级过
+	}
+	healthyVer := readTrimmed(HealthyMarkerPath(stageDir))
+	return lastVer == healthyVer
+}
+
+// HasLastUpgrade 报告是否发生过至少一次 upgrade swap（last_upgrade_ver 存在）。
+// supervisor 启动时用此区分"从未升级"（无需 rollback）和"升级了但不健康"（需 rollback）。
+func HasLastUpgrade(stageDir string) bool {
+	return readTrimmed(LastUpgradeVerPath(stageDir)) != ""
+}
+
+// WriteUpgradeMeta 在 swap 完成后写入版本元数据，并删除旧 healthy_marker
+// 重新武装健康检查（对称 Linux apply_bundle 完成后 `rm -f "$HEALTHY_MARKER"`）。
+// 删 healthy_marker 是关键步骤：如果不删，旧 marker 仍在 → IsUpgradeHealthy
+// 立刻返回 true → watchdog 永不触发 rollback。
+// 新 worker register_edge 成功后会写新的 healthy_marker。
+func WriteUpgradeMeta(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	// last_upgrade_ver
+	if err := os.WriteFile(LastUpgradeVerPath(stageDir), []byte(version+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write last_upgrade_ver: %w", err)
+	}
+	// last_upgrade_at（ISO8601 UTC）
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if err := os.WriteFile(LastUpgradeAtPath(stageDir), []byte(ts+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write last_upgrade_at: %w", err)
+	}
+	// 删 healthy_marker（不存在时 Remove 报错，忽略 — 可能是首次升级）
+	markerPath := HealthyMarkerPath(stageDir)
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove old healthy_marker: %w", err)
+	}
+	return nil
+}
+
+// ReadStagedVersion 从 incoming/VERSION 读取版本号。
+// 文件不存在时返回空字符串（不报错 — 旧版 bundle 可能无 VERSION）。
+func ReadStagedVersion(stageDir string) (string, error) {
+	verPath := StagedVersionPath(stageDir)
+	if _, err := os.Stat(verPath); err != nil {
+		return "", nil // 不存在 = 无版本信息
+	}
+	return readTrimmed(verPath), nil
+}
+
+// ClearPending 删除 incoming/ 目录（bundle 已 apply 或 rollback 后清理）。
+func ClearPending(stageDir string) error {
+	incoming := IncomingDir(stageDir)
+	if err := os.RemoveAll(incoming); err != nil {
+		return fmt.Errorf("remove incoming/: %w", err)
+	}
+	return nil
+}
+
+// RollbackDoneExists 报告 rollback.done 哨兵文件是否存在。
+// superviseWorker 每轮启动前检查 → 存在则跳过 upgrade watch（避免死循环）。
+func RollbackDoneExists(stageDir string) bool {
+	_, err := os.Stat(RollbackDonePath(stageDir))
+	return err == nil
+}
+
+// WriteRollbackDone 写 rollback.done 哨兵文件。
+func WriteRollbackDone(stageDir string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	return os.WriteFile(RollbackDonePath(stageDir), []byte("done\n"), 0o640)
+}
+
+// readTrimmed 读取文件并 trim 空白。文件不存在或读失败时返回空字符串。
+func readTrimmed(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/edgeagent/upgrademachine/health_test.go
+++ b/internal/edgeagent/upgrademachine/health_test.go
@@ -1,0 +1,198 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsUpgradeHealthy_Match(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.50")
+
+	if !IsUpgradeHealthy(dir) {
+		t.Error("expected healthy when versions match")
+	}
+}
+
+func TestIsUpgradeHealthy_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.49")
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when versions mismatch")
+	}
+}
+
+func TestIsUpgradeHealthy_NoMarker(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	// 不写 healthy_marker — 模拟新 worker 启动但未 register_edge
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when healthy_marker missing")
+	}
+}
+
+func TestIsUpgradeHealthy_NoMeta(t *testing.T) {
+	dir := t.TempDir()
+	// 两个文件都不存在 — 首次安装或未升级
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when no upgrade meta exists")
+	}
+}
+
+func TestWriteUpgradeMeta_WritesBoth(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteUpgradeMeta: %v", err)
+	}
+
+	ver, err := os.ReadFile(filepath.Join(dir, LastUpgradeVerFile))
+	if err != nil {
+		t.Fatalf("read last_upgrade_ver: %v", err)
+	}
+	if strings.TrimSpace(string(ver)) != "v0.7.50" {
+		t.Errorf("last_upgrade_ver = %q, want %q", ver, "v0.7.50")
+	}
+
+	at, err := os.ReadFile(filepath.Join(dir, LastUpgradeAtFile))
+	if err != nil {
+		t.Fatalf("read last_upgrade_at: %v", err)
+	}
+	if strings.TrimSpace(string(at)) == "" {
+		t.Error("last_upgrade_at should not be empty")
+	}
+}
+
+func TestWriteUpgradeMeta_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "upgrade")
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("should create nested dir: %v", err)
+	}
+}
+
+func TestWriteUpgradeMeta_DeletesOldHealthyMarker(t *testing.T) {
+	dir := t.TempDir()
+	// 先写一个旧 healthy_marker（模拟上次升级的标记）
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.49")
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.49")
+
+	// 执行新升级的 meta 写入
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteUpgradeMeta: %v", err)
+	}
+
+	// healthy_marker 应被删除（重新武装健康检查）
+	if _, err := os.Stat(filepath.Join(dir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should be removed after WriteUpgradeMeta")
+	}
+
+	// 但 last_upgrade_ver 应更新为新版本
+	ver := readTrimmed(filepath.Join(dir, LastUpgradeVerFile))
+	if ver != "v0.7.50" {
+		t.Errorf("last_upgrade_ver = %q, want v0.7.50", ver)
+	}
+
+	// 新版本未写 healthy_marker → IsUpgradeHealthy 应返回 false
+	if IsUpgradeHealthy(dir) {
+		t.Error("should NOT be healthy — marker was deleted, new worker hasn't registered yet")
+	}
+}
+
+func TestWriteUpgradeMeta_NoOldMarker_NoError(t *testing.T) {
+	dir := t.TempDir()
+	// 首次升级，无旧 marker → Remove 报 IsNotExist，应被忽略
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("should not error when no old marker: %v", err)
+	}
+}
+
+func TestIsPending_ManifestExists(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), "fake manifest")
+
+	if !IsPending(dir) {
+		t.Error("expected pending when MANIFEST.txt exists")
+	}
+}
+
+func TestIsPending_ManifestMissing(t *testing.T) {
+	dir := t.TempDir()
+	// incoming/ 不存在
+	if IsPending(dir) {
+		t.Error("expected NOT pending when MANIFEST.txt missing")
+	}
+}
+
+func TestClearPending_RemovesIncomingDir(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), "fake")
+	writeTestFile(t, filepath.Join(incoming, "worker.exe"), "binary")
+
+	if err := ClearPending(dir); err != nil {
+		t.Fatalf("ClearPending: %v", err)
+	}
+
+	if _, err := os.Stat(incoming); !os.IsNotExist(err) {
+		t.Error("incoming/ should be removed")
+	}
+}
+
+func TestClearPending_NoIncomingDir(t *testing.T) {
+	dir := t.TempDir()
+	// 不存在 incoming/ — 幂等，不报错
+	if err := ClearPending(dir); err != nil {
+		t.Fatalf("ClearPending on missing dir should not error: %v", err)
+	}
+}
+
+func TestReadStagedVersion(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v0.7.50")
+
+	ver, err := ReadStagedVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadStagedVersion: %v", err)
+	}
+	if ver != "v0.7.50" {
+		t.Errorf("version = %q, want %q", ver, "v0.7.50")
+	}
+}
+
+func TestReadStagedVersion_NoVersionFile(t *testing.T) {
+	dir := t.TempDir()
+	// incoming/ 存在但无 VERSION 文件
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake")
+
+	ver, err := ReadStagedVersion(dir)
+	if err != nil {
+		t.Fatalf("should not error when VERSION missing: %v", err)
+	}
+	if ver != "" {
+		t.Errorf("version = %q, want empty", ver)
+	}
+}
+
+func TestRollbackDoneExists_Present(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+
+	if !RollbackDoneExists(dir) {
+		t.Error("expected rollback.done to exist")
+	}
+}
+
+func TestRollbackDoneExists_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if RollbackDoneExists(dir) {
+		t.Error("expected rollback.done to NOT exist")
+	}
+}

--- a/internal/edgeagent/upgrademachine/ipc.go
+++ b/internal/edgeagent/upgrademachine/ipc.go
@@ -1,0 +1,185 @@
+// ipc.go 定义升级状态机的所有文件系统 IPC 常量（单一真相源）。
+// 这些常量消除原先 upgradeapply / upgradebundle / cmd 三包各自的私有/导出定义 drift。
+// 任何包需要引用文件名时，import 本包的导出常量，而非重新定义。
+//  supervisor 自升级 sentinel 常量也在此定义（保持单一真相源）。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StageDir 下的 IPC 文件名常量。
+const (
+	// HealthyMarkerFile 是 worker register_edge 成功后写的版本号文件名。
+	// supervisor 的 IsUpgradeHealthy 对比此文件内容与 last_upgrade_ver 判定升级是否健康。
+	HealthyMarkerFile = "healthy_marker"
+
+	// RollbackDoneFile 是 rollback 完成后的哨兵文件名。
+	// supervisor 检测到此文件 → 跳过 rollback 检查（避免死循环）。
+	// edge DownloadBundle 步骤 2 自动删除此文件（upgradebundle.DeleteRollbackSentinel，
+	// edge 自治清理，manager 是远程进程不持有 edge 本地 stageDir）。
+	RollbackDoneFile = "rollback.done"
+
+	// LastUpgradeVerFile 是 supervisor swap 后写的当前版本号文件名。
+	LastUpgradeVerFile = "last_upgrade_ver"
+
+	// LastUpgradeAtFile 是 supervisor swap 后写的 ISO8601 时间戳文件名。
+	LastUpgradeAtFile = "last_upgrade_at"
+
+	// IncomingDirName 是 StageDir 下存放解压 bundle 的子目录名。
+	IncomingDirName = "incoming"
+
+	// ManifestFileName 是 swap 指令清单文件名（也是 pending 触发器）。
+	ManifestFileName = "MANIFEST.txt"
+
+	// VersionFileName 是 bundle 内携带的版本号文件名。
+	VersionFileName = "VERSION"
+
+	// PreviousSuffix 是 .previous 备份文件的统一后缀。
+	PreviousSuffix = ".previous"
+
+	// SupervisorUpgradePendingFile 是 supervisor 自升级哨兵 — applyOne 检测到
+	// supervisor.exe dest 时写入此文件，跳过原子 rename（深模块不能 rename 运行中的自身）。
+	// Machine.BootCheck / superviseWorker 检测到此文件 → 触发 SupervisorSelfSwap。
+	SupervisorUpgradePendingFile = "supervisor_upgrade.pending"
+
+	// SupervisorUpgradeAppliedFile 是 supervisor 自升级完成哨兵 —
+	// SupervisorSelfSwap 成功后写入，BootCheck 检测到后清理 .old 备份 + 删此哨兵。
+	SupervisorUpgradeAppliedFile = "supervisor_upgrade.applied"
+
+	// SupervisorSelfSwapAwaitingHealthFile 标记 supervisor self-swap 已完成 + 等待
+	// worker 健康确认。
+	// 生命周期：
+	//   - 写：SupervisorSelfSwap step 3 成功路径（与 applied 同时写）
+	//   - 读：BootCheck 步骤 1 检测到 → 设 pendingHealthCheck=true → 跳过立即 rollback
+	//   - 清：HealthPoll 成功路径 + superviseWorker 循环顶部 deadline rollback 路径（HealthPoll redesign）；ResetUpgradeIPC brick 兜底
+	// 解决 BootCheck 时序问题：BootCheck 步骤 1 无 grace period 会在 self-swap
+	// happy path 下于 worker 启动写 healthy_marker 前就 rollback。
+	SupervisorSelfSwapAwaitingHealthFile = "supervisor_selfswap_awaiting_health"
+)
+
+// 二进制文件名常量（对称 edgedirs.WorkerBinary，本包自包含以避免 cmd → edgedirs 反向依赖）。
+const (
+	// SupervisorBinaryName 是 supervisor.exe 文件名（MANIFEST dest 匹配键）。
+	SupervisorBinaryName = "ongrid-edge-supervisor.exe"
+
+	// WorkerBinaryName 是 worker.exe 文件名（BootCheck KillByImage 清理 orphan worker 用）。
+	WorkerBinaryName = "ongrid-edge-worker.exe"
+)
+
+// IncomingDir 返回 StageDir 下的 incoming/ 子目录路径。
+func IncomingDir(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName)
+}
+
+// ManifestPath 返回 incoming/MANIFEST.txt 的完整路径。
+func ManifestPath(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName, ManifestFileName)
+}
+
+// HealthyMarkerPath 返回 healthy_marker 的完整路径。
+func HealthyMarkerPath(stageDir string) string {
+	return filepath.Join(stageDir, HealthyMarkerFile)
+}
+
+// RollbackDonePath 返回 rollback.done 的完整路径。
+func RollbackDonePath(stageDir string) string {
+	return filepath.Join(stageDir, RollbackDoneFile)
+}
+
+// LastUpgradeVerPath 返回 last_upgrade_ver 的完整路径。
+func LastUpgradeVerPath(stageDir string) string {
+	return filepath.Join(stageDir, LastUpgradeVerFile)
+}
+
+// LastUpgradeAtPath 返回 last_upgrade_at 的完整路径。
+func LastUpgradeAtPath(stageDir string) string {
+	return filepath.Join(stageDir, LastUpgradeAtFile)
+}
+
+// StagedVersionPath 返回 incoming/VERSION 的完整路径。
+func StagedVersionPath(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName, VersionFileName)
+}
+
+// SupervisorUpgradePendingPath 返回 supervisor_upgrade.pending 的完整路径。
+func SupervisorUpgradePendingPath(stageDir string) string {
+	return filepath.Join(stageDir, SupervisorUpgradePendingFile)
+}
+
+// SupervisorUpgradeAppliedPath 返回 supervisor_upgrade.applied 的完整路径。
+func SupervisorUpgradeAppliedPath(stageDir string) string {
+	return filepath.Join(stageDir, SupervisorUpgradeAppliedFile)
+}
+
+// SupervisorSelfSwapAwaitingHealthPath 返回 supervisor_selfswap_awaiting_health
+// 哨兵的完整路径。
+func SupervisorSelfSwapAwaitingHealthPath(stageDir string) string {
+	return filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)
+}
+
+// IsSupervisorUpgradePending 报告是否存在 supervisor 自升级 pending 哨兵。
+// 存在 = applyOne 已 stage supervisor.exe.new，等待 SupervisorSelfSwap 执行 rename-aside。
+func IsSupervisorUpgradePending(stageDir string) bool {
+	_, err := os.Stat(SupervisorUpgradePendingPath(stageDir))
+	return err == nil
+}
+
+// WriteSupervisorUpgradePending 写 supervisor_upgrade.pending 哨兵。
+// applyOne 检测到 supervisor dest 时调用，内容是 supervisor.exe.new 的预期版本（可空）。
+func WriteSupervisorUpgradePending(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	body := version
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return os.WriteFile(SupervisorUpgradePendingPath(stageDir), []byte(body), 0o640)
+}
+
+// IsSupervisorUpgradeApplied 报告是否存在 supervisor 自升级 applied 哨兵。
+// 存在 = SupervisorSelfSwap 已完成 rename-aside，BootCheck 应清理 .old 并删此哨兵。
+func IsSupervisorUpgradeApplied(stageDir string) bool {
+	_, err := os.Stat(SupervisorUpgradeAppliedPath(stageDir))
+	return err == nil
+}
+
+// WriteSupervisorUpgradeApplied 写 supervisor_upgrade.applied 哨兵。
+// SupervisorSelfSwap 成功后调用，内容是新版本号（可空）。
+func WriteSupervisorUpgradeApplied(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	body := version
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return os.WriteFile(SupervisorUpgradeAppliedPath(stageDir), []byte(body), 0o640)
+}
+
+// IsSupervisorSelfSwapAwaitingHealth 报告是否存在 supervisor self-swap awaiting health
+// 哨兵。存在 = self-swap 刚完成，等待 worker register_edge 健康确认。
+// BootCheck 步骤 1 检测到 → 设 m.pendingHealthCheck=true → 跳过立即 rollback，
+// 委托给 superviseWorker 的 HealthCheck 180s grace。
+func IsSupervisorSelfSwapAwaitingHealth(stageDir string) bool {
+	_, err := os.Stat(SupervisorSelfSwapAwaitingHealthPath(stageDir))
+	return err == nil
+}
+
+// WriteSupervisorSelfSwapAwaitingHealth 写 supervisor_selfswap_awaiting_health 哨兵。
+// SupervisorSelfSwap step 3 成功路径调用（与 applied 同时写）。
+func WriteSupervisorSelfSwapAwaitingHealth(stageDir string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	return os.WriteFile(
+		SupervisorSelfSwapAwaitingHealthPath(stageDir),
+		[]byte("awaiting\n"),
+		0o640,
+	)
+}

--- a/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
@@ -1,0 +1,71 @@
+// ipc_supervisor_test.go 测试  supervisor 自升级 sentinel helper。
+// 覆盖 IsSupervisorUpgradePending / WriteSupervisorUpgradePending /
+// IsSupervisorUpgradeApplied / WriteSupervisorUpgradeApplied 四个 helper
+// + Path 函数。
+
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSupervisorUpgradeSentinels_RoundTrip(t *testing.T) {
+	stageDir := t.TempDir()
+
+	// 初始：两个哨兵都不存在
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 不应初始存在")
+	}
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 不应初始存在")
+	}
+
+	// 写 pending（含版本号）
+	if err := WriteSupervisorUpgradePending(stageDir, "v0.9.2"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending: %v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 写入后应存在")
+	}
+	got, _ := os.ReadFile(SupervisorUpgradePendingPath(stageDir))
+	if string(got) != "v0.9.2\n" {
+		t.Errorf("pending 内容 = %q, want %q", got, "v0.9.2\n")
+	}
+
+	// 写 applied（空版本号 — 允许）
+	if err := WriteSupervisorUpgradeApplied(stageDir, ""); err != nil {
+		t.Fatalf("WriteSupervisorUpgradeApplied: %v", err)
+	}
+	if !IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 写入后应存在")
+	}
+	got, _ = os.ReadFile(SupervisorUpgradeAppliedPath(stageDir))
+	if string(got) != "" {
+		t.Errorf("applied 空版本号应写空内容，got %q", got)
+	}
+}
+
+func TestSupervisorUpgradeSentinels_ParentDirMissing(t *testing.T) {
+	// stageDir 不存在时 Write 应自动 mkdir
+	stageDir := filepath.Join(t.TempDir(), "nested", "stage")
+	if err := WriteSupervisorUpgradePending(stageDir, "v1"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending 自动 mkdir 失败：%v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 写入后应存在")
+	}
+}
+
+func TestSupervisorUpgradeSentinels_NewlineIdempotent(t *testing.T) {
+	// 带现有 \n 的版本号不应被加双重换行
+	stageDir := t.TempDir()
+	if err := WriteSupervisorUpgradePending(stageDir, "v0.9.2\n"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending: %v", err)
+	}
+	got, _ := os.ReadFile(SupervisorUpgradePendingPath(stageDir))
+	if string(got) != "v0.9.2\n" {
+		t.Errorf("idempotent newline = %q, want %q", got, "v0.9.2\n")
+	}
+}

--- a/internal/edgeagent/upgrademachine/machine.go
+++ b/internal/edgeagent/upgrademachine/machine.go
@@ -1,0 +1,744 @@
+// machine.go 实现升级状态机深模块。
+//
+// Machine 将原先分散在 cmd/upgrade_windows.go 的编排逻辑（applyAndSwap、
+// maybeApplyOnBoot、maybeRollbackOnBoot、watchUpgradeHealth、rollbackAndMark、
+// checkPendingUpgrade）集中到一个类型中。
+//
+// supervisor 侧（cmd/）通过 NewMachine 创建实例，注入平台专属的 ProcessController，
+// 然后调用 4 个高层方法：BootCheck / Apply / HealthPoll / RollbackAndMark。
+//
+// 纯 Go（无 Windows 专属依赖），测试可在 Linux CI 跑。
+
+package upgrademachine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrApplied 是 sentinel error，CheckPending 返回它告诉 superviseWorker：
+// "bundle swap 已完成，跳过 restartDelay 立即重启 worker"。
+var ErrApplied = errors.New("upgrade applied; restart immediately")
+
+// DefaultAwaitingHealthMaxAge 是 awaiting_health 哨兵总年龄上限的默认值
+// upgradeWatchTimeout（cmd 包，180s）的 5 倍。
+// 若 cmd 侧超时窗口调整，此值应保持"数倍"关系（窗口太小会让
+// 慢但健康的 worker 被误回滚，太大则崩溃循环收敛慢）。
+const DefaultAwaitingHealthMaxAge = 15 * time.Minute
+
+// supervisorDiscardSuffix 是 supervisor 双恢复时运行中新 exe
+// 的 rename-aside 后缀：恢复 .old 前必须先把当前 supervisor.exe 挪走（rename
+// 运行中 exe 可行，直接替换/删除不可行 — Windows image section 语义）。
+// 恢复趟 best-effort 删除；运行中删不掉时下次 BootCheck 步骤 4 前补删。
+const supervisorDiscardSuffix = ".discard"
+
+// ProcessController 抽象进程终止操作，供跨平台 DI。
+//
+// Windows 生产实现用 taskkill；测试传 mock。
+type ProcessController interface {
+	// KillTree 终止 pid 及其所有子进程（taskkill /T /F /PID）。
+	// 进程已退出时应返回非 nil error（调用方忽略，幂等）。
+	KillTree(pid int) error
+
+	// KillByImage 按镜像名终止所有同名进程（taskkill /F /IM <name>）。
+	// 进程不存在时返回非 nil error（调用方忽略，幂等）。
+	KillByImage(name string) error
+}
+
+// Machine 是升级状态机深模块，封装 supervisor 侧的升级编排逻辑。
+//
+// 持有 stageDir（IPC 文件根）和 binDir（swap 目标目录），
+// 通过注入的 ProcessController 执行平台专属的进程终止。
+type Machine struct {
+	stageDir string
+	binDir   string
+	log      *slog.Logger
+	pc       ProcessController
+	// selfPathResolver 返回 supervisor 进程实际运行的 .exe 路径。
+	// 生产默认 os.Executable（edgedirs.BinDir 硬编码可能与
+	// 运行路径不一致，如旧 nssm 遗留的 C:\ongrid-edge\ 安装路径）。
+	// 测试注入 stub 模拟非标准安装路径。
+	// nil 时 resolveSupervisorPath fallback 到 m.binDir + SupervisorBinaryName。
+	selfPathResolver func() (string, error)
+	// awaitingHealthMaxAge 是 awaiting_health 哨兵的总年龄上限。
+	// 默认 DefaultAwaitingHealthMaxAge；测试注入短值（零新缝：同包直接改字段）。
+	awaitingHealthMaxAge time.Duration
+	// pendingHealthCheck 由 BootCheck 步骤 1 的 awaiting-health 分支设置：
+	// 检测到 supervisor_selfswap_awaiting_health sentinel 时置 true，告诉
+	// superviseWorker 初始化 watchUpgrade=true，启 worker 后跑 HealthPoll 180s
+	// grace 确认健康（健康判定必须发生在 worker 实际启动后 — BootCheck 阶段
+	// worker 尚未启动，此时回滚会在 worker 有机会写健康标记前误杀刚换入的
+	// 版本；超时 rollback 由 superviseWorker 循环顶部执行，HealthPoll 本身
+	// 只 polling 不持 timer）。
+	pendingHealthCheck bool
+	// stageDirGuard 可选的 stage 目录安全校验（fail-closed 消费门控）。
+	// 升级 bundle 无签名，完整性依赖 stage 目录 ACL；guard 返回 error 时
+	// 拒绝消费 pending bundle（不解压、不 apply），但不影响 rollback /
+	// self-swap 恢复路径 — 那些输入来自 BinDir（受 Program Files ACL 保护）
+	// 而非 stage 目录。由平台调用方注入（Windows 为 ACL 校验；nil = 不设防，
+	// 仅限测试或无本地多用户威胁的平台）。
+	stageDirGuard func() error
+}
+
+// NewMachine 创建升级状态机实例。
+//
+// 参数：
+//   - stageDir: IPC 文件根目录（incoming/、last_upgrade_ver 等在此下）
+//   - binDir: swap 目标目录（worker.exe、.previous 文件在此下）
+//   - log: 结构化日志
+//   - pc: 平台专属进程控制器（nil 时跳过 kill 操作，仅用于 boot 无 worker 场景）
+func NewMachine(stageDir, binDir string, log *slog.Logger, pc ProcessController) *Machine {
+	return &Machine{
+		stageDir:             stageDir,
+		binDir:               binDir,
+		log:                  log,
+		pc:                   pc,
+		selfPathResolver:     os.Executable,
+		awaitingHealthMaxAge: DefaultAwaitingHealthMaxAge,
+	}
+}
+
+// resolveSupervisorPath 返回 supervisor.exe 实际运行路径。
+// 生产用 os.Executable（NewMachine 默认注入）；测试注入 stub。
+// selfPathResolver 为 nil 时 fail-fast（显式失败而非静默降级）—
+// NewMachine 已保证注入，nil 说明调用方未走标准构造路径。
+func (m *Machine) resolveSupervisorPath() (string, error) {
+	if m.selfPathResolver == nil {
+		return "", fmt.Errorf("selfPathResolver is nil (NewMachine not used)")
+	}
+	p, err := m.selfPathResolver()
+	if err != nil {
+		return "", fmt.Errorf("resolve supervisor self path: %w", err)
+	}
+	return filepath.Clean(p), nil
+}
+
+// BootCheck 是 supervisor 启动时的 boot hook，合并原 maybeRollbackOnBoot + maybeApplyOnBoot
+// + supervisor 自升级收尾 / brick 恢复 / self-swap 触发。
+//
+// 执行顺序（不可反转）：
+//  1. 检测上次升级是否健康 → 不健康则 RollbackAndMark；含双恢复（dual
+//     recovery）：rollback.done + awaiting_health 共存且 rollback.done 晚于
+//     awaiting（mtime 判据，排除 stale 假阳性）= 补 supervisor 侧恢复；
+//     awaiting_health 年龄超上限 = 强制双恢复（先 worker 后 supervisor）→
+//     SCM 自然重启
+//  2. 检测残留 pending upgrade → 有则 Apply（boot 时无 worker，不 kill）
+//  3. supervisor_upgrade.applied sentinel → 清理 .old 备份 + 删 sentinel
+//  4. brick recovery（supervisor.exe 缺失 + .old 存在）→ rename .old 恢复
+//  5. supervisor_upgrade.pending sentinel → KillByImage 清 orphan worker
+//     → SupervisorSelfSwap → 返回 ErrSupervisorRestartSoon 让 SCM 重启
+//
+// 返回最后遇到的错误（如有）。返回 ErrSupervisorRestartSoon 时调用方（service.go）
+// 应返回 (false, 1) 让 SCM 按 recovery action 重启（exitCode=0 不触发 restart）。
+func (m *Machine) BootCheck(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	var lastErr error
+
+	// 1. rollback.done sentinel → 上次已 rollback，跳过（避免死循环）
+	rollbackDone := RollbackDoneExists(m.stageDir)
+	awaiting := IsSupervisorSelfSwapAwaitingHealth(m.stageDir)
+	if rollbackDone && awaiting && !rollbackDoneAfterAwaitingHealth(m.stageDir) {
+		// stale rollback.done（mtime 早于/等于 awaiting_health）是旧周期
+		// 回滚残留（DownloadBundle / ConvergeResidualBackups 清理点均在
+		// BootCheck 步骤 1 之后，直投 pending 路径先到达这里），与本周期 SelfSwap
+		// 刚写的 awaiting_health 同形假阳性 — 只看共存会把健康的刚 selfswap
+		// supervisor 误回滚。清残留哨兵后按 awaiting-only 语义继续。
+		m.log.Warn("upgrade: stale rollback.done (older than awaiting_health); clearing and treating as selfswap-in-progress")
+		if err := os.Remove(RollbackDonePath(m.stageDir)); err != nil && !os.IsNotExist(err) {
+			m.log.Warn("upgrade: remove stale rollback.done failed (will retry next boot)", "err", err)
+		}
+		rollbackDone = false
+	}
+	if rollbackDone {
+		// rollback.done + awaiting_health 共存且 rollback.done 晚于
+		// awaiting = superviseWorker 超时路径的中间态 —
+		// worker 已回滚、supervisor 侧恢复待执行。保留哨兵不删（superviseWorker）
+		// + 本分支补 supervisor 恢复 = 双恢复「先 worker 后 supervisor」顺序；
+		// 任意中间点断电后下次 BootCheck 都到达这里（幂等）。
+		if awaiting {
+			restored, err := m.restoreSupervisorFromOld()
+			if err != nil {
+				m.log.Error("upgrade: supervisor restore after worker rollback failed", "err", err)
+				lastErr = err
+				// 不 return — 若 exe 已 rename aside，步骤 4 brick recovery 兜底
+			} else if restored {
+				return ErrSupervisorRestartSoon // SCM 自然重启加载旧 supervisor
+			} else {
+				m.log.Warn("upgrade: awaiting_health sentinel present but no .old to restore; clearing stale sentinel")
+			}
+		} else {
+			m.log.Info("upgrade: rollback.done sentinel present; skipping rollback check")
+		}
+	} else if awaiting {
+		if m.awaitingHealthAgeExceeded(time.Now()) {
+			// 哨兵总年龄超上限 → 强制双恢复。彻底解决坏
+			// supervisor 崩溃循环：每轮 SCM 重启都重新武装 HealthPoll 定时器，
+			// 180s deadline 永不到达；哨兵 mtime（= selfswap 武装时刻，无人重写）
+			// 是唯一不被重启重置的时钟，超限即判定回滚窗口已彻底耗尽。
+			if IsUpgradeHealthy(m.stageDir) {
+				// 健康已确认但哨兵残留（HealthPoll 成功路径删除失败的罕见自愈）：
+				// 只清残留哨兵，绝不回滚健康升级。
+				m.log.Info("upgrade: stale awaiting_health sentinel (age exceeded) but healthy; clearing")
+				_ = os.Remove(SupervisorSelfSwapAwaitingHealthPath(m.stageDir))
+			} else {
+				m.log.Warn("upgrade: awaiting_health sentinel age exceeded; forcing dual rollback")
+				// 先 worker 后 supervisor。崩溃循环场景 orphan worker
+				// 可能持 worker.exe 文件锁 → 先 KillByImage（对称步骤 5 先例）。
+				if m.pc != nil {
+					if err := m.pc.KillByImage(WorkerBinaryName); err != nil {
+						m.log.Debug("KillByImage returned non-zero (process may not be running)",
+							"image", WorkerBinaryName, "err", err)
+					}
+				}
+				if err := m.RollbackAndMark(); err != nil {
+					// worker 回滚失败（半回滚可重试）— 仍恢复 supervisor：
+					// rollback.done 未写 → 下次 BootCheck 步骤 1 末分支重试 worker 回滚
+					m.log.Error("upgrade: worker rollback during forced dual rollback failed", "err", err)
+					lastErr = err
+				}
+				restored, err := m.restoreSupervisorFromOld()
+				if err != nil {
+					m.log.Error("upgrade: supervisor restore during forced dual rollback failed", "err", err)
+					// Join 而非覆盖：worker 回滚失败 + supervisor 恢复失败可能同时发生，
+					// 丢前一个 error 会让调用方误判。
+					lastErr = errors.Join(lastErr, err)
+				} else if restored {
+					return ErrSupervisorRestartSoon
+				}
+			}
+		} else {
+			// supervisor self-swap 刚完成（上次启动写的 sentinel），
+			// worker 还没机会启动写 healthy_marker → 本次启动不 rollback，委托给
+			// superviseWorker 的 HealthPoll 180s grace。健康判定必须在 worker
+			// 实际启动后：BootCheck 阶段 worker 尚未运行，立即 rollback 会误杀
+			// 刚换入的版本（worker 根本没机会证明自己健康）。
+			m.pendingHealthCheck = true
+			m.log.Info("upgrade: self-swap awaiting health sentinel present; arming HealthPoll")
+		}
+	} else if HasLastUpgrade(m.stageDir) && !IsUpgradeHealthy(m.stageDir) {
+		// 上次升级不健康 → rollback
+		m.log.Warn("upgrade: last upgrade not confirmed healthy; rolling back")
+		if err := m.RollbackAndMark(); err != nil {
+			m.log.Error("upgrade: rollback on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	// 2. 残留 pending → apply（boot 时无 worker，PID 传 0）
+	// Windows 兼容：pending tar.gz 可能尚未解压（无 systemd ExecStartPre 对等机制），
+	// 与 CheckPending 对称处理。stage 目录安全校验不通过时整段跳过
+	// （fail-closed：拒绝消费，rollback / self-swap 恢复不受影响）。
+	if guardErr := m.checkStageDir(); guardErr != nil {
+		m.log.Error("upgrade: stage dir security check failed; skipping pending apply on boot", "err", guardErr)
+		lastErr = guardErr
+	} else {
+		m.applyPendingOnBoot(ctx, &lastErr)
+	}
+
+	// 3. supervisor_upgrade.applied → 清理 .old 备份 + 删 sentinel
+	if IsSupervisorUpgradeApplied(m.stageDir) {
+		m.log.Info("supervisor self-swap: applied sentinel detected")
+		// .old 仅在健康已确认或无待决升级状态（从未升级）
+		// 时删除。SelfSwap 写 applied 在健康确认之前 — 无条件删 .old 会让健康判定
+		// 失败时 supervisor 永久停留坏新版（.old 是唯一回滚源，brick 兜底也依赖它）。
+		// 唯一权威删除点 = HealthPoll 成功路径；此处仅是健康态/无待决态的幂等 backstop。
+		if !HasLastUpgrade(m.stageDir) || IsUpgradeHealthy(m.stageDir) {
+			m.cleanupSupervisorOld()
+		} else {
+			m.log.Info("supervisor self-swap: .old preserved until health confirmed")
+		}
+		// 删 applied 前先求值新周期判据 — pending 严格晚于 applied（mtime）
+		// 说明 applied 是上周期残留 + pending 是步骤 2 Apply 本轮刚写，无条件清
+		// 会误删新周期 pending → 步骤 5 SelfSwap 不触发 → supervisor.exe.new
+		// 永久残留（实机现场：上周期 applied 残留场景）。早于/等于 = 同周期断电孤儿。
+		newCyclePending := pendingAfterApplied(m.stageDir)
+
+		// best-effort 删 applied sentinel — 残留下次 BootCheck 会重复清理（幂等）
+		_ = os.Remove(SupervisorUpgradeAppliedPath(m.stageDir))
+		// applied 已写 = 升级完成权威信号，孤儿 pending 是断电窗口残留
+		// （SelfSwap step 3 写 applied 后 + 删 pending 前断电）。不清会导致步骤 5
+		// 触发 SelfSwap，但 supervisor.exe 已新版 + .new 不存在 → relocate 失败 →
+		// SCM restart 死循环。applied 是真相源时清 pending 是收尾职责的自然延伸。
+		// best-effort：删失败下次 BootCheck 步骤 5 会再判 pending（幂等）。
+		if newCyclePending {
+			m.log.Info("supervisor self-swap: pending sentinel is newer than applied; preserving for self-swap")
+		} else {
+			_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+		}
+	}
+
+	// 4. brick recovery: supervisor.exe 缺失 + .old 存在 → rename 恢复
+	// 双恢复趟的 .discard aside 残留 best-effort 补删（恢复趟运行中
+	// exe 删不掉；正常路径恢复趟内已自清，此处兜底恢复失败的趟次）。
+	if supervisorPath, err := m.resolveSupervisorPath(); err == nil {
+		if err := os.Remove(supervisorPath + supervisorDiscardSuffix); err == nil {
+			m.log.Info("supervisor: removed leftover .discard from dual-restore")
+		}
+	}
+	if m.isSupervisorBrickState() {
+		m.log.Warn("supervisor brick state: supervisor.exe missing + .old exists; restoring")
+		supervisorPath, err := m.resolveSupervisorPath()
+		if err != nil {
+			m.log.Error("supervisor brick recovery: resolve self path failed", "err", err)
+			lastErr = err
+		} else {
+			oldPath := supervisorPath + ".old"
+			if err := renameWithAVRetry(oldPath, supervisorPath, m.log); err != nil {
+				m.log.Error("supervisor brick recovery: restore failed", "err", err)
+				lastErr = err
+			}
+		}
+	}
+
+	// 5. supervisor self-swap: pending sentinel → KillByImage → SupervisorSelfSwap
+	if IsSupervisorUpgradePending(m.stageDir) {
+		// BootCheck 恢复路径可能存在 orphan worker，先清理（幂等）
+		if m.pc != nil {
+			m.log.Warn("supervisor self-swap on boot: killing orphan worker first",
+				"image", WorkerBinaryName)
+			if err := m.pc.KillByImage(WorkerBinaryName); err != nil {
+				m.log.Debug("KillByImage returned non-zero (process may not be running)",
+					"image", WorkerBinaryName, "err", err)
+			}
+		}
+		err := m.SupervisorSelfSwap()
+		if errors.Is(err, ErrSupervisorRestartSoon) {
+			return err // 让 service.go 触发 SCM restart
+		}
+		if err != nil {
+			m.log.Error("supervisor self-swap on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+// restoreSupervisorFromOld 执行 supervisor 侧恢复：
+// 运行中的新 supervisor.exe rename aside（.discard）→ .old 改名回 supervisor.exe
+// → 清 awaiting_health / applied 哨兵。调用方随后返回 ErrSupervisorRestartSoon
+// 让 SCM 自然重启加载旧 supervisor（分钟级延迟可接受，异常路径不追速度）。
+//
+// 返回 (restored, error)：
+//   - .old 不存在：restored=false，err=nil（无事可做；顺带清残留哨兵自愈）
+//   - rename 失败：restored=false，err 非 nil（若 exe 已 aside，调用方不 return，
+//     BootCheck 步骤 4 brick recovery 兜底 rename .old → exe）
+//
+// 顺序不可反转：必须先把当前 exe 挪走（rename 运行中 exe 可行），才能把 .old
+// rename 回原路径（rename onto 运行中 exe 不可行 — Windows image section）。
+// 路径用 resolveSupervisorPath。
+func (m *Machine) restoreSupervisorFromOld() (bool, error) {
+	supervisorPath, err := m.resolveSupervisorPath()
+	if err != nil {
+		return false, fmt.Errorf("supervisor restore: %w", err)
+	}
+	oldPath := supervisorPath + ".old"
+	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
+		// 无处恢复 — 清残留哨兵（调用方据 restored=false 走自愈路径）
+		_ = os.Remove(SupervisorSelfSwapAwaitingHealthPath(m.stageDir))
+		return false, nil
+	}
+
+	// 当前 exe（新版，待废弃）rename aside。exe 缺失（brick 态）时跳过 —
+	// .old 直接 rename 回原路径即可。
+	discardPath := supervisorPath + supervisorDiscardSuffix
+	if _, err := os.Stat(supervisorPath); err == nil {
+		if err := renameWithAVRetry(supervisorPath, discardPath, m.log); err != nil {
+			return false, fmt.Errorf("supervisor restore: rename aside to %s: %w", discardPath, err)
+		}
+	}
+
+	if err := renameWithAVRetry(oldPath, supervisorPath, m.log); err != nil {
+		return false, fmt.Errorf("supervisor restore: rename %s back: %w", oldPath, err)
+	}
+	m.log.Info("supervisor restore: .old renamed back; supervisor.exe is previous version",
+		"restored_from", oldPath)
+
+	// 哨兵清理：awaiting_health（生命周期右端点）+ applied（升级未成立的收尾）。
+	// best-effort — 残留下次 BootCheck 幂等清理。
+	_ = os.Remove(SupervisorSelfSwapAwaitingHealthPath(m.stageDir))
+	_ = os.Remove(SupervisorUpgradeAppliedPath(m.stageDir))
+	// aside 的新 exe 已无价值（坏版本）；运行中删不掉（Windows），best-effort。
+	_ = os.Remove(discardPath)
+	return true, nil
+}
+
+// awaitingHealthAgeExceeded 报告 awaiting_health 哨兵的总年龄是否超上限。
+// 年龄 = now - 哨兵 mtime；mtime 即 selfswap 武装时刻
+// （哨兵仅在 SupervisorSelfSwap step 3 写一次，重启/重新武装定时器不会重写 —
+// 这正是崩溃循环中唯一不被重置的时钟）。严格大于语义：恰好等于不触发。
+// 哨兵缺失/Stat 失败返回 false（防御：让 awaiting-health 分支按既有语义处理）。
+func (m *Machine) awaitingHealthAgeExceeded(now time.Time) bool {
+	fi, err := os.Stat(SupervisorSelfSwapAwaitingHealthPath(m.stageDir))
+	if err != nil {
+		return false
+	}
+	return now.Sub(fi.ModTime()) > m.awaitingHealthMaxAge
+}
+
+// rollbackDoneAfterAwaitingHealth 报告 rollback.done 的 mtime 是否严格晚于
+// awaiting_health 的 mtime — 共存分支的真中间态判据。
+//
+// 真中间态时序：selfswap 武装（写 awaiting_health）→ 健康超时（≥180s grace）→
+// worker 回滚（写 rollback.done），故 rollback.done 必晚于 awaiting_health。
+// 早于/相等 = stale rollback.done 是旧周期回滚残留（与刚武装的 awaiting_health
+// 同形假阳性）。Stat 失败返回 false（防御：宁可漏恢复也不误回滚健康的
+// supervisor — 误回滚一个刚换入且健康的版本正是此判据要防的事故）。
+func rollbackDoneAfterAwaitingHealth(stageDir string) bool {
+	rbFi, err := os.Stat(RollbackDonePath(stageDir))
+	if err != nil {
+		return false
+	}
+	ahFi, err := os.Stat(SupervisorSelfSwapAwaitingHealthPath(stageDir))
+	if err != nil {
+		return false
+	}
+	return rbFi.ModTime().After(ahFi.ModTime())
+}
+
+// pendingAfterApplied 报告 supervisor_upgrade.pending 的 mtime 是否严格晚于
+// applied 的 mtime — 步骤 3 清孤儿 pending 前的新周期判据（与
+// rollbackDoneAfterAwaitingHealth 同族的 mtime 顺序判据）。
+//
+// 真孤儿时序：Apply 先写 pending → SelfSwap 后写 applied，故 pending
+// 必早于 applied。新周期时序：上周期 SelfSwap 写 applied →
+// SCM restart → 步骤 2 Apply 写新 pending（跨 restart ≥ 秒级），故 pending
+// 必严格晚于 applied。两集合无交集；相等归孤儿（真孤儿两哨兵至少隔一次
+// SelfSwap，不可能相等）。
+//
+// Stat 失败返回 false（判孤儿，防御方向与 rollbackDoneAfterAwaitingHealth
+// 相反但各自正确）：
+// 误判新周期（不清）会让真孤儿残留 → 步骤 5 SelfSwap → relocate 失败 →
+// SCM restart 死循环（服务不可用）；误判孤儿（清）只损失本轮升级（下轮投喂
+// 可恢复）。死循环 > 升级丢失，故偏向维持孤儿清理行为。
+func pendingAfterApplied(stageDir string) bool {
+	pdFi, err := os.Stat(SupervisorUpgradePendingPath(stageDir))
+	if err != nil {
+		return false
+	}
+	apFi, err := os.Stat(SupervisorUpgradeAppliedPath(stageDir))
+	if err != nil {
+		return false
+	}
+	return pdFi.ModTime().After(apFi.ModTime())
+}
+
+// cleanupSupervisorOld 删除 supervisor.exe.old 备份。
+//
+// 调用点（唯一两处，均为健康已确认/无待决态）：
+//   - HealthPoll 成功路径（权威删除点，与 CleanupPrevious 同点同趟）
+//   - BootCheck 步骤 3 applied 分支的幂等 backstop
+//
+// best-effort：失败仅 Warn — .old 多活一轮无害（下轮 HealthPoll 成功 / BootCheck
+// backstop 再试），误删才是不可逆损失。
+// 路径用 resolveSupervisorPath。
+func (m *Machine) cleanupSupervisorOld() {
+	supervisorPath, err := m.resolveSupervisorPath()
+	if err != nil {
+		m.log.Warn("supervisor self-swap: resolve self path for .old cleanup failed (non-fatal)", "err", err)
+		return
+	}
+	oldPath := supervisorPath + ".old"
+	if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+		m.log.Warn("supervisor self-swap: cleanup .old failed (non-fatal)", "err", err)
+	}
+}
+
+// PendingHealthCheck 报告 BootCheck 是否检测到 supervisor_selfswap_awaiting_health
+// sentinel 并要求 superviseWorker 启用 HealthPoll。
+//
+// superviseWorker 在初始化 watchUpgrade 时调用此 getter：true = 启 worker 后跑
+// HealthPoll 180s grace 确认健康（健康判定发生在 worker 实际启动后，避免在
+// worker 有机会写健康标记前误回滚）。180s 超时判定移到 superviseWorker 循环
+// 顶部，HealthPoll 仅负责 polling。
+func (m *Machine) PendingHealthCheck() bool { return m.pendingHealthCheck }
+
+// isSupervisorBrickState 报告 supervisor brick 状态：supervisor.exe 缺失 + .old 存在。
+// 此状态发生在 SupervisorSelfSwap step 1 成功（supervisor.exe → .old）+ step 2 失败 +
+// brick 兜底也失败 + SCM 重启后。BootCheck 步骤 4 尝试 rename .old 恢复。
+//
+// 路径用 resolveSupervisorPath。
+func (m *Machine) isSupervisorBrickState() bool {
+	supervisorPath, err := m.resolveSupervisorPath()
+	if err != nil {
+		// resolver 失败时不能判断 brick 状态：安全起见返回 false（不触发恢复），
+		// 但必须显式 log warn（显式失败而非静默失败）。
+		m.log.Warn("supervisor brick check: resolve self path failed (non-fatal)", "err", err)
+		return false
+	}
+	oldPath := supervisorPath + ".old"
+	_, supErr := os.Stat(supervisorPath)
+	_, oldErr := os.Stat(oldPath)
+	return os.IsNotExist(supErr) && oldErr == nil
+}
+
+// Apply 编排 bundle swap 的完整顺序：
+//  1. KillTree — 释放文件锁（worker 子进程可能持有 .exe 句柄）
+//  2. ParseManifest
+//     2.5 ValidateAllEntries — 白名单校验（失败零磁盘变动零 kill）
+//  3. KillManifestExes — 杀孤儿子进程（windows_exporter 等）
+//     3.5 ConvergeResidualBackups — 入口残留收敛
+//  4. ApplyBundle — 原子 swap + .previous 备份（失败自恢复）
+//  5. WriteUpgradeMeta — 写版本元数据 + 删旧 healthy_marker
+//  6. ClearPending — 删 incoming/
+//
+// workerPID <= 0 时跳过 KillTree（boot 场景 worker 尚未启动）。
+//
+// ctx 仅用于启动前检查；swap 操作不可中途取消（原子性要求），
+// ctx 仅用于启动前检查（boot hooks 调用方可在 swap 前取消）。
+func (m *Machine) Apply(ctx context.Context, workerPID int) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// 1. Kill worker tree（释放 .exe 文件锁）
+	if workerPID > 0 && m.pc != nil {
+		m.log.Info("upgrade: killing worker tree before swap", "pid", workerPID)
+		if err := m.pc.KillTree(workerPID); err != nil {
+			// 进程已退出时 taskkill 返回非零，忽略（幂等）
+			m.log.Warn("upgrade: KillTree returned error (process may have exited)",
+				"err", err)
+		}
+	}
+
+	// 2. Parse manifest
+	entries, err := ParseManifest(ManifestPath(m.stageDir))
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	// 2.5 白名单校验：必须在任何 kill/swap 之前 —
+	// 恶意 manifest 的 Dest 既驱动文件写入也驱动 KillByImage，
+	// 校验失败时零磁盘变动、零进程终止（KillTree 是按 PID 杀 worker 树，
+	// 不受 manifest 控制，先于校验执行无旁路面）。
+	if err := ValidateAllEntries(ctx, m.binDir, IncomingDir(m.stageDir), entries); err != nil {
+		return fmt.Errorf("validate manifest entries: %w", err)
+	}
+
+	// 3. Kill plugin processes by image name
+	m.KillManifestExes(entries)
+
+	// 3.5 入口残留收敛：上次崩溃轮次的 .previous 残留与合法
+	// 备份同形（健康标记假阳性使回滚不可达）→ 先幂等收敛再 apply。必须在
+	// ValidateAllEntries 之后（未校验 manifest 不得驱动目录操作）、kill 之后
+	// （恢复 rename 需文件锁已释放）。
+	restored, err := ConvergeResidualBackups(m.stageDir, m.binDir, entries)
+	if err != nil {
+		return fmt.Errorf("converge residual backups before apply: %w", err)
+	}
+	if restored > 0 {
+		m.log.Warn("upgrade: converged residual backups from crashed apply", "restored", restored)
+	}
+
+	// 4. Apply bundle (atomic swap + backup)
+	result, err := ApplyBundle(m.stageDir, IncomingDir(m.stageDir), m.log, entries)
+	if err != nil {
+		return fmt.Errorf("apply bundle: %w", err)
+	}
+	m.log.Info("upgrade: bundle applied",
+		"swapped", len(result.Swapped), "backed_up", len(result.BackedUp))
+
+	// 5. Write upgrade meta
+	ver, err := ReadStagedVersion(m.stageDir)
+	if err != nil {
+		return fmt.Errorf("read staged version: %w", err)
+	}
+	if err := WriteUpgradeMeta(m.stageDir, ver); err != nil {
+		return fmt.Errorf("write upgrade meta: %w", err)
+	}
+
+	// 6. Clear pending
+	if err := ClearPending(m.stageDir); err != nil {
+		return fmt.Errorf("clear pending: %w", err)
+	}
+
+	m.log.Info("upgrade: meta written + pending cleared", "version", ver)
+	return nil
+}
+
+// checkStageDir 执行 stage 目录安全校验（stageDirGuard 为 nil 时恒通过 —
+// 仅限无本地多用户威胁的平台或测试场景）。
+func (m *Machine) checkStageDir() error {
+	if m.stageDirGuard == nil {
+		return nil
+	}
+	return m.stageDirGuard()
+}
+
+// SetStageDirGuard 注入 stage 目录安全校验（平台 ACL 检查等）。
+// 见 Machine.stageDirGuard 字段注释。须在首次 BootCheck / CheckPending 前调用。
+func (m *Machine) SetStageDirGuard(guard func() error) {
+	m.stageDirGuard = guard
+}
+
+// applyPendingOnBoot 是 BootCheck 步骤 2 的实现：解压未解压的 pending tar.gz
+// 并 apply（boot 时无 worker，PID 传 0）。错误记入 lastErr 不中断后续步骤。
+func (m *Machine) applyPendingOnBoot(ctx context.Context, lastErr *error) {
+	if !IsPending(m.stageDir) && HasPendingBundle(m.stageDir) {
+		m.log.Info("upgrade: pending tar.gz detected on boot; extracting to incoming/")
+		if err := ExtractPendingBundle(m.stageDir); err != nil {
+			m.log.Error("upgrade: extract pending bundle on boot failed", "err", err)
+			*lastErr = err
+		}
+	}
+	if IsPending(m.stageDir) {
+		m.log.Info("upgrade: pending bundle detected on boot; applying")
+		if err := m.Apply(ctx, 0); err != nil {
+			m.log.Error("upgrade: apply on boot failed", "err", err)
+			*lastErr = err
+		}
+	}
+}
+
+// CheckPending 在 worker 退出后检查是否有 pending upgrade，有则 apply。
+//
+// 返回 ErrApplied 表示 swap 成功（调用方 superviseWorker 应跳过 restartDelay）。
+// 返回其他 error 表示 swap 失败（调用方按普通崩溃处理）。
+// 返回 nil 表示无 pending upgrade（调用方按普通崩溃重启）。
+//
+// Windows 兼容：worker agent_upgrade RPC 下载 bundle
+// 到 {stageDir}/pending（tar.gz），Linux 由 systemd ExecStartPre 脚本解压到
+// incoming/；Windows 无对等机制，这里自动检测 pending tar.gz 并解压。
+func (m *Machine) CheckPending(ctx context.Context, workerPID int) error {
+	// fail-closed 消费门控：stage 目录安全校验不通过时拒绝消费 pending bundle。
+	// 返回 nil（视同无 pending）而非 error — 升级通道关闭但 worker 监控不受影响，
+	// 避免 ACL 异常演变成服务崩溃循环；每次 worker 退出都会重查（自愈 + 告警可见）。
+	if guardErr := m.checkStageDir(); guardErr != nil {
+		m.log.Error("upgrade: stage dir security check failed; refusing to consume pending bundle", "err", guardErr)
+		return nil
+	}
+	if !IsPending(m.stageDir) {
+		// Windows: pending tar.gz 未解压 → 先解压到 incoming/
+		if !HasPendingBundle(m.stageDir) {
+			return nil
+		}
+		m.log.Info("upgrade: pending tar.gz detected; extracting to incoming/")
+		if err := ExtractPendingBundle(m.stageDir); err != nil {
+			m.log.Error("upgrade: extract pending bundle failed", "err", err)
+			return err
+		}
+		if !IsPending(m.stageDir) {
+			m.log.Error("upgrade: pending extracted but MANIFEST.txt missing")
+			return fmt.Errorf("extract pending: no MANIFEST.txt after extraction")
+		}
+	}
+	m.log.Info("upgrade: pending bundle detected after worker exit; applying swap")
+	if err := m.Apply(ctx, workerPID); err != nil {
+		m.log.Error("upgrade: Apply failed", "err", err)
+		return err
+	}
+	return ErrApplied
+}
+
+// HealthPoll 在新 worker 启动后监控 healthy_marker，确认升级成功。
+//
+// 此方法阻塞，直到以下之一发生：
+//
+//   - IsUpgradeHealthy = true → CleanupPrevious → 清 awaiting_health sentinel → 返回 nil（成功）
+//   - workerCtx 取消（worker 提前退出或 supervisor 停止）→ 返回 workerCtx.Err
+//
+// 设计要点：HealthPoll 仅 polling（无 timer / 无 RollbackAndMark）。
+// 原因：goroutine 内持 timer 到期调 RollbackAndMark 会撞
+// Windows image section 文件锁（运行中的 worker.exe 不可 rename），且 timer
+// 分支在 worker 崩溃连锁取消 workerCtx 时永不触发（timer 与 ctx.Done 竞争，
+// ctx 总是先到）。故 180s 超时判定 + RollbackAndMark 放在 superviseWorker 循环
+// 顶部（worker 已退出空窗 = 文件锁释放），见 worker.go superviseWorker。
+//
+// pollInterval 是轮询 IsUpgradeHealthy 的间隔（测试可传短值）。
+func (m *Machine) HealthPoll(ctx context.Context, pollInterval time.Duration) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if IsUpgradeHealthy(m.stageDir) {
+				m.log.Info("upgrade: confirmed healthy; cleaning up .previous")
+				n, err := CleanupPrevious([]string{m.binDir})
+				if err != nil {
+					m.log.Error("upgrade: cleanup failed", "err", err)
+				} else {
+					m.log.Info("upgrade: cleaned up .previous files", "count", n)
+				}
+				// .old 权威删除点 — 健康已确认，与 worker 备份清理
+				// 同点同趟（best-effort，失败下轮 BootCheck backstop 再试）。
+				m.cleanupSupervisorOld()
+				// 升级确认 → 清 awaiting_health sentinel（成功路径
+				// 右端点）。超时 rollback 路径的清理移到 superviseWorker。
+				_ = os.Remove(SupervisorSelfSwapAwaitingHealthPath(m.stageDir))
+				return nil
+			}
+		}
+	}
+}
+
+// RollbackAndMark 执行 rollback 并写 rollback.done 哨兵。
+// 被 BootCheck（启动时不健康）和 superviseWorker 循环顶部（HealthPoll 窗口超时）
+// 共用。
+func (m *Machine) RollbackAndMark() error {
+	n, err := Rollback([]string{m.binDir})
+	if err != nil {
+		m.log.Error("upgrade: rollback failed", "err", err)
+		return err
+	}
+	m.log.Info("upgrade: rolled back files", "count", n)
+
+	if err := WriteRollbackDone(m.stageDir); err != nil {
+		m.log.Error("upgrade: failed to write rollback.done sentinel", "err", err)
+		// sentinel 写失败不阻断 — 下次启动可能再次 rollback（best-effort）
+	}
+	return nil
+}
+
+// KillManifestExes 遍历 MANIFEST 条目，对白名单内的 .exe dest 用 KillByImage 杀进程。
+//
+// 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
+// orphaned（reparented to PID 1），KillTree 无法触达。
+// 这些孤儿进程持有 .exe 文件锁，导致 ApplyBundle 的 rename 失败。
+// 幂等：进程不存在时 KillByImage 返回非 nil，忽略。
+//
+// 白名单过滤：kill 目标必须 ∈ Dest 白名单同一集合。
+// kill 按 basename 全局匹配，与 dest 是否落盘无关，不套白名单 = 任意进程杀
+// 旁路（manifest 写 BinDir 外的 svchost.exe 即可杀系统进程）。
+func (m *Machine) KillManifestExes(entries []ManifestEntry) {
+	if m.pc == nil {
+		return
+	}
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		name := destBase(e.Dest)
+		key := strings.ToLower(name)
+		if seen[key] {
+			continue
+		}
+		// 白名单过滤：与 validateDest 同一集合、同一 EqualFold 语义
+		if !destBaseAllowed(name) {
+			m.log.Warn("upgrade: refusing to kill process outside dest whitelist", "image", name)
+			continue
+		}
+		// 跳过 supervisor 自己：supervisor binary 在 MANIFEST 里用于 rename-aside
+		// 自升级，不能 kill 自己；SupervisorSelfSwap 在 superviseWorker
+		// 里单独处理。不跳过会导致 supervisor 自杀 → SCM restart 死循环。
+		// EqualFold：与 isSupervisorBinary / 白名单比较语义全链路统一。
+		if strings.EqualFold(name, SupervisorBinaryName) {
+			continue
+		}
+		seen[key] = true
+		m.log.Info("upgrade: killing plugin process by image name", "image", name)
+		if err := m.pc.KillByImage(name); err != nil {
+			m.log.Debug("upgrade: KillByImage returned non-zero (process may not be running)",
+				"image", name, "err", err)
+		}
+	}
+}

--- a/internal/edgeagent/upgrademachine/machine_test.go
+++ b/internal/edgeagent/upgrademachine/machine_test.go
@@ -1,0 +1,580 @@
+// machine_test.go 测试 Machine 深模块的编排逻辑。
+//
+// 从 cmd/upgrade_windows_test.go 迁移，适配 Machine API：
+//   - applyAndSwap → Machine.Apply
+//   - maybeApplyOnBoot / maybeRollbackOnBoot → Machine.BootCheck
+//   - checkPendingUpgrade → Machine.CheckPending
+//   - watchUpgradeHealth → Machine.HealthPoll (renamed from HealthCheck)
+//   - rollbackAndMark → Machine.RollbackAndMark
+//
+// 纯 Go（无 Windows 专属依赖），在 Linux CI 可跑。
+
+package upgrademachine
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- 测试辅助 ---
+
+// testLogger 返回一个日志级别设为 100（高于所有级别）的 Logger，
+// 实际效果是抑制所有日志输出。
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(100)}))
+}
+
+// testLoggerCapturing 返回一个写入 buf 的 WARN 级别 Logger，
+// 用于断言被测代码是否输出了期望的 warn 日志（显式失败原则）。
+func testLoggerCapturing(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+// mockProcessController 是 ProcessController 的测试 mock。
+type mockProcessController struct {
+	killTreeCalls   atomic.Int32
+	killTreeLastPID atomic.Int32
+	killImageCalls  atomic.Int32
+	killImageNames  []string
+	treeErr         error // 非 nil 时 KillTree 返回此 error
+}
+
+func (m *mockProcessController) KillTree(pid int) error {
+	m.killTreeCalls.Add(1)
+	m.killTreeLastPID.Store(int32(pid))
+	if m.treeErr != nil {
+		return m.treeErr
+	}
+	return nil
+}
+
+func (m *mockProcessController) KillByImage(name string) error {
+	m.killImageCalls.Add(1)
+	m.killImageNames = append(m.killImageNames, name)
+	return nil
+}
+
+// buildMachineBundle 创建完整 fake bundle：stageDir/incoming/ 下有 MANIFEST.txt
+// + src 文件 + VERSION。destDir 模拟部署目标（已有旧版本）。
+func buildMachineBundle(t *testing.T, stageDir, destDir, version string,
+	files []struct{ Src, Dest, Content string }) {
+
+	t.Helper()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+
+	var lines []string
+	for _, f := range files {
+		sha := writeTestFile(t, filepath.Join(incoming, f.Src), f.Content)
+		lines = append(lines, sha+" 0755 "+f.Src+" "+filepath.Join(destDir, f.Dest))
+	}
+	// MANIFEST.txt
+	manifestContent := strings.Join(lines, "\n") + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifestContent)
+	// VERSION
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), version)
+}
+
+// --- Machine.Apply ---
+
+func TestMachine_Apply_KillCalledWhenPIDPositive(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new"},
+	})
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, destDir, testLogger(), &pc)
+	if err := m.Apply(context.Background(), 12345); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+	if pc.killTreeCalls.Load() != 1 {
+		t.Errorf("KillTree called %d times, want 1", pc.killTreeCalls.Load())
+	}
+	if pc.killTreeLastPID.Load() != 12345 {
+		t.Errorf("KillTree called with pid=%d, want 12345", pc.killTreeLastPID.Load())
+	}
+}
+
+func TestMachine_Apply_KillSkippedWhenPIDZero(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new"},
+	})
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, destDir, testLogger(), &pc)
+	// PID=0 → 应跳过 kill
+	if err := m.Apply(context.Background(), 0); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+	if pc.killTreeCalls.Load() != 0 {
+		t.Errorf("KillTree should NOT be called when PID=0")
+	}
+}
+
+// TestKillManifestExes_SkipsSupervisorBinary 验证 KillManifestExes 不 kill
+// supervisor 自己。MANIFEST 包含 supervisor.exe 用于 rename-aside 自升级，
+// 但 kill supervisor 进程会导致 SCM restart 死循环。
+func TestKillManifestExes_SkipsSupervisorBinary(t *testing.T) {
+	entries := []ManifestEntry{
+		{Dest: `C:\bin\` + WorkerBinaryName},
+		{Dest: `C:\bin\windows_exporter.exe`},
+		{Dest: `C:\bin\` + SupervisorBinaryName},
+	}
+	var pc mockProcessController
+	m := NewMachine(t.TempDir(), t.TempDir(), testLogger(), &pc)
+
+	m.KillManifestExes(entries)
+
+	if len(pc.killImageNames) != 2 {
+		t.Fatalf("KillByImage should be called 2 times (worker + exporter), got %d: %v",
+			len(pc.killImageNames), pc.killImageNames)
+	}
+	for _, name := range pc.killImageNames {
+		if name == SupervisorBinaryName {
+			t.Errorf("KillByImage must NOT be called for %q (supervisor self-kill)", SupervisorBinaryName)
+		}
+	}
+}
+
+func TestMachine_Apply_KillErrorIgnored(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new"},
+	})
+
+	pc := &mockProcessController{treeErr: errors.New("ERROR: not found")}
+	m := NewMachine(stageDir, destDir, testLogger(), pc)
+	// KillTree 报错但 Apply 应继续（幂等语义）
+	if err := m.Apply(context.Background(), 12345); err != nil {
+		t.Fatalf("Machine.Apply should ignore kill error: %v", err)
+	}
+}
+
+func TestMachine_Apply_FullOrdering(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old-worker")
+	writeTestFile(t, filepath.Join(destDir, "windows_exporter.exe"), "old-exporter")
+	buildMachineBundle(t, stageDir, destDir, "v2.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new-worker"},
+		{"windows_exporter.exe", "windows_exporter.exe", "new-exporter"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), nil)
+	if err := m.Apply(context.Background(), 0); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+
+	// 验证 swap：dest 内容是新版本
+	got, _ := os.ReadFile(filepath.Join(destDir, WorkerBinaryName))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe = %q, want %q", got, "new-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(destDir, "windows_exporter.exe"))
+	if string(got) != "new-exporter" {
+		t.Errorf("exporter.exe = %q, want %q", got, "new-exporter")
+	}
+
+	// 验证 .previous 备份存在（旧版本）
+	got, _ = os.ReadFile(filepath.Join(destDir, WorkerBinaryName+PreviousSuffix))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe.previous = %q, want %q", got, "old-worker")
+	}
+
+	// 验证 incoming/ 已删除
+	if _, err := os.Stat(filepath.Join(stageDir, IncomingDirName)); !os.IsNotExist(err) {
+		t.Error("incoming/ should be removed after Apply")
+	}
+
+	// 验证 last_upgrade_ver 已写
+	ver, _ := os.ReadFile(filepath.Join(stageDir, LastUpgradeVerFile))
+	if string(ver)[:len("v2.0.0")] != "v2.0.0" {
+		t.Errorf("last_upgrade_ver = %q, want v2.0.0", ver)
+	}
+
+	// 验证 healthy_marker 已删（重新武装 watchdog）
+	if _, err := os.Stat(filepath.Join(stageDir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should be removed after Apply")
+	}
+}
+
+func TestMachine_Apply_BadManifest(t *testing.T) {
+	stageDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, IncomingDirName, ManifestFileName), "bad line")
+
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	err := m.Apply(context.Background(), 0)
+	if err == nil {
+		t.Fatal("expected error for malformed manifest")
+	}
+}
+
+// --- Machine.BootCheck ---
+
+func TestMachine_BootCheck_NoPending(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when no pending: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_PendingApplied(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+	if IsPending(stageDir) {
+		t.Error("pending should be cleared after boot apply")
+	}
+}
+
+func TestMachine_BootCheck_NeverUpgraded(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when never upgraded: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_Healthy(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when healthy: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_UnhealthyRollsBack(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-broken")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old-good")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "old-good" {
+		t.Errorf("worker.exe = %q, want %q (rolled back)", got, "old-good")
+	}
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); err != nil {
+		t.Errorf("rollback.done sentinel should exist: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_RollbackDoneSkips(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-broken")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old-good")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when rollback.done present: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "new-broken" {
+		t.Errorf("worker.exe = %q, should remain unchanged", got)
+	}
+}
+
+// --- Machine.CheckPending ---
+
+// TestMachine_BootCheck_ExtractsPendingBundle 验证 BootCheck 在 incoming/ 为空但
+// pending tar.gz 存在时自动解压再 apply。
+func TestMachine_BootCheck_ExtractsPendingBundle(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	// 写 pending tar.gz（不含 incoming/，模拟 Windows 无 ExecStartPre 的场景）
+	h := sha256.Sum256([]byte("new"))
+	sha := hex.EncodeToString(h[:])
+	manifestContent := sha + " 0755 " + WorkerBinaryName + " " + filepath.Join(destDir, WorkerBinaryName) + "\n"
+	writePendingBundle(t, stageDir, map[string]string{
+		"MANIFEST.txt":   manifestContent,
+		"VERSION":        "v9.9.9",
+		WorkerBinaryName: "new",
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	_ = m.BootCheck(context.Background())
+
+	// pending tar.gz 应被删除（解压后清理）
+	if _, err := os.Stat(filepath.Join(stageDir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after BootCheck extraction, got err: %v", err)
+	}
+	// worker.exe 应被更新（apply 成功）
+	data, err := os.ReadFile(filepath.Join(destDir, WorkerBinaryName))
+	if err != nil {
+		t.Fatalf("read worker.exe after BootCheck: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("worker.exe not updated after BootCheck pending extraction, got %q", string(data))
+	}
+}
+
+// TestMachine_CheckPending_ExtractsPendingBundle 验证 CheckPending 在 incoming/ 为空但
+// pending tar.gz 存在时自动解压再 apply。
+func TestMachine_CheckPending_ExtractsPendingBundle(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	h := sha256.Sum256([]byte("new"))
+	sha := hex.EncodeToString(h[:])
+	manifestContent := sha + " 0755 " + WorkerBinaryName + " " + filepath.Join(destDir, WorkerBinaryName) + "\n"
+	writePendingBundle(t, stageDir, map[string]string{
+		"MANIFEST.txt":   manifestContent,
+		"VERSION":        "v9.9.9",
+		WorkerBinaryName: "new",
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	err := m.CheckPending(context.Background(), 123)
+	if !errors.Is(err, ErrApplied) {
+		t.Errorf("expected ErrApplied after pending extraction, got %v", err)
+	}
+	// pending tar.gz 应被删除
+	if _, err := os.Stat(filepath.Join(stageDir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after CheckPending extraction, got err: %v", err)
+	}
+}
+
+func TestMachine_CheckPending_NoPending(t *testing.T) {
+	stageDir := t.TempDir()
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), &mockProcessController{})
+	if err := m.CheckPending(context.Background(), 123); err != nil {
+		t.Fatalf("should return nil when no pending: %v", err)
+	}
+}
+
+func TestMachine_CheckPending_PendingReturnsSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, WorkerBinaryName), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{WorkerBinaryName, WorkerBinaryName, "new"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	err := m.CheckPending(context.Background(), 123)
+	if !errors.Is(err, ErrApplied) {
+		t.Errorf("expected ErrApplied, got %v", err)
+	}
+}
+
+// --- Machine.HealthPoll ---
+//
+// 设计要点：HealthPoll 只做 polling + IsUpgradeHealthy + CleanupPrevious +
+// 清 awaiting_health sentinel（成功路径），不持 timer、不直接调用
+// RollbackAndMark — rollback 决策统一放在 superviseWorker 循环顶部
+// （worker 已退出的空窗执行，rename 不会撞文件锁）。
+//
+// 注意：timer 触发的 rollback 决策在 superviseWorker 侧（worker_test.go 覆盖），
+// HealthPoll 自身无超时分支。
+
+func TestMachine_HealthPoll_HealthyCleanup(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 短 poll（50ms）确保轮询快速发现健康状态
+	err := m.HealthPoll(ctx, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected nil (healthy), got %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix)); !os.IsNotExist(err) {
+		t.Error(".previous should be cleaned up after healthy confirmation")
+	}
+}
+
+func TestMachine_HealthPoll_ContextCancelled(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+
+	cancel()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.HealthPoll(ctx, 50*time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// --- awaiting-health：BootCheck supervisor_selfswap_awaiting_health sentinel ---
+//
+// self-swap 刚完成的启动：BootCheck 步骤 1 不立即 rollback
+// （worker 尚未启动，没有健康标记不等于升级失败），而是检测 awaiting_health
+// sentinel → arm HealthCheck（设 pendingHealthCheck=true），
+// 让 superviseWorker 启 worker 后用 HealthCheck 180s grace 确认健康。
+
+// TestMachine_BootCheck_SelfSwapAwaitingHealth_ArmsHealthCheck 验证 awaiting-health 分支：
+// supervisor self-swap 完成后的文件系统状态（lastVer 写入 + marker 删除 + awaiting
+// sentinel 写入）下，BootCheck 应 arm HealthCheck 而非立即 rollback。
+//
+// 状态模拟（SupervisorSelfSwap step 3 成功后的真机状态，见  实证）：
+//   - last_upgrade_ver = "dev"（WriteUpgradeMeta 写入）
+//   - healthy_marker 缺失（WriteUpgradeMeta 删除）
+//   - supervisor_selfswap_awaiting_health sentinel 存在（SelfSwap step 3 写入）
+//
+// 期望：BootCheck 不 rollback + m.PendingHealthCheck==true。
+func TestMachine_BootCheck_SelfSwapAwaitingHealth_ArmsHealthCheck(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// self-swap 后状态：lastVer 写 + marker 缺 + awaiting sentinel 写
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "dev")
+	// healthy_marker 故意不写（WriteUpgradeMeta 已删）
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+	// worker.exe 新版本（self-swap 后的状态），不应被 rollback
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "new-supervisor-swap")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+
+	// awaiting-health：应 arm HealthCheck
+	if !m.PendingHealthCheck() {
+		t.Error("PendingHealthCheck() = false, want true (awaiting-health 应 arm HealthCheck)")
+	}
+
+	// rollback.done 不应存在（未 rollback）
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); err == nil {
+		t.Error("rollback.done sentinel 不应存在（awaiting-health 跳过 rollback）")
+	}
+
+	// worker.exe 不应被回滚（仍是新版本）
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "new-supervisor-swap" {
+		t.Errorf("worker.exe = %q, want %q (awaiting-health 不应 rollback)",
+			got, "new-supervisor-swap")
+	}
+
+	// awaiting_health sentinel 应保留（HealthCheck 解决时才清，BootCheck 不清）
+	if _, err := os.Stat(filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)); err != nil {
+		t.Error("supervisor_selfswap_awaiting_health sentinel 应保留（BootCheck 不清，HealthCheck 解决时清）")
+	}
+}
+
+// TestMachine_HealthPoll_Success_DeletesSupervisorOld 验证：
+// .old 的唯一权威删除点 = HealthPoll 成功路径，与 worker 备份清理
+// （CleanupPrevious）同点同趟。健康确认前 .old 由 BootCheck 条件化保护
+// （见 TestBootCheck_AppliedAwaitingHealth_PreservesOld）。
+func TestMachine_HealthPoll_Success_DeletesSupervisorOld(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 健康状态：lastVer == marker
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v0.9.3")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v0.9.3")
+	// worker 备份 + supervisor .old 都在（健康后都应清理）
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old-worker")
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	oldPath := supervisorPath + ".old"
+	writeTestFile(t, supervisorPath, "new-supervisor")
+	writeTestFile(t, oldPath, "good-old-supervisor")
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	if err := m.HealthPoll(ctx, 50*time.Millisecond); err != nil {
+		t.Fatalf("expected nil (healthy), got %v", err)
+	}
+
+	// .old 权威删除点：健康确认后同趟删除
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Error("supervisor .old 应在 HealthPoll 成功后被删除（权威删除点）")
+	}
+	// worker 备份同趟清理
+	if _, err := os.Stat(filepath.Join(binDir, WorkerBinaryName+PreviousSuffix)); !os.IsNotExist(err) {
+		t.Error(".previous 应同趟清理")
+	}
+	// awaiting sentinel 同点清除（既有语义）
+	if _, err := os.Stat(filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)); err == nil {
+		t.Error("awaiting_health sentinel 应被清除")
+	}
+}
+
+// TestMachine_HealthPoll_Success_ClearsAwaitingSentinel 验证 HealthPoll 健康确认路径
+// 清除 supervisor_selfswap_awaiting_health sentinel（awaiting-health sentinel 生命周期右端点
+// 的成功路径分支；超时 rollback 路径的清理在 superviseWorker，见 worker_test.go）。
+func TestMachine_HealthPoll_Success_ClearsAwaitingSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 健康状态：lastVer == marker
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old")
+	// awaiting sentinel 存在（awaiting-health BootCheck 留下的）
+	writeTestFile(t, filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile), "awaiting")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.HealthPoll(ctx, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected nil (healthy), got %v", err)
+	}
+
+	// awaiting sentinel 应被清除
+	if _, err := os.Stat(filepath.Join(stageDir, SupervisorSelfSwapAwaitingHealthFile)); err == nil {
+		t.Error("supervisor_selfswap_awaiting_health sentinel 应在 HealthPoll 成功后被清除")
+	}
+}

--- a/internal/edgeagent/upgrademachine/manifest.go
+++ b/internal/edgeagent/upgrademachine/manifest.go
@@ -1,0 +1,108 @@
+// manifest.go 实现 MANIFEST.txt 的解析 + per-file sha256 验证。
+// 从 upgradeapply/manifest.go 移入，消除 upgradeapply 和 upgradebundle 的重复解析。
+// upgradebundle/download.go 原有的 verifyManifest + fileSHA256 已删除，
+// 改用本包的 ParseManifest + VerifyAll。
+
+package upgrademachine
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ManifestEntry 是 MANIFEST.txt 中一行的结构化表示。
+// 格式：`<sha256> <mode> <src> <dest>`
+//   - SHA256：src 文件的预期 sha256（小写 hex，64 字符）
+//   - Mode：文件权限（如 "0755"），apply 时设到新文件
+//   - Src：incoming/ 目录内的相对路径
+//   - Dest：swap 目标绝对路径
+type ManifestEntry struct {
+	SHA256 string
+	Mode   string
+	Src    string
+	Dest   string
+}
+
+// ParseManifest 读取并解析 MANIFEST.txt。
+// 跳过空行和 # 开头的注释行。字段少于 4 个的行视为格式错误。
+// 返回零条目时报错（空 manifest = 打包错误）。
+func ParseManifest(path string) ([]ManifestEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open manifest %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var entries []ManifestEntry
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// dest 可能含空格（Windows: C:\Program Files\...），
+		// sha/mode/src 不含空格，所以前 3 个字段严格分割，
+		// 第 4 个字段起合并为 dest 路径。
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("malformed manifest line: %q", line)
+		}
+		entries = append(entries, ManifestEntry{
+			SHA256: fields[0],
+			Mode:   fields[1],
+			Src:    fields[2],
+			Dest:   strings.Join(fields[3:], " "),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan manifest: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("manifest declared zero files")
+	}
+	return entries, nil
+}
+
+// VerifyEntry 检查 incomingDir/<Src> 的 sha256 是否与 entry.SHA256 匹配。
+func VerifyEntry(incomingDir string, entry ManifestEntry) error {
+	srcPath := filepath.Join(incomingDir, entry.Src)
+	got, err := fileSHA256(srcPath)
+	if err != nil {
+		return fmt.Errorf("sha %s: %w", entry.Src, err)
+	}
+	if !strings.EqualFold(got, entry.SHA256) {
+		return fmt.Errorf("sha mismatch for %s (got %s want %s)", entry.Src, got, entry.SHA256)
+	}
+	return nil
+}
+
+// VerifyAll 验证所有条目。遇到第一个错误即返回（all-or-nothing 语义）。
+func VerifyAll(incomingDir string, entries []ManifestEntry) error {
+	for _, e := range entries {
+		if err := VerifyEntry(incomingDir, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fileSHA256 计算文件 sha256 并返回小写 hex。
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/edgeagent/upgrademachine/manifest_test.go
+++ b/internal/edgeagent/upgrademachine/manifest_test.go
@@ -1,0 +1,218 @@
+package upgrademachine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestFile 创建一个文件，内容为 content，返回其 sha256。
+func writeTestFile(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])
+}
+
+// writeManifest 写一个 MANIFEST.txt（每行 `<sha> <mode> <src> <dest>`）。
+func writeManifest(t *testing.T, path string, lines []string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write manifest %s: %v", path, err)
+	}
+}
+
+func TestParseManifest_ValidSingleEntry(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890ab 0755 bin/worker.exe /usr/local/bin/worker",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.SHA256 != "abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890ab" {
+		t.Errorf("SHA256 = %q", e.SHA256)
+	}
+	if e.Mode != "0755" {
+		t.Errorf("Mode = %q", e.Mode)
+	}
+	if e.Src != "bin/worker.exe" {
+		t.Errorf("Src = %q", e.Src)
+	}
+	if e.Dest != "/usr/local/bin/worker" {
+		t.Errorf("Dest = %q", e.Dest)
+	}
+}
+
+func TestParseManifest_MultipleEntriesWithComments(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"# ongrid-edge bundle v0.7.50",
+		"",
+		"aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222 0755 worker.exe C:\\bin\\worker.exe",
+		"# plugin section",
+		"bbbb3333cccc4444dddd5555eeee6666ffff7777aaaa8888bbbb3333cccc4444 0644 exporter.exe C:\\bin\\exporter.exe",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (skip comment + blank), got %d", len(entries))
+	}
+	if entries[0].Src != "worker.exe" {
+		t.Errorf("entries[0].Src = %q", entries[0].Src)
+	}
+	if entries[1].Src != "exporter.exe" {
+		t.Errorf("entries[1].Src = %q", entries[1].Src)
+	}
+}
+
+func TestParseManifest_MalformedLine(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"abc 0755 only_three_fields",
+	})
+
+	_, err := ParseManifest(manPath)
+	if err == nil {
+		t.Fatal("expected error for malformed line, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error should mention malformed, got: %v", err)
+	}
+}
+
+func TestParseManifest_EmptyManifest(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"# only comments",
+		"",
+		"   ",
+	})
+
+	_, err := ParseManifest(manPath)
+	if err == nil {
+		t.Fatal("expected error for zero-file manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "zero") {
+		t.Errorf("error should mention zero files, got: %v", err)
+	}
+}
+
+func TestParseManifest_DestWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222 0755 worker.exe C:\\Program Files\\ongrid-edge\\bin\\worker.exe",
+		"bbbb3333cccc4444dddd5555eeee6666ffff7777aaaa8888bbbb3333cccc4444 0755 exporter.exe C:\\Program Files\\ongrid-edge\\bin\\exporter.exe",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	want0 := `C:\Program Files\ongrid-edge\bin\worker.exe`
+	if entries[0].Dest != want0 {
+		t.Errorf("entries[0].Dest = %q, want %q", entries[0].Dest, want0)
+	}
+	want1 := `C:\Program Files\ongrid-edge\bin\exporter.exe`
+	if entries[1].Dest != want1 {
+		t.Errorf("entries[1].Dest = %q, want %q", entries[1].Dest, want1)
+	}
+}
+
+func TestParseManifest_FileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ParseManifest(filepath.Join(dir, "nonexistent.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestVerifyEntry_SHA_MATCH(t *testing.T) {
+	dir := t.TempDir()
+	content := "fake binary content"
+	srcPath := filepath.Join(dir, "worker.exe")
+	realSHA := writeTestFile(t, srcPath, content)
+
+	entry := ManifestEntry{SHA256: realSHA, Src: "worker.exe"}
+	if err := VerifyEntry(dir, entry); err != nil {
+		t.Fatalf("VerifyEntry should pass for matching SHA: %v", err)
+	}
+}
+
+func TestVerifyEntry_SHA_MISMATCH(t *testing.T) {
+	dir := t.TempDir()
+	content := "fake binary content"
+	writeTestFile(t, filepath.Join(dir, "worker.exe"), content)
+
+	entry := ManifestEntry{SHA256: "0000000000000000000000000000000000000000000000000000000000000000", Src: "worker.exe"}
+	err := VerifyEntry(dir, entry)
+	if err == nil {
+		t.Fatal("expected error for SHA mismatch")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch, got: %v", err)
+	}
+}
+
+func TestVerifyEntry_SRC_MISSING(t *testing.T) {
+	dir := t.TempDir()
+	entry := ManifestEntry{SHA256: "abc", Src: "nonexistent.exe"}
+	err := VerifyEntry(dir, entry)
+	if err == nil {
+		t.Fatal("expected error for missing src file")
+	}
+}
+
+func TestVerifyAll_AllMatch(t *testing.T) {
+	incoming := t.TempDir()
+	sha1 := writeTestFile(t, filepath.Join(incoming, "a.exe"), "content-a")
+	sha2 := writeTestFile(t, filepath.Join(incoming, "b.exe"), "content-b")
+
+	entries := []ManifestEntry{
+		{SHA256: sha1, Src: "a.exe"},
+		{SHA256: sha2, Src: "b.exe"},
+	}
+	if err := VerifyAll(incoming, entries); err != nil {
+		t.Fatalf("VerifyAll should pass: %v", err)
+	}
+}
+
+func TestVerifyAll_OneFails(t *testing.T) {
+	incoming := t.TempDir()
+	sha1 := writeTestFile(t, filepath.Join(incoming, "a.exe"), "content-a")
+	writeTestFile(t, filepath.Join(incoming, "b.exe"), "content-b")
+
+	entries := []ManifestEntry{
+		{SHA256: sha1, Src: "a.exe"},
+		{SHA256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", Src: "b.exe"},
+	}
+	err := VerifyAll(incoming, entries)
+	if err == nil {
+		t.Fatal("expected error for one mismatch")
+	}
+}

--- a/internal/edgeagent/upgrademachine/rename_other.go
+++ b/internal/edgeagent/upgrademachine/rename_other.go
@@ -1,0 +1,21 @@
+// rename_other.go 提供 renameWithAVRetry 的非 Windows stub。
+// Linux 上 bundle swap 无 AV 干扰（对称 dist/build-edge-bundle.sh Linux 版本），
+// isAVRetryable 永远 false，renameWithAVRetry 等价于单次 os.Rename。
+// 这让 machine.go 的 SupervisorSelfSwap 逻辑在 Linux CI 可测试（正常路径）。
+
+//go:build !windows
+
+package upgrademachine
+
+import (
+	"log/slog"
+	"os"
+)
+
+// isAVRetryable 非 Windows 永远 false（无 AV 干扰）。
+func isAVRetryable(err error) bool { return false }
+
+// renameWithAVRetry 非 Windows 等价于单次 os.Rename（无 AV retry 需求）。
+func renameWithAVRetry(src, dst string, log *slog.Logger) error {
+	return os.Rename(src, dst)
+}

--- a/internal/edgeagent/upgrademachine/rename_windows.go
+++ b/internal/edgeagent/upgrademachine/rename_windows.go
@@ -1,0 +1,61 @@
+// rename_windows.go 实现 renameWithAVRetry 的 Windows 专属逻辑。
+// Windows Defender / 第三方 AV 实时扫描未签名 PE 文件时持 FILE_SHARE_READ
+// 句柄，期间 os.Rename 失败（ERROR_SHARING_VIOLATION = errno 0x20）。
+// renameWithAVRetry 重试 5 次 × 200ms = 1s，覆盖 99% AV 扫描窗口。
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+)
+
+// ERROR_SHARING_VIOLATION Windows errno 32 (0x20)。
+const windowsSharingViolation = syscall.Errno(0x20)
+
+// isAVRetryable 判定 rename 错误是否值得 AV retry。
+// Windows 上只对 ERROR_SHARING_VIOLATION retry（AV 扫描瞬时持锁）。
+func isAVRetryable(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == windowsSharingViolation
+	}
+	return false
+}
+
+// renameWithAVRetry 对 os.Rename 做 AV 扫描瞬时失败的 retry。
+// 5 次 × 200ms = 1s 总等待。非共享冲突错误立即返回（不重试）。
+// log 为 nil 时静默重试（测试场景）。
+func renameWithAVRetry(src, dst string, log *slog.Logger) error {
+	const maxRetry = 5
+	const retryDelay = 200 * time.Millisecond
+
+	var lastErr error
+	for i := 0; i < maxRetry; i++ {
+		err := os.Rename(src, dst)
+		if err == nil {
+			if i > 0 && log != nil {
+				log.Info("rename succeeded after AV retry",
+					"src", src, "dst", dst, "attempts", i+1)
+			}
+			return nil
+		}
+		lastErr = err
+		if !isAVRetryable(err) {
+			return err // 非共享冲突，不重试
+		}
+		if log != nil {
+			log.Warn("rename blocked (likely AV scan); retrying",
+				"src", src, "dst", dst, "attempt", i+1, "err", err)
+		}
+		time.Sleep(retryDelay)
+	}
+	return fmt.Errorf("rename %s → %s: AV scan did not release after %d retries: %w",
+		src, dst, maxRetry, lastErr)
+}

--- a/internal/edgeagent/upgrademachine/rollback.go
+++ b/internal/edgeagent/upgrademachine/rollback.go
@@ -1,0 +1,99 @@
+// rollback.go 实现 upgrade 失败时的 .previous 恢复逻辑。
+//
+// 对称 Linux apply-pending-upgrade.sh 的 maybe_rollback 函数：
+//   - 遍历指定目录（递归），找 *.previous 文件
+//   - rollback: rename(dest.previous, dest) 恢复旧版本
+//   - cleanup: delete *.previous（upgrade 确认健康后）
+//
+// 错误语义：Rollback 单文件恢复失败不阻断其他文件恢复，但必须
+// 使整体返回 error（调用方 RollbackAndMark 据此不写 rollback.done 哨兵，半回滚
+// 状态保持可重试）。CleanupPrevious 仍为 best-effort（健康路径清理，失败仅日志）。
+//
+// context 约定例外：Rollback / CleanupPrevious 操作本地文件系统，
+// rollback 必须原子完成（半回滚 = 部分恢复 + 部分未恢复），中途取消不可接受。
+// 取消检查由编排层入口完成：BootCheck / superviseWorker 循环顶部 deadline rollback。
+
+package upgrademachine
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Rollback 遍历 dirs（递归），将所有 *.previous 文件恢复到原路径。
+//
+// 例如：worker.exe.previous → worker.exe（原子 rename 替换当前版本）。
+// 返回成功恢复的文件数。目录不存在或无 .previous 文件时返回 (0, nil)。
+//
+// 单文件恢复失败不中断其他文件恢复（能恢复多少恢复多少），
+// 但整体返回 error — RollbackAndMark 收到 error 时不写 rollback.done 哨兵，
+// 半回滚状态（.previous 未清空）下轮可重试，rename 幂等（已恢复的不再匹配遍历）。
+func Rollback(dirs []string) (int, error) {
+	return walkPreviousDirs(dirs, "rollback", false, func(prevPath string) error {
+		target := strings.TrimSuffix(prevPath, PreviousSuffix)
+		return os.Rename(prevPath, target)
+	})
+}
+
+// CleanupPrevious 删除指定目录（递归）下所有 *.previous 文件。
+// 在 upgrade 确认健康后调用（healthy_marker 匹配 last_upgrade_ver）。
+// 对称 Linux 的 `find ... -name '*.previous' -delete`。
+// best-effort：单文件删除失败跳过，不使整体失败（失败文件残留由日志暴露）。
+func CleanupPrevious(dirs []string) (int, error) {
+	return walkPreviousDirs(dirs, "cleanup", true, func(prevPath string) error {
+		return os.Remove(prevPath)
+	})
+}
+
+// walkPreviousDirs 对 dirs 中每个目录递归遍历 *.previous 文件，执行 op。
+// bestEffort=true 时 op 失败跳过（CleanupPrevious）；
+// bestEffort=false 时 op 失败收集为整体 error（Rollback）。
+// WalkDir 自身的错误（目录不可访问等）向上传播（与已收集的 op 错误合并）。
+func walkPreviousDirs(dirs []string, opName string, bestEffort bool, op func(prevPath string) error) (int, error) {
+	total := 0
+	var opErrs []error
+	for _, dir := range dirs {
+		n, err := forEachPrevious(dir, bestEffort, op, &opErrs)
+		total += n
+		if err != nil {
+			opErrs = append(opErrs, fmt.Errorf("%s %s: %w", opName, dir, err))
+			break // 目录遍历失败：该目录后续不可达，保留已收集的 op 错误一并返回
+		}
+	}
+	return total, errors.Join(opErrs...)
+}
+
+// forEachPrevious 递归遍历 dir，对每个 *.previous 文件调用 fn。
+// bestEffort=true 时 fn 失败跳过（best-effort）；
+// bestEffort=false 时 fn 失败追加到 opErrs（不中断遍历）。
+func forEachPrevious(dir string, bestEffort bool, fn func(prevPath string) error, opErrs *[]error) (int, error) {
+	count := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil // 目录不存在：合法状态（从未升级过），跳过
+			}
+			// 其他遍历错误（目录不可访问、权限丢失等）必须向上传播：
+			// 吞掉会让 Rollback 返回 (0, nil) 静默成功，调用方据此写入
+			// rollback.done 哨兵，半回滚状态从此永久停止恢复。
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), PreviousSuffix) {
+			return nil
+		}
+		if ferr := fn(path); ferr != nil {
+			if bestEffort {
+				return nil // best-effort：跳过该文件
+			}
+			*opErrs = append(*opErrs, fmt.Errorf("restore %s: %w", path, ferr))
+			return nil // D3：记录失败但继续其他文件，遍历结束后聚合传播
+		}
+		count++
+		return nil
+	})
+	return count, err
+}

--- a/internal/edgeagent/upgrademachine/rollback_test.go
+++ b/internal/edgeagent/upgrademachine/rollback_test.go
@@ -1,0 +1,214 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRollback_RestoresPrevious(t *testing.T) {
+	dest := t.TempDir()
+
+	// 模拟 swap 后状态：新版本 + .previous 备份
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "new-broken-worker")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old-good-worker")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe"), "new-exporter")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe.previous"), "old-exporter")
+
+	restored, err := Rollback([]string{dest})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored != 2 {
+		t.Fatalf("expected 2 restored, got %d", restored)
+	}
+
+	// 验证恢复为旧内容
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "old-good-worker" {
+		t.Errorf("worker.exe = %q, want %q", got, "old-good-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(dest, "exporter.exe"))
+	if string(got) != "old-exporter" {
+		t.Errorf("exporter.exe = %q, want %q", got, "old-exporter")
+	}
+
+	// .previous 应被 rename 掉（不再存在）
+	if _, err := os.Stat(filepath.Join(dest, "worker.exe.previous")); !os.IsNotExist(err) {
+		t.Errorf("worker.exe.previous should be gone after rollback")
+	}
+}
+
+func TestRollback_NoPreviousFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "only-version")
+
+	restored, err := Rollback([]string{dest})
+	if err != nil {
+		t.Fatalf("Rollback with no .previous should not error: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("expected 0 restored, got %d", restored)
+	}
+}
+
+func TestRollback_MultipleDirs(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dir1, "a.exe"), "new-a")
+	writeTestFile(t, filepath.Join(dir1, "a.exe.previous"), "old-a")
+	writeTestFile(t, filepath.Join(dir2, "b.exe"), "new-b")
+	writeTestFile(t, filepath.Join(dir2, "b.exe.previous"), "old-b")
+
+	restored, err := Rollback([]string{dir1, dir2})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored != 2 {
+		t.Fatalf("expected 2 restored across dirs, got %d", restored)
+	}
+}
+
+func TestRollback_IgnoresNonPreviousFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "current")
+	writeTestFile(t, filepath.Join(dest, "readme.txt"), "info")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old")
+
+	restored, _ := Rollback([]string{dest})
+	if restored != 1 {
+		t.Errorf("expected 1 restored (only .previous), got %d", restored)
+	}
+
+	// readme.txt 不应被动
+	got, _ := os.ReadFile(filepath.Join(dest, "readme.txt"))
+	if string(got) != "info" {
+		t.Errorf("readme.txt should be untouched")
+	}
+}
+
+func TestRollback_DirNotExist(t *testing.T) {
+	restored, err := Rollback([]string{"/nonexistent/path/xyz"})
+	if err != nil {
+		t.Fatalf("Rollback on missing dir should not error: %v", err)
+	}
+	if restored != 0 {
+		t.Errorf("expected 0 restored, got %d", restored)
+	}
+}
+
+// TestRollback_SingleFileFailure_PropagatesError 验证：
+// 单文件恢复失败必须使整体返回错误（保持可重试），而非 best-effort 吞错。
+//
+// 失败注入：worker.exe 预置为目录 → rename(worker.exe.previous, worker.exe)
+// 跨平台必败（file → 已存在目录）。exporter.exe 正常，验证「失败不阻断其他
+// 文件恢复」+「失败文件 .previous 保留供重试」。
+func TestRollback_SingleFileFailure_PropagatesError(t *testing.T) {
+	dest := t.TempDir()
+
+	// worker.exe 是目录（rename 障碍）+ .previous 备份
+	if err := os.Mkdir(filepath.Join(dest, "worker.exe"), 0o755); err != nil {
+		t.Fatalf("mkdir obstacle: %v", err)
+	}
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old-worker")
+	// exporter.exe 正常半换态
+	writeTestFile(t, filepath.Join(dest, "exporter.exe"), "new-exporter")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe.previous"), "old-exporter")
+
+	restored, err := Rollback([]string{dest})
+	if err == nil {
+		t.Fatal("expected error when single file rollback fails")
+	}
+
+	// 其他文件应已恢复（错误传播 ≠ 中断其他恢复）
+	got, _ := os.ReadFile(filepath.Join(dest, "exporter.exe"))
+	if string(got) != "old-exporter" {
+		t.Errorf("exporter.exe = %q, want %q (other files must still restore)", got, "old-exporter")
+	}
+	// 失败文件的 .previous 必须保留（不写完成态 = 可重试）
+	if _, statErr := os.Stat(filepath.Join(dest, "worker.exe.previous")); statErr != nil {
+		t.Errorf("worker.exe.previous must be preserved for retry: %v", statErr)
+	}
+	if restored != 1 {
+		t.Errorf("expected 1 restored (exporter only), got %d", restored)
+	}
+
+	// 障碍移除后重试 → 全部恢复成功
+	if err := os.Remove(filepath.Join(dest, "worker.exe")); err != nil {
+		t.Fatalf("remove obstacle dir: %v", err)
+	}
+	restored, err = Rollback([]string{dest})
+	if err != nil {
+		t.Fatalf("retry after obstacle removed should succeed: %v", err)
+	}
+	if restored != 1 {
+		t.Fatalf("expected 1 restored on retry, got %d", restored)
+	}
+	got, _ = os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe = %q after retry, want %q", got, "old-worker")
+	}
+}
+
+// TestRollbackAndMark_Failure_NoRollbackDone 验证：回滚失败时
+// 不写 rollback.done 哨兵（半回滚状态保持可重试，而非被哨兵标记为完成）。
+func TestRollbackAndMark_Failure_NoRollbackDone(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// worker.exe 是目录（rename 障碍）
+	if err := os.Mkdir(filepath.Join(binDir, WorkerBinaryName), 0o755); err != nil {
+		t.Fatalf("mkdir obstacle: %v", err)
+	}
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName+PreviousSuffix), "old-worker")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.RollbackAndMark(); err == nil {
+		t.Fatal("expected RollbackAndMark to fail when rename blocked")
+	}
+
+	// 失败 → 不写 rollback.done（保持可重试）
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); !os.IsNotExist(err) {
+		t.Errorf("rollback.done must NOT be written on failed rollback, stat err = %v", err)
+	}
+
+	// 障碍移除后重试 → 成功 + 哨兵写入
+	if err := os.Remove(filepath.Join(binDir, WorkerBinaryName)); err != nil {
+		t.Fatalf("remove obstacle dir: %v", err)
+	}
+	if err := m.RollbackAndMark(); err != nil {
+		t.Fatalf("retry RollbackAndMark: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); err != nil {
+		t.Errorf("rollback.done should exist after successful retry: %v", err)
+	}
+}
+
+func TestCleanupPrevious_DeletesBackupFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "good-new")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old-to-delete")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe.previous"), "old-to-delete")
+
+	removed, err := CleanupPrevious([]string{dest})
+	if err != nil {
+		t.Fatalf("CleanupPrevious: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("expected 2 removed, got %d", removed)
+	}
+
+	// .previous 应被删除
+	for _, f := range []string{"worker.exe.previous", "exporter.exe.previous"} {
+		if _, err := os.Stat(filepath.Join(dest, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should be deleted", f)
+		}
+	}
+	// 非 .previous 文件不动
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if !strings.Contains(string(got), "good-new") {
+		t.Errorf("worker.exe should be untouched")
+	}
+}

--- a/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
+++ b/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
@@ -1,0 +1,222 @@
+// running_exe_rename_windows_test.go — Windows 文件锁语义探针测试。
+// 实测 Windows 文件锁语义，决定 supervisor 自升级方案走向：
+//   - 场景 1 + 2 通过 → 进程内 rename-aside 方案可行
+//   - 都失败 → fallback detached helper 方案（cmd.exe）
+// 决策依据（PLAN.md v3 "关键技术不确定性"）：
+//   - 观点 A：Windows Server 2003+ image loader 用 FILE_SHARE_READ | FILE_SHARE_DELETE
+//     → rename 运行中 .exe 成功
+//   - 观点 B：image loader 只 share READ → rename 失败 ERROR_SHARING_VIOLATION
+// 5 场景表驱动测试（PLAN 附录 A）：
+//  1. 进程 B rename 进程 A 启动中的 .exe（rename-aside 第 1 步核心验证）
+//  2. 进程 A 自己 rename 自己的 .exe（supervisor 进程内 self-swap 验证）
+//  3. replace 模式（new → 正在运行的 dest，诊断价值：验证直接 replace 是否可行）
+//  4. 恢复（.old → supervisor.exe， brick 兜底验证）
+//  5. MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT) fallback（delayed-until-reboot 方案可行性）
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestStep0_RunningExeRename 是文件锁语义决策门测试。
+// 通过/失败直接决定 rename-aside / detached helper 方案走向，结果以 t.Logf 明示（不因场景 3/5 预期失败而 t.Fail）。
+func TestStep0_RunningExeRename(t *testing.T) {
+	dummy := buildDummy(t)
+
+	scenarios := []struct {
+		name     string
+		critical bool // critical=true 时失败意味着进程内 rename-aside 方案不可行
+		fn       func(t *testing.T, dummy string)
+	}{
+		{"scenario1_B_rename_A_running_exe", true, scenarioB_rename_A_running_exe},
+		{"scenario2_A_self_rename", true, scenarioA_self_rename},
+		{"scenario3_replace_running_exe", false, scenarioReplaceRunningExe},
+		{"scenario4_restore_from_old", true, scenarioRestoreFromOld},
+		{"scenario5_movefile_delay_until_reboot", false, scenarioMoveFileDelayUntilReboot},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sc.fn(t, dummy)
+		})
+	}
+}
+
+// scenarioB_rename_A_running_exe：外部进程 B rename 正在运行的 A.exe。
+// 这是 rename-aside 第 1 步 (supervisor.exe → supervisor.exe.old) 的核心验证。
+func scenarioB_rename_A_running_exe(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "dummyA.exe")
+	copyFileExe(t, dummy, exePath)
+
+	cmd := exec.Command(exePath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start dummyA: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond) // 等待 image 完全加载
+
+	oldPath := exePath + ".old"
+	err := os.Rename(exePath, oldPath)
+
+	if err != nil {
+		t.Errorf("场景 1 失败（rename-aside 第 1 步不可行）：os.Rename(%s, %s) = %v",
+			exePath, oldPath, err)
+		return
+	}
+
+	// 验证 rename 成功：原路径不存在，.old 存在
+	if _, err := os.Stat(exePath); !os.IsNotExist(err) {
+		t.Errorf("场景 1 异常：rename 后原路径仍存在（err=%v）", err)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("场景 1 异常：.old 不存在（err=%v）", err)
+	}
+	t.Logf("场景 1 通过：进程 B 可以 rename 运行中进程 A 的 .exe → rename-aside 第 1 步可行")
+}
+
+// scenarioA_self_rename：进程 A 自己 rename 自己的 .exe。
+// 这是 supervisor 进程内 SupervisorSelfSwap step 1 的核心验证。
+func scenarioA_self_rename(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "dummySelf.exe")
+	copyFileExe(t, dummy, exePath)
+
+	// dummy 启动后自己做 os.Rename(exePath, exePath+".old")
+	cmd := exec.Command(exePath, "--self-rename", exePath)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("场景 2 启动 dummy --self-rename 失败：%v (stderr: %s)", err, out)
+	}
+
+	var result struct {
+		OK  bool   `json:"ok"`
+		Err string `json:"err"`
+		Src string `json:"src"`
+		Dst string `json:"dst"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("场景 2 解析 dummy stdout 失败：%v (raw: %s)", err, out)
+	}
+
+	if !result.OK {
+		t.Errorf("场景 2 失败（进程内 self-swap 不可行）：dummy self-rename err=%q",
+			result.Err)
+		return
+	}
+	t.Logf("场景 2 通过：进程 A 可以自己 rename 自己的 .exe → 进程内 self-swap 可行")
+}
+
+// scenarioReplaceRunningExe：把 .new rename 到正在运行的 dest（直接 replace）。
+// 诊断价值：若通过，方案可简化为单步 replace；若失败，确认必须用 rename-aside 两步。
+// 预期 Windows 行为：失败（ERROR_SHARING_VIOLATION / ACCESS_DENIED）— image loader 不 share WRITE。
+func scenarioReplaceRunningExe(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	destExe := filepath.Join(dir, "dummyDest.exe")
+	newExe := filepath.Join(dir, "dummyDest.exe.new")
+	copyFileExe(t, dummy, destExe)
+	copyFileExe(t, dummy, newExe)
+	appendMarker(t, newExe, "NEW-CONTENT\n")
+
+	cmd := exec.Command(destExe)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start dummyDest: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	err := os.Rename(newExe, destExe)
+	if err == nil {
+		t.Logf("场景 3 通过（意外）：直接 replace 运行中 .exe 可行 — 方案可简化为单步")
+		// 验证内容确实被替换
+		got, _ := os.ReadFile(destExe)
+		if !strings.Contains(string(got), "NEW-CONTENT") {
+			t.Errorf("场景 3 异常：rename 成功但内容未替换")
+		}
+		return
+	}
+	// 预期失败：这是用 rename-aside（两步）而非直接 replace 的根因
+	t.Logf("场景 3 预期失败（符合 Windows image loader 语义）：os.Rename(new, running_dest) = %v", err)
+	t.Logf("→ 确认必须用 rename-aside 两步（step 1: dest→.old; step 2: .new→dest）")
+}
+
+// scenarioRestoreFromOld：模拟  brick 兜底 — step 1 成功后，把 .old rename 回原路径。
+// 验证：进程 A 持有的 image 被 rename 到 .old 后，能否再次被 rename 回原路径。
+func scenarioRestoreFromOld(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "supervisor.exe")
+	copyFileExe(t, dummy, exePath)
+
+	cmd := exec.Command(exePath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	oldPath := exePath + ".old"
+	// step 1: supervisor.exe → .old（预期成功，场景 1 已验证）
+	if err := os.Rename(exePath, oldPath); err != nil {
+		t.Fatalf("场景 4 前置 step 1 失败：%v", err)
+	}
+
+	// brick 兜底：.old → supervisor.exe（恢复）
+	if err := os.Rename(oldPath, exePath); err != nil {
+		t.Errorf("场景 4 失败：os.Rename(%s, %s) = %v",
+			oldPath, exePath, err)
+		return
+	}
+	if _, err := os.Stat(exePath); err != nil {
+		t.Errorf("场景 4 异常：恢复后 supervisor.exe 不存在（err=%v）", err)
+	}
+	t.Logf("场景 4 通过：进程持有的 .old 可以 rename 回原路径 →  brick 兜底可行")
+}
+
+// scenarioMoveFileDelayUntilReboot：调用 MoveFileExW + MOVEFILE_DELAY_UNTIL_REBOOT。
+// 方案 D（延迟到下次 reboot）的可行性验证。仅验证 API 可调用，不验证重启效果。
+// 预期：API 调用成功（返回 nil），但实际 rename 延迟到下次 reboot。
+func scenarioMoveFileDelayUntilReboot(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "delay_src.exe")
+	dst := filepath.Join(dir, "delay_dst.exe")
+	copyFileExe(t, dummy, src)
+
+	srcW, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		t.Fatalf("场景 5 UTF16 src： %v", err)
+	}
+	dstW, err := windows.UTF16PtrFromString(dst)
+	if err != nil {
+		t.Fatalf("场景 5 UTF16 dst： %v", err)
+	}
+
+	// MOVEFILE_DELAY_UNTIL_REBOOT = 0x4（需管理员权限）
+	const MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
+	err = windows.MoveFileEx(srcW, dstW, MOVEFILE_DELAY_UNTIL_REBOOT)
+	if err != nil {
+		t.Logf("场景 5 失败（预期非管理员或系统不支持）：MoveFileEx DELAY_UNTIL_REBOOT = %v", err)
+		return
+	}
+	t.Logf("场景 5 通过：MoveFileEx DELAY_UNTIL_REBOOT API 调用成功（方案 D 可行，需管理员权限）")
+	// 清理：src 仍存在（rename 延迟），测试 tempDir 自动清理
+}

--- a/internal/edgeagent/upgrademachine/stagedir_guard_test.go
+++ b/internal/edgeagent/upgrademachine/stagedir_guard_test.go
@@ -1,0 +1,105 @@
+// stagedir_guard_test.go 测试 stage 目录安全门控（stageDirGuard）：
+// guard 校验失败时 CheckPending / BootCheck 拒绝消费 pending bundle（fail-closed），
+// 且不影响 rollback / self-swap 恢复路径。
+
+package upgrademachine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeBarePending 写入裸 pending 文件（不解压内容，仅让 HasPendingBundle 为 true）。
+func writeBarePending(t *testing.T, stageDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(stageDir, PendingFileName), []byte("fake-tar-gz"), 0o600); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+}
+
+// TestCheckPending_StageDirGuardRefuses 验证 guard 失败时 CheckPending 返回 nil
+// （视同无 pending），pending 不被解压、不被消费。
+func TestCheckPending_StageDirGuardRefuses(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeBarePending(t, stageDir)
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.SetStageDirGuard(func() error { return errors.New("acl: dir is writable by Users") })
+
+	err := m.CheckPending(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("CheckPending 应返回 nil（升级通道关闭但不报错）： %v", err)
+	}
+
+	// pending 应原样保留（未被消费）
+	if !HasPendingBundle(stageDir) {
+		t.Error("pending bundle 不应被消费")
+	}
+	// incoming/ 不应被创建（未解压）
+	if _, err := os.Stat(filepath.Join(stageDir, "incoming")); !os.IsNotExist(err) {
+		t.Errorf("incoming/ 不应被创建（err=%v）", err)
+	}
+}
+
+// TestBootCheck_StageDirGuardSkipsPendingApply 验证 guard 失败时 BootCheck
+// 跳过 pending 解压/apply 并把 guard 错误记入 lastErr（向上可见）。
+func TestBootCheck_StageDirGuardSkipsPendingApply(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeBarePending(t, stageDir)
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	m.SetStageDirGuard(func() error { return errors.New("acl: dir is writable by Users") })
+
+	err := m.BootCheck(context.Background())
+	if err == nil {
+		t.Fatal("BootCheck 应把 guard 错误记入 lastErr 向上返回")
+	}
+
+	// pending 应原样保留（未解压、未 apply）
+	if !HasPendingBundle(stageDir) {
+		t.Error("pending bundle 不应被消费")
+	}
+	if _, statErr := os.Stat(filepath.Join(stageDir, "incoming")); !os.IsNotExist(statErr) {
+		t.Errorf("incoming/ 不应被创建（err=%v）", statErr)
+	}
+}
+
+// TestCheckPending_NilGuardAllowsConsumption 验证 guard 为 nil（无本地多用户
+// 威胁的平台 / 测试）时行为与门控引入前一致：pending 走正常解压路径。
+func TestCheckPending_NilGuardAllowsConsumption(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeBarePending(t, stageDir)
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.checkStageDir(); err != nil {
+		t.Fatalf("nil guard 应恒通过： %v", err)
+	}
+}
+
+// TestEqualFoldPrefix 验证 Windows 大小写不敏感前缀判定的边界。
+func TestEqualFoldPrefix(t *testing.T) {
+	cases := []struct {
+		s, prefix string
+		want      bool
+	}{
+		{`C:\a\dst\file`, `C:\A\DST\`, true},   // 大小写不同
+		{`C:\A\DST\file`, `c:\a\dst\`, true},   // 全小写 prefix
+		{`C:\a\dstx\file`, `C:\a\dst\`, false}, // 前缀是目录名的部分匹配，必须拒绝
+		{`C:\a\ds`, `C:\a\dst\`, false},        // s 比 prefix 短
+		{`C:\a\dst`, `C:\a\dst\`, false},       // 完全相等但无尾分隔符场景由调用方处理
+		{"", "", true},                         // 空对空
+		{"abc", "", true},                      // 空 prefix 恒匹配
+		{"", "a", false},
+	}
+	for _, c := range cases {
+		if got := EqualFoldPrefix(c.s, c.prefix); got != c.want {
+			t.Errorf("EqualFoldPrefix(%q, %q) = %v, want %v", c.s, c.prefix, got, c.want)
+		}
+	}
+}

--- a/internal/edgeagent/upgrademachine/state.go
+++ b/internal/edgeagent/upgrademachine/state.go
@@ -1,0 +1,86 @@
+// state.go 定义升级状态机的 State 类型 + 状态检测函数。
+// 状态机使原先分散在 7 文件中的隐式状态（通过文件存在性 + sentinel error 推断）
+// 变为显式的、可检测的、可文档化的类型。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+)
+
+// State 表示升级状态机的当前状态。
+type State int
+
+const (
+	// StateIdle 无升级进行中（incoming/ 不存在，无 last_upgrade_ver）。
+	StateIdle State = iota
+
+	// StatePending incoming/MANIFEST.txt 存在（bundle 已下载，等待 swap）。
+	StatePending
+
+	// StateSwapped 文件已替换（last_upgrade_ver 已写），等待健康确认。
+	// 此状态通过 "last_upgrade_ver 存在但 healthy_marker 不匹配" 检测。
+	StateSwapped
+
+	// StateHealthy healthy_marker 内容匹配 last_upgrade_ver（升级成功）。
+	StateHealthy
+
+	// StateRolledBack rollback.done 存在（旧版本已恢复，等待下次升级）。
+	StateRolledBack
+)
+
+// String 返回状态的人类可读名称。
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "idle"
+	case StatePending:
+		return "pending"
+	case StateSwapped:
+		return "swapped"
+	case StateHealthy:
+		return "healthy"
+	case StateRolledBack:
+		return "rolled_back"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// DetectState 根据 StageDir 下的文件状态推断当前升级状态。
+// 这是一个公共观测函数，供调试、日志、测试断言使用。
+// Machine 内部编排逻辑使用更细粒度的检测函数（IsPending、IsUpgradeHealthy 等）
+// 而非 DetectState，因为编排需要区分具体条件（如 rollback.done vs pending 的优先级）。
+// 检测优先级（互斥）：
+//  1. rollback.done 存在 → StateRolledBack
+//  2. incoming/MANIFEST.txt 存在 → StatePending
+//  3. last_upgrade_ver 不存在 → StateIdle
+//  4. healthy_marker 匹配 last_upgrade_ver → StateHealthy
+//  5. last_upgrade_ver 存在但 healthy_marker 不匹配 → StateSwapped
+func DetectState(stageDir string) State {
+	// 1. rollback.done → 已回滚
+	if _, err := os.Stat(RollbackDonePath(stageDir)); err == nil {
+		return StateRolledBack
+	}
+
+	// 2. incoming/MANIFEST.txt → 有 pending
+	if _, err := os.Stat(ManifestPath(stageDir)); err == nil {
+		return StatePending
+	}
+
+	// 3. 无 last_upgrade_ver → 从未升级
+	lastVer := readTrimmed(LastUpgradeVerPath(stageDir))
+	if lastVer == "" {
+		return StateIdle
+	}
+
+	// 4. healthy_marker 匹配 → 健康
+	healthyVer := readTrimmed(HealthyMarkerPath(stageDir))
+	if lastVer == healthyVer {
+		return StateHealthy
+	}
+
+	// 5. last_upgrade_ver 存在但不匹配 → swapped（等待确认）
+	return StateSwapped
+}

--- a/internal/edgeagent/upgrademachine/state_test.go
+++ b/internal/edgeagent/upgrademachine/state_test.go
@@ -1,0 +1,89 @@
+package upgrademachine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectState_Idle(t *testing.T) {
+	dir := t.TempDir()
+	// 空目录 → 从未升级
+	if s := DetectState(dir); s != StateIdle {
+		t.Errorf("DetectState() = %s, want idle", s)
+	}
+}
+
+func TestDetectState_Pending(t *testing.T) {
+	dir := t.TempDir()
+	// 创建 incoming/MANIFEST.txt
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake manifest")
+	if s := DetectState(dir); s != StatePending {
+		t.Errorf("DetectState() = %s, want pending", s)
+	}
+}
+
+func TestDetectState_RolledBack(t *testing.T) {
+	dir := t.TempDir()
+	// rollback.done 存在（优先级高于 pending）
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+	if s := DetectState(dir); s != StateRolledBack {
+		t.Errorf("DetectState() = %s, want rolled_back", s)
+	}
+}
+
+func TestDetectState_RolledBack_HigherThanPending(t *testing.T) {
+	dir := t.TempDir()
+	// 同时存在 rollback.done 和 incoming/MANIFEST.txt → rollback.done 优先
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake manifest")
+	if s := DetectState(dir); s != StateRolledBack {
+		t.Errorf("DetectState() = %s, want rolled_back (higher priority than pending)", s)
+	}
+}
+
+func TestDetectState_Healthy(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v1.0.0")
+	if s := DetectState(dir); s != StateHealthy {
+		t.Errorf("DetectState() = %s, want healthy", s)
+	}
+}
+
+func TestDetectState_Swapped(t *testing.T) {
+	dir := t.TempDir()
+	// last_upgrade_ver 存在但 healthy_marker 不匹配
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v1.0.0")
+	if s := DetectState(dir); s != StateSwapped {
+		t.Errorf("DetectState() = %s, want swapped", s)
+	}
+}
+
+func TestDetectState_Swapped_NoMarker(t *testing.T) {
+	dir := t.TempDir()
+	// last_upgrade_ver 存在，无 healthy_marker
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v2.0.0")
+	if s := DetectState(dir); s != StateSwapped {
+		t.Errorf("DetectState() = %s, want swapped", s)
+	}
+}
+
+func TestState_String(t *testing.T) {
+	tests := []struct {
+		state State
+		want  string
+	}{
+		{StateIdle, "idle"},
+		{StatePending, "pending"},
+		{StateSwapped, "swapped"},
+		{StateHealthy, "healthy"},
+		{StateRolledBack, "rolled_back"},
+		{State(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("State(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap.go
@@ -1,0 +1,184 @@
+// supervisor_selfswap.go 实现 supervisor.exe 的进程内 rename-aside 自升级
+//。
+// 核心：supervisor 无法 kill 自己（KillTree/Restart 自己 = 自杀），所以不能用
+// worker swap 模式（KillTree → rename）。改为进程内 rename-aside：
+//  1. smokeTestVersion— 跑 supervisor.exe.new --version 验证 binary 可执行
+//  2. renameWithAVRetry(supervisor.exe, supervisor.exe.old)
+//  3. renameWithAVRetry(supervisor.exe.new, supervisor.exe)
+//     失败时 / brick 兜底：
+//     a. m.RollbackAndMark — worker rollback（保证版本一致）
+//     b. renameWithAVRetry(supervisor.exe.old, supervisor.exe) — supervisor 恢复
+//     c. m.ResetUpgradeIPC — 清 IPC 状态文件
+//  4. WriteSupervisorUpgradeApplied + 删 pending sentinel
+//  5. 返回 ErrSupervisorRestartSoon → service.go Execute 返回 (false, 1) → SCM restart
+// 文件锁语义探针确认：Windows Server 2003+ image loader 用 FILE_SHARE_DELETE，
+// rename 运行中 .exe 成功；直接 replace 失败（见 running_exe_rename_windows_test.go）。
+
+package upgrademachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrSupervisorRestartSoon 哨兵：service.go 收到后返回 (false, 1) 让 SCM 按
+// recovery action 重启（samesession=false + 非 0 exitCode → failure 路径）。
+// 调用方（BootCheck / superviseWorker）应将其向上传播给 service.Execute，
+// 由 Execute 返回 false, 1 触发 SCM restart（exitCode=0 不触发）。
+var ErrSupervisorRestartSoon = fmt.Errorf("supervisor self-swap done; restart via SCM")
+
+// SupervisorSelfSwap 在 supervisor 进程内执行 rename-aside 自升级。
+// 调用时机：
+//   - BootCheck 检测到 supervisor_upgrade.pending sentinel 时（supervisor 崩溃后 SCM 重启）
+//   - superviseWorker 检测到 worker swap 完成 + pending sentinel 时（热升级路径）
+//
+// 返回 ErrSupervisorRestartSoon 表示 swap 成功，调用方应让 SCM 重启 supervisor。
+// 返回其他 error 表示 swap 失败（可能是 brick 兜底成功 — worker + supervisor 已恢复旧版本）。
+// 路径解析：用 selfPathResolver 取 supervisor.exe 实际运行路径
+// （生产用 os.Executable），不依赖 edgedirs.BinDir 硬编码常量。
+// applyOne 按 MANIFEST dest 把 .new 放在 m.binDir 下（worker 进程无法知道
+// supervisor 实际路径）；若 supervisorPath 同目录无 .new，先从 m.binDir 重定位。
+func (m *Machine) SupervisorSelfSwap() error {
+	supervisorPath, err := m.resolveSupervisorPath()
+	if err != nil {
+		return fmt.Errorf("supervisor self-swap: %w", err)
+	}
+	supervisorDir := filepath.Dir(supervisorPath)
+	newPath := filepath.Join(supervisorDir, SupervisorBinaryName+".new")
+	oldPath := supervisorPath + ".old"
+
+	// .new 重定位：applyOne 按 MANIFEST dest 放在 m.binDir/.new，
+	// 当 supervisor 实际路径 ≠ m.binDir 时，需先把 .new 拷贝到 supervisorPath 同目录。
+	// 对称 apply.go 的 stage-then-rename 模式：同卷拷贝 + 后续原子 rename。
+	if _, err := os.Stat(newPath); err != nil {
+		bundledNew := filepath.Join(m.binDir, SupervisorBinaryName+".new")
+		if err := copyFile(bundledNew, newPath); err != nil {
+			return fmt.Errorf("supervisor self-swap: relocate .new from %s to %s: %w",
+				bundledNew, newPath, err)
+		}
+		m.log.Info("supervisor self-swap: relocated .new",
+			"from", bundledNew, "to", newPath)
+		// 重定位成功后立即清理 m.binDir/.new 残留（applyOne 放错地方的）。
+		// best-effort：失败只 Warn，不阻断 swap（残留下次 upgrade 会被 applyOne 覆盖）。
+		if rerr := os.Remove(bundledNew); rerr != nil && !os.IsNotExist(rerr) {
+			m.log.Warn("supervisor self-swap: cleanup bundled .new failed (non-fatal)",
+				"path", bundledNew, "err", rerr)
+		}
+	}
+
+	// 0. : 冒烟测试 — 跑 supervisor.exe.new --version 验证 binary 可执行
+	if err := m.smokeTestVersion(newPath); err != nil {
+		return fmt.Errorf("supervisor self-swap aborted (smoke test): %w", err)
+	}
+
+	// 1. : rename supervisor.exe → .old（AV retry）
+	if err := renameWithAVRetry(supervisorPath, oldPath, m.log); err != nil {
+		return fmt.Errorf("supervisor self-swap step 1 (rename to .old): %w", err)
+	}
+
+	// 2. : rename .new → supervisor.exe（AV retry）
+	if err := renameWithAVRetry(newPath, supervisorPath, m.log); err != nil {
+		// / brick 兜底：worker rollback + supervisor 恢复 + IPC reset
+		m.log.Error("supervisor self-swap step 2 failed; initiating full rollback", "err", err)
+
+		// 2a. worker rollback（保证版本一致）
+		if rerr := m.RollbackAndMark(); rerr != nil {
+			return fmt.Errorf("brick: worker rollback failed: %w (supervisor.exe.old preserved at %s)",
+				rerr, oldPath)
+		}
+
+		// 2b. supervisor.exe.old → supervisor.exe 恢复
+		if rerr := renameWithAVRetry(oldPath, supervisorPath, m.log); rerr != nil {
+			return fmt.Errorf("brick: supervisor restore failed (worker rolled back): %w", rerr)
+		}
+
+		// 2c. : 清 IPC 状态文件（保留 pending 让 BootCheck 重试升级）
+		if rerr := m.ResetUpgradeIPC(); rerr != nil {
+			m.log.Error("brick recovery: IPC reset partial fail (non-fatal)", "err", rerr)
+		}
+
+		return fmt.Errorf("supervisor self-swap aborted; worker rolled back + supervisor restored + IPC reset: %w", err)
+	}
+
+	// 3. 成功路径：写 applied sentinel + awaiting_health sentinel + 删 pending
+	if err := WriteSupervisorUpgradeApplied(m.stageDir, ""); err != nil {
+		m.log.Error("supervisor self-swap: failed to write applied sentinel", "err", err)
+	}
+	// async health arming ：写 awaiting_health sentinel — BootCheck 下次启动检测到
+	// 后 arm HealthCheck（设 pendingHealthCheck=true），让 superviseWorker 用 180s
+	// grace 确认 worker 健康，修复 BootCheck ordering deadlock。best-effort：写失败只 Warn，
+	// 不阻断 swap（缺 sentinel 时 BootCheck 步骤 1 仍会 rollback，等价旧行为）。
+	if err := WriteSupervisorSelfSwapAwaitingHealth(m.stageDir); err != nil {
+		m.log.Warn("supervisor self-swap: failed to write awaiting_health sentinel (non-fatal)",
+			"err", err)
+	}
+	// best-effort 清理 pending sentinel — swap 已成功，sentinel 残留无意义
+	_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+
+	// 4. 返回哨兵让 service.go 触发 SCM restart
+	m.log.Info("supervisor self-swap done; exiting for SCM restart", "old_backup", oldPath)
+	return ErrSupervisorRestartSoon
+}
+
+// smokeTestVersion 跑 supervisor.exe.new --version，验证退出码 0 + stdout 非空。
+// 超时 5s。失败时清理 stage + sentinel，不进入 self-swap。
+// 防御场景：
+//   - bundle 构建 bug 导致 binary 损坏
+//   - AV 半清理（quarantine 部分 PE section）
+//   - 架构错（amd64 binary 跑在 arm64 Windows）
+func (m *Machine) smokeTestVersion(exePath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, exePath, "--version").Output()
+	if err != nil {
+		// best-effort 清理坏 binary + pending sentinel — 冒烟失败不进入 self-swap
+		_ = os.Remove(exePath)
+		_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+		return fmt.Errorf("smoke test exit: %w (output: %s)", err, out)
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		// best-effort 清理 — 同上，空输出视为坏 binary
+		_ = os.Remove(exePath)
+		_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+		return fmt.Errorf("smoke test: empty version output")
+	}
+	m.log.Info("supervisor self-swap smoke test passed",
+		"version_output", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// ResetUpgradeIPC 清理升级状态机文件，让 DetectState 回到 StateIdle。
+// 用于 brick 兜底成功后让下一次升级从干净状态开始。
+// 清理：last_upgrade_ver, last_upgrade_at, healthy_marker, rollback.done,
+// supervisor_selfswap_awaiting_health
+// 保留：supervisor_upgrade.pending（让 BootCheck 可重试升级）
+//
+//	incoming/MANIFEST.txt（pending bundle 应保留）
+//
+// 职责分工：
+//   - smokeTestVersion：处理 ".new 本身损坏"（rename 之前）— 失败时清 .new + pending
+//   - ResetUpgradeIPC：处理 "rename 瞬时失败但 .new 完好"（rename step 2 失败 brick 兜底）
+//     — 保留 pending 让 BootCheck 重试（AV 锁 / 句柄延迟释放等 Windows 瞬时错误）
+//     重试时 smokeTest 仍是 .new 损坏的精准兜底，不会死循环。
+//
+// best-effort：单个文件删除失败不阻断（os.IsNotExist 忽略）。
+func (m *Machine) ResetUpgradeIPC() error {
+	var firstErr error
+	for _, p := range []string{
+		LastUpgradeVerPath(m.stageDir),
+		LastUpgradeAtPath(m.stageDir),
+		HealthyMarkerPath(m.stageDir),
+		RollbackDonePath(m.stageDir),
+		SupervisorSelfSwapAwaitingHealthPath(m.stageDir),
+	} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
@@ -1,0 +1,316 @@
+// supervisor_selfswap_test.go 测试  SupervisorSelfSwap + smokeTestVersion +
+// ResetUpgradeIPC（跨平台可测部分，Linux CI 可跑）。
+// Windows 专属场景在 supervisor_self_swap_windows_test.go（补充测试）。
+
+package upgrademachine
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- smokeTestVersion ---
+
+func TestSmokeTestVersion_Success(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	copyFileExe(t, dummy, exePath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.smokeTestVersion(exePath); err != nil {
+		t.Fatalf("smokeTestVersion: %v", err)
+	}
+
+	// 成功时 exePath + pending sentinel 应保留
+	if _, err := os.Stat(exePath); err != nil {
+		t.Errorf("exePath 应保留： %v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应保留")
+	}
+}
+
+func TestSmokeTestVersion_BadBinary_CleansStageAndSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	// 写一个非可执行文件（内容是文本）
+	writeTestFile(t, exePath, "not-an-exe")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.smokeTestVersion(exePath)
+	if err == nil {
+		t.Fatal("smokeTestVersion 应失败（非可执行文件）")
+	}
+
+	// 失败时清理 exePath + pending sentinel
+	if _, err := os.Stat(exePath); !os.IsNotExist(err) {
+		t.Errorf("exePath 应被清理（err=%v）", err)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被清理")
+	}
+}
+
+func TestSmokeTestVersion_NotExist_Fails(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new") // 不存在
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.smokeTestVersion(exePath)
+	if err == nil {
+		t.Fatal("smokeTestVersion 应失败（文件不存在）")
+	}
+}
+
+// --- ResetUpgradeIPC ---
+
+func TestResetUpgradeIPC_ClearsFiveFiles_KeepsPending(t *testing.T) {
+	stageDir := t.TempDir()
+	// 铺 5 个 IPC 文件（last_ver / last_at / healthy_marker / rollback.done /
+	// supervisor_selfswap_awaiting_health —  async health arming sentinel 防泄露兜底）
+	writeTestFile(t, LastUpgradeVerPath(stageDir), "v0.9.2")
+	writeTestFile(t, LastUpgradeAtPath(stageDir), "T00:00:00Z")
+	writeTestFile(t, HealthyMarkerPath(stageDir), "v0.9.2")
+	writeTestFile(t, RollbackDonePath(stageDir), "done")
+	writeTestFile(t, SupervisorSelfSwapAwaitingHealthPath(stageDir), "awaiting")
+	// 铺 pending sentinel（应保留）
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	if err := m.ResetUpgradeIPC(); err != nil {
+		t.Fatalf("ResetUpgradeIPC: %v", err)
+	}
+
+	// 5 个 IPC 文件应被清
+	for _, path := range []string{
+		LastUpgradeVerPath(stageDir),
+		LastUpgradeAtPath(stageDir),
+		HealthyMarkerPath(stageDir),
+		RollbackDonePath(stageDir),
+		SupervisorSelfSwapAwaitingHealthPath(stageDir),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s 应被清理（err=%v）", path, err)
+		}
+	}
+	// pending sentinel 应保留
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应保留（让 BootCheck 重试升级）")
+	}
+}
+
+func TestResetUpgradeIPC_Idempotent_NoFiles(t *testing.T) {
+	// 无任何 IPC 文件时不报错
+	stageDir := t.TempDir()
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	if err := m.ResetUpgradeIPC(); err != nil {
+		t.Fatalf("ResetUpgradeIPC 空目录应 nil： %v", err)
+	}
+}
+
+// --- SupervisorSelfSwap 正常路径 ---
+
+func TestSupervisorSelfSwap_HappyPath(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺地板：supervisor.exe（旧版本，内容标记）+ supervisor.exe.new（dummy binary）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	copyFileExe(t, dummy, supervisorPath)
+	appendMarker(t, supervisorPath, "OLD-VERSION\n")
+	copyFileExe(t, dummy, newPath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	err := m.SupervisorSelfSwap()
+
+	// 应返回 ErrSupervisorRestartSoon
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
+	}
+
+	// supervisor.exe 应被替换为新版本（dummy binary，无 OLD-VERSION marker）
+	got, _ := os.ReadFile(supervisorPath)
+	if strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf("supervisor.exe 仍是旧版本（含 OLD-VERSION marker）")
+	}
+
+	// .old 应存在（旧版本备份）
+	got, _ = os.ReadFile(oldPath)
+	if !strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf(".old 应含旧版本 marker，got %q", got)
+	}
+
+	// .new 应不存在（已被 rename 走）
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf(".new 应不存在（err=%v）", err)
+	}
+
+	// applied sentinel 应写入
+	if !IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应写入")
+	}
+	// pending sentinel 应删除
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应删除")
+	}
+}
+
+// --- SupervisorSelfSwap 冒烟失败 ---
+
+func TestSupervisorSelfSwap_SmokeFail_AbortsBeforeRename(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	// supervisor.exe（旧版本）
+	writeTestFile(t, supervisorPath, "old-supervisor")
+	// supervisor.exe.new 是非可执行文件（冒烟失败）
+	writeTestFile(t, newPath, "bad-binary")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	err := m.SupervisorSelfSwap()
+
+	if err == nil {
+		t.Fatal("期望冒烟失败错误，got nil")
+	}
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Errorf("冒烟失败不应返回 ErrSupervisorRestartSoon，got %v", err)
+	}
+	// supervisor.exe 应未被改动
+	got, _ := os.ReadFile(supervisorPath)
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应未被改动，got %q", got)
+	}
+	// .new + pending 应被清理（smokeTestVersion 内部清理）
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf(".new 应被清理（err=%v）", err)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被清理")
+	}
+}
+
+// --- SupervisorSelfSwap step 1 失败（supervisor.exe 不存在）---
+
+func TestSupervisorSelfSwap_Step1Fail_SupervisorMissing(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 只有 .new，没有 supervisor.exe（brick 恢复场景）
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	copyFileExe(t, dummy, newPath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际在 binDir（标准安装路径）
+	m.selfPathResolver = func() (string, error) {
+		return filepath.Join(binDir, SupervisorBinaryName), nil
+	}
+	err := m.SupervisorSelfSwap()
+
+	if err == nil {
+		t.Fatal("期望 step 1 失败错误（supervisor.exe 不存在），got nil")
+	}
+	// 错误信息应提及 step 1
+	if !strings.Contains(err.Error(), "step 1") {
+		t.Errorf("错误应提及 step 1，got %q", err.Error())
+	}
+}
+
+// ---supervisor 实际运行路径与 edgedirs.BinDir 不一致 ---
+
+// TestSupervisorSelfSwap_SelfPathDiffersFromBinDir_RelocatesNew 复现  根因：
+// supervisor 从非标准路径启动（如 dev machine 的 C:\ongrid-edge\，旧 nssm 遗留），
+// 但 bundle apply 把 .new 放在 m.binDir（C:\Program Files\ongrid-edge\bin\）。
+// 修复后 SupervisorSelfSwap 用 os.Executable 取实际路径，并把 .new 从 m.binDir
+// 重定位到 supervisorPath 同目录后再 swap。
+func TestSupervisorSelfSwap_SelfPathDiffersFromBinDir_RelocatesNew(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()  // bundle apply 放置 .new 的目录（edgedirs.BinDir 语义）
+	selfDir := t.TempDir() // supervisor 实际运行目录（≠ binDir）
+
+	// 铺地板：binDir 下只有 .new（bundle apply 放的）
+	bundledNew := filepath.Join(binDir, SupervisorBinaryName+".new")
+	copyFileExe(t, dummy, bundledNew)
+	appendMarker(t, bundledNew, "NEW-VERSION\n")
+
+	// 铺地板：selfDir 下有实际运行的 supervisor.exe（旧版本）
+	supervisorPath := filepath.Join(selfDir, SupervisorBinaryName)
+	copyFileExe(t, dummy, supervisorPath)
+	appendMarker(t, supervisorPath, "OLD-VERSION\n")
+	oldPath := supervisorPath + ".old"
+
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 注入 stub：supervisor 实际路径在 selfDir（≠ binDir）
+	m.selfPathResolver = func() (string, error) {
+		return supervisorPath, nil
+	}
+	err := m.SupervisorSelfSwap()
+
+	// 应返回 ErrSupervisorRestartSoon（swap 成功）
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
+	}
+
+	// supervisorPath 应被替换为新版本（含 NEW-VERSION marker，不含 OLD-VERSION）
+	got, _ := os.ReadFile(supervisorPath)
+	if !strings.Contains(string(got), "NEW-VERSION") {
+		t.Errorf("supervisor.exe 应含 NEW-VERSION marker（重定位 + swap 成功），got %q", got)
+	}
+	if strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf("supervisor.exe 不应含 OLD-VERSION marker（旧版本应被替换）")
+	}
+
+	// .old 应在 selfDir 下（不在 binDir），含旧版本 marker
+	got, _ = os.ReadFile(oldPath)
+	if !strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf("selfDir/.old 应含旧版本 marker，got %q", got)
+	}
+
+	// binDir 下的 .new 应被清理（重定位成功后删除）
+	if _, err := os.Stat(bundledNew); !os.IsNotExist(err) {
+		t.Errorf("binDir/.new 应被清理（err=%v）", err)
+	}
+
+	// selfDir 下的 .new 也不应残留（swap 成功后 rename 走）
+	selfNew := filepath.Join(selfDir, SupervisorBinaryName+".new")
+	if _, err := os.Stat(selfNew); !os.IsNotExist(err) {
+		t.Errorf("selfDir/.new 应不存在（err=%v）", err)
+	}
+
+	// applied sentinel 应写入，pending sentinel 应删除
+	if !IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应写入")
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应删除")
+	}
+}

--- a/internal/edgeagent/upgrademachine/testdata/dummy_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/dummy_main.go
@@ -1,0 +1,52 @@
+// dummy_main.go 是文件锁语义探针的测试辅助程序。
+// 与 sleeper_main.go 的区别：dummy 支持 --version（验证  smokeTestVersion
+// 前置）和 --self-rename（验证运行中进程能否 rename 自己的 .exe）。
+// 三种模式：
+//   - 默认：sleep 60s 然后退出 0（模拟运行中的 supervisor.exe 被外部 rename）
+//   - --version：输出 "ongrid-dummy v0.0.1" 并退出 0（模拟 supervisor --version）
+//   - --self-rename <path>：尝试 os.Rename(path, path+".old")，
+//     通过 stdout JSON 报告结果后立即退出（验证进程内自 rename 语义）
+//
+// 与 sleeper_main.go 一样，通过 `go build -o dummy.exe testdata/dummy_main.go`
+// 显式编译（testdata 不参与包编译）。
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	version := flag.Bool("version", false, "print version and exit")
+	selfRename := flag.String("self-rename", "", "rename this binary to <path>.old then report result and exit")
+	flag.Parse()
+
+	if *version {
+		fmt.Println("ongrid-dummy v0.0.1")
+		return
+	}
+
+	if *selfRename != "" {
+		oldPath := *selfRename + ".old"
+		err := os.Rename(*selfRename, oldPath)
+		result := map[string]any{
+			"op":  "self_rename",
+			"src": *selfRename,
+			"dst": oldPath,
+		}
+		if err != nil {
+			result["ok"] = false
+			result["err"] = err.Error()
+		} else {
+			result["ok"] = true
+		}
+		_ = json.NewEncoder(os.Stdout).Encode(result)
+		return
+	}
+
+	// 默认：持续运行 60s 模拟 supervisor 进程持有自身 .exe 文件锁
+	time.Sleep(60 * time.Second)
+}

--- a/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
@@ -1,0 +1,30 @@
+// sleeper_main.go 是测试辅助程序：启动后持续运行直到被 kill。
+// 用于模拟 windows_exporter.exe 等长期运行的 plugin 进程。
+// 通过持有自身 .exe 文件锁，模拟  的核心场景：
+// worker 退出后 plugin 进程 orphaned → .exe 文件锁阻塞 rename。
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	// 捕获 Ctrl-Break（taskkill /T 默认发送），但忽略它模拟"被 orphaned 后无法触达"
+	// 实际生产中 windows_exporter 不响应 taskkill /T（不在 worker 的进程树）
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	// 真正的 orphaned 模拟：只接受 SIGKILL（taskkill /F）
+	go func() {
+		<-sigCh
+		// 什么都不做 — 模拟进程不响应优雅信号
+	}()
+
+	// 持续运行直到被强制 kill
+	for {
+		time.Sleep(time.Hour)
+	}
+}

--- a/internal/edgeagent/upgrademachine/validate.go
+++ b/internal/edgeagent/upgrademachine/validate.go
@@ -1,0 +1,195 @@
+// validate.go 实现 manifest 条目的路径/权限白名单校验 + kill 双防线。
+//
+// 威胁模型：被篡改的 bundle / 部分被控的 manager。
+// 三重 Dest 校验把「写什么」和「杀谁」同时锁死：
+//  1. 文件名段字符正则 — 拒 ADS 冒号、尾点、尾空格、8.3 短名（~）、路径分隔符变体
+//  2. 文件名 ∈ 构建期已知精确集合（EqualFold，NTFS 大小写不敏感语义）
+//  3. 父目录 canonical（EvalSymlinks）+ 受管根前缀断言 — 拒 symlink/junction 逃逸与
+//     兄弟目录前缀碰撞（尾随分隔符断言）
+//
+// 纯 Go（无 Windows 专属依赖），Linux CI 可跑；EqualFold 对大小写敏感文件系统无害
+// （canonical 路径源自同一根字符串派生，大小写一致）。
+
+package upgrademachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// destBase 取 Dest/镜像路径的 basename。Dest 是 supervisor 产出的 Windows
+// 路径（反斜杠分隔）；filepath.Base 在非 Windows 平台不认 '\'，跨平台测试
+// （Linux CI）会把整串当 basename 导致白名单误拒，故对两种分隔符取最后一段。
+func destBase(p string) string {
+	if i := strings.LastIndexAny(p, `\/`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// destBaseWhitelist 是 Dest 文件名的精确白名单。
+//
+// 单一真相源镜像：dist/build-edge-bundle-windows.sh 的 ENTRIES（构建侧固定清单）。
+// 插件文件名是构建期已知的，不是运行期用户输入 —
+// 新增插件 = 同步改构建脚本 + 这里（升级白名单与 bundle 产物同步演进）。
+// KillManifestExes 复用同一集合：kill 目标 ⊆ swap 目标（kill 不存在独立的合法面）。
+var destBaseWhitelist = []string{
+	WorkerBinaryName,
+	SupervisorBinaryName,
+	"windows_exporter.exe",
+	"promtail.exe",
+	"otelcol-contrib.exe",
+}
+
+// destBasePattern 是文件名段字符白名单（一律拒绝，不做宽容清洗）。
+// 字符集排除冒号（ADS）、波浪号（8.3 短名）、空格；`.exe$` 锚点排除尾点；
+// (?i) 对齐 NTFS 大小写不敏感语义（与白名单 EqualFold 一致）。
+var destBasePattern = regexp.MustCompile(`(?i)^[A-Za-z0-9._-]+\.exe$`)
+
+// protectedSystemImages 是 KillByImage 实现层的系统关键镜像黑名单。
+//
+// 异源第二道防线：kill 路径不经 Dest 写校验是独立旁路，黑名单
+// 与白名单不同代码路径、不同失败模式。杀这些镜像 = 系统失稳（lsass 触发强制重启、
+// MsMpEng 是 Defender 自身）。explorer.exe 等用户会话进程刻意不入名单（YAGNI）。
+var protectedSystemImages = []string{
+	"smss.exe",
+	"csrss.exe",
+	"wininit.exe",
+	"winlogon.exe",
+	"services.exe",
+	"lsass.exe",
+	"svchost.exe",
+	"MsMpEng.exe",
+}
+
+// IsProtectedSystemImage 报告 name（取 basename，大小写不敏感）是否属于系统关键镜像
+// 黑名单。KillByImage 实现层调用：命中即拒绝执行（返回 error 而非静默跳过 —
+// 显式失败让攻击与配置错误都可见）。
+func IsProtectedSystemImage(name string) bool {
+	base := destBase(name)
+	for _, p := range protectedSystemImages {
+		if strings.EqualFold(base, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateAllEntries 校验全部 manifest 条目（all-or-nothing，遇首错即返回）。
+// Machine.Apply 在 ParseManifest 之后、任何 kill/swap 之前调用 — 校验失败时
+// 零磁盘变动、零进程终止。
+//
+// context 约定：入口处 ctx.Err guard（对称 ApplyBundle
+// 的入口取消检查）；进入逐条校验后不中断（与后续 swap 的原子语义衔接）。
+func ValidateAllEntries(ctx context.Context, binDir, incomingDir string, entries []ManifestEntry) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	for _, e := range entries {
+		if err := validateMode(e.Mode); err != nil {
+			return fmt.Errorf("entry %s: %w", e.Src, err)
+		}
+		if err := validateSrc(incomingDir, e.Src); err != nil {
+			return fmt.Errorf("entry src %s: %w", e.Src, err)
+		}
+		if err := validateDest(binDir, e.Dest); err != nil {
+			return fmt.Errorf("entry dest %s: %w", e.Dest, err)
+		}
+	}
+	return nil
+}
+
+// validateMode：Mode 字段白名单。
+// 仅接受 bundle 产物实际使用的两个值 + 空串（空 = 不 chmod，applyOne 对空
+// Mode 跳过权限设置 — 兼容无权限语义的 manifest 条目）；其余拒绝 —
+// 防 read-only（0444）注入让下轮升级 rename 撞只读位永久 brick，
+// 也防 parseMode 对非八进制字符静默截断。
+// 空串放行属实施期偏差（设计原文两值），理由：拒绝空串会让
+// 「不设权限」这一合法语义不可表达，且空串无攻击面（不进 chmod 路径）。
+func validateMode(mode string) error {
+	switch mode {
+	case "", "0755", "0644":
+		return nil
+	}
+	return fmt.Errorf("mode %q not in whitelist (allowed: 0755/0644/empty)", mode)
+}
+
+// validateDest 三重校验。
+func validateDest(binDir, dest string) error {
+	base := destBase(dest)
+	if !destBasePattern.MatchString(base) {
+		return fmt.Errorf("dest base %q fails filename pattern (rejects ADS colon/trailing dot/8.3 short name)", base)
+	}
+	if !destBaseAllowed(base) {
+		return fmt.Errorf("dest base %q not in whitelist", base)
+	}
+	// 父目录 canonical（dest 文件可能不存在（首装），对父目录做 EvalSymlinks —
+	// 父目录必须存在且解析后仍在受管根内，junction/symlink 逃逸在此被拒）
+	if err := ensureWithinDir(binDir, filepath.Dir(dest)); err != nil {
+		return fmt.Errorf("dest dir: %w", err)
+	}
+	return nil
+}
+
+// destBaseAllowed：basename ∈ 白名单（EqualFold 全链路统一比较语义，H3）。
+func destBaseAllowed(base string) bool {
+	for _, w := range destBaseWhitelist {
+		if strings.EqualFold(base, w) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateSrc：src 是 incoming 内的相对路径，必须是常规文件。
+func validateSrc(incomingDir, src string) error {
+	// src 永不支持空格 — 显式拒绝（解析格式固定，不做「兼容」）
+	if strings.ContainsAny(src, " \t") {
+		return fmt.Errorf("src %q contains whitespace (never supported)", src)
+	}
+	if filepath.IsAbs(src) {
+		return fmt.Errorf("src %q must be relative to incoming dir", src)
+	}
+	srcPath := filepath.Join(incomingDir, src)
+	// Lstat 不解引用 — symlink/管道/目录一律拒（解引用语义的 io.Copy 有
+	// 内容污染与挂起面）
+	if fi, err := os.Lstat(srcPath); err != nil {
+		return fmt.Errorf("lstat src: %w", err)
+	} else if !fi.Mode().IsRegular() {
+		return fmt.Errorf("src %q is not a regular file (mode %s)", src, fi.Mode())
+	}
+	// canonical 前缀：src 所在目录解析后不得逃逸 incoming（防目录挂载点逃逸；
+	// symlink 已被 Lstat 拒，此处是纵深第二层）
+	if err := ensureWithinDir(incomingDir, filepath.Dir(srcPath)); err != nil {
+		return fmt.Errorf("src dir: %w", err)
+	}
+	return nil
+}
+
+// ensureWithinDir 断言 canonical(path) 位于 canonical(root) 之内（含等于 root）。
+//
+// 比较语义：尾随分隔符断言防兄弟目录前缀碰撞（upgrade vs upgrade-evil）；
+// EqualFold 对齐 NTFS 大小写不敏感语义（大小写敏感文件系统上 canonical 路径
+// 同源派生、大小写一致，EqualFold 无害）。
+func ensureWithinDir(rootDir, path string) error {
+	rootCanon, err := filepath.EvalSymlinks(rootDir)
+	if err != nil {
+		return fmt.Errorf("canonical root %s: %w", rootDir, err)
+	}
+	pathCanon, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("canonical %s: %w", path, err)
+	}
+	if pathCanon == rootCanon {
+		return nil
+	}
+	rootPrefix := rootCanon + string(filepath.Separator)
+	if len(pathCanon) > len(rootPrefix) && strings.EqualFold(pathCanon[:len(rootPrefix)], rootPrefix) {
+		return nil
+	}
+	return fmt.Errorf("canonical %s escapes managed root %s", pathCanon, rootCanon)
+}

--- a/internal/edgeagent/upgrademachine/validate_test.go
+++ b/internal/edgeagent/upgrademachine/validate_test.go
@@ -1,0 +1,336 @@
+// validate_test.go 测试 manifest 路径校验 + kill 双防线。
+//
+// 校验语义：
+//   - Dest：文件名段字符正则（拒 ADS 冒号/尾点/尾空格/8.3 短名）+ 精确白名单
+//     （构建期已知集，EqualFold）+ 父目录 canonical 前缀（拒 junction/symlink 逃逸）
+//   - Src：canonical 前缀 + 常规文件（拒 symlink/管道/目录）+ 无空格
+//   - Mode：仅 0755/0644/空
+//   - KillManifestExes：basename 套同一白名单（拒任意镜像名旁路）
+//   - KillByImage 实现层：系统关键镜像黑名单兜底
+package upgrademachine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- 白名单集合本身 ---
+
+func TestDestBaseWhitelist_Membership(t *testing.T) {
+	// 构建期完整已知集（dist/build-edge-bundle-windows.sh ENTRIES 的 edge 侧镜像）
+	want := []string{
+		WorkerBinaryName, SupervisorBinaryName,
+		"windows_exporter.exe", "promtail.exe", "otelcol-contrib.exe",
+	}
+	if len(destBaseWhitelist) != len(want) {
+		t.Fatalf("白名单成员数 = %d, want %d: %v", len(destBaseWhitelist), len(want), destBaseWhitelist)
+	}
+	for _, w := range want {
+		found := false
+		for _, g := range destBaseWhitelist {
+			if strings.EqualFold(g, w) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("白名单缺少 %q", w)
+		}
+	}
+}
+
+// --- Dest 校验 ---
+
+func TestValidateEntry_DestWhitelist(t *testing.T) {
+	binDir := t.TempDir()
+	// 大小写变体用例需要大小写不敏感文件系统（Windows/NTFS）；Linux CI 跳过
+	if _, err := filepath.EvalSymlinks(strings.ToUpper(binDir)); err != nil {
+		t.Skipf("文件系统大小写敏感，大小写变体用例不适用: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		dest    string
+		wantErr bool
+	}{
+		{"worker 合法", filepath.Join(binDir, WorkerBinaryName), false},
+		{"supervisor 合法", filepath.Join(binDir, SupervisorBinaryName), false},
+		{"plugin 合法", filepath.Join(binDir, "windows_exporter.exe"), false},
+		{"大小写变体合法（NTFS 不区分大小写）", filepath.Join(strings.ToUpper(binDir), strings.ToUpper(WorkerBinaryName)), false},
+		{"系统镜像被拒", filepath.Join(binDir, "svchost.exe"), true},
+		{"任意文件名被拒", filepath.Join(binDir, "evil.exe"), true},
+		{"受管根外被拒", filepath.Join(t.TempDir(), WorkerBinaryName), true},
+		{"父目录穿越被拒", filepath.Join(binDir, "..", "..", "Windows", "system32", "svchost.exe"), true},
+		{"ADS 冒号被拒", filepath.Join(binDir, WorkerBinaryName+":hidden"), true},
+		{"尾点被拒（Win32 落盘剥离后变合法名）", filepath.Join(binDir, WorkerBinaryName+"."), true},
+		{"尾空格被拒（Win32 落盘剥离后变合法名）", filepath.Join(binDir, WorkerBinaryName+" "), true},
+		{"8.3 短名被拒", filepath.Join(binDir, "WORKER~1.EXE"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDest(binDir, tc.dest)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateDest(%q) err=%v, wantErr=%v", tc.dest, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// symlink/junction 逃逸：binDir 内的子目录被符号链接指向受管根外 → dest 解析后逃逸被拒。
+func TestValidateEntry_DestSymlinkEscape(t *testing.T) {
+	if testing.Short() {
+		t.Skip("symlink 需要真实文件系统")
+	}
+	binDir := t.TempDir()
+	outside := t.TempDir()
+
+	link := filepath.Join(binDir, "plugins")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("此环境不支持 symlink: %v", err)
+	}
+
+	// 字符串前缀合法（plugins 在 binDir 下），canonical 解析后指向 outside → 必须被拒
+	err := validateDest(binDir, filepath.Join(link, "promtail.exe"))
+	if err == nil {
+		t.Errorf("symlink 逃逸必须被拒: dest=%s → %s", filepath.Join(link, "promtail.exe"), outside)
+	}
+}
+
+// 兄弟目录前缀碰撞：upgrade-evil 不是 upgrade 的子目录，必须被拒（尾随分隔符断言）。
+func TestValidateEntry_DestSiblingPrefixCollision(t *testing.T) {
+	parent := t.TempDir()
+	binDir := filepath.Join(parent, "upgrade")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evilDir := filepath.Join(parent, "upgrade-evil")
+	if err := os.MkdirAll(evilDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateDest(binDir, filepath.Join(evilDir, WorkerBinaryName)); err == nil {
+		t.Errorf("兄弟目录前缀碰撞必须被拒")
+	}
+}
+
+// --- Src 校验 ---
+
+func TestValidateEntry_Src(t *testing.T) {
+	incoming := t.TempDir()
+	goodSrc := filepath.Join(incoming, "ongrid-edge-worker.exe")
+	writeTestFile(t, goodSrc, "bin")
+
+	cases := []struct {
+		name    string
+		src     string
+		wantErr bool
+	}{
+		{"直接子文件合法", "ongrid-edge-worker.exe", false},
+		{"incoming 内子目录合法", filepath.Join("sub", "file.exe"), false}, // 子目录由 fixture 创建
+		{"绝对路径被拒", goodSrc, true},
+		{"父目录穿越被拒", filepath.Join("..", "etc", "passwd"), true},
+		{"空格被拒（M4：src 永不支持空格）", "my file.exe", true},
+		{"不存在被拒", "missing.exe", true},
+	}
+	// 子目录 fixture
+	writeTestFile(t, filepath.Join(incoming, "sub", "file.exe"), "x")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSrc(incoming, tc.src)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateSrc(%q) err=%v, wantErr=%v", tc.src, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// src 是 symlink → 不是常规文件，必须被拒。
+func TestValidateEntry_SrcSymlinkRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("symlink 需要真实文件系统")
+	}
+	incoming := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "evil.exe")
+	writeTestFile(t, target, "evil")
+
+	link := filepath.Join(incoming, "link.exe")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("此环境不支持 symlink: %v", err)
+	}
+	if err := validateSrc(incoming, "link.exe"); err == nil {
+		t.Errorf("symlink src 必须被拒")
+	}
+}
+
+// src 是目录 → 必须被拒。
+func TestValidateEntry_SrcDirectoryRejected(t *testing.T) {
+	incoming := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(incoming, "dir.exe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSrc(incoming, "dir.exe"); err == nil {
+		t.Errorf("目录 src 必须被拒")
+	}
+}
+
+// --- Mode 白名单 ---
+
+func TestValidateEntry_ModeWhitelist(t *testing.T) {
+	cases := []struct {
+		mode    string
+		wantErr bool
+	}{
+		{"", false},
+		{"0755", false},
+		{"0644", false},
+		{"0444", true},    // read-only 注入 → 下轮升级 rename 失败 brick
+		{"777", true},     // 非 bundle 产物权限
+		{"0444abc", true}, // parseMode 静默截断防护
+	}
+	for _, tc := range cases {
+		err := validateMode(tc.mode)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateMode(%q) err=%v, wantErr=%v", tc.mode, err, tc.wantErr)
+		}
+	}
+}
+
+// --- ValidateAllEntries：Machine.Apply 的单点门卫 ---
+
+func TestValidateAllEntries_RejectsBadManifest(t *testing.T) {
+	binDir := t.TempDir()
+	incoming := t.TempDir()
+	writeTestFile(t, filepath.Join(incoming, "x.exe"), "x")
+
+	entries := []ManifestEntry{
+		{SHA256: "00", Mode: "0755", Src: "x.exe", Dest: filepath.Join(binDir, WorkerBinaryName)},
+		{SHA256: "00", Mode: "0755", Src: "x.exe", Dest: `C:\Windows\system32\svchost.exe`},
+	}
+	if err := ValidateAllEntries(context.Background(), binDir, incoming, entries); err == nil {
+		t.Fatalf("含系统镜像 dest 的 manifest 必须整体被拒")
+	}
+}
+
+// Apply 集成：恶意 manifest 在 kill/swap 之前被拒（零磁盘变动、零进程终止）。
+func TestMachine_Apply_RejectsMaliciousManifestBeforeKill(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()  // 受管根
+	evilDir := t.TempDir() // 受管根外
+	writeTestFile(t, filepath.Join(binDir, WorkerBinaryName), "old")
+
+	// manifest 一条合法 + 一条恶意（dest 指向受管根外的系统镜像名）
+	buildMachineBundle(t, stageDir, binDir, "v1", []struct{ Src, Dest, Content string }{
+		{"a.exe", WorkerBinaryName, "new"},
+	})
+	// 追加恶意行（buildMachineBundle 只写白名单文件名，这里手工追加）
+	manifest := filepath.Join(stageDir, IncomingDirName, ManifestFileName)
+	writeTestFile(t, filepath.Join(stageDir, IncomingDirName, "evil.exe"), "evil")
+	f, err := os.OpenFile(manifest, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(sha256Of(t, "evil") + " 0755 evil.exe " + filepath.Join(evilDir, "svchost.exe") + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+	if err := m.Apply(context.Background(), 12345); err == nil {
+		t.Fatalf("恶意 manifest 的 Apply 必须失败")
+	}
+	if pc.killImageCalls.Load() != 0 {
+		t.Errorf("校验必须先于 kill：KillByImage 被调用了 %d 次", pc.killImageCalls.Load())
+	}
+	// 零磁盘变动：合法条目也不得被换
+	got, _ := os.ReadFile(filepath.Join(binDir, WorkerBinaryName))
+	if string(got) != "old" {
+		t.Errorf("校验失败必须零磁盘变动, dest content = %q", got)
+	}
+}
+
+// --- KillManifestExes 白名单过滤 ---
+
+func TestKillManifestExes_WhitelistFilter(t *testing.T) {
+	entries := []ManifestEntry{
+		{Dest: `C:\bin\` + WorkerBinaryName},
+		{Dest: `C:\bin\windows_exporter.exe`}, // 插件在白名单内 → 合法 kill 目标（文件锁场景）
+		{Dest: `C:\bin\` + SupervisorBinaryName},
+		{Dest: `C:\bin\ONGRID-EDGE-SUPERVISOR.EXE`}, // 大小写变体 → 同样跳过（EqualFold）
+		{Dest: `C:\bin\svchost.exe`},                // 白名单外 → 不杀（C1 旁路封死）
+		{Dest: `C:\temp\evil.exe`},                  // 白名单外 → 不杀
+	}
+	var pc mockProcessController
+	m := NewMachine(t.TempDir(), t.TempDir(), testLogger(), &pc)
+
+	m.KillManifestExes(entries)
+
+	want := []string{WorkerBinaryName, "windows_exporter.exe"}
+	if len(pc.killImageNames) != len(want) {
+		t.Fatalf("KillByImage calls = %v, want %v", pc.killImageNames, want)
+	}
+	for i, w := range want {
+		if !strings.EqualFold(pc.killImageNames[i], w) {
+			t.Errorf("kill[%d] = %q, want %q", i, pc.killImageNames[i], w)
+		}
+	}
+}
+
+// --- 系统镜像黑名单（KillByImage 实现层兜底）---
+
+func TestIsProtectedSystemImage(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"svchost.exe", true},
+		{"SVCHOST.EXE", true}, // 大小写不敏感
+		{"lsass.exe", true},
+		{"csrss.exe", true},
+		{"smss.exe", true},
+		{"wininit.exe", true},
+		{"winlogon.exe", true},
+		{"services.exe", true},
+		{"MsMpEng.exe", true},
+		{WorkerBinaryName, false}, // 白名单内正常目标不受黑名单影响
+		{"windows_exporter.exe", false},
+		{"explorer.exe", false}, // 不在最小黑名单（YAGNI：用户会话进程，非系统关键）
+	}
+	for _, tc := range cases {
+		if got := IsProtectedSystemImage(tc.name); got != tc.want {
+			t.Errorf("IsProtectedSystemImage(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// sha256Of 计算内容 sha（测试 helper，恶意 manifest 行需要真实 sha 让校验走到 dest 检查）。
+func sha256Of(t *testing.T, content string) string {
+	t.Helper()
+	// writeTestFile 返回值即内容 sha256
+	return writeTestFile(t, filepath.Join(t.TempDir(), "sha_tmp"), content)
+}
+
+// TestDestBase 分隔符无关性回归：Dest 是 Windows 反斜杠路径，Linux CI 上
+// filepath.Base 不认 '\' 曾导致白名单误拒（KillManifestExes 0 次 kill）。
+func TestDestBase(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`C:\bin\` + WorkerBinaryName, WorkerBinaryName},
+		{`C:\bin\sub\windows_exporter.exe`, "windows_exporter.exe"},
+		{`C:/bin/promtail.exe`, "promtail.exe"}, // 正斜杠变体同拒同收
+		{WorkerBinaryName, WorkerBinaryName},
+	}
+	for _, tc := range cases {
+		if got := destBase(tc.in); got != tc.want {
+			t.Errorf("destBase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -409,6 +409,37 @@ type EdgeConfig struct {
 	//
 	// env: ONGRID_EDGE_COLLECTOR_INTERVAL; default 10s
 	CollectorInterval time.Duration
+
+	// TLSCAFile is the path to a PEM CA file used to verify the frontier
+	// broker's TLS cert. Empty = plaintext (no TLS). Set when the broker
+	// has tls.enable=true in frontier.yaml.
+	//
+	// env: ONGRID_EDGE_TLS_CA_FILE; default empty.
+	TLSCAFile string
+
+	// TLSServerName overrides the TLS SNI / cert verification name.
+	// Set when dialing by IP but the broker cert uses a DNS name.
+	//
+	// env: ONGRID_EDGE_TLS_SERVER_NAME; default empty.
+	TLSServerName string
+
+	// TLSRequired records that this edge was installed with TLS enabled
+	// (installer writes ONGRID_EDGE_TLS_REQUIRED=1 next to the CA path).
+	// When true, a missing TLSCAFile is a hard startup error instead of
+	// a silent plaintext fallback — the tunnel credential channel must
+	// never downgrade to cleartext unnoticed.
+	//
+	// env: ONGRID_EDGE_TLS_REQUIRED; default false.
+	TLSRequired bool
+
+	// SecretsFile is the path to the DPAPI-encrypted secrets.enc. When
+	// set and the file exists, the broker token is loaded from it via
+	// DPAPI. When the file is missing or decryption fails, fall back to
+	// SecretKey (env var).
+	//
+	// env: ONGRID_EDGE_SECRETS_FILE; default empty (the platform default
+	// from defaultSecretsFile() in paths_{windows,linux}.go applies).
+	SecretsFile string
 }
 
 // Load reads env vars and returns a Config with defaults applied.
@@ -490,6 +521,10 @@ func Load() (*Config, error) {
 	c.Edge.CollectorMode = getEnv("ONGRID_EDGE_COLLECTOR_MODE", "off")
 	c.Edge.ScrapeConfigFile = getEnv("ONGRID_EDGE_SCRAPE_CONFIG_FILE", "/etc/ongrid-edge/scrape.yaml")
 	c.Edge.CollectorInterval = getEnvDuration("ONGRID_EDGE_COLLECTOR_INTERVAL", 10*time.Second)
+	c.Edge.TLSCAFile = getEnv("ONGRID_EDGE_TLS_CA_FILE", "")
+	c.Edge.TLSServerName = getEnv("ONGRID_EDGE_TLS_SERVER_NAME", "")
+	c.Edge.TLSRequired = getEnvBool("ONGRID_EDGE_TLS_REQUIRED", false)
+	c.Edge.SecretsFile = getEnv("ONGRID_EDGE_SECRETS_FILE", "")
 
 	c.FrontierClient.Addr = getEnv("ONGRID_FRONTIER_ADDR", "frontier:40011")
 	c.FrontierClient.ServiceName = getEnv("ONGRID_FRONTIER_SERVICE_NAME", "ongrid-manager")

--- a/internal/pkg/tunnel/client.go
+++ b/internal/pkg/tunnel/client.go
@@ -172,6 +172,14 @@ func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
 		return nil, errors.New("tunnel: ServerAddr (or CloudAddr) is required")
 	}
 	if caFile == "" {
+		// Fail closed: TLS was configured at install time (the installer
+		// records ONGRID_EDGE_TLS_REQUIRED=1 alongside the CA path), but the
+		// CA file setting is now missing — e.g. the service Environment was
+		// recreated or cleaned. Falling back to plaintext here would expose
+		// the broker token (and every rotated token) on the wire.
+		if c.cfg.TLSRequired {
+			return nil, errors.New("tunnel: TLS required (installed with --tls-ca-file) but ONGRID_EDGE_TLS_CA_FILE is unset; refusing plaintext downgrade")
+		}
 		d := &net.Dialer{Timeout: 10 * time.Second}
 		return func() (net.Conn, error) {
 			conn, err := d.Dial("tcp", addr)
@@ -192,6 +200,24 @@ func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
 	tlsCfg := &tls.Config{
 		RootCAs:    pool,
 		MinVersion: tls.VersionTLS12,
+	}
+	// Derive the TLS ServerName from the address (required for cert
+	// verification). When the address is an IP literal but the cert's
+	// CN is a DNS name, the caller must override it via
+	// ONGRID_EDGE_TLS_SERVER_NAME.
+	if c.cfg.TLSServerName != "" {
+		tlsCfg.ServerName = c.cfg.TLSServerName
+	} else if host, _, err := net.SplitHostPort(addr); err == nil && net.ParseIP(host) == nil {
+		tlsCfg.ServerName = host
+	}
+	// Fail closed: a non-empty TLSCAFile with an unresolved ServerName
+	// (IP-literal address and no TLSServerName override) refuses to
+	// start. Otherwise the TLS handshake would fail later with a
+	// cryptic error ("certificate signed by unknown authority" or
+	// "x509: cannot validate certificate") that operators tend to
+	// misread as a CA misconfiguration.
+	if tlsCfg.ServerName == "" {
+		return nil, fmt.Errorf("tunnel: TLS ServerName unresolved (addr=%q is IP literal; set ONGRID_EDGE_TLS_SERVER_NAME)", addr)
 	}
 	d := &net.Dialer{Timeout: 10 * time.Second}
 	return func() (net.Conn, error) {

--- a/internal/pkg/tunnel/dialer_servername_test.go
+++ b/internal/pkg/tunnel/dialer_servername_test.go
@@ -1,0 +1,117 @@
+package tunnel
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCA generates a throwaway self-signed certificate and writes it
+// as a PEM CA file. Only used to get buildDialer past the CA parsing step
+// so the ServerName resolution logic can be exercised.
+func writeTestCA(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tunnel-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write ca pem: %v", err)
+	}
+	return path
+}
+
+// TestBuildDialerFailsClosedOnIPLiteral verifies the fail-closed behavior:
+// with a CA configured, an IP-literal address and no TLSServerName
+// override, buildDialer refuses to build a dialer instead of letting the
+// TLS handshake fail later with a cryptic certificate error.
+func TestBuildDialerFailsClosedOnIPLiteral(t *testing.T) {
+	caFile := writeTestCA(t)
+	c := NewClient(ClientConfig{
+		ServerAddr: "192.0.2.10:40011",
+		TLSCAFile:  caFile,
+	})
+	gc := c.(*geminioClient)
+
+	_, err := gc.buildDialer()
+	if err == nil {
+		t.Fatal("buildDialer succeeded with IP-literal addr and no TLSServerName; want fail-closed error")
+	}
+}
+
+// TestBuildDialerAcceptsIPLiteralWithOverride verifies the escape hatch:
+// an explicit TLSServerName resolves the ambiguity and the dialer builds.
+func TestBuildDialerAcceptsIPLiteralWithOverride(t *testing.T) {
+	caFile := writeTestCA(t)
+	c := NewClient(ClientConfig{
+		ServerAddr:    "192.0.2.10:40011",
+		TLSCAFile:     caFile,
+		TLSServerName: "broker.example.com",
+	})
+	gc := c.(*geminioClient)
+
+	dialer, err := gc.buildDialer()
+	if err != nil {
+		t.Fatalf("buildDialer with TLSServerName override: %v", err)
+	}
+	if dialer == nil {
+		t.Fatal("buildDialer returned nil dialer without error")
+	}
+}
+
+// TestBuildDialerFailsClosedWhenTLSRequiredNoCA verifies the TLS anchor:
+// when the edge was installed with TLS (TLSRequired=1) but the CA env var
+// is now missing, buildDialer must refuse to fall back to plaintext —
+// the credential channel must never downgrade to cleartext unnoticed.
+func TestBuildDialerFailsClosedWhenTLSRequiredNoCA(t *testing.T) {
+	c := NewClient(ClientConfig{
+		ServerAddr:  "broker.example.com:40011",
+		TLSRequired: true,
+	})
+	gc := c.(*geminioClient)
+
+	_, err := gc.buildDialer()
+	if err == nil {
+		t.Fatal("buildDialer succeeded with TLSRequired and no CA file; want fail-closed error")
+	}
+}
+
+// TestBuildDialerAllowsPlaintextWithoutTLSRequired verifies the legacy
+// behavior is preserved: without the TLS anchor an empty CA config still
+// builds a plaintext dialer (install-time opt-in only).
+func TestBuildDialerAllowsPlaintextWithoutTLSRequired(t *testing.T) {
+	c := NewClient(ClientConfig{
+		ServerAddr: "broker.example.com:40011",
+	})
+	gc := c.(*geminioClient)
+
+	dialer, err := gc.buildDialer()
+	if err != nil {
+		t.Fatalf("buildDialer without TLS anchor: %v", err)
+	}
+	if dialer == nil {
+		t.Fatal("buildDialer returned nil dialer without error")
+	}
+}

--- a/internal/pkg/tunnel/types.go
+++ b/internal/pkg/tunnel/types.go
@@ -45,6 +45,15 @@ type ClientConfig struct {
 	TLSCAFile string
 	// TLSCA is a legacy alias for TLSCAFile (Phase 1 naming).
 	TLSCA string
+	// TLSServerName overrides the TLS SNI / cert verification name.
+	// Empty = use the host part of ServerAddr. Set when dialing by IP
+	// but the broker cert's CN/SAN uses a DNS name.
+	TLSServerName string
+	// TLSRequired makes an empty CA config a hard error instead of a
+	// silent plaintext fallback. The installer sets it whenever TLS was
+	// configured at install time, so a lost / corrupted CA env var can
+	// never silently downgrade the credential channel to cleartext.
+	TLSRequired bool
 	// Log is optional; a default discard-style logger is used when nil.
 	Log *slog.Logger
 }


### PR DESCRIPTION
Windows edge supervisor (Windows Service wrapper) + rename-aside self-upgrade state machine. Consumes PR1 scaffolding (#228) — **depends on #228 merging first**.

## Scope (this PR)

- `cmd/ongrid-edge-supervisor`: Windows Service entry (`main` / `service` / `worker` / `upgrade_windows` / `install_windows`)
  - `supervisor.exe --install` / `--uninstall` / `--upgrade` subcommands
  - Worker process lifecycle (start / monitor / restart)
  - Schtasks SYSTEM identity for DPAPI install
- `internal/edgeagent/supervisorhealth`: supervisor health check + `health.json` writer
- `internal/edgeagent/upgradebundle`: bundle download + SHA256 verification + healthy marker
- `internal/edgeagent/upgrademachine`: deep module — rename-aside self-upgrade state machine
  - 4 interfaces (ProcessController / State / IPC / Manifest)
  - Supervisor self-swap (running .exe self-replacement)
  - W1-W5 hardening: orphan worker race / Defender file lock / brick rollback / SCM recovery / pending bundle extract

## Stacked on #228

This PR's branch includes commit `b705400` (PR1). Once #228 merges to `ongridio:main`, this PR auto-rebases and the diff collapses to PR2-only files. Reviewers can review PR1 + PR2 independently in the meantime.

## Why supervisor + upgrade in one PR

Supervisor is the only consumer of `upgrademachine`. Splitting them would leave `upgrademachine` as dead code with no integration entry point. This PR is the minimum scope where both packages become live.

## Verification

- `GOOS=linux go build ./...` — full repo builds clean
- `GOOS=windows go build ./cmd/ongrid-edge-supervisor/... ./internal/edgeagent/{supervisorhealth,upgradebundle,upgrademachine}/...` — PR2 packages compile clean
- Unit tests: `cmd-ongrid-edge-supervisor` + `supervisorhealth` + `upgradebundle` + `upgrademachine` all pass; `upgrademachine` includes 10-cycle stability + parallel race condition tests

## Out of scope (PR3)

- Windows host skills (`internal/skill/builtin/windows/*`)
- Plugins Windows branches (`plugins/hostmetrics/plugin_windows.go`, `plugins/logs/render_windows.go`)
- `skill/quota_windows.go`

## ADR references

Like PR1, some comments reference `ADR-033` / `ADR-037` codes (internal design docs, not in this repo). A small follow-up will inline the relevant context once the PR sequence lands.
- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

---
**Notes:**

- Rebased onto current `main`; the full suite (`go test -race ./...`) was previewed green on a fork CI run before this update.
- Two cross-compile warnings are pre-existing on `main` (onnxruntime CGO and platform-directory artifacts), verified identical at the merge base.
- Security trade-off disclosure: since bundles are unsigned, the install path archives and rebuilds pre-existing directories whose DACL deviates from the expected SID allowlist. On hosts running antivirus with aggressive quarantine heuristics, excluding the ongrid-edge program directory from real-time scanning is recommended — rename-based self-upgrade retries tolerate transient AV locks, but exclusion avoids spurious rollbacks.


## Final round (2026-08-27)

The three items from the [follow-up review](https://github.com/ongridio/ongrid/pull/229#issuecomment-5412682897) are addressed; details in the delivery comment below.

1. **Token rotation path removed** (only PR-introduced code; files individually attributed against `main`)
2. **Windows CI builds both deliverable binaries** inside the existing job
3. **Installer fail-fast** on SCM recovery configuration and service start failures

> Disclosures: this update modifies `.github/workflows/ci-windows-cross.yml` at reviewer's request (build steps appended to the existing job, no new jobs/files). Known pre-existing build failures on this repo's own `main` baseline (e.g. `yalue/onnxruntime_go` under GOOS=linux) also affect this branch and are unrelated to it.