### PR TITLE
chore(edge/windows): inline comment context (cleanup PR1/PR2 ADR refs)

### DIFF
--- a/cmd/ongrid-edge-supervisor/install_windows.go
+++ b/cmd/ongrid-edge-supervisor/install_windows.go
@@ -1,24 +1,19 @@
 // install_windows.go 实现 supervisor.exe --install / --uninstall 子命令
-// （ADR-037 A2 CR4 首次装机流程）。
-//
+//。
 // --install --token <X> --cloud-addr <X> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>]:
 //   1. DPAPI CryptProtectData(token) → secrets.enc
 //   2. 验证 CryptUnprotectData(secrets.enc) 能还原
 //   3. 清零明文 token 内存
 //   4. sc.exe create → 启动服务
 //   5. 写注册表 Environment MultiString（cloud_addr / access_key / collector_mode / plugin_*_dir）
-//
 // --uninstall:
 //   1. sc.exe stop + delete（注册表 Environment 字段随服务键一起清除）
 //   2. 删除 secrets.enc
-//
 // 安全：明文 token 仅在 CLI flag 时刻存在于内存，加密后立即清零。
 // 不写日志/临时文件。Go string 不可变（无法真正清零 argv），但 []byte 可以。
-//
-// 注：access_key 暂以明文存于 Environment（与 ADR-037 CR4 现状一致；CR4 仅要求 SECRET_KEY
-// 走 DPAPI，ACCESS_KEY 在现有 dogfood 服务中也是明文环境变量）。
-//
-// MVP-3 #18-1 深化：runInstall 从 66 行单体函数拆为 ≤30 行 orchestrator，
+// 注：access_key 暂以明文存于 Environment（与 R4 现状一致； 仅要求 SECRET_KEY
+// 走 DPAPI，ACCESS_KEY 在现有  服务中也是明文环境变量）。
+//  深化：runInstall 从 66 行单体函数拆为 ≤30 行 orchestrator，
 // 3 个正交关注点委托给 install 包接口（SecretStore / ServiceController / EnvWriter）。
 
 //go:build windows
@@ -96,12 +91,11 @@ func (o *installOptions) envPairs() []string {
 }
 
 // runInstall 执行 --install 流程，编排接口的调用顺序。
-//
-// 编排顺序（ADR-037 A2 CR4 + #21 supervisor 自升级加固）：
+// 编排顺序：
 //  1. SecretStore.Install — DPAPI 加密 + round-trip 验证（内部自清理）
 //  2. ServiceController.Create — sc.exe create（失败时回滚凭证）
-//  3. ServiceController.ConfigureDefenderExclusion — Add-MpPreference（W3，失败仅 warn）
-//  4. ServiceController.ConfigureRecovery — sc.exe failure（#21，失败仅 warn）
+//  3. ServiceController.ConfigureDefenderExclusion — Add-MpPreference
+//  4. ServiceController.ConfigureRecovery — sc.exe failure
 //  5. EnvWriter.Write — registry Environment（失败不回滚服务）
 //  6. ServiceController.Start — sc.exe start（失败仅告警，不报错）
 func runInstall(
@@ -138,13 +132,13 @@ func runInstall(
 		return fmt.Errorf("create service: %w", err)
 	}
 
-	// 3. Defender exclusion（#21 Step 7a W3 — 失败仅 warn，不阻断 install）
+	// 3. Defender exclusion
 	if err := sc.ConfigureDefenderExclusion(); err != nil {
 		log.Warn("failed to configure Windows Defender exclusion (non-fatal; AV may interfere with supervisor self-swap)",
 			slog.String("err", err.Error()))
 	}
 
-	// 4. SCM failure recovery（#21 Step 7 — 失败仅 warn，service.go samesession=false 依赖此配置）
+	// 4. SCM failure recovery
 	if err := sc.ConfigureRecovery(); err != nil {
 		log.Warn("failed to configure SCM failure recovery (non-fatal; supervisor won't auto-restart on crash)",
 			slog.String("err", err.Error()))

--- a/cmd/ongrid-edge-supervisor/install_windows.go
+++ b/cmd/ongrid-edge-supervisor/install_windows.go
@@ -1,0 +1,233 @@
+// install_windows.go 实现 supervisor.exe --install / --uninstall 子命令
+// （ADR-037 A2 CR4 首次装机流程）。
+//
+// --install --token <X> --cloud-addr <X> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>]:
+//   1. DPAPI CryptProtectData(token) → secrets.enc
+//   2. 验证 CryptUnprotectData(secrets.enc) 能还原
+//   3. 清零明文 token 内存
+//   4. sc.exe create → 启动服务
+//   5. 写注册表 Environment MultiString（cloud_addr / access_key / collector_mode / plugin_*_dir）
+//
+// --uninstall:
+//   1. sc.exe stop + delete（注册表 Environment 字段随服务键一起清除）
+//   2. 删除 secrets.enc
+//
+// 安全：明文 token 仅在 CLI flag 时刻存在于内存，加密后立即清零。
+// 不写日志/临时文件。Go string 不可变（无法真正清零 argv），但 []byte 可以。
+//
+// 注：access_key 暂以明文存于 Environment（与 ADR-037 CR4 现状一致；CR4 仅要求 SECRET_KEY
+// 走 DPAPI，ACCESS_KEY 在现有 dogfood 服务中也是明文环境变量）。
+//
+// MVP-3 #18-1 深化：runInstall 从 66 行单体函数拆为 ≤30 行 orchestrator，
+// 3 个正交关注点委托给 install 包接口（SecretStore / ServiceController / EnvWriter）。
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+// secretsFileName 是 DPAPI 加密的 token 文件名。
+const secretsFileName = "secrets.enc"
+
+// serviceRegKeyPath 是 Windows Service 注册表路径（HKLM 前缀由 registry.OpenKey 自动加）。
+const serviceRegKeyPath = `SYSTEM\CurrentControlSet\Services\` + serviceName
+
+// installOptions 是 --install 子命令接收的所有参数。
+type installOptions struct {
+	// Token 是 broker SECRET_KEY（DPAPI 加密后存 secrets.enc）。必需。
+	Token string
+	// CloudAddr 是 frontier broker 地址（host:port）。必需。
+	CloudAddr string
+	// AccessKey 是 broker ACCESS_KEY（明文存服务 Environment）。必需。
+	AccessKey string
+	// CollectorMode 是 node_* 采集模式（off / all），默认 off。
+	CollectorMode string
+	// PluginBinDir / PluginWorkDir 可选，缺省由 edgedirs 默认值决定。
+	PluginBinDir  string
+	PluginWorkDir string
+}
+
+// Validate 校验必需字段并应用默认值。
+func (o *installOptions) Validate() error {
+	if o.Token == "" {
+		return fmt.Errorf("--token <X> is required")
+	}
+	if o.CloudAddr == "" {
+		return fmt.Errorf("--cloud-addr <host:port> is required")
+	}
+	if o.AccessKey == "" {
+		return fmt.Errorf("--access-key <X> is required")
+	}
+	if o.CollectorMode == "" {
+		o.CollectorMode = "off"
+	}
+	if o.PluginBinDir == "" {
+		o.PluginBinDir = edgedirs.BinDir
+	}
+	if o.PluginWorkDir == "" {
+		o.PluginWorkDir = edgedirs.PluginWorkDir
+	}
+	return nil
+}
+
+// envPairs 返回写入服务 Environment 字段的 KEY=VALUE 多字符串数组。
+// 顺序固定，便于人工排查与重装比对。
+func (o *installOptions) envPairs() []string {
+	return []string{
+		"ONGRID_EDGE_CLOUD_ADDR=" + o.CloudAddr,
+		"ONGRID_EDGE_ACCESS_KEY=" + o.AccessKey,
+		// SECRET_KEY 由 secrets.enc 提供（DPAPI），不写入 Environment
+		"ONGRID_EDGE_COLLECTOR_MODE=" + o.CollectorMode,
+		"ONGRID_EDGE_PLUGIN_BIN_DIR=" + o.PluginBinDir,
+		"ONGRID_EDGE_PLUGIN_WORK_DIR=" + o.PluginWorkDir,
+		// secrets.enc 路径（让 worker main.go 知道从哪加载 DPAPI token）
+		"ONGRID_EDGE_SECRETS_FILE=" + filepath.Join(edgedirs.DataDir, secretsFileName),
+	}
+}
+
+// runInstall 执行 --install 流程，编排接口的调用顺序。
+//
+// 编排顺序（ADR-037 A2 CR4 + #21 supervisor 自升级加固）：
+//  1. SecretStore.Install — DPAPI 加密 + round-trip 验证（内部自清理）
+//  2. ServiceController.Create — sc.exe create（失败时回滚凭证）
+//  3. ServiceController.ConfigureDefenderExclusion — Add-MpPreference（W3，失败仅 warn）
+//  4. ServiceController.ConfigureRecovery — sc.exe failure（#21，失败仅 warn）
+//  5. EnvWriter.Write — registry Environment（失败不回滚服务）
+//  6. ServiceController.Start — sc.exe start（失败仅告警，不报错）
+func runInstall(
+	log *slog.Logger, opts installOptions,
+	ss install.SecretStore, sc install.ServiceController, ew install.EnvWriter,
+) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	// 将 token 转为 []byte 一次，全链路复用，defer 清零
+	// Go string 不可变（argv 残留到进程退出），但 []byte 副本可以清零
+	tokenBytes := []byte(opts.Token)
+	defer zeroBytes(tokenBytes)
+
+	// 确保 data 目录存在
+	if err := os.MkdirAll(edgedirs.DataDir, 0755); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+
+	// 1. 凭证（DPAPI 加密 + 验证；失败时 Install 内部自清理）
+	if err := ss.Install(tokenBytes); err != nil {
+		return err
+	}
+
+	// 2. 服务注册（失败时回滚凭证）
+	exePath, err := os.Executable()
+	if err != nil {
+		_ = ss.Remove()
+		return fmt.Errorf("resolve executable path: %w", err)
+	}
+	if err := sc.Create(exePath); err != nil {
+		_ = ss.Remove()
+		return fmt.Errorf("create service: %w", err)
+	}
+
+	// 3. Defender exclusion（#21 Step 7a W3 — 失败仅 warn，不阻断 install）
+	if err := sc.ConfigureDefenderExclusion(); err != nil {
+		log.Warn("failed to configure Windows Defender exclusion (non-fatal; AV may interfere with supervisor self-swap)",
+			slog.String("err", err.Error()))
+	}
+
+	// 4. SCM failure recovery（#21 Step 7 — 失败仅 warn，service.go samesession=false 依赖此配置）
+	if err := sc.ConfigureRecovery(); err != nil {
+		log.Warn("failed to configure SCM failure recovery (non-fatal; supervisor won't auto-restart on crash)",
+			slog.String("err", err.Error()))
+	}
+
+	// 5. 环境配置（失败不回滚服务 — 由调用方决定是否 --uninstall）
+	if err := ew.Write(opts.envPairs()); err != nil {
+		log.Warn("service created but failed to set Environment; manual cleanup needed",
+			slog.String("err", err.Error()))
+		return fmt.Errorf("write service Environment: %w", err)
+	}
+
+	// 6. 启动（失败仅告警，不阻断 install）
+	if err := sc.Start(); err != nil {
+		log.Warn("service created but failed to start",
+			slog.String("err", err.Error()))
+	}
+
+	log.Info("install completed",
+		slog.String("binary", exePath),
+		slog.String("cloud_addr", opts.CloudAddr))
+	return nil
+}
+
+// runUninstall 执行 --uninstall 流程。
+func runUninstall(log *slog.Logger, sc install.ServiceController, ss install.SecretStore) error {
+	// 1. 停止服务（忽略 "服务未运行" 错误）
+	_ = sc.Stop()
+
+	// 2. 删除服务（注册表 Environment 字段随服务键一起删除）
+	if err := sc.Delete(); err != nil {
+		return err
+	}
+
+	// 3. 删除 secrets.enc
+	if err := ss.Remove(); err != nil {
+		log.Warn("failed to remove secrets.enc", slog.String("err", err.Error()))
+	}
+
+	log.Info("uninstall completed")
+	return nil
+}
+
+// zeroBytes 清零 byte slice（SecureString cleanup）。
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// parseInstallOptions 从 args 中提取所有 --install 子命令参数。
+// 支持两种格式：--flag <VALUE> 和 --flag=<VALUE>。
+func parseInstallOptions(args []string) installOptions {
+	var opts installOptions
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		// 提取 --flag 或 --flag=VALUE
+		flag, inlineVal, hasInline := strings.Cut(a, "=")
+		// 取值：优先 inline，否则看下一个 arg
+		getValue := func() string {
+			if hasInline {
+				return inlineVal
+			}
+			if i+1 < len(args) {
+				i++
+				return args[i]
+			}
+			return ""
+		}
+		switch flag {
+		case "--token":
+			opts.Token = getValue()
+		case "--cloud-addr":
+			opts.CloudAddr = getValue()
+		case "--access-key":
+			opts.AccessKey = getValue()
+		case "--collector-mode":
+			opts.CollectorMode = getValue()
+		case "--plugin-bin-dir":
+			opts.PluginBinDir = getValue()
+		case "--plugin-work-dir":
+			opts.PluginWorkDir = getValue()
+		}
+	}
+	return opts
+}

--- a/cmd/ongrid-edge-supervisor/install_windows_test.go
+++ b/cmd/ongrid-edge-supervisor/install_windows_test.go
@@ -285,7 +285,7 @@ func (m *mockEnvWriter) Write(pairs []string) error {
 }
 
 // ---------------------------------------------------------------------------
-// runInstall orchestrator 测试（MVP-3 #18-1：4 错误路径 + happy path）
+// runInstall orchestrator 测试
 // ---------------------------------------------------------------------------
 
 // validInstallOptions 返回通过 Validate 的 installOptions。
@@ -423,10 +423,10 @@ func TestRunInstall_Success(t *testing.T) {
 		t.Error("service should be created")
 	}
 	if !sc.recoveryConfigured {
-		t.Error("SCM failure recovery should be configured (#21 Step 7)")
+		t.Error("SCM failure recovery should be configured")
 	}
 	if !sc.defenderConfigured {
-		t.Error("Defender exclusion should be configured (#21 Step 7a)")
+		t.Error("Defender exclusion should be configured")
 	}
 	if !sc.started {
 		t.Error("service should be started")
@@ -440,7 +440,7 @@ func TestRunInstall_Success(t *testing.T) {
 	}
 }
 
-// TestRunInstall_DefenderExclusionFailure_NonFatal 验证 Defender exclusion 失败不阻断 install（#21 Step 7a W3）。
+// TestRunInstall_DefenderExclusionFailure_NonFatal 验证 Defender exclusion 失败不阻断 install。
 func TestRunInstall_DefenderExclusionFailure_NonFatal(t *testing.T) {
 	ss := &mockSecretStore{}
 	sc := &mockServiceController{
@@ -462,7 +462,7 @@ func TestRunInstall_DefenderExclusionFailure_NonFatal(t *testing.T) {
 	}
 }
 
-// TestRunInstall_RecoveryFailure_NonFatal 验证 ConfigureRecovery 失败不阻断 install（#21 Step 7）。
+// TestRunInstall_RecoveryFailure_NonFatal 验证 ConfigureRecovery 失败不阻断 install。
 func TestRunInstall_RecoveryFailure_NonFatal(t *testing.T) {
 	ss := &mockSecretStore{}
 	sc := &mockServiceController{

--- a/cmd/ongrid-edge-supervisor/install_windows_test.go
+++ b/cmd/ongrid-edge-supervisor/install_windows_test.go
@@ -1,0 +1,484 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+// TestZeroBytes_ClearsContent 验证 zeroBytes 清零内容。
+func TestZeroBytes_ClearsContent(t *testing.T) {
+	cases := [][]byte{
+		[]byte("secret"),
+		[]byte("ed_bk_token_123"),
+		{0xFF, 0xAA, 0x55, 0x00},
+		{},
+	}
+	for i, b := range cases {
+		original := make([]byte, len(b))
+		copy(original, b)
+		zeroBytes(b)
+		for j, v := range b {
+			if v != 0 {
+				t.Errorf("case %d byte %d = %d (0x%02X), want 0 (original was 0x%02X)",
+					i, j, v, v, original[j])
+			}
+		}
+	}
+}
+
+// TestParseInstallOptions_ExtractsAllFields 验证所有参数解析（B3）。
+func TestParseInstallOptions_ExtractsAllFields(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want installOptions
+	}{
+		{
+			"all_flags_space",
+			[]string{"--token", "tok", "--cloud-addr", "1.2.3.4:40012", "--access-key", "ak123", "--collector-mode", "all", "--plugin-bin-dir", "C:\\bin", "--plugin-work-dir", "C:\\data"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123", CollectorMode: "all", PluginBinDir: "C:\\bin", PluginWorkDir: "C:\\data"},
+		},
+		{
+			"all_flags_equals",
+			[]string{"--token=tok", "--cloud-addr=1.2.3.4:40012", "--access-key=ak123"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123"},
+		},
+		{
+			"mixed_inline_and_space",
+			[]string{"--token=tok", "--cloud-addr", "1.2.3.4:40012", "--access-key=ak123"},
+			installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak123"},
+		},
+		{
+			"empty_args",
+			[]string{},
+			installOptions{},
+		},
+		{
+			"missing_value_at_end",
+			[]string{"--token"},
+			installOptions{}, // Token 仍为空（缺值）
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseInstallOptions(tc.args)
+			if got != tc.want {
+				t.Errorf("parseInstallOptions(%v)\n  got  = %+v\n  want = %+v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInstallOptions_Validate 验证 Validate 校验必需字段并填默认值。
+func TestInstallOptions_Validate(t *testing.T) {
+	t.Run("missing_token", func(t *testing.T) {
+		o := installOptions{CloudAddr: "1.2.3.4:40012", AccessKey: "ak"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing token")
+		}
+	})
+	t.Run("missing_cloud_addr", func(t *testing.T) {
+		o := installOptions{Token: "tok", AccessKey: "ak"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing cloud_addr")
+		}
+	})
+	t.Run("missing_access_key", func(t *testing.T) {
+		o := installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012"}
+		if err := o.Validate(); err == nil {
+			t.Error("expected error for missing access_key")
+		}
+	})
+	t.Run("applies_defaults", func(t *testing.T) {
+		o := installOptions{Token: "tok", CloudAddr: "1.2.3.4:40012", AccessKey: "ak"}
+		if err := o.Validate(); err != nil {
+			t.Fatalf("Validate failed: %v", err)
+		}
+		if o.CollectorMode != "off" {
+			t.Errorf("default CollectorMode = %q, want off", o.CollectorMode)
+		}
+		if o.PluginBinDir == "" {
+			t.Error("default PluginBinDir should be set")
+		}
+		if o.PluginWorkDir == "" {
+			t.Error("default PluginWorkDir should be set")
+		}
+	})
+}
+
+// TestInstallOptions_EnvPairs 验证 envPairs 输出格式正确。
+func TestInstallOptions_EnvPairs(t *testing.T) {
+	o := installOptions{
+		Token:         "tok",
+		CloudAddr:     "1.2.3.4:40012",
+		AccessKey:     "ak123",
+		CollectorMode: "off",
+		PluginBinDir:  `C:\bin`,
+		PluginWorkDir: `C:\data`,
+	}
+	pairs := o.envPairs()
+	if len(pairs) != 6 {
+		t.Fatalf("envPairs len = %d, want 6", len(pairs))
+	}
+	// 必须含 ACCESS_KEY 明文（不加密）
+	foundAccessKey := false
+	for _, p := range pairs {
+		if p == "ONGRID_EDGE_ACCESS_KEY=ak123" {
+			foundAccessKey = true
+		}
+	}
+	if !foundAccessKey {
+		t.Error("envPairs missing ONGRID_EDGE_ACCESS_KEY")
+	}
+	// 必须含 SECRETS_FILE 路径（让 worker 知道从哪加载 DPAPI token）
+	foundSecretsFile := false
+	for _, p := range pairs {
+		if strings.HasPrefix(p, "ONGRID_EDGE_SECRETS_FILE=") {
+			foundSecretsFile = true
+		}
+	}
+	if !foundSecretsFile {
+		t.Error("envPairs missing ONGRID_EDGE_SECRETS_FILE")
+	}
+	// 不应含 SECRET_KEY 明文（仅 secrets.enc 提供）
+	for _, p := range pairs {
+		if strings.HasPrefix(p, "ONGRID_EDGE_SECRET_KEY=") {
+			t.Errorf("SECRET_KEY should NOT be in Environment (DPAPI only): %s", p)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock 实现（用于 runInstall orchestrator 测试）
+// ---------------------------------------------------------------------------
+
+// errDPAPI / errSC / errReg / errStart 是测试用的 sentinel 错误。
+var (
+	errDPAPI = fmt.Errorf("mock: dpapi failure")
+	errSC    = fmt.Errorf("mock: sc.exe failure")
+	errReg   = fmt.Errorf("mock: registry failure")
+	errStart = fmt.Errorf("mock: sc.exe start failure")
+)
+
+// 编译时断言：mock 类型实现 install 包接口。
+var (
+	_ install.SecretStore        = (*mockSecretStore)(nil)
+	_ install.ServiceController  = (*mockServiceController)(nil)
+	_ install.EnvWriter          = (*mockEnvWriter)(nil)
+)
+
+// mockSecretStore 实现 install.SecretStore。
+type mockSecretStore struct {
+	installErr error
+	removeErr  error
+	installed  []byte
+	removeCall int
+}
+
+func (m *mockSecretStore) Install(token []byte) error {
+	if m.installErr != nil {
+		return m.installErr
+	}
+	m.installed = append([]byte(nil), token...)
+	return nil
+}
+
+func (m *mockSecretStore) Rotate(token []byte) error {
+	if m.installErr != nil {
+		return m.installErr
+	}
+	m.installed = append([]byte(nil), token...)
+	return nil
+}
+
+func (m *mockSecretStore) Remove() error {
+	m.removeCall++
+	if m.removeErr != nil {
+		return m.removeErr
+	}
+	return nil
+}
+
+// mockServiceController 实现 install.ServiceController。
+type mockServiceController struct {
+	createErr             error
+	recoveryErr           error
+	defenderExclusionErr  error
+	startErr              error
+	stopErr               error
+	deleteErr             error
+	created               string
+	recoveryConfigured    bool
+	defenderConfigured    bool
+	started               bool
+	stopped               bool
+	deleted               bool
+}
+
+func (m *mockServiceController) Create(binPath string) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = binPath
+	return nil
+}
+
+func (m *mockServiceController) ConfigureRecovery() error {
+	if m.recoveryErr != nil {
+		return m.recoveryErr
+	}
+	m.recoveryConfigured = true
+	return nil
+}
+
+func (m *mockServiceController) ConfigureDefenderExclusion() error {
+	if m.defenderExclusionErr != nil {
+		return m.defenderExclusionErr
+	}
+	m.defenderConfigured = true
+	return nil
+}
+
+func (m *mockServiceController) Start() error {
+	if m.startErr != nil {
+		return m.startErr
+	}
+	m.started = true
+	return nil
+}
+
+func (m *mockServiceController) Stop() error {
+	m.stopped = true
+	if m.stopErr != nil {
+		return m.stopErr
+	}
+	return nil
+}
+
+func (m *mockServiceController) Delete() error {
+	m.deleted = true
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	return nil
+}
+
+// mockEnvWriter 实现 install.EnvWriter。
+type mockEnvWriter struct {
+	writeErr error
+	written  []string
+}
+
+func (m *mockEnvWriter) Write(pairs []string) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	m.written = pairs
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// runInstall orchestrator 测试（MVP-3 #18-1：4 错误路径 + happy path）
+// ---------------------------------------------------------------------------
+
+// validInstallOptions 返回通过 Validate 的 installOptions。
+func validInstallOptions() installOptions {
+	return installOptions{
+		Token:         "test_token_abc123",
+		CloudAddr:     "1.2.3.4:40012",
+		AccessKey:     "ak_test",
+		CollectorMode: "off",
+		PluginBinDir:  `C:\bin`,
+		PluginWorkDir: `C:\data`,
+	}
+}
+
+// TestRunInstall_DPAPIFailure 验证 DPAPI 加密失败时 install 中止，不创建服务。
+func TestRunInstall_DPAPIFailure(t *testing.T) {
+	ss := &mockSecretStore{installErr: errDPAPI}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for DPAPI failure, got nil")
+	}
+
+	// 服务不应被创建
+	if sc.created != "" {
+		t.Errorf("service should not be created, got binPath=%s", sc.created)
+	}
+	// Environment 不应被写
+	if ew.written != nil {
+		t.Error("Environment should not be written")
+	}
+	// Remove 不应被调用（Install 内部自清理，orchestrator 不介入）
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should not be called, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_SCCreateFailure 验证 sc.exe create 失败时回滚 secrets.enc。
+func TestRunInstall_SCCreateFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{createErr: errSC}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for sc.exe create failure, got nil")
+	}
+
+	// Remove 应被调用（回滚 secrets）
+	if ss.removeCall != 1 {
+		t.Errorf("Remove should be called once for rollback, got %d calls", ss.removeCall)
+	}
+	// Environment 不应被写
+	if ew.written != nil {
+		t.Error("Environment should not be written after sc.exe create failure")
+	}
+	// Start 不应被调用
+	if sc.started {
+		t.Error("Start should not be called")
+	}
+}
+
+// TestRunInstall_RegistryFailure 验证 registry 失败时报错但不回滚服务。
+func TestRunInstall_RegistryFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{writeErr: errReg}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err == nil {
+		t.Fatal("expected error for registry failure, got nil")
+	}
+
+	// Remove 不应被调用（服务已创建，不回滚）
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called for registry failure, got %d calls", ss.removeCall)
+	}
+	// 服务应已创建
+	if sc.created == "" {
+		t.Error("service should be created before registry write")
+	}
+	// Start 不应被调用
+	if sc.started {
+		t.Error("Start should not be called after registry failure")
+	}
+}
+
+// TestRunInstall_SCStartFailure 验证 sc.exe start 失败时不报错（仅告警）。
+func TestRunInstall_SCStartFailure(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{startErr: errStart}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("start failure should NOT return error, got: %v", err)
+	}
+
+	// 服务应已创建 + Environment 已写
+	if sc.created == "" {
+		t.Error("service should be created")
+	}
+	if ew.written == nil {
+		t.Error("Environment should be written")
+	}
+	// Remove 不应被调用
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called for start failure, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_Success 验证 happy path：全部步骤成功执行。
+func TestRunInstall_Success(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 所有步骤应执行
+	if len(ss.installed) == 0 {
+		t.Error("token should be installed")
+	}
+	if sc.created == "" {
+		t.Error("service should be created")
+	}
+	if !sc.recoveryConfigured {
+		t.Error("SCM failure recovery should be configured (#21 Step 7)")
+	}
+	if !sc.defenderConfigured {
+		t.Error("Defender exclusion should be configured (#21 Step 7a)")
+	}
+	if !sc.started {
+		t.Error("service should be started")
+	}
+	if ew.written == nil {
+		t.Error("Environment should be written")
+	}
+	// Remove 不应被调用
+	if ss.removeCall != 0 {
+		t.Errorf("Remove should NOT be called on success, got %d calls", ss.removeCall)
+	}
+}
+
+// TestRunInstall_DefenderExclusionFailure_NonFatal 验证 Defender exclusion 失败不阻断 install（#21 Step 7a W3）。
+func TestRunInstall_DefenderExclusionFailure_NonFatal(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{
+		defenderExclusionErr: fmt.Errorf("mock: Add-MpPreference failed"),
+	}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("Defender exclusion 失败不应阻断 install： %v", err)
+	}
+	// 后续步骤应继续
+	if !sc.recoveryConfigured {
+		t.Error("ConfigureRecovery 应在 Defender 失败后继续执行")
+	}
+	if !sc.started {
+		t.Error("Start 应在 Defender 失败后继续执行")
+	}
+}
+
+// TestRunInstall_RecoveryFailure_NonFatal 验证 ConfigureRecovery 失败不阻断 install（#21 Step 7）。
+func TestRunInstall_RecoveryFailure_NonFatal(t *testing.T) {
+	ss := &mockSecretStore{}
+	sc := &mockServiceController{
+		recoveryErr: fmt.Errorf("mock: sc.exe failure failed"),
+	}
+	ew := &mockEnvWriter{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	err := runInstall(log, validInstallOptions(), ss, sc, ew)
+	if err != nil {
+		t.Fatalf("ConfigureRecovery 失败不应阻断 install： %v", err)
+	}
+	if !sc.defenderConfigured {
+		t.Error("Defender exclusion 应已配置（在 Recovery 之前）")
+	}
+	if !sc.started {
+		t.Error("Start 应在 Recovery 失败后继续执行")
+	}
+}

--- a/cmd/ongrid-edge-supervisor/main.go
+++ b/cmd/ongrid-edge-supervisor/main.go
@@ -1,0 +1,115 @@
+// Command ongrid-edge-supervisor 是 Windows 版 Edge Agent 的 supervisor 进程
+// （ADR-033 U3 父子进程架构）。
+//
+// MVP-1 职责（issue #4）：
+//   - Windows Service 入口（golang.org/x/sys/windows/svc）
+//   - 启动 + 监控 worker.exe（cmd/ongrid-edge 编译产物）
+//   - 健康感知（health.json 文件 IPC，30s 心跳窗口）
+//
+// MVP-2（issue #9）：
+//   - ✅ --install / --uninstall 子命令 + DPAPI 加密 token
+//   - ✅ token 90 天轮转检查（edge 端）
+//   - ❌ bundle upgrade staging + swap + rollback（MVP-3）
+//
+// 整个包 //go:build windows（Linux 不编译，对称 cmdpolicy 的 //go:build linux）。
+// health 逻辑在 internal/edgeagent/supervisorhealth 包，跨平台可测。
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows/svc"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/install"
+)
+
+const serviceName = "ongrid-edge"
+
+// version 是编译期版本号（Makefile -ldflags "-X main.version=v$(VERSION)" 注入）。
+// SupervisorSelfSwap.smokeTestVersion 跑 `supervisor.exe.new --version` 验证
+// binary 可执行 + 版本非空（W5 加固，防止坏 binary 进入 rename-aside）。
+var version = "dev"
+
+func main() {
+	// Windows Service 模式下 os.Stderr 写入 invalid handle 返回 error，
+	// io.MultiWriter 遇到第一个 writer 失败就 short-circuit 不写后续 writer。
+	// 因此 logFile 必须排在 os.Stderr 之前，确保文件一定拿到日志。
+	_ = os.MkdirAll(edgedirs.DataDir, 0o755)
+	logFile, logErr := os.OpenFile(filepath.Join(edgedirs.DataDir, "supervisor.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	var w io.Writer = os.Stderr
+	if logErr == nil {
+		w = io.MultiWriter(logFile, os.Stderr)
+	}
+	log := slog.New(slog.NewJSONHandler(w, nil))
+
+	// --install / --uninstall 子命令（ADR-037 A2 CR4）
+	if len(os.Args) >= 2 {
+		switch os.Args[1] {
+		case "--install":
+			opts := parseInstallOptions(os.Args[2:])
+			if err := opts.Validate(); err != nil {
+				log.Error("--install 参数错误", "err", err)
+				fmt.Fprintf(os.Stderr, "Usage: ongrid-edge-supervisor.exe --install --token <X> --cloud-addr <host:port> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>]\n")
+				os.Exit(2)
+			}
+			if err := runInstall(log, opts,
+					install.NewSecretStore(filepath.Join(edgedirs.DataDir, secretsFileName)),
+					install.NewServiceController(serviceName),
+					install.NewEnvWriter(serviceRegKeyPath),
+				); err != nil {
+				log.Error("install failed", "err", err)
+				os.Exit(1)
+			}
+			return
+		case "--uninstall":
+			if err := runUninstall(log,
+					install.NewServiceController(serviceName),
+					install.NewSecretStore(filepath.Join(edgedirs.DataDir, secretsFileName)),
+				); err != nil {
+				log.Error("uninstall failed", "err", err)
+				os.Exit(1)
+			}
+			return
+		case "--version", "-v":
+			fmt.Fprintf(os.Stdout, "ongrid-edge-supervisor %s\n", version)
+			return
+		case "--help", "-h":
+			fmt.Fprintf(os.Stdout, "Usage:\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe --install --token <X> --cloud-addr <host:port> --access-key <X> [--collector-mode off] [--plugin-bin-dir <P>] [--plugin-work-dir <P>]\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe --uninstall\n")
+			fmt.Fprintf(os.Stdout, "  ongrid-edge-supervisor.exe (run as Windows Service)\n")
+			return
+		}
+	}
+
+	isSvc, err := svc.IsWindowsService()
+	if err != nil {
+		log.Error("detect windows service context failed", "err", err)
+		os.Exit(1)
+	}
+
+	if !isSvc {
+		// 开发调试模式：直接跑 worker（不通过 SCM）。
+		log.Info("running in interactive mode; starting worker directly (dev mode)")
+		if err := runWorkerOnly(log); err != nil {
+			log.Error("interactive worker exited with error", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	h := &serviceHandler{log: log}
+	if err := svc.Run(serviceName, h); err != nil {
+		log.Error("service Run failed", "err", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/ongrid-edge-supervisor/main.go
+++ b/cmd/ongrid-edge-supervisor/main.go
@@ -1,16 +1,13 @@
 // Command ongrid-edge-supervisor 是 Windows 版 Edge Agent 的 supervisor 进程
-// （ADR-033 U3 父子进程架构）。
-//
-// MVP-1 职责（issue #4）：
+//。
+//  职责：
 //   - Windows Service 入口（golang.org/x/sys/windows/svc）
 //   - 启动 + 监控 worker.exe（cmd/ongrid-edge 编译产物）
 //   - 健康感知（health.json 文件 IPC，30s 心跳窗口）
-//
-// MVP-2（issue #9）：
+// ：
 //   - ✅ --install / --uninstall 子命令 + DPAPI 加密 token
 //   - ✅ token 90 天轮转检查（edge 端）
-//   - ❌ bundle upgrade staging + swap + rollback（MVP-3）
-//
+//   - ❌ bundle upgrade staging + swap + rollback
 // 整个包 //go:build windows（Linux 不编译，对称 cmdpolicy 的 //go:build linux）。
 // health 逻辑在 internal/edgeagent/supervisorhealth 包，跨平台可测。
 
@@ -35,7 +32,7 @@ const serviceName = "ongrid-edge"
 
 // version 是编译期版本号（Makefile -ldflags "-X main.version=v$(VERSION)" 注入）。
 // SupervisorSelfSwap.smokeTestVersion 跑 `supervisor.exe.new --version` 验证
-// binary 可执行 + 版本非空（W5 加固，防止坏 binary 进入 rename-aside）。
+// binary 可执行 + 版本非空。
 var version = "dev"
 
 func main() {
@@ -51,7 +48,7 @@ func main() {
 	}
 	log := slog.New(slog.NewJSONHandler(w, nil))
 
-	// --install / --uninstall 子命令（ADR-037 A2 CR4）
+	// --install / --uninstall 子命令
 	if len(os.Args) >= 2 {
 		switch os.Args[1] {
 		case "--install":

--- a/cmd/ongrid-edge-supervisor/service.go
+++ b/cmd/ongrid-edge-supervisor/service.go
@@ -1,5 +1,4 @@
-// service.go 实现 Windows Service 的 svc.Handler 接口（ADR-033 U3）。
-//
+// service.go 实现 Windows Service 的 svc.Handler 接口。
 // serviceHandler.Execute 是 SCM 调用的入口：
 //   - 启动 worker supervisor goroutine（superviseWorker）
 //   - 接受 Stop / Shutdown 请求，优雅取消 ctx，等 worker 退出
@@ -27,11 +26,9 @@ type serviceHandler struct {
 // Execute 是 SCM 调用的服务主循环。返回 (samesession, exitCode)：
 //   - samesession=true 表示非致命错误，SCM 不重启（用于 graceful shutdown）
 //   - samesession=false 表示需要 SCM 介入（按 recovery action 决定是否重启）
-//
-// MVP-1：worker 挂了 supervisor 自动重启（superviseWorker 内部循环），只有
+// ：worker 挂了 supervisor 自动重启（superviseWorker 内部循环），只有
 // supervisor 自身循环异常退出才返回 samesession=false。
-//
-// Upgrade boot hooks（ADR-033 U3）：
+// Upgrade boot hooks：
 //  1. maybeRollbackOnBoot — 先回滚未健康的升级（上次 swap 后 worker 没活过 180s）
 //  2. maybeApplyOnBoot — 再 apply 残留的 pending bundle（断电恢复）
 func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
@@ -41,7 +38,7 @@ func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, statu
 	defer cancel()
 
 	// upgrade boot hook：rollback 不健康升级 → apply 残留 pending bundle
-	// → supervisor self-swap（#21 rename-aside）
+	// → supervisor self-swap
 	m := upgrademachine.NewMachine(
 		edgedirs.StageDir, edgedirs.BinDir,
 		h.log, &windowsProcessController{},
@@ -51,7 +48,7 @@ func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, statu
 			// supervisor self-swap 完成 — 必须在 worker goroutine 启动前退出，
 			// 让 SCM 按 recovery action 重启加载新 supervisor.exe。
 			// exitCode=1（非 0）让 SCM 视为 failure → 触发 restart action；
-			// exitCode=0 会被视为"正常停止"→ SCM 不 restart（P5 dogfood 发现）。
+			// exitCode=0 会被视为"正常停止"→ SCM 不 restart（P5  发现）。
 			h.log.Info("supervisor self-swap done; exiting for SCM restart")
 			status <- svc.Status{State: svc.StopPending, Accepts: 0}
 			status <- svc.Status{State: svc.Stopped, Accepts: 0}
@@ -93,7 +90,7 @@ func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, statu
 			}
 		case err := <-workerExit:
 			// superviseWorker 返回 ErrSupervisorRestartSoon = supervisor self-swap 完成
-			//（#21 热升级路径：worker swap → pending sentinel → SupervisorSelfSwap）。
+			//。
 			// 返回 false, 1 让 SCM 视为 failure → 触发 recovery restart 加载新 supervisor.exe。
 			if errors.Is(err, upgrademachine.ErrSupervisorRestartSoon) {
 				h.log.Info("supervisor self-swap done (worker path); exiting for SCM restart")

--- a/cmd/ongrid-edge-supervisor/service.go
+++ b/cmd/ongrid-edge-supervisor/service.go
@@ -1,0 +1,113 @@
+// service.go 实现 Windows Service 的 svc.Handler 接口（ADR-033 U3）。
+//
+// serviceHandler.Execute 是 SCM 调用的入口：
+//   - 启动 worker supervisor goroutine（superviseWorker）
+//   - 接受 Stop / Shutdown 请求，优雅取消 ctx，等 worker 退出
+//   - worker supervisor 异常退出 → 服务停止 + 报告错误码（依赖 SCM recovery action 重启）
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+	"golang.org/x/sys/windows/svc"
+)
+
+// serviceHandler 实现 svc.Handler。
+type serviceHandler struct {
+	log *slog.Logger
+}
+
+// Execute 是 SCM 调用的服务主循环。返回 (samesession, exitCode)：
+//   - samesession=true 表示非致命错误，SCM 不重启（用于 graceful shutdown）
+//   - samesession=false 表示需要 SCM 介入（按 recovery action 决定是否重启）
+//
+// MVP-1：worker 挂了 supervisor 自动重启（superviseWorker 内部循环），只有
+// supervisor 自身循环异常退出才返回 samesession=false。
+//
+// Upgrade boot hooks（ADR-033 U3）：
+//  1. maybeRollbackOnBoot — 先回滚未健康的升级（上次 swap 后 worker 没活过 180s）
+//  2. maybeApplyOnBoot — 再 apply 残留的 pending bundle（断电恢复）
+func (h *serviceHandler) Execute(_ []string, req <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
+	status <- svc.Status{State: svc.StartPending, Accepts: 0}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// upgrade boot hook：rollback 不健康升级 → apply 残留 pending bundle
+	// → supervisor self-swap（#21 rename-aside）
+	m := upgrademachine.NewMachine(
+		edgedirs.StageDir, edgedirs.BinDir,
+		h.log, &windowsProcessController{},
+	)
+	if err := m.BootCheck(ctx); err != nil {
+		if errors.Is(err, upgrademachine.ErrSupervisorRestartSoon) {
+			// supervisor self-swap 完成 — 必须在 worker goroutine 启动前退出，
+			// 让 SCM 按 recovery action 重启加载新 supervisor.exe。
+			// exitCode=1（非 0）让 SCM 视为 failure → 触发 restart action；
+			// exitCode=0 会被视为"正常停止"→ SCM 不 restart（P5 dogfood 发现）。
+			h.log.Info("supervisor self-swap done; exiting for SCM restart")
+			status <- svc.Status{State: svc.StopPending, Accepts: 0}
+			status <- svc.Status{State: svc.Stopped, Accepts: 0}
+			return false, 1 // samesession=false + 非0 exitCode → SCM restart
+		}
+		h.log.Error("upgrade: BootCheck failed", "err", err)
+		// 不中止启动 — rollback/apply 失败不阻塞 supervisor 运行
+	}
+
+	workerExit := make(chan error, 1)
+	go func() {
+		workerExit <- superviseWorker(ctx, h.log, m)
+	}()
+
+	// 报告 Running，声明只接受 Stop / Shutdown（不处理 Pause/Continue）。
+	status <- svc.Status{
+		State:   svc.Running,
+		Accepts: svc.AcceptStop | svc.AcceptShutdown,
+	}
+
+	for {
+		select {
+		case cr := <-req:
+			switch cr.Cmd {
+			case svc.Interrogate:
+				// SCM 周期性 ping 检查服务存活，回显当前状态。
+				status <- cr.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				h.log.Info("service stop requested", "cmd", cr.Cmd)
+				status <- svc.Status{State: svc.StopPending, Accepts: 0}
+				cancel()
+				if err := <-workerExit; err != nil {
+					h.log.Error("worker supervisor exit on stop", "err", err)
+				}
+				status <- svc.Status{State: svc.Stopped, Accepts: 0}
+				return false, 0
+			default:
+				h.log.Warn("unsupported service command", "cmd", cr.Cmd)
+			}
+		case err := <-workerExit:
+			// superviseWorker 返回 ErrSupervisorRestartSoon = supervisor self-swap 完成
+			//（#21 热升级路径：worker swap → pending sentinel → SupervisorSelfSwap）。
+			// 返回 false, 1 让 SCM 视为 failure → 触发 recovery restart 加载新 supervisor.exe。
+			if errors.Is(err, upgrademachine.ErrSupervisorRestartSoon) {
+				h.log.Info("supervisor self-swap done (worker path); exiting for SCM restart")
+				status <- svc.Status{State: svc.StopPending, Accepts: 0}
+				status <- svc.Status{State: svc.Stopped, Accepts: 0}
+				return false, 1
+			}
+			// worker supervisor 异常退出（ctx 未取消）= 真异常。
+			if ctx.Err() != nil {
+				return false, 0
+			}
+			h.log.Error("worker supervisor unexpected exit", "err", err)
+			status <- svc.Status{State: svc.Stopped, Accepts: 0}
+			return false, 1
+		}
+	}
+}

--- a/cmd/ongrid-edge-supervisor/upgrade_windows.go
+++ b/cmd/ongrid-edge-supervisor/upgrade_windows.go
@@ -1,0 +1,43 @@
+// upgrade_windows.go 定义 Windows 专属的进程控制器 + 升级超时常量
+// （ADR-033 U3，issue #23）。
+//
+// 升级编排逻辑（applyAndSwap、maybeApply/maybeRollback、watchUpgradeHealth、
+// rollbackAndMark、checkPendingUpgrade）已移至 upgrademachine.Machine。
+// 本文件仅保留 Windows 平台的 taskkill 实现和超时常量。
+
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// upgradeWatchTimeout 是 swap 后等待新 worker register_edge 成功的窗口。
+// 超过此时间 healthy_marker 仍未匹配 → rollback（对称 Linux 180s watchdog）。
+const upgradeWatchTimeout = 180 * time.Second
+
+// upgradePollInterval 是 Machine.HealthCheck 轮询 IsUpgradeHealthy 的间隔。
+const upgradePollInterval = 5 * time.Second
+
+// windowsProcessController 实现 upgrademachine.ProcessController 接口。
+// 用 Windows taskkill 终止进程树和按镜像名杀进程。
+type windowsProcessController struct{}
+
+// KillTree 用 taskkill /T /F /PID 终止 pid 及其所有子进程
+// （windows_exporter / promtail 等），释放 .exe 文件锁。
+// 进程已退出时 taskkill 返回非零退出码，调用方应忽略错误（幂等）。
+func (windowsProcessController) KillTree(pid int) error {
+	return exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}
+
+// KillByImage 用 taskkill /F /IM <name> 按镜像名杀进程。
+//
+// 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
+// orphaned（reparented to PID 1），KillTree 无法触达。
+// 幂等：进程不存在时 taskkill 返回非零，调用方忽略。
+func (windowsProcessController) KillByImage(name string) error {
+	return exec.Command("taskkill", "/F", "/IM", name).Run()
+}

--- a/cmd/ongrid-edge-supervisor/upgrade_windows.go
+++ b/cmd/ongrid-edge-supervisor/upgrade_windows.go
@@ -1,6 +1,5 @@
 // upgrade_windows.go 定义 Windows 专属的进程控制器 + 升级超时常量
-// （ADR-033 U3，issue #23）。
-//
+//。
 // 升级编排逻辑（applyAndSwap、maybeApply/maybeRollback、watchUpgradeHealth、
 // rollbackAndMark、checkPendingUpgrade）已移至 upgrademachine.Machine。
 // 本文件仅保留 Windows 平台的 taskkill 实现和超时常量。
@@ -34,7 +33,6 @@ func (windowsProcessController) KillTree(pid int) error {
 }
 
 // KillByImage 用 taskkill /F /IM <name> 按镜像名杀进程。
-//
 // 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
 // orphaned（reparented to PID 1），KillTree 无法触达。
 // 幂等：进程不存在时 taskkill 返回非零，调用方忽略。

--- a/cmd/ongrid-edge-supervisor/worker.go
+++ b/cmd/ongrid-edge-supervisor/worker.go
@@ -1,8 +1,7 @@
 // worker.go 实现 supervisor.exe 对 worker.exe 的启动 + 监控 + 心跳 watchdog
-// （ADR-033 U3）。MVP-1 仅做"崩溃重启 + 心跳超时 kill 重启"，bundle upgrade
-// 推 MVP-2。
-//
-// 健康感知走 health.json 文件 IPC（ADR-033 I2 / U3）：
+//。 仅做"崩溃重启 + 心跳超时 kill 重启"，bundle upgrade
+// 推。
+// 健康感知走 health.json 文件 IPC：
 //   - worker 每 30s 写一次心跳
 //   - supervisor 每 30s 读 + 判断超时（90s 阈值，3× 心跳间隔）
 //   - 超时 → kill worker → superviseWorker 外层循环重启
@@ -27,10 +26,9 @@ import (
 )
 
 // 部署路径常量统一在 internal/edgeagent/edgedirs 包，与 cmd/ongrid-edge
-// 共享（ADR-033 I2）。
-//
+// 共享。
 // 重启间隔是 worker 异常退出后的固定等待时间。
-// MVP-1 不做指数退避（YAGNI）；MVP-2 加资源限制 / 指数退避。
+//  不做指数退避； 加资源限制 / 指数退避。
 const (
 	restartDelay     = 5 * time.Second
 	workerKillTimeout = 10 * time.Second
@@ -68,8 +66,7 @@ func signalInterruptContext() (context.Context, context.CancelFunc) {
 
 // superviseWorker 是 supervisor 主循环：启动 worker → 监控 → 异常退出则等待
 // restartDelay 后重启。ctx 取消时优雅停止 worker 并返回 ctx.Err()。
-//
-// upgrade 集成（ADR-033 U3）：
+// upgrade 集成：
 //   - errUpgradeApplied → 跳过 restartDelay 立即重启 + 下一轮进入 upgrade watch
 //   - rollback.done sentinel 存在 → 跳过 upgrade watch（避免死循环）
 func superviseWorker(ctx context.Context, log *slog.Logger, m *upgrademachine.Machine) error {
@@ -84,8 +81,7 @@ func superviseWorker(ctx context.Context, log *slog.Logger, m *upgrademachine.Ma
 
 		if errors.Is(err, upgrademachine.ErrApplied) {
 			// swap 完成 → 检查是否需要 supervisor 自升级
-			//（#21：bundle 含 supervisor.exe 时 applyOne 写 pending sentinel）
-			if upgrademachine.IsSupervisorUpgradePending(edgedirs.StageDir) {
+						if upgrademachine.IsSupervisorUpgradePending(edgedirs.StageDir) {
 				log.Info("supervisor self-swap pending; triggering rename-aside")
 				swapErr := m.SupervisorSelfSwap()
 				if errors.Is(swapErr, upgrademachine.ErrSupervisorRestartSoon) {
@@ -130,10 +126,8 @@ func superviseWorker(ctx context.Context, log *slog.Logger, m *upgrademachine.Ma
 // runWorkerOnce 启动一次 worker.exe，阻塞等待其退出。
 // 退出原因有三：(1) worker 自己崩溃（Wait 返回 err）；(2) watchdog 发现心跳
 // 超时，cancel workerCtx → kill worker；(3) 父 ctx 取消（服务停止）。
-//
 // watchUpgrade=true 时，worker 启动后额外启动 upgrade watch goroutine
 // （180s 窗口确认 register_edge 成功）。watch 成功 → 继续监控；超时 → rollback。
-//
 // worker 退出后检测 pending upgrade（checkPendingUpgrade），有则 swap 并返回
 // errUpgradeApplied sentinel 让 superviseWorker 跳过 restartDelay。
 func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, m *upgrademachine.Machine) error {
@@ -146,7 +140,7 @@ func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, m *
 	cmd := exec.CommandContext(workerCtx, workerExe())
 	// worker stdout/stderr 重定向到轮转日志文件（supervisor.log 已有自己的 sink）。
 	// Windows Service 进程无 console，nil inherit = 丢弃；改用 append-only file
-	// 让 worker 的 slog 输出可观测（issue #20 dogfood 调试）。
+	// 让 worker 的 slog 输出可观测。
 	if workerStdout, err := openWorkerLog("worker-stdout.log"); err == nil {
 		cmd.Stdout = workerStdout
 		defer workerStdout.Close()
@@ -166,7 +160,7 @@ func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, m *
 	// （taskkill /T 先 send Ctrl-Break，再 workerKillTimeout 后强制 kill）。
 	cmd.Cancel = func() error {
 		// taskkill /T /F 等于 SIGKILL 整个进程树。
-		// MVP-1 不做优雅停止（worker 收到 TerminateProcess 直接退出，状态由
+		//  不做优雅停止（worker 收到 TerminateProcess 直接退出，状态由
 		// health.json + 启动时从 manager 重连 tunnel 恢复）。
 		return exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
 	}
@@ -253,7 +247,6 @@ func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, m *
 // watchHeartbeat 周期性读 health.json 判断 worker 心跳是否过期。
 // 发现过期 → 返回 error（触发外层 kill worker）。
 // workerCtx 取消时立即返回 nil（worker 已被外层 kill，不需要再报警）。
-//
 // startupGrace 是 worker 启动到首次写 health.json 的宽限时间（2× HeartbeatTimeout = 180s），
 // 超过此窗口 health.json 还未出现 → 视为 worker 启动失败。
 func watchHeartbeat(workerCtx context.Context, workerPID int, log *slog.Logger) error {

--- a/cmd/ongrid-edge-supervisor/worker.go
+++ b/cmd/ongrid-edge-supervisor/worker.go
@@ -1,0 +1,304 @@
+// worker.go 实现 supervisor.exe 对 worker.exe 的启动 + 监控 + 心跳 watchdog
+// （ADR-033 U3）。MVP-1 仅做"崩溃重启 + 心跳超时 kill 重启"，bundle upgrade
+// 推 MVP-2。
+//
+// 健康感知走 health.json 文件 IPC（ADR-033 I2 / U3）：
+//   - worker 每 30s 写一次心跳
+//   - supervisor 每 30s 读 + 判断超时（90s 阈值，3× 心跳间隔）
+//   - 超时 → kill worker → superviseWorker 外层循环重启
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+	"github.com/ongridio/ongrid/internal/edgeagent/supervisorhealth"
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// 部署路径常量统一在 internal/edgeagent/edgedirs 包，与 cmd/ongrid-edge
+// 共享（ADR-033 I2）。
+//
+// 重启间隔是 worker 异常退出后的固定等待时间。
+// MVP-1 不做指数退避（YAGNI）；MVP-2 加资源限制 / 指数退避。
+const (
+	restartDelay     = 5 * time.Second
+	workerKillTimeout = 10 * time.Second
+)
+
+// workerExe 返回 worker.exe 的绝对路径（edgedirs.BinDir + 文件名）。
+func workerExe() string {
+	return edgedirs.BinDir + `\` + edgedirs.WorkerBinary
+}
+
+// runWorkerOnly 是交互模式（非 Service）入口，直接启动 worker。
+// 用于开发调试（RDP 跑 supervisor.exe 看日志）。
+func runWorkerOnly(log *slog.Logger) error {
+	ctx, cancel := signalInterruptContext()
+	defer cancel()
+	m := upgrademachine.NewMachine(
+		edgedirs.StageDir, edgedirs.BinDir,
+		log, &windowsProcessController{},
+	)
+	return superviseWorker(ctx, log, m)
+}
+
+// signalInterruptContext 返回一个在 Ctrl+C 时 cancel 的 ctx。
+// 仅用于交互模式（runWorkerOnly）；服务模式由 SCM Stop 回调 cancel。
+func signalInterruptContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	go func() {
+		<-ch
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// superviseWorker 是 supervisor 主循环：启动 worker → 监控 → 异常退出则等待
+// restartDelay 后重启。ctx 取消时优雅停止 worker 并返回 ctx.Err()。
+//
+// upgrade 集成（ADR-033 U3）：
+//   - errUpgradeApplied → 跳过 restartDelay 立即重启 + 下一轮进入 upgrade watch
+//   - rollback.done sentinel 存在 → 跳过 upgrade watch（避免死循环）
+func superviseWorker(ctx context.Context, log *slog.Logger, m *upgrademachine.Machine) error {
+	watchUpgrade := false
+	for attempt := 0; ; attempt++ {
+		// rollback.done sentinel → 上次 rollback 过，本轮不 watch
+		if upgrademachine.RollbackDoneExists(edgedirs.StageDir) {
+			watchUpgrade = false
+		}
+
+		err := runWorkerOnce(ctx, log, watchUpgrade, m)
+
+		if errors.Is(err, upgrademachine.ErrApplied) {
+			// swap 完成 → 检查是否需要 supervisor 自升级
+			//（#21：bundle 含 supervisor.exe 时 applyOne 写 pending sentinel）
+			if upgrademachine.IsSupervisorUpgradePending(edgedirs.StageDir) {
+				log.Info("supervisor self-swap pending; triggering rename-aside")
+				swapErr := m.SupervisorSelfSwap()
+				if errors.Is(swapErr, upgrademachine.ErrSupervisorRestartSoon) {
+					return swapErr // 让 service.go 触发 SCM restart 加载新 supervisor
+				}
+				if swapErr != nil {
+					log.Error("supervisor self-swap failed (worker continues with current supervisor; HealthCheck will catch version mismatch)",
+						"err", swapErr)
+				}
+			}
+			// 立即重启新 worker + 进入 upgrade watch
+			log.Info("upgrade applied; restarting worker without delay")
+			watchUpgrade = true
+			continue
+		}
+
+		// 普通路径（含 ErrRolledBack）：重置 watch 标志
+		if watchUpgrade {
+			watchUpgrade = false
+		}
+
+		if errors.Is(err, upgrademachine.ErrRolledBack) {
+			log.Warn("upgrade rolled back; restarting with previous version", "attempt", attempt)
+		} else if err != nil && ctx.Err() == nil {
+			log.Error("worker exited unexpectedly", "attempt", attempt, "err", err)
+		}
+
+		if ctx.Err() != nil {
+			log.Info("supervisor context cancelled; exiting worker loop")
+			return ctx.Err()
+		}
+
+		log.Info("restarting worker", "after", restartDelay, "attempt", attempt+1)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(restartDelay):
+		}
+	}
+}
+
+// runWorkerOnce 启动一次 worker.exe，阻塞等待其退出。
+// 退出原因有三：(1) worker 自己崩溃（Wait 返回 err）；(2) watchdog 发现心跳
+// 超时，cancel workerCtx → kill worker；(3) 父 ctx 取消（服务停止）。
+//
+// watchUpgrade=true 时，worker 启动后额外启动 upgrade watch goroutine
+// （180s 窗口确认 register_edge 成功）。watch 成功 → 继续监控；超时 → rollback。
+//
+// worker 退出后检测 pending upgrade（checkPendingUpgrade），有则 swap 并返回
+// errUpgradeApplied sentinel 让 superviseWorker 跳过 restartDelay。
+func runWorkerOnce(ctx context.Context, log *slog.Logger, watchUpgrade bool, m *upgrademachine.Machine) error {
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	defer workerCancel()
+
+	// CommandContext 而非 exec.Command：Go 1.20+ 要求设了 cmd.Cancel 的命令
+	// 必须用 CommandContext 创建，否则 Start 返回
+	// "exec: command with a non-nil Cancel was not created with CommandContext"。
+	cmd := exec.CommandContext(workerCtx, workerExe())
+	// worker stdout/stderr 重定向到轮转日志文件（supervisor.log 已有自己的 sink）。
+	// Windows Service 进程无 console，nil inherit = 丢弃；改用 append-only file
+	// 让 worker 的 slog 输出可观测（issue #20 dogfood 调试）。
+	if workerStdout, err := openWorkerLog("worker-stdout.log"); err == nil {
+		cmd.Stdout = workerStdout
+		defer workerStdout.Close()
+	} else {
+		log.Warn("supervisor: open worker stdout log failed; falling back to discard", "err", err)
+		cmd.Stdout = nil
+	}
+	if workerStderr, err := openWorkerLog("worker-stderr.log"); err == nil {
+		cmd.Stderr = workerStderr
+		defer workerStderr.Close()
+	} else {
+		log.Warn("supervisor: open worker stderr log failed; falling back to discard", "err", err)
+		cmd.Stderr = nil
+	}
+
+	// Go 1.20+ CommandContext 自动 kill 进程当 ctx 取消；指定 Cancel 用优雅方式
+	// （taskkill /T 先 send Ctrl-Break，再 workerKillTimeout 后强制 kill）。
+	cmd.Cancel = func() error {
+		// taskkill /T /F 等于 SIGKILL 整个进程树。
+		// MVP-1 不做优雅停止（worker 收到 TerminateProcess 直接退出，状态由
+		// health.json + 启动时从 manager 重连 tunnel 恢复）。
+		return exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
+	}
+	cmd.WaitDelay = workerKillTimeout
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start worker %q: %w", workerExe(), err)
+	}
+
+	log.Info("worker started", "pid", cmd.Process.Pid, "path", workerExe())
+
+	workerPID := cmd.Process.Pid
+	wdErr := make(chan error, 1)
+	go func() {
+		wdErr <- watchHeartbeat(workerCtx, workerPID, log)
+	}()
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+	}()
+
+	// upgrade watch goroutine（仅 swap 后首次启动时活跃）
+	var uwErr chan error
+	if watchUpgrade {
+		uwErr = make(chan error, 1)
+		go func() {
+			uwErr <- m.HealthCheck(workerCtx, upgradeWatchTimeout, upgradePollInterval)
+		}()
+		log.Info("upgrade: watch activated", "timeout", upgradeWatchTimeout)
+	}
+
+	for {
+		select {
+		case err := <-waitErr:
+			// worker 自己挂了。watchdog goroutine 在 workerCtx cancel 后会返回 nil。
+			workerCancel()
+			<-wdErr
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// worker 退出后检测 pending upgrade
+			if uerr := m.CheckPending(ctx, workerPID); uerr != nil {
+				return uerr
+			}
+			if err != nil {
+				return fmt.Errorf("worker wait: %w", err)
+			}
+			return nil
+
+		case err := <-wdErr:
+			// watchdog 触发：kill worker → 等 Wait 返回。
+			if err != nil {
+				log.Error("watchdog killed worker", "reason", err, "pid", workerPID)
+			}
+			workerCancel()
+			<-waitErr
+			// watchdog kill 后也检测 pending upgrade
+			if uerr := m.CheckPending(ctx, workerPID); uerr != nil {
+				return uerr
+			}
+			return err
+
+		case err := <-uwErr:
+			// upgrade watch 结果（只处理一次，然后置 nil 防止重复 select）
+			uwErr = nil
+			if err == nil {
+				// healthy_marker 匹配 → cleanup 已完成，继续监控 worker
+				continue
+			}
+			if errors.Is(err, upgrademachine.ErrRolledBack) {
+				// rollback 完成 → cancel worker → 等 Wait → 返回
+				workerCancel()
+				<-waitErr
+				return err
+			}
+			// workerCtx.Err()（worker 先退出导致）→ 交给 waitErr/wdErr 处理
+			log.Debug("upgrade watch ended with ctx error", "err", err)
+			continue
+		}
+	}
+}
+
+// watchHeartbeat 周期性读 health.json 判断 worker 心跳是否过期。
+// 发现过期 → 返回 error（触发外层 kill worker）。
+// workerCtx 取消时立即返回 nil（worker 已被外层 kill，不需要再报警）。
+//
+// startupGrace 是 worker 启动到首次写 health.json 的宽限时间（2× HeartbeatTimeout = 180s），
+// 超过此窗口 health.json 还未出现 → 视为 worker 启动失败。
+func watchHeartbeat(workerCtx context.Context, workerPID int, log *slog.Logger) error {
+	startupGrace := 2 * supervisorhealth.HeartbeatTimeout
+	startupDeadline := time.Now().Add(startupGrace)
+	ticker := time.NewTicker(supervisorhealth.HeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-workerCtx.Done():
+			return nil
+		case <-ticker.C:
+			h, err := supervisorhealth.Read(edgedirs.HealthFile)
+			if err != nil {
+				if supervisorhealth.IsNotExist(err) {
+					if time.Now().After(startupDeadline) {
+						return fmt.Errorf("worker (pid=%d) 启动超过 %v 未写 health.json", workerPID, startupGrace)
+					}
+					log.Info("health.json not yet written; worker still starting")
+					continue
+				}
+				log.Error("read health.json failed", "err", err)
+				continue
+			}
+
+			// PID race 检查：health.json 可能是上一个 worker 进程残留。
+			if h.WorkerPID != workerPID {
+				log.Warn("health.json PID mismatch; ignoring",
+					"expected", workerPID, "got", h.WorkerPID)
+				continue
+			}
+
+			if supervisorhealth.IsStale(h, time.Now(), supervisorhealth.HeartbeatTimeout) {
+				return fmt.Errorf("worker (pid=%d) heartbeat stale (last: %s)",
+					workerPID, h.LastHeartbeat.Format(time.RFC3339))
+			}
+		}
+	}
+}
+
+// openWorkerLog 打开 DataDir 下的 worker 日志文件（append 模式）。
+// 用于将 worker stdout/stderr 从 Windows Service nil-sink 救出来。
+// 失败时返回 error，调用方降级为 nil（= 丢弃）。
+func openWorkerLog(name string) (*os.File, error) {
+	path := edgedirs.DataDir + `\` + name
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+}

--- a/internal/edgeagent/config/rotation.go
+++ b/internal/edgeagent/config/rotation.go
@@ -1,0 +1,36 @@
+package config
+
+import "time"
+
+// token 轮转周期常量（ADR-037 A2 CR4）。
+const (
+	defaultRotationDays = 90
+	minRotationDays     = 30
+	maxRotationDays     = 365
+)
+
+// CheckTokenRotation 检查 token 是否需要轮转。
+//
+// tokenAge 是当前 token 的存活时间（通常从 secrets.enc 文件修改时间计算）。
+// rotationDays 是配置的轮转周期，钳制到 [30, 365]，0 或负值用默认 90。
+//
+// 返回 true 表示需要轮转（tokenAge >= rotationDays 天）。
+func CheckTokenRotation(tokenAge time.Duration, rotationDays int) bool {
+	threshold := time.Duration(clampRotationDays(rotationDays)) * 24 * time.Hour
+	return tokenAge >= threshold
+}
+
+// clampRotationDays 将 rotationDays 钳制到 [30, 365]。
+// 0 或负值 → 默认 90；<30 → 30；>365 → 365。
+func clampRotationDays(days int) int {
+	if days <= 0 {
+		return defaultRotationDays
+	}
+	if days < minRotationDays {
+		return minRotationDays
+	}
+	if days > maxRotationDays {
+		return maxRotationDays
+	}
+	return days
+}

--- a/internal/edgeagent/config/rotation_test.go
+++ b/internal/edgeagent/config/rotation_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCheckTokenRotation_NotExpired 验证未过期返回 false。
+func TestCheckTokenRotation_NotExpired(t *testing.T) {
+	cases := []struct {
+		name         string
+		tokenAge     time.Duration
+		rotationDays int
+	}{
+		{"89_days_default_90", 89 * 24 * time.Hour, 90},
+		{"1_day_default_90", 1 * 24 * time.Hour, 90},
+		{"0_age", 0, 90},
+		{"29_days_custom_30", 29 * 24 * time.Hour, 30},
+		{"364_days_custom_365", 364 * 24 * time.Hour, 365},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if CheckTokenRotation(tc.tokenAge, tc.rotationDays) {
+				t.Errorf("CheckTokenRotation(%v, %d) = true, want false", tc.tokenAge, tc.rotationDays)
+			}
+		})
+	}
+}
+
+// TestCheckTokenRotation_Expired 验证过期返回 true。
+func TestCheckTokenRotation_Expired(t *testing.T) {
+	cases := []struct {
+		name         string
+		tokenAge     time.Duration
+		rotationDays int
+	}{
+		{"90_days_default_90", 90 * 24 * time.Hour, 90},
+		{"91_days_default_90", 91 * 24 * time.Hour, 90},
+		{"365_days_default_90", 365 * 24 * time.Hour, 90},
+		{"30_days_custom_30", 30 * 24 * time.Hour, 30},
+		{"365_days_custom_365", 365 * 24 * time.Hour, 365},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !CheckTokenRotation(tc.tokenAge, tc.rotationDays) {
+				t.Errorf("CheckTokenRotation(%v, %d) = false, want true", tc.tokenAge, tc.rotationDays)
+			}
+		})
+	}
+}
+
+// TestCheckTokenRotation_ClampDays 验证 rotationDays 钳制到 [30, 365]。
+func TestCheckTokenRotation_ClampDays(t *testing.T) {
+	// 负值 → 默认 90
+	if CheckTokenRotation(89*24*time.Hour, -1) {
+		t.Error("negative days should clamp to 90, 89 days should not rotate")
+	}
+	if !CheckTokenRotation(90*24*time.Hour, -1) {
+		t.Error("negative days should clamp to 90, 90 days should rotate")
+	}
+
+	// 0 → 默认 90
+	if CheckTokenRotation(89*24*time.Hour, 0) {
+		t.Error("zero days should clamp to 90, 89 days should not rotate")
+	}
+	if !CheckTokenRotation(90*24*time.Hour, 0) {
+		t.Error("zero days should clamp to 90, 90 days should rotate")
+	}
+
+	// <30 → 钳制到 30
+	if CheckTokenRotation(29*24*time.Hour, 10) {
+		t.Error("10 days should clamp to 30, 29 days should not rotate")
+	}
+	if !CheckTokenRotation(30*24*time.Hour, 10) {
+		t.Error("10 days should clamp to 30, 30 days should rotate")
+	}
+
+	// >365 → 钳制到 365
+	if CheckTokenRotation(364*24*time.Hour, 999) {
+		t.Error("999 days should clamp to 365, 364 days should not rotate")
+	}
+	if !CheckTokenRotation(365*24*time.Hour, 999) {
+		t.Error("999 days should clamp to 365, 365 days should rotate")
+	}
+}
+
+// TestClampRotationDays 验证 clampRotationDays 独立函数。
+func TestClampRotationDays(t *testing.T) {
+	cases := []struct {
+		input int
+		want  int
+	}{
+		{-1, 90},       // 负值 → 默认 90
+		{0, 90},        // 0 → 默认 90
+		{1, 30},        // <30 → 30
+		{29, 30},       // <30 → 30
+		{30, 30},       // 边界 → 30
+		{90, 90},       // 默认值
+		{180, 180},     // 正常值
+		{365, 365},     // 边界 → 365
+		{366, 365},     // >365 → 365
+		{9999, 365},    // 远超上限 → 365
+	}
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := clampRotationDays(tc.input)
+			if got != tc.want {
+				t.Errorf("clampRotationDays(%d) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/edgeagent/config/secrets.go
+++ b/internal/edgeagent/config/secrets.go
@@ -1,0 +1,38 @@
+// Package config 提供 edge agent 的运行时配置加载逻辑，
+// 包括 DPAPI 加密的 secrets.enc 读取（ADR-037 A2 CR4）。
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// LoadSecrets 读取 secrets.enc 文件并使用 DPAPI 解密 broker token。
+//
+// 流程：os.ReadFile → dpapi.Unprotect → 返回明文 token。
+//
+// 返回值：
+//   - (token, nil)：成功解密
+//   - ("", err)：文件不存在 / 解密失败 / token 为空
+//
+// 调用方应在失败时回退到 ONGRID_EDGE_SECRET_KEY 环境变量（向后兼容）。
+func LoadSecrets(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("secrets: read %s: %w", path, err)
+	}
+
+	plaintext, err := dpapi.Unprotect(data)
+	if err != nil {
+		return "", fmt.Errorf("secrets: decrypt: %w", err)
+	}
+
+	token := string(plaintext)
+	if token == "" {
+		return "", fmt.Errorf("secrets: decrypted token is empty")
+	}
+
+	return token, nil
+}

--- a/internal/edgeagent/config/secrets_test.go
+++ b/internal/edgeagent/config/secrets_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// TestLoadSecrets_ValidFile 验证合法 secrets.enc 能正确解密出 token。
+func TestLoadSecrets_ValidFile(t *testing.T) {
+	token := "ed_bk_test_token_abc123"
+	encrypted, err := dpapi.Protect([]byte(token))
+	if err != nil {
+		t.Fatalf("dpapi.Protect failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	if err := os.WriteFile(path, encrypted, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	got, err := LoadSecrets(path)
+	if err != nil {
+		t.Fatalf("LoadSecrets failed: %v", err)
+	}
+	if got != token {
+		t.Errorf("token mismatch:\n  want %q\n  got  %q", token, got)
+	}
+}
+
+// TestLoadSecrets_FileNotFound 验证文件不存在时返回可识别错误。
+func TestLoadSecrets_FileNotFound(t *testing.T) {
+	_, err := LoadSecrets(filepath.Join(t.TempDir(), "nonexistent.enc"))
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+}
+
+// TestLoadSecrets_InvalidPayload 验证损坏文件返回错误。
+func TestLoadSecrets_InvalidPayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.enc")
+	if err := os.WriteFile(path, []byte("not a valid dpapi blob"), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err := LoadSecrets(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt file, got nil")
+	}
+}
+
+// TestLoadSecrets_EmptyFile 验证空文件返回错误。
+func TestLoadSecrets_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.enc")
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err := LoadSecrets(path)
+	if err == nil {
+		t.Fatal("expected error for empty file, got nil")
+	}
+}
+

--- a/internal/edgeagent/dpapi/dpapi_other.go
+++ b/internal/edgeagent/dpapi/dpapi_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+// Package dpapi 提供 DPAPI（Data Protection API）加密/解密功能。
+//
+// 在非 Windows 平台上，所有操作返回 ErrUnsupportedPlatform。
+// 这使得 manager（Linux）可以引用 dpapi 包的符号而不编译失败。
+package dpapi
+
+import "errors"
+
+// ErrUnsupportedPlatform 表示当前平台不支持 DPAPI（仅 Windows 可用）。
+var ErrUnsupportedPlatform = errors.New("dpapi: unsupported platform (Windows only)")
+
+// Protect 在非 Windows 平台始终返回 ErrUnsupportedPlatform。
+func Protect(_ []byte) ([]byte, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+// Unprotect 在非 Windows 平台始终返回 ErrUnsupportedPlatform。
+func Unprotect(_ []byte) ([]byte, error) {
+	return nil, ErrUnsupportedPlatform
+}

--- a/internal/edgeagent/dpapi/dpapi_windows.go
+++ b/internal/edgeagent/dpapi/dpapi_windows.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+// Package dpapi 提供 DPAPI（Data Protection API）加密/解密功能，
+// 用于保护 broker token 等敏感凭证（ADR-037 A2 CR4）。
+//
+// DPAPI scope：CRYPTPROTECT_LOCAL_MACHINE（绑定机器 + SystemCredential scope）。
+//   - LocalSystem 和 NetworkService 都能解密（同为 System 身份）
+//   - 拷贝到其他机器无法解密（防横向移动）
+//   - 不防本机 System 服务被攻破（威胁模型见 ADR-037）
+//
+// 使用 golang.org/x/sys/windows 的高层 CryptProtectData/CryptUnprotectData 包装，
+// 无需 raw syscall。
+package dpapi
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// CRYPTPROTECT_LOCAL_MACHINE 绑定密文到机器而非用户 logon session。
+// Windows Service 跑在 session 0，没有交互式 user logon，必须用此 flag。
+const CRYPTPROTECT_LOCAL_MACHINE = 0x1
+
+// Protect 使用 DPAPI 加密数据（CRYPTPROTECT_LOCAL_MACHINE scope）。
+//
+// 加密后的 blob 只能在同一机器上由 System 身份进程解密。
+// 同一明文每次加密产生不同密文（DPAPI 使用随机 IV）。
+func Protect(plaintext []byte) ([]byte, error) {
+	if len(plaintext) == 0 {
+		return nil, fmt.Errorf("dpapi: Protect: empty plaintext")
+	}
+
+	dataIn := windows.DataBlob{
+		Size: uint32(len(plaintext)),
+		Data: &plaintext[0],
+	}
+	var dataOut windows.DataBlob
+
+	err := windows.CryptProtectData(
+		&dataIn,
+		nil, // name（可选描述，不设）
+		nil, // optionalEntropy（不使用额外熵）
+		0,   // reserved
+		nil, // promptStruct（不弹 UI）
+		CRYPTPROTECT_LOCAL_MACHINE,
+		&dataOut,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dpapi: CryptProtectData: %w", err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(dataOut.Data)))
+
+	return blobToBytes(dataOut), nil
+}
+
+// Unprotect 使用 DPAPI 解密数据（需与加密时相同的机器 + System 身份）。
+func Unprotect(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) == 0 {
+		return nil, fmt.Errorf("dpapi: Unprotect: empty ciphertext")
+	}
+
+	dataIn := windows.DataBlob{
+		Size: uint32(len(ciphertext)),
+		Data: &ciphertext[0],
+	}
+	var dataOut windows.DataBlob
+
+	err := windows.CryptUnprotectData(
+		&dataIn,
+		nil, // name（可选描述指针，不接收）
+		nil, // optionalEntropy
+		0,   // reserved
+		nil, // promptStruct
+		0,   // flags（解密时不需要 flag）
+		&dataOut,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dpapi: CryptUnprotectData: %w", err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(dataOut.Data)))
+
+	return blobToBytes(dataOut), nil
+}
+
+// blobToBytes 将 windows.DataBlob 转为 Go []byte（拷贝，不持有原生内存）。
+func blobToBytes(blob windows.DataBlob) []byte {
+	if blob.Data == nil || blob.Size == 0 {
+		return nil
+	}
+	// unsafe.Slice 创建指向原生内存的切片，copy 拷贝到 Go 堆
+	src := unsafe.Slice(blob.Data, blob.Size)
+	result := make([]byte, blob.Size)
+	copy(result, src)
+	return result
+}

--- a/internal/edgeagent/dpapi/dpapi_windows_test.go
+++ b/internal/edgeagent/dpapi/dpapi_windows_test.go
@@ -1,0 +1,173 @@
+//go:build windows
+
+package dpapi
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestProtect_Unprotect_RoundTrip 验证加密→解密还原原始数据。
+func TestProtect_Unprotect_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"short_string", []byte("hello world")},
+		{"broker_token_like", []byte("ed_bk_abc123xyz789")},
+		{"unicode", []byte("中文token")},
+		{"binary_data", []byte{0x00, 0x01, 0xFF, 0xFE, 0x80, 0x7F}},
+		{"exact_1kb", bytes.Repeat([]byte("A"), 1024)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encrypted, err := Protect(tc.plaintext)
+			if err != nil {
+				t.Fatalf("Protect failed: %v", err)
+			}
+			if bytes.Equal(encrypted, tc.plaintext) {
+				t.Error("encrypted output should differ from plaintext")
+			}
+			decrypted, err := Unprotect(encrypted)
+			if err != nil {
+				t.Fatalf("Unprotect failed: %v", err)
+			}
+			if !bytes.Equal(decrypted, tc.plaintext) {
+				t.Errorf("round-trip mismatch:\n  want %x\n  got  %x", tc.plaintext, decrypted)
+			}
+		})
+	}
+}
+
+// TestProtect_EmptyInput_ReturnsError 验证空输入返回错误。
+func TestProtect_EmptyInput_ReturnsError(t *testing.T) {
+	_, err := Protect(nil)
+	if err == nil {
+		t.Fatal("expected error for nil input, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty, got: %v", err)
+	}
+
+	_, err = Protect([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty slice, got nil")
+	}
+}
+
+// TestUnprotect_EmptyInput_ReturnsError 验证空密文返回错误。
+func TestUnprotect_EmptyInput_ReturnsError(t *testing.T) {
+	_, err := Unprotect(nil)
+	if err == nil {
+		t.Fatal("expected error for nil input, got nil")
+	}
+	_, err = Unprotect([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty slice, got nil")
+	}
+}
+
+// TestProtect_LargeInput 验证大块数据（1MB+）正确加密解密。
+func TestProtect_LargeInput(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("ONGRID"), 200*1024) // ~1.2MB
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect 1MB+ failed: %v", err)
+	}
+	decrypted, err := Unprotect(encrypted)
+	if err != nil {
+		t.Fatalf("Unprotect 1MB+ failed: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("large input round-trip mismatch (len want=%d got=%d)", len(plaintext), len(decrypted))
+	}
+}
+
+// TestUnprotect_InvalidPayload_ReturnsError 验证损坏数据返回错误。
+func TestUnprotect_InvalidPayload_ReturnsError(t *testing.T) {
+	// 完全无效的 payload
+	_, err := Unprotect([]byte("not a valid dpapi blob"))
+	if err == nil {
+		t.Fatal("expected error for invalid payload, got nil")
+	}
+
+	// 篡改有效密文
+	original := []byte("secret token data")
+	encrypted, err := Protect(original)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+	tampered := make([]byte, len(encrypted))
+	copy(tampered, encrypted)
+	// 翻转最后一个字节
+	tampered[len(tampered)-1] ^= 0xFF
+	_, err = Unprotect(tampered)
+	if err == nil {
+		t.Error("expected error for tampered ciphertext, got nil")
+	}
+}
+
+// TestProtect_OutputIsNonDeterministic 验证同一明文加密两次产生不同密文
+// （DPAPI 使用随机 IV，确保相同输入不产生相同输出）。
+func TestProtect_OutputIsNonDeterministic(t *testing.T) {
+	plaintext := []byte("same input twice")
+	enc1, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("first Protect failed: %v", err)
+	}
+	enc2, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("second Protect failed: %v", err)
+	}
+	if bytes.Equal(enc1, enc2) {
+		t.Error("DPAPI output should be non-deterministic (random IV), but two calls produced identical output")
+	}
+
+	// 两者都应能正确解密
+	dec1, err := Unprotect(enc1)
+	if err != nil {
+		t.Fatalf("Unprotect enc1 failed: %v", err)
+	}
+	dec2, err := Unprotect(enc2)
+	if err != nil {
+		t.Fatalf("Unprotect enc2 failed: %v", err)
+	}
+	if !bytes.Equal(dec1, plaintext) || !bytes.Equal(dec2, plaintext) {
+		t.Error("both non-deterministic outputs should decrypt to original")
+	}
+}
+
+// TestProtect_LocalMachineScope 验证使用 CRYPTPROTECT_LOCAL_MACHINE flag。
+//
+// LOCAL_MACHINE scope 的语义：加密绑定到机器而非用户 logon session。
+// 本测试验证加密结果可以被同机器上的当前进程解密（基础验证）。
+// 跨用户/跨机器解密失败是 adversarial test，需要多用户/多机器 CI 环境验证。
+func TestProtect_LocalMachineScope(t *testing.T) {
+	plaintext := []byte("machine-bound secret")
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+
+	// 同一进程解密应成功（LOCAL_MACHINE scope 下，同一机器的 System 进程都能解密）
+	decrypted, err := Unprotect(encrypted)
+	if err != nil {
+		t.Fatalf("Unprotect failed: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("LOCAL_MACHINE round-trip mismatch")
+	}
+}
+
+// TestProtect_DoesNotLeakPlaintextInOutput 验证加密输出不含明文。
+func TestProtect_DoesNotLeakPlaintextInOutput(t *testing.T) {
+	plaintext := []byte("supersecret_broker_token_12345")
+	encrypted, err := Protect(plaintext)
+	if err != nil {
+		t.Fatalf("Protect failed: %v", err)
+	}
+	if bytes.Contains(encrypted, plaintext) {
+		t.Error("encrypted output contains plaintext — DPAPI encryption failed to protect data")
+	}
+}

--- a/internal/edgeagent/edgedirs/doc.go
+++ b/internal/edgeagent/edgedirs/doc.go
@@ -1,0 +1,14 @@
+// Package edgedirs 定义 edge agent 部署目录约定（ADR-033 I2）。
+//
+// 这是跨 binary 共享的路径 source of truth：
+//   - cmd/ongrid-edge（worker.exe / linux edge）的数据目录
+//   - cmd/ongrid-edge-supervisor（supervisor.exe）的 binary / 数据目录
+//
+// 历史：原 cmd/ongrid-edge/paths_{linux,windows}.go 在本包建立前就存在
+// （issue #3 build tag 骨架）。MVP-2 时 paths_*.go 迁移到 import 本包。
+// 新代码（supervisor / worker 心跳写端）一律用本包。
+package edgedirs
+
+// 跨平台行为：每个平台专属文件（edgedirs_{linux,windows}.go）定义自己的
+// BinDir / DataDir / PluginWorkDir / StageDir 常量。本文件不包含任何
+// 平台相关定义，仅作包文档。

--- a/internal/edgeagent/edgedirs/edgedirs_linux.go
+++ b/internal/edgeagent/edgedirs/edgedirs_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package edgedirs
+
+// Linux 部署目录约定（FHS / ADR-024）。
+//
+// 注：Linux edge 没有 supervisor.exe（ADR-033 U3 是 Windows 专属）。
+// 本文件仅为 cmd/ongrid-edge 未来 import 提供对称 API，supervisor 包
+// 不会用到。
+const (
+	BinDir        = `/usr/local/bin`
+	DataDir       = `/var/lib/ongrid-edge`
+	PluginWorkDir = `/var/lib/ongrid-edge/plugins`
+	StageDir      = `/var/lib/ongrid-edge/.upgrade`
+)

--- a/internal/edgeagent/edgedirs/edgedirs_windows.go
+++ b/internal/edgeagent/edgedirs/edgedirs_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package edgedirs
+
+// Windows 部署目录约定（ADR-033 I2）。
+//
+//   - binary → C:\Program Files\ongrid-edge\bin\
+//   - data   → C:\ProgramData\ongrid-edge\
+//
+// ProgramData 是 Windows Service 标准数据目录，NetworkService 可写
+// （ADR-036 P4 默认服务账户）。
+const (
+	BinDir       = `C:\Program Files\ongrid-edge\bin`
+	DataDir      = `C:\ProgramData\ongrid-edge`
+	PluginWorkDir = `C:\ProgramData\ongrid-edge\plugins`
+	StageDir     = `C:\ProgramData\ongrid-edge\upgrade`
+)
+
+// HealthFile 是 worker.exe 与 supervisor.exe 之间的 health.json IPC 文件
+// 路径（ADR-033 U3）。
+const HealthFile = DataDir + `\health.json`
+
+// WorkerBinary 是 worker.exe 在 BinDir 下的文件名。
+const WorkerBinary = "ongrid-edge-worker.exe"

--- a/internal/edgeagent/host_files/owner_unix.go
+++ b/internal/edgeagent/host_files/owner_unix.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package host_files
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// fileOwner extracts owner/group names from FileInfo on Unix-like
+// systems (Linux + Darwin). Uses syscall.Stat_t to get uid/gid, then
+// resolves to names via os/user. Falls back to numeric string when
+// LookupId fails (common in scratch containers without /etc/passwd).
+//
+// Windows uses ACL/SID for ownership (fundamentally different from
+// uid/gid); see owner_windows.go for the MVP-1 stub that returns
+// empty strings.
+func fileOwner(fi os.FileInfo) (owner, group string) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if u, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10)); err == nil {
+			owner = u.Username
+		} else {
+			owner = strconv.FormatUint(uint64(st.Uid), 10)
+		}
+		if g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10)); err == nil {
+			group = g.Name
+		} else {
+			group = strconv.FormatUint(uint64(st.Gid), 10)
+		}
+	}
+	return owner, group
+}

--- a/internal/edgeagent/host_files/owner_windows.go
+++ b/internal/edgeagent/host_files/owner_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package host_files
+
+import "os"
+
+// fileOwner is a stub on Windows. Windows uses ACLs/SIDs for file
+// ownership (not uid/gid), and resolving SID → account name requires
+// heavier Win32 API calls (LookupAccountSid). For MVP-1 the host_files
+// response omits owner/group on Windows — full support is deferred
+// until a Windows skill actually needs this data (YAGNI).
+func fileOwner(_ os.FileInfo) (owner, group string) {
+	return "", ""
+}

--- a/internal/edgeagent/host_files/times_windows.go
+++ b/internal/edgeagent/host_files/times_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package host_files
+
+import (
+	"os"
+	"time"
+)
+
+// fileTimes returns mtime and atime for the given FileInfo on Windows.
+// Windows file timestamps use a different syscall
+// (windows.Win32FileAttributeData) than Unix syscall.Stat_t. For MVP-1
+// we return mtime for both fields — accurate atime resolution on
+// Windows is deferred until a skill needs it (YAGNI). handlers.go
+// treats atime as optional metadata, so this stub keeps the handler
+// compiling without altering its control flow.
+func fileTimes(fi os.FileInfo) (time.Time, time.Time) {
+	mtime := fi.ModTime().UTC()
+	return mtime, mtime
+}

--- a/internal/edgeagent/install/doc.go
+++ b/internal/edgeagent/install/doc.go
@@ -1,0 +1,16 @@
+// Package install 提供 Windows edge agent 的安装/卸载抽象。
+//
+// 将 runInstall 的 3 个正交关注点拆为独立接口（ADR-037 A2 CR4,
+// MVP-3 #18-1 深化 pass）：
+//
+//   - SecretStore: DPAPI 加密的凭证文件（secrets.enc）
+//   - ServiceController: Windows Service 生命周期（sc.exe 包装）
+//   - EnvWriter: 服务注册表 Environment 字段（REG_MULTI_SZ）
+//
+// 接口定义在 interfaces.go（无 build tag，跨平台可见）。
+// 具体实现按平台分文件：*_windows.go 为真实实现，
+// install_other.go 为非 Windows stub（返回 ErrUnsupportedPlatform）。
+//
+// 这使得 manager（Linux）可以引用 install 包的符号而不编译失败，
+// 与 dpapi / edgedirs 包的跨平台模式一致。
+package install

--- a/internal/edgeagent/install/env_windows.go
+++ b/internal/edgeagent/install/env_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// RegistryEnvWriter 是 EnvWriter 的 Windows 实现，
+// 通过注册表写服务 Environment 字段（REG_MULTI_SZ）。
+type RegistryEnvWriter struct {
+	regPath string
+}
+
+// NewEnvWriter 创建注册表 EnvWriter。
+// regPath 是服务注册表路径（如 `SYSTEM\CurrentControlSet\Services\ongrid-edge`）。
+func NewEnvWriter(regPath string) EnvWriter {
+	return &RegistryEnvWriter{regPath: regPath}
+}
+
+// Write 写入 KEY=VALUE 多字符串到注册表 Environment 字段。
+// 在 ServiceController.Create 之后调用（服务键此时已存在）。
+func (w *RegistryEnvWriter) Write(pairs []string) error {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, w.regPath,
+		registry.SET_VALUE|registry.QUERY_VALUE)
+	if err != nil {
+		return fmt.Errorf("open service registry key: %w", err)
+	}
+	defer key.Close()
+
+	if err := key.SetStringsValue("Environment", pairs); err != nil {
+		return fmt.Errorf("set Environment MultiString: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/install_other.go
+++ b/internal/edgeagent/install/install_other.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+// 非 Windows stub：所有方法返回 ErrUnsupportedPlatform。
+// 这使得 manager（Linux）可以引用 install 包的符号而不编译失败。
+
+package install
+
+// unsupportedSecretStore 是非 Windows 平台的 SecretStore stub。
+type unsupportedSecretStore struct{}
+
+// NewSecretStore 在非 Windows 平台返回 stub 实现。
+func NewSecretStore(_ string) SecretStore {
+	return unsupportedSecretStore{}
+}
+
+func (unsupportedSecretStore) Install(_ []byte) error { return ErrUnsupportedPlatform }
+func (unsupportedSecretStore) Rotate(_ []byte) error  { return ErrUnsupportedPlatform }
+func (unsupportedSecretStore) Remove() error           { return ErrUnsupportedPlatform }
+
+// unsupportedServiceController 是非 Windows 平台的 ServiceController stub。
+type unsupportedServiceController struct{}
+
+// NewServiceController 在非 Windows 平台返回 stub 实现。
+func NewServiceController(_ string) ServiceController {
+	return unsupportedServiceController{}
+}
+
+func (unsupportedServiceController) Create(_ string) error                  { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) ConfigureRecovery() error              { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) ConfigureDefenderExclusion() error     { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Start() error                          { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Stop() error                           { return ErrUnsupportedPlatform }
+func (unsupportedServiceController) Delete() error                         { return ErrUnsupportedPlatform }
+
+// unsupportedEnvWriter 是非 Windows 平台的 EnvWriter stub。
+type unsupportedEnvWriter struct{}
+
+// NewEnvWriter 在非 Windows 平台返回 stub 实现。
+func NewEnvWriter(_ string) EnvWriter {
+	return unsupportedEnvWriter{}
+}
+
+func (unsupportedEnvWriter) Write(_ []string) error { return ErrUnsupportedPlatform }

--- a/internal/edgeagent/install/install_windows_test.go
+++ b/internal/edgeagent/install/install_windows_test.go
@@ -1,0 +1,154 @@
+//go:build windows
+
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWindowsSecretStore_Install_CreatesValidFile 验证 Install 创建合法 DPAPI 加密文件 + round-trip。
+func TestWindowsSecretStore_Install_CreatesValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	token := []byte("ed_bk_test_token_abc123")
+
+	ss := NewSecretStore(path)
+	if err := ss.Install(token); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// 文件应存在且非空
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("secrets.enc is empty")
+	}
+}
+
+// TestWindowsSecretStore_Install_OverwritesExisting 验证写入覆盖已有文件。
+func TestWindowsSecretStore_Install_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	// 先写 token1
+	if err := ss.Install([]byte("token1")); err != nil {
+		t.Fatalf("first Install failed: %v", err)
+	}
+	// 再写 token2
+	if err := ss.Install([]byte("token2")); err != nil {
+		t.Fatalf("second Install failed: %v", err)
+	}
+	// 验证文件内容对应 token2：如果 token1 仍匹配则说明覆盖失败
+	// （无法直接验证 round-trip 因为 Install 内部已验证，这里间接验证：
+	//   如果文件没更新，第二次 Install 的 round-trip 会用旧密文 → mismatch → error）
+	// 所以只要第二次 Install 不报错就说明覆盖成功
+}
+
+// TestWindowsSecretStore_Remove_DeletesFile 验证 Remove 删除文件。
+func TestWindowsSecretStore_Remove_DeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	if err := ss.Install([]byte("token")); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if err := ss.Remove(); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should not exist after Remove, got err: %v", err)
+	}
+}
+
+// TestWindowsSecretStore_Remove_NonExistentNoError 验证 Remove 不存在的文件不报错。
+func TestWindowsSecretStore_Remove_NonExistentNoError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.enc")
+	ss := NewSecretStore(path)
+
+	if err := ss.Remove(); err != nil {
+		t.Errorf("Remove non-existent file should not error, got: %v", err)
+	}
+}
+
+// TestWindowsSecretStore_Install_WrongTokenRoundTrip 验证不同 token 产生不同密文。
+func TestWindowsSecretStore_Install_WrongTokenRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	ss := NewSecretStore(path)
+
+	// 写 token1
+	if err := ss.Install([]byte("correct_token")); err != nil {
+		t.Fatalf("Install correct_token failed: %v", err)
+	}
+	// 再写 token2（覆盖）
+	if err := ss.Install([]byte("wrong_token")); err != nil {
+		t.Fatalf("Install wrong_token failed: %v", err)
+	}
+	// 如果覆盖失败，第二次 Install 的 round-trip 会验证到旧密文 → mismatch → error
+	// 所以只要第二次 Install 不报错就说明覆盖成功
+}
+
+// --- Rotate tests (#16 D4 tmp→rename) ---
+
+// TestWindowsSecretStore_Rotate_ReplacesToken 验证 Rotate 原子替换文件内容。
+func TestWindowsSecretStore_Rotate_ReplacesToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+	token1 := []byte("original-cred-value")
+	token2 := []byte("rotated-cred-value")
+
+	ss := NewSecretStore(path)
+	if err := ss.Install(token1); err != nil {
+		t.Fatalf("Install token1: %v", err)
+	}
+
+	// 记录旧文件修改时间
+	infoBefore, _ := os.Stat(path)
+
+	if err := ss.Rotate(token2); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// 验证文件存在且非空
+	infoAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("file not found after Rotate: %v", err)
+	}
+	if infoAfter.Size() == 0 {
+		t.Error("secrets.enc is empty after Rotate")
+	}
+
+	// 验证 tmp 文件已被清理
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("tmp file should not exist after Rotate, got err: %v", err)
+	}
+
+	// 验证文件确实被更新（修改时间不同）
+	if !infoAfter.ModTime().After(infoBefore.ModTime()) {
+		t.Error("file ModTime not updated after Rotate")
+	}
+}
+
+// TestWindowsSecretStore_Rotate_OnNonExistentFile 验证 Rotate 对不存在的文件也能工作
+// （os.Rename 会创建目标文件）。
+func TestWindowsSecretStore_Rotate_OnNonExistentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.enc")
+
+	ss := NewSecretStore(path)
+	if err := ss.Rotate([]byte("fresh-cred")); err != nil {
+		t.Fatalf("Rotate on non-existent file: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file should exist after Rotate: %v", err)
+	}
+}

--- a/internal/edgeagent/install/interfaces.go
+++ b/internal/edgeagent/install/interfaces.go
@@ -1,0 +1,74 @@
+// interfaces.go 定义安装/卸载流程的 3 个核心接口。
+//
+// 设计原则（MVP-3 #18-1）：
+//   - YAGNI：仅定义 install + uninstall 流程当前所需方法，0 投机方法
+//   - 编排顺序由调用方（runInstall orchestrator）决定，接口不规定顺序
+//   - 每个方法是一个可独立测试的 seam
+
+package install
+
+import "errors"
+
+// ErrUnsupportedPlatform 表示当前平台不支持安装操作（仅 Windows 可用）。
+// 非 Windows 构建中所有方法返回此错误。
+var ErrUnsupportedPlatform = errors.New("install: unsupported platform (Windows only)")
+
+// SecretStore 管理 DPAPI 加密的凭证文件（secrets.enc）。
+//
+// Install 内部执行完整流程：DPAPI 加密 → 写文件 → round-trip 验证。
+// 验证失败时 Install 自行删除文件（保持调用前状态）。
+//
+// #16 token rotation 将通过组合 Install + 文件 backup/restore 实现，
+// 不需要独立的 Rotate 方法（YAGNI — 等语义明确再加）。
+type SecretStore interface {
+	// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+	// 失败时文件应处于调用前状态（不存在或旧内容）。
+	Install(token []byte) error
+
+	// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
+	// 流程：DPAPI 加密新 token → 写 tmp 文件 → rename 覆盖 → round-trip 验证。
+	// 失败时旧文件保持不变。
+	Rotate(token []byte) error
+
+	// Remove 删除 secrets.enc（用于 --uninstall）。
+	Remove() error
+}
+
+// ServiceController 管理 Windows Service 生命周期（sc.exe 包装）。
+//
+// Create 与 Start 分离：orchestrator 需在两者之间插入 EnvWriter.Write
+// （服务启动前必须有环境变量）。
+//
+// #21 supervisor 自升级：ConfigureRecovery 配置 SCM failure action（service.go
+// 的 samesession=false 设计依赖此配置）；ConfigureDefenderExclusion 为 ongrid
+// 目录添加 Defender exclusion（W3 加固，减少 AV 干扰 rename-aside）。
+type ServiceController interface {
+	// Create 注册 Windows 服务（sc.exe create）。
+	Create(binPath string) error
+
+	// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+	// reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
+	// service.go 的 return false, 0（samesession=false）依赖此配置触发 SCM 重启。
+	ConfigureRecovery() error
+
+	// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
+	//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+	// 第三方 AV 或 Defender 已禁用时静默失败（返回 error 但调用方仅 warn）。
+	ConfigureDefenderExclusion() error
+
+	// Start 启动已注册的服务（sc.exe start）。
+	Start() error
+
+	// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+	Stop() error
+
+	// Delete 删除服务（sc.exe delete）。
+	Delete() error
+}
+
+// EnvWriter 管理服务注册表 Environment 字段（REG_MULTI_SZ）。
+type EnvWriter interface {
+	// Write 写入 KEY=VALUE 多字符串到注册表 Environment 字段。
+	// 在 ServiceController.Create 之后、Start 之前调用。
+	Write(pairs []string) error
+}

--- a/internal/edgeagent/install/secrets_windows.go
+++ b/internal/edgeagent/install/secrets_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package install
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/dpapi"
+)
+
+// WindowsSecretStore 是 SecretStore 的 Windows 实现，
+// 使用 DPAPI CryptProtectData 加密凭证（ADR-037 A2 CR4）。
+type WindowsSecretStore struct {
+	path string
+}
+
+// NewSecretStore 创建 Windows DPAPI SecretStore。
+// secretsPath 是 secrets.enc 的完整路径。
+func NewSecretStore(secretsPath string) SecretStore {
+	return &WindowsSecretStore{path: secretsPath}
+}
+
+// Install 加密 token 并写入 secrets.enc，含 round-trip 验证。
+//
+// 流程：
+//  1. dpapi.Protect(token) → 加密
+//  2. os.WriteFile(path, encrypted, 0600)
+//  3. 读回 + dpapi.Unprotect → 验证 round-trip
+//  4. 验证失败时删除文件（保持调用前状态）
+//
+// token 的 []byte 副本清零由调用方负责（defer zeroBytes）。
+func (s *WindowsSecretStore) Install(token []byte) error {
+	encrypted, err := dpapi.Protect(token)
+	if err != nil {
+		return fmt.Errorf("dpapi encrypt token: %w", err)
+	}
+	if err := os.WriteFile(s.path, encrypted, 0600); err != nil {
+		return fmt.Errorf("write secrets.enc: %w", err)
+	}
+	// round-trip 验证
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("read secrets.enc for verify: %w", err)
+	}
+	decrypted, err := dpapi.Unprotect(data)
+	if err != nil {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("decrypt secrets.enc for verify: %w", err)
+	}
+	if !bytes.Equal(decrypted, token) {
+		_ = os.Remove(s.path)
+		return fmt.Errorf("secrets.enc round-trip mismatch")
+	}
+	return nil
+}
+
+// Remove 删除 secrets.enc。不存在时不报错。
+func (s *WindowsSecretStore) Remove() error {
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove secrets.enc: %w", err)
+	}
+	return nil
+}
+
+// Rotate 原子地替换 secrets.enc 中的 token（#16 D4 tmp→rename）。
+//
+// 流程：
+//  1. dpapi.Protect(newToken) → 加密
+//  2. 写入 tmp 文件（path + ".tmp"）
+//  3. round-trip 验证 tmp 文件
+//  4. os.Rename(tmp, path) — Windows 上 ReplaceFile/os.Rename 是原子操作
+//  5. 验证失败或任何错误 → 删除 tmp，旧文件不受影响
+//
+// 轮转过程中进程崩溃：tmp 文件残留，secrets.enc 保持旧内容不受影响。
+func (s *WindowsSecretStore) Rotate(token []byte) error {
+	encrypted, err := dpapi.Protect(token)
+	if err != nil {
+		return fmt.Errorf("dpapi encrypt token: %w", err)
+	}
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, encrypted, 0600); err != nil {
+		return fmt.Errorf("write tmp secrets: %w", err)
+	}
+	// round-trip 验证 tmp 文件
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("read tmp secrets for verify: %w", err)
+	}
+	decrypted, err := dpapi.Unprotect(data)
+	if err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("decrypt tmp secrets for verify: %w", err)
+	}
+	if !bytes.Equal(decrypted, token) {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("tmp secrets round-trip mismatch")
+	}
+	// 原子替换：os.Rename 在 Windows 上等价于 MoveFileEx(MOVEFILE_REPLACE_EXISTING)
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		_ = os.Remove(tmpPath) // best-effort: 清理 tmp，错误由 return 暴露
+		return fmt.Errorf("rename tmp to secrets.enc: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/service_windows.go
+++ b/internal/edgeagent/install/service_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/edgedirs"
+)
+
+// SCServiceController 是 ServiceController 的 Windows 实现，
+// 通过 sc.exe 管理 Windows Service 生命周期。
+type SCServiceController struct {
+	name string
+}
+
+// NewServiceController 创建 sc.exe ServiceController。
+// serviceName 是 Windows Service 名称（如 "ongrid-edge"）。
+func NewServiceController(serviceName string) ServiceController {
+	return &SCServiceController{name: serviceName}
+}
+
+// Create 注册 Windows 服务（sc.exe create）。
+func (sc *SCServiceController) Create(binPath string) error {
+	cmd := exec.Command("sc.exe", "create", sc.name,
+		"binPath=", binPath,
+		"start=", "auto",
+		"DisplayName=", "Ongrid Edge Agent",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe create: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// ConfigureRecovery 配置 SCM failure recovery action（#21 Step 7）。
+// reset=86400（24h window），actions=restart/60000×3（3 次 retry，60s 延迟）。
+// service.go Execute 返回 (false, 1)（samesession=false + 非 0 exitCode）时 SCM 按此配置重启。
+// 3 次/24h 上限后停止，等价于"立即停止"行为。
+func (sc *SCServiceController) ConfigureRecovery() error {
+	cmd := exec.Command("sc.exe", "failure", sc.name,
+		"reset=", "86400",
+		"actions=", "restart/60000/restart/60000/restart/60000",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe failure: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// ConfigureDefenderExclusion 为 ongrid 目录添加 Windows Defender exclusion
+//（#21 Step 7a，W3 加固）。仅在 Windows Server with Defender 时生效；
+// 第三方 AV 或 Defender 已禁用时返回 error，调用方仅 warn 不阻断。
+//
+// 参数格式：PowerShell Add-MpPreference 的 -ExclusionPath 接受字符串数组，
+// 必须用逗号分隔（"-ExclusionPath A,B"），不能重复同名参数
+// （"-ExclusionPath A -ExclusionPath B" 会报 ParameterAlreadyBound）。
+func (sc *SCServiceController) ConfigureDefenderExclusion() error {
+	ps := buildDefenderExclusionCmd(edgedirs.BinDir, edgedirs.DataDir)
+	out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive",
+		"-Command", ps).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Add-MpPreference: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// buildDefenderExclusionCmd 生成 Add-MpPreference 命令字符串。
+// 提取为独立纯函数以便单元测试验证参数格式（防止 ParameterAlreadyBound 回归）。
+func buildDefenderExclusionCmd(binDir, dataDir string) string {
+	return fmt.Sprintf(
+		`Add-MpPreference -ExclusionPath "%s","%s" -ErrorAction SilentlyContinue`,
+		binDir, dataDir,
+	)
+}
+
+// Start 启动已注册的服务（sc.exe start）。
+func (sc *SCServiceController) Start() error {
+	cmd := exec.Command("sc.exe", "start", sc.name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe start: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// Stop 停止服务（sc.exe stop），忽略"服务未运行"错误。
+func (sc *SCServiceController) Stop() error {
+	cmd := exec.Command("sc.exe", "stop", sc.name)
+	_ = cmd.Run() // 忽略所有错误（服务可能未运行）
+	return nil
+}
+
+// Delete 删除服务（sc.exe delete）。
+func (sc *SCServiceController) Delete() error {
+	cmd := exec.Command("sc.exe", "delete", sc.name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sc.exe delete: %w (output: %s)", err, out)
+	}
+	return nil
+}

--- a/internal/edgeagent/install/service_windows_test.go
+++ b/internal/edgeagent/install/service_windows_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDefenderExclusionCmd_SingleParamName 验证 -ExclusionPath 参数名只出现一次。
+// 回归防护：旧代码用 `-ExclusionPath A -ExclusionPath B` 会导致 PowerShell
+// ParameterAlreadyBound 错误（#21 dogfood 2026-07-16 发现）。
+func TestBuildDefenderExclusionCmd_SingleParamName(t *testing.T) {
+	cmd := buildDefenderExclusionCmd(`C:\bin`, `C:\data`)
+	if count := strings.Count(cmd, "-ExclusionPath"); count != 1 {
+		t.Errorf("-ExclusionPath should appear exactly once, got %d (cmd: %s)", count, cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_CommaSeparated 验证两个路径用逗号分隔。
+// PowerShell 数组参数语法：`-ParamName "val1","val2"`。
+func TestBuildDefenderExclusionCmd_CommaSeparated(t *testing.T) {
+	binDir := `C:\Program Files\ongrid-edge\bin`
+	dataDir := `C:\ProgramData\ongrid-edge`
+	cmd := buildDefenderExclusionCmd(binDir, dataDir)
+
+	if !strings.Contains(cmd, `"`+binDir+`","`+dataDir+`"`) {
+		t.Errorf("expected comma-separated paths in command, got: %s", cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_BothPathsPresent 验证两个目录都出现在命令中。
+func TestBuildDefenderExclusionCmd_BothPathsPresent(t *testing.T) {
+	binDir := `C:\test\bin`
+	dataDir := `C:\test\data`
+	cmd := buildDefenderExclusionCmd(binDir, dataDir)
+
+	if !strings.Contains(cmd, binDir) {
+		t.Errorf("binDir missing from command: %s", cmd)
+	}
+	if !strings.Contains(cmd, dataDir) {
+		t.Errorf("dataDir missing from command: %s", cmd)
+	}
+}
+
+// TestBuildDefenderExclusionCmd_AddMpPreferencePresent 验证命令前缀正确。
+func TestBuildDefenderExclusionCmd_AddMpPreferencePresent(t *testing.T) {
+	cmd := buildDefenderExclusionCmd(`C:\a`, `C:\b`)
+	if !strings.HasPrefix(cmd, "Add-MpPreference ") {
+		t.Errorf("command should start with Add-MpPreference, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "-ErrorAction SilentlyContinue") {
+		t.Errorf("command should contain -ErrorAction SilentlyContinue, got: %s", cmd)
+	}
+}

--- a/internal/edgeagent/supervisorhealth/health.go
+++ b/internal/edgeagent/supervisorhealth/health.go
@@ -1,12 +1,10 @@
 // Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
-// health.json 文件 IPC（ADR-033 U3）。
-//
+// health.json 文件 IPC。
 // worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
 // 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
-// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启（MVP-1 仅重启）。
-//
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启。
 // 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 L1 Linux CI 跑
-// （ADR-035 Q7 C5 分层策略：L1 交叉编译秒级，L2 windows-latest 跑 Windows 专属）。
+//。
 package supervisorhealth
 
 import (
@@ -24,7 +22,7 @@ import (
 // 字段增删或语义变更时 +1，supervisor 读到不兼容版本应拒绝启动 worker。
 const HealthSchemaVersion = 1
 
-// HeartbeatInterval 是 worker.exe 写心跳的频率（ADR-033 U3 "30s 心跳"）。
+// HeartbeatInterval 是 worker.exe 写心跳的频率。
 const HeartbeatInterval = 30 * time.Second
 
 // HeartbeatTimeout 是 supervisor.exe 视为 worker 卡死的阈值。
@@ -42,13 +40,12 @@ const (
 	// StatusHealthy 表示 worker 正常运行。
 	StatusHealthy Status = "healthy"
 	// StatusDegraded 表示 worker 自报部分 skill 不可用（如 windows_exporter 挂了）。
-	// MVP-1 supervisor 不对 degraded 做特殊处理，仅记录。
+	//  supervisor 不对 degraded 做特殊处理，仅记录。
 	StatusDegraded Status = "degraded"
 )
 
 // Health 是 health.json 文件的 schema。worker 写，supervisor 读。
-//
-// 字段对齐 ADR-033 U3：worker_pid 用于 supervisor 检测 PID race（旧 worker
+// 字段对齐 ：worker_pid 用于 supervisor 检测 PID race（旧 worker
 // 崩溃后新 worker 复用 PID 槽位但 started_at 不同）；started_at 与
 // last_heartbeat 都是 RFC3339 纳秒精度。
 type Health struct {
@@ -120,7 +117,6 @@ func Read(path string) (Health, error) {
 
 // IsStale 判断心跳是否过期：now - LastHeartbeat > timeout。
 // 边界恰好等于 timeout 视为未过期（属于"最后的有效时刻"）。
-//
 // 错误的判断由调用方做（文件不存在 ≠ worker 卡死，可能是首次启动）。
 func IsStale(h Health, now time.Time, timeout time.Duration) bool {
 	return now.Sub(h.LastHeartbeat) > timeout

--- a/internal/edgeagent/supervisorhealth/health.go
+++ b/internal/edgeagent/supervisorhealth/health.go
@@ -1,0 +1,133 @@
+// Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
+// health.json 文件 IPC（ADR-033 U3）。
+//
+// worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
+// 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启（MVP-1 仅重启）。
+//
+// 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 L1 Linux CI 跑
+// （ADR-035 Q7 C5 分层策略：L1 交叉编译秒级，L2 windows-latest 跑 Windows 专属）。
+package supervisorhealth
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// HealthSchemaVersion 是 health.json schema 的当前版本。
+// 字段增删或语义变更时 +1，supervisor 读到不兼容版本应拒绝启动 worker。
+const HealthSchemaVersion = 1
+
+// HeartbeatInterval 是 worker.exe 写心跳的频率（ADR-033 U3 "30s 心跳"）。
+const HeartbeatInterval = 30 * time.Second
+
+// HeartbeatTimeout 是 supervisor.exe 视为 worker 卡死的阈值。
+// 设为 3× HeartbeatInterval 给 GC / 临时文件锁 / antivirus 扫描留 margin，
+// 避免误杀健康 worker。
+const HeartbeatTimeout = 90 * time.Second
+
+// Status 枚举 worker 自报的健康状态。supervisor 主要靠 LastHeartbeat 时间戳
+// 做超时判断；Status 是辅助信号（如 worker 启动中但还没就绪）。
+type Status string
+
+const (
+	// StatusStarting 表示 worker 进程已启动但 skill dispatcher 未就绪。
+	StatusStarting Status = "starting"
+	// StatusHealthy 表示 worker 正常运行。
+	StatusHealthy Status = "healthy"
+	// StatusDegraded 表示 worker 自报部分 skill 不可用（如 windows_exporter 挂了）。
+	// MVP-1 supervisor 不对 degraded 做特殊处理，仅记录。
+	StatusDegraded Status = "degraded"
+)
+
+// Health 是 health.json 文件的 schema。worker 写，supervisor 读。
+//
+// 字段对齐 ADR-033 U3：worker_pid 用于 supervisor 检测 PID race（旧 worker
+// 崩溃后新 worker 复用 PID 槽位但 started_at 不同）；started_at 与
+// last_heartbeat 都是 RFC3339 纳秒精度。
+type Health struct {
+	Version       int       `json:"version"`
+	WorkerPID     int       `json:"worker_pid"`
+	StartedAt     time.Time `json:"started_at"`
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+	Status        Status    `json:"status"`
+}
+
+// Write 原子地写入 health.json：先写到同目录的临时文件，再 rename 覆盖。
+// 原子写避免 supervisor 读到半写入的 JSON（Windows 上 rename 是原子的，
+// 同分区下 NTFS保证原子性）。
+func Write(path string, h Health) error {
+	buf, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal health: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	// 同目录临时文件保证 rename 是同分区原子操作（跨分区 rename 退化成 copy+unlink）。
+	tmp, err := os.CreateTemp(dir, ".health-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			// cleanup 路径：tmp 文件已写坏或 rename 失败，删除残留。
+			// 错误丢弃是刻意的（cleanup 失败无处理手段，下次 CreateTemp 会冲突触发上层报错）。
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(buf); err != nil {
+		// Write 失败后 Close 错误丢弃（已经被 write 错误掩盖，无诊断价值）。
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
+	}
+	cleanup = false
+	return nil
+}
+
+// Read 读取 health.json 并反序列化。文件不存在时返回包装 fs.ErrNotExist 的错误。
+func Read(path string) (Health, error) {
+	var h Health
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return h, fmt.Errorf("read %s: %w", path, err)
+	}
+	// 提前 trim BOM（有些编辑器在 Windows 自动加 BOM，会让 encoding/json 报错）。
+	buf = bytes.TrimPrefix(buf, []byte("\xef\xbb\xbf"))
+	if err := json.Unmarshal(buf, &h); err != nil {
+		return h, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+	return h, nil
+}
+
+// IsStale 判断心跳是否过期：now - LastHeartbeat > timeout。
+// 边界恰好等于 timeout 视为未过期（属于"最后的有效时刻"）。
+//
+// 错误的判断由调用方做（文件不存在 ≠ worker 卡死，可能是首次启动）。
+func IsStale(h Health, now time.Time, timeout time.Duration) bool {
+	return now.Sub(h.LastHeartbeat) > timeout
+}
+
+// IsNotExist 报告错误链中是否包含 fs.ErrNotExist。supervisor 用这个区分
+// "health.json 还没写"（worker 启动中，等待）vs "health.json 损坏"（告警）。
+func IsNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/edgeagent/supervisorhealth/health_test.go
+++ b/internal/edgeagent/supervisorhealth/health_test.go
@@ -1,0 +1,140 @@
+// Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
+// health.json 文件 IPC（ADR-033 U3）。
+//
+// worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
+// 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启（MVP-1 仅重启）。
+//
+// 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 L1 Linux CI 跑
+// （ADR-035 Q7 C5 分层策略：L1 交叉编译秒级，L2 windows-latest 跑 Windows 专属）。
+package supervisorhealth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWrite_Then_Read_RoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+
+	want := Health{
+		Version:       HealthSchemaVersion,
+		WorkerPID:     12345,
+		StartedAt:     time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC),
+		LastHeartbeat: time.Date(2026, 7, 12, 10, 0, 30, 0, time.UTC),
+		Status:        StatusHealthy,
+	}
+
+	if err := Write(path, want); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestRead_NotExist_Returns_Error(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := Read(filepath.Join(dir, "missing.json"))
+	if err == nil {
+		t.Fatal("Read should fail for missing file")
+	}
+}
+
+func TestRead_InvalidJSON_Returns_Error(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("setup WriteFile failed: %v", err)
+	}
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("Read should fail for invalid JSON")
+	}
+}
+
+func TestWrite_Overwrite_Existing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "health.json")
+
+	first := Health{Version: 1, WorkerPID: 1, Status: StatusStarting}
+	if err := Write(path, first); err != nil {
+		t.Fatalf("first Write failed: %v", err)
+	}
+	second := Health{Version: 1, WorkerPID: 2, Status: StatusHealthy}
+	if err := Write(path, second); err != nil {
+		t.Fatalf("second Write failed: %v", err)
+	}
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if got.WorkerPID != 2 || got.Status != StatusHealthy {
+		t.Errorf("overwrite failed: got %+v, want PID=2 Status=healthy", got)
+	}
+}
+
+func TestIsStale_FreshHeartbeat_False(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	h := Health{LastHeartbeat: now.Add(-10 * time.Second)}
+	if IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be false for 10s-old heartbeat (within 90s window)")
+	}
+}
+
+func TestIsStale_ExpiredHeartbeat_True(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	h := Health{LastHeartbeat: now.Add(-120 * time.Second)} // 120s > 90s
+	if !IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be true for 120s-old heartbeat (beyond 90s window)")
+	}
+}
+
+func TestIsStale_Boundary_ExactlyAtTimeout_True(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	// 超时判断用 > 比较：恰好等于 timeout 视为未超时（边界属于"最后的有效时刻"）
+	h := Health{LastHeartbeat: now.Add(-HeartbeatTimeout)}
+	if IsStale(h, now, HeartbeatTimeout) {
+		t.Error("IsStale should be false at exactly timeout boundary (>)")
+	}
+	h2 := Health{LastHeartbeat: now.Add(-(HeartbeatTimeout + time.Second))}
+	if !IsStale(h2, now, HeartbeatTimeout) {
+		t.Error("IsStale should be true 1s past timeout boundary")
+	}
+}
+
+func TestWrite_PermissionDenied_Returns_Error(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits behave differently on Windows; covered by L2 windows-latest runner")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, permission test unreliable")
+	}
+	dir := t.TempDir()
+	readOnlyDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0o500); err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	err := Write(filepath.Join(readOnlyDir, "health.json"), Health{Version: 1})
+	if err == nil {
+		t.Fatal("Write should fail on read-only directory")
+	}
+}

--- a/internal/edgeagent/supervisorhealth/health_test.go
+++ b/internal/edgeagent/supervisorhealth/health_test.go
@@ -1,12 +1,10 @@
 // Package supervisorhealth 实现 supervisor.exe 与 worker.exe 之间的
-// health.json 文件 IPC（ADR-033 U3）。
-//
+// health.json 文件 IPC。
 // worker.exe 每 30s 写一次心跳到 health.json，supervisor.exe 读 + 超时判断。
 // 超过 HeartbeatTimeout（90s，3× 心跳间隔，给 GC/network jitter 留 margin）
-// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启（MVP-1 仅重启）。
-//
+// 未刷新 → supervisor 视为 worker 卡死，触发回滚/重启。
 // 此包故意保持纯 Go（无 Windows 专属依赖），测试可在 L1 Linux CI 跑
-// （ADR-035 Q7 C5 分层策略：L1 交叉编译秒级，L2 windows-latest 跑 Windows 专属）。
+//。
 package supervisorhealth
 
 import (

--- a/internal/edgeagent/upgradebundle/doc.go
+++ b/internal/edgeagent/upgradebundle/doc.go
@@ -1,0 +1,15 @@
+// Package upgradebundle 实现 worker 侧的 bundle 下载与健康标记写入（ADR-033 U3 Phase 3）。
+//
+// 职责分工（对称 supervisor 侧的 upgrademachine 包）：
+//   - upgradebundle（本包，worker 侧）— 下载 bundle 到 incoming/ + 写 healthy_marker
+//   - upgrademachine（supervisor 侧）— swap + rollback + 状态机编排 + IPC 常量单一真相源
+//
+// 文件系统 IPC（常量定义在 upgrademachine 包，两侧共享引用）：
+//
+//   <StageDir>/incoming/MANIFEST.txt — 存在 = pending upgrade 触发器
+//   <StageDir>/incoming/VERSION     — bundle 版本号
+//   <StageDir>/healthy_marker       — register_edge 成功后写的版本号
+//   <StageDir>/rollback.done        — rollback 完成 sentinel（本包负责清理）
+//
+// 本包纯 Go（无 Windows 专属依赖），L1 Linux CI 可测。
+package upgradebundle

--- a/internal/edgeagent/upgradebundle/doc.go
+++ b/internal/edgeagent/upgradebundle/doc.go
@@ -1,15 +1,11 @@
-// Package upgradebundle 实现 worker 侧的 bundle 下载与健康标记写入（ADR-033 U3 Phase 3）。
-//
+// Package upgradebundle 实现 worker 侧的 bundle 下载与健康标记写入。
 // 职责分工（对称 supervisor 侧的 upgrademachine 包）：
 //   - upgradebundle（本包，worker 侧）— 下载 bundle 到 incoming/ + 写 healthy_marker
 //   - upgrademachine（supervisor 侧）— swap + rollback + 状态机编排 + IPC 常量单一真相源
-//
 // 文件系统 IPC（常量定义在 upgrademachine 包，两侧共享引用）：
-//
 //   <StageDir>/incoming/MANIFEST.txt — 存在 = pending upgrade 触发器
 //   <StageDir>/incoming/VERSION     — bundle 版本号
 //   <StageDir>/healthy_marker       — register_edge 成功后写的版本号
 //   <StageDir>/rollback.done        — rollback 完成 sentinel（本包负责清理）
-//
 // 本包纯 Go（无 Windows 专属依赖），L1 Linux CI 可测。
 package upgradebundle

--- a/internal/edgeagent/upgradebundle/download.go
+++ b/internal/edgeagent/upgradebundle/download.go
@@ -1,8 +1,6 @@
-// download.go 实现 worker 侧的 bundle 下载 + sha256 校验 + 解压（ADR-033 U3 Phase 3）。
-//
+// download.go 实现 worker 侧的 bundle 下载 + sha256 校验 + 解压。
 // 对称 Linux 侧 biz/handleFetchPackage，但作为独立纯函数 API（不绑定 Agent 结构体），
 // 可被 Windows worker / 测试 / Phase 4 RPC handler 直接调用。
-//
 // 流程（all-or-nothing，任何步骤失败都清理残留）：
 //  1. 校验输入（URL 协议、sha256 格式）
 //  2. 清理旧残留（incoming/ + incoming.tar.gz）
@@ -11,7 +9,6 @@
 //  5. 解压 → incoming/（拒绝路径逃逸、symlink、超限）
 //  6. 删 tarball（只保留解压后的树）
 //  7. 验证 incoming/MANIFEST.txt（per-file sha256 all-or-nothing）
-//
 // 成功后 incoming/MANIFEST.txt 存在 = 触发器就绪，supervisor 检测到此文件 → swap。
 
 package upgradebundle
@@ -45,14 +42,11 @@ const bundleTarballName = "incoming.tar.gz"
 
 // DownloadBundle 从 downloadURL 下载 .tar.gz bundle，校验 sha256，解压到
 // stageDir/incoming/，并验证 MANIFEST.txt 中每个文件的 sha256。
-//
 // 返回 (下载字节数, manifest 文件数, error)。
 // 成功后 stageDir/incoming/MANIFEST.txt 存在（= pending upgrade 触发器）。
 // 任何步骤失败时清理所有残留文件（tarball + incoming/），不留半成品。
-//
 // ctx 用于请求级取消（RPC 超时、客户端断开）。内部用 downloadTimeout
 // 作为上限封顶，避免慢网络无限挂起。ctx.Done() 触发时 HTTP 请求中止。
-//
 // client 为 nil 时使用 http.DefaultClient。调用方可注入跳过 TLS 验证的
 // client（私有部署自签名 nginx 场景，对称 biz.bundleDownloadClient）。
 func DownloadBundle(ctx context.Context, client *http.Client, downloadURL, expectedSHA, stageDir string) (int64, int, error) {

--- a/internal/edgeagent/upgradebundle/download.go
+++ b/internal/edgeagent/upgradebundle/download.go
@@ -1,0 +1,252 @@
+// download.go 实现 worker 侧的 bundle 下载 + sha256 校验 + 解压（ADR-033 U3 Phase 3）。
+//
+// 对称 Linux 侧 biz/handleFetchPackage，但作为独立纯函数 API（不绑定 Agent 结构体），
+// 可被 Windows worker / 测试 / Phase 4 RPC handler 直接调用。
+//
+// 流程（all-or-nothing，任何步骤失败都清理残留）：
+//  1. 校验输入（URL 协议、sha256 格式）
+//  2. 清理旧残留（incoming/ + incoming.tar.gz）
+//  3. 流式下载 → incoming.tar.gz（边下边算 sha256）
+//  4. sha256 校验（不信任下载内容）
+//  5. 解压 → incoming/（拒绝路径逃逸、symlink、超限）
+//  6. 删 tarball（只保留解压后的树）
+//  7. 验证 incoming/MANIFEST.txt（per-file sha256 all-or-nothing）
+//
+// 成功后 incoming/MANIFEST.txt 存在 = 触发器就绪，supervisor 检测到此文件 → swap。
+
+package upgradebundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// maxBundleBytes 限制接受的最大 bundle 大小（解压后）。
+// 对称 biz/upgrade_package.go 的 maxBundleBytes（1 GB）。
+const maxBundleBytes = 1024 * 1024 * 1024
+
+// downloadTimeout 是单次下载的最大时长。
+const downloadTimeout = 45 * time.Minute
+
+// bundleTarballName 是下载暂存的 tarball 文件名（解压后删除）。
+const bundleTarballName = "incoming.tar.gz"
+
+// DownloadBundle 从 downloadURL 下载 .tar.gz bundle，校验 sha256，解压到
+// stageDir/incoming/，并验证 MANIFEST.txt 中每个文件的 sha256。
+//
+// 返回 (下载字节数, manifest 文件数, error)。
+// 成功后 stageDir/incoming/MANIFEST.txt 存在（= pending upgrade 触发器）。
+// 任何步骤失败时清理所有残留文件（tarball + incoming/），不留半成品。
+//
+// ctx 用于请求级取消（RPC 超时、客户端断开）。内部用 downloadTimeout
+// 作为上限封顶，避免慢网络无限挂起。ctx.Done() 触发时 HTTP 请求中止。
+//
+// client 为 nil 时使用 http.DefaultClient。调用方可注入跳过 TLS 验证的
+// client（私有部署自签名 nginx 场景，对称 biz.bundleDownloadClient）。
+func DownloadBundle(ctx context.Context, client *http.Client, downloadURL, expectedSHA, stageDir string) (int64, int, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// 1. 校验输入。
+	expectedSHA = strings.ToLower(strings.TrimSpace(expectedSHA))
+	if len(expectedSHA) != 64 {
+		return 0, 0, fmt.Errorf("download_bundle: sha256 must be 64 hex chars (got %d)", len(expectedSHA))
+	}
+	for _, c := range expectedSHA {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return 0, 0, fmt.Errorf("download_bundle: sha256 not lower-hex")
+		}
+	}
+	url := strings.TrimSpace(downloadURL)
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return 0, 0, fmt.Errorf("download_bundle: url must be http(s)")
+	}
+
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return 0, 0, fmt.Errorf("download_bundle: mkdir stage: %w", err)
+	}
+
+	tarballPath := filepath.Join(stageDir, bundleTarballName)
+	incomingPath := filepath.Join(stageDir, upgrademachine.IncomingDirName)
+
+	// 2. 清理旧残留（幂等）。
+	_ = os.Remove(tarballPath)
+	_ = os.RemoveAll(incomingPath)
+
+	// 3-4. 下载 + sha256 校验。
+	n, err := downloadAndVerify(ctx, client, url, expectedSHA, tarballPath)
+	if err != nil {
+		_ = os.Remove(tarballPath)
+		return 0, 0, fmt.Errorf("download_bundle: %w", err)
+	}
+
+	// 5. 解压 → incoming/。
+	if err := extractTarGz(tarballPath, incomingPath); err != nil {
+		_ = os.Remove(tarballPath)
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: extract: %w", err)
+	}
+
+	// 6. 删 tarball（只保留解压后的树）。
+	_ = os.Remove(tarballPath)
+
+	// 7. 验证 MANIFEST.txt（per-file sha256 all-or-nothing）。
+	manifestPath := filepath.Join(incomingPath, upgrademachine.ManifestFileName)
+	entries, err := upgrademachine.ParseManifest(manifestPath)
+	if err != nil {
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: manifest parse: %w", err)
+	}
+	if err := upgrademachine.VerifyAll(incomingPath, entries); err != nil {
+		_ = os.RemoveAll(incomingPath)
+		return 0, 0, fmt.Errorf("download_bundle: manifest verify: %w", err)
+	}
+
+	return n, len(entries), nil
+}
+
+// downloadAndVerify 流式下载 url 到 out，边下边算 sha256，校验后返回字节数。
+// 失败时删除 out 文件。ctx 用上层 RPC 的 context（可取消），内部用
+// downloadTimeout 封顶防止慢网络无限挂起。
+func downloadAndVerify(ctx context.Context, client *http.Client, url, expectedSHA, out string) (int64, error) {
+	// downloadTimeout 作为上限封顶；ctx 自身的 deadline 可能更短（RPC 超时）。
+	dlCtx, cancel := context.WithTimeout(ctx, downloadTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(dlCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build req: %w", err)
+	}
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return 0, fmt.Errorf("get: %w", err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("get: status %d", httpResp.StatusCode)
+	}
+
+	f, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return 0, fmt.Errorf("open: %w", err)
+	}
+	hasher := sha256.New()
+	n, err := io.Copy(io.MultiWriter(f, hasher), io.LimitReader(httpResp.Body, maxBundleBytes+1))
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("stream: %w", err)
+	}
+	if n > maxBundleBytes {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("bundle too large (%d > %d)", n, maxBundleBytes)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("sync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("close: %w", err)
+	}
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != expectedSHA {
+		_ = os.Remove(out)
+		return 0, fmt.Errorf("sha256 mismatch (got %s, want %s)", got, expectedSHA)
+	}
+	return n, nil
+}
+
+// extractTarGz 解压 src（.tar.gz）到 dst。
+// 安全措施：拒绝路径逃逸（zip-slip）、symlink/hardlink、超限总大小。
+func extractTarGz(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return fmt.Errorf("mkdir dst: %w", err)
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("abs dst: %w", err)
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		// 只接受普通文件和目录（拒绝 symlink/hardlink/device）。
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeDir:
+		default:
+			return fmt.Errorf("disallowed tar entry type %v in %q", hdr.Typeflag, hdr.Name)
+		}
+		cleaned := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(cleaned, "/") || strings.Contains(cleaned, "..") {
+			return fmt.Errorf("disallowed tar path %q (escapes archive root)", hdr.Name)
+		}
+		target := filepath.Join(absDst, cleaned)
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("abs target: %w", err)
+		}
+		if !strings.HasPrefix(absTarget, absDst+string(os.PathSeparator)) && absTarget != absDst {
+			return fmt.Errorf("target %q escapes %q", absTarget, absDst)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("mkdir parent of %s: %w", target, err)
+		}
+		w, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+			os.FileMode(hdr.Mode)&0o755)
+		if err != nil {
+			return fmt.Errorf("open out %s: %w", target, err)
+		}
+		n, err := io.Copy(w, io.LimitReader(tr, maxBundleBytes-totalBytes+1))
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", target, err)
+		}
+		totalBytes += n
+		if totalBytes > maxBundleBytes {
+			return fmt.Errorf("extracted size exceeded %d bytes", maxBundleBytes)
+		}
+	}
+	return nil
+}

--- a/internal/edgeagent/upgradebundle/download_test.go
+++ b/internal/edgeagent/upgradebundle/download_test.go
@@ -1,0 +1,308 @@
+package upgradebundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeBundle 构造一个合法的 .tar.gz bundle 字节流。
+//
+// 文件映射：name → content。自动生成对应的 MANIFEST.txt（每行
+// `<sha256> <mode> <src> <dest>` 格式）。
+func makeBundle(t *testing.T, files map[string]string, includeManifest bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	var manifestLines []string
+
+	// 先写普通文件
+	for name, content := range files {
+		h := sha256.Sum256([]byte(content))
+		sha := hex.EncodeToString(h[:])
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+		// manifest 行：sha / mode / src(incoming 相对) / dest(绝对路径占位)
+		manifestLines = append(manifestLines, fmt.Sprintf("%s 0755 %s /usr/local/bin/%s", sha, name, name))
+	}
+
+	if includeManifest {
+		manifest := strings.Join(manifestLines, "\n") + "\n"
+		if err := tw.WriteHeader(&tar.Header{
+			Name: "MANIFEST.txt",
+			Mode: 0644,
+			Size: int64(len(manifest)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(manifest)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// bundleSHA256 计算 bundle 字节流的 sha256（供 DownloadBundle 的 expectedSHA 参数用）。
+func bundleSHA256(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// TestDownloadBundle_Success 验证完整正常路径：
+// 下载 → sha256 校验 → 解压 → manifest 验证 → incoming/MANIFEST.txt 就绪。
+func TestDownloadBundle_Success(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{
+		"worker": "fake binary content",
+	}, true)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	expectedSHA := bundleSHA256(bundleData)
+
+	n, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, expectedSHA, dir)
+	if err != nil {
+		t.Fatalf("DownloadBundle: %v", err)
+	}
+	if n != int64(len(bundleData)) {
+		t.Errorf("bytes = %d, want %d", n, len(bundleData))
+	}
+
+	// 触发器就绪：incoming/MANIFEST.txt 存在
+	manifestPath := filepath.Join(dir, "incoming", "MANIFEST.txt")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("MANIFEST.txt should exist at %s: %v", manifestPath, err)
+	}
+
+	// tarball 应被删除（只保留解压后的文件）
+	if _, err := os.Stat(filepath.Join(dir, "incoming.tar.gz")); !os.IsNotExist(err) {
+		t.Error("incoming.tar.gz should be removed after extract")
+	}
+}
+
+// TestDownloadBundle_SHA256Mismatch 验证 sha256 不匹配时报错 + 清理。
+func TestDownloadBundle_SHA256Mismatch(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{"worker": "x"}, true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		"0000000000000000000000000000000000000000000000000000000000000000", dir)
+	if err == nil {
+		t.Fatal("expected sha mismatch error")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error should mention sha256 mismatch, got: %v", err)
+	}
+
+	// tarball 应被删除
+	if _, err := os.Stat(filepath.Join(dir, "incoming.tar.gz")); !os.IsNotExist(err) {
+		t.Error("tarball should be removed on sha mismatch")
+	}
+	// incoming/ 不应存在（sha 校验在解压前）
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should not exist when sha fails before extract")
+	}
+}
+
+// TestDownloadBundle_BadURL 验证非 http(s) URL 被拒绝。
+func TestDownloadBundle_BadURL(t *testing.T) {
+	dir := t.TempDir()
+	// 传合法 sha256 格式，确保报错来自 URL 校验而非 sha
+	validSHA := hex.EncodeToString(make([]byte, 32))
+	_, _, err := DownloadBundle(context.Background(), http.DefaultClient, "ftp://example.com/bundle.tar.gz",
+		validSHA, dir)
+	if err == nil || !strings.Contains(err.Error(), "must be http(s)") {
+		t.Errorf("expected URL protocol error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_BadSHAFormat 验证 sha256 格式校验。
+func TestDownloadBundle_BadSHAFormat(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), http.DefaultClient, "http://example.com/x",
+		"tooshort", dir)
+	if err == nil || !strings.Contains(err.Error(), "sha256 must be 64") {
+		t.Errorf("expected sha format error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_HTTP404 验证 HTTP 错误状态码。
+func TestDownloadBundle_HTTP404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256([]byte("x")), dir)
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Errorf("expected HTTP 404 error, got: %v", err)
+	}
+}
+
+// TestDownloadBundle_ManifestVerifyFail 验证 manifest per-file sha 不匹配时报错。
+// 构造一个 MANIFEST.txt 声明的 sha 与实际文件不符的 bundle。
+func TestDownloadBundle_ManifestVerifyFail(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// 写一个内容固定的文件
+	content := []byte("real content")
+	tw.WriteHeader(&tar.Header{Name: "worker", Mode: 0644, Size: int64(len(content))})
+	tw.Write(content)
+
+	// MANIFEST.txt 声明一个错误的 sha
+	badManifest := fmt.Sprintf("%s 0755 worker /usr/local/bin/worker\n",
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	tw.WriteHeader(&tar.Header{Name: "MANIFEST.txt", Mode: 0644, Size: int64(len(badManifest))})
+	tw.Write([]byte(badManifest))
+
+	tw.Close()
+	gz.Close()
+	bundleData := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, bundleSHA256(bundleData), dir)
+	if err == nil {
+		t.Fatal("expected manifest verify error")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Errorf("error should mention manifest, got: %v", err)
+	}
+
+	// 失败后 incoming/ 应被清理
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should be cleaned up after manifest verify failure")
+	}
+}
+
+// TestDownloadBundle_CleansStaleIncoming 验证下载前清理旧残留（幂等）。
+func TestDownloadBundle_CleansStaleIncoming(t *testing.T) {
+	bundleData := makeBundle(t, map[string]string{"worker": "new"}, true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bundleData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	// 放一个旧的 incoming/ 目录 + 旧 tarball
+	oldIncoming := filepath.Join(dir, "incoming")
+	os.MkdirAll(oldIncoming, 0o750)
+	os.WriteFile(filepath.Join(oldIncoming, "MANIFEST.txt"), []byte("stale"), 0o640)
+	os.WriteFile(filepath.Join(dir, "incoming.tar.gz"), []byte("stale"), 0o640)
+
+	expectedSHA := bundleSHA256(bundleData)
+	if _, _, err := DownloadBundle(context.Background(), server.Client(), server.URL, expectedSHA, dir); err != nil {
+		t.Fatalf("DownloadBundle: %v", err)
+	}
+
+	// 旧 MANIFEST.txt 应被新内容覆盖
+	got, _ := os.ReadFile(filepath.Join(oldIncoming, "MANIFEST.txt"))
+	if strings.Contains(string(got), "stale") {
+		t.Error("stale MANIFEST.txt should be replaced")
+	}
+}
+
+// TestDownloadBundle_RejectsPathEscape 验证 tar 条目含 ../ 时解压被拒绝。
+func TestDownloadBundle_RejectsPathEscape(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	tw.WriteHeader(&tar.Header{Name: "../escape.txt", Mode: 0644, Size: 1})
+	tw.Write([]byte("x"))
+	tw.Close()
+	gz.Close()
+	evilBundle := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(evilBundle)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256(evilBundle), dir)
+	if err == nil {
+		t.Fatal("expected path escape rejection")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Errorf("error should mention escape, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "incoming")); !os.IsNotExist(err) {
+		t.Error("incoming/ should be cleaned after path escape rejection")
+	}
+}
+
+// TestDownloadBundle_RejectsSymlink 验证 tar 条目含 symlink 时被拒绝。
+func TestDownloadBundle_RejectsSymlink(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	tw.WriteHeader(&tar.Header{
+		Name:     "evil",
+		Linkname: "/etc/passwd",
+		Typeflag: tar.TypeSymlink,
+	})
+	tw.Close()
+	gz.Close()
+	symlinkBundle := buf.Bytes()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(symlinkBundle)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	_, _, err := DownloadBundle(context.Background(), server.Client(), server.URL,
+		bundleSHA256(symlinkBundle), dir)
+	if err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "disallowed tar entry type") {
+		t.Errorf("error should mention disallowed type, got: %v", err)
+	}
+}

--- a/internal/edgeagent/upgradebundle/health.go
+++ b/internal/edgeagent/upgradebundle/health.go
@@ -1,6 +1,5 @@
-// health.go 实现 worker 侧的健康标记 + rollback sentinel 管理（ADR-033 U3 Phase 3）。
-//
-// 常量引用 upgrademachine 包（单一真相源，issue #23），消除跨包 drift。
+// health.go 实现 worker 侧的健康标记 + rollback sentinel 管理。
+// 常量引用 upgrademachine 包（单一真相源），消除跨包 drift。
 
 package upgradebundle
 
@@ -22,10 +21,8 @@ const HealthyMarkerFile = upgrademachine.HealthyMarkerFile
 const RollbackDoneFile = upgrademachine.RollbackDoneFile
 
 // WriteHealthyMarker 在 register_edge 成功后写 <stageDir>/healthy_marker。
-//
 // 内容 = version + "\n"。supervisor 的 Machine.HealthCheck 检测到此文件
 // 内容匹配 last_upgrade_ver 时判定升级成功。
-//
 // 空 version 时跳过（不报错）— 适配 dev 模式或未配 AgentVersion 的场景。
 // stageDir 不存在时自动创建。
 func WriteHealthyMarker(stageDir, version string) error {
@@ -44,11 +41,9 @@ func WriteHealthyMarker(stageDir, version string) error {
 }
 
 // DeleteRollbackSentinel 删除 <stageDir>/rollback.done sentinel 文件。
-//
 // manager 推送新 bundle 前必须调用此函数清理上次 rollback 留下的 sentinel，
 // 否则 supervisor 启动时检测到 rollback.done 存在会跳过 rollback 检查，
 // 导致 upgrade 流程死循环。
-//
 // 幂等：文件不存在时返回 nil（首次升级或已清理）。
 func DeleteRollbackSentinel(stageDir string) error {
 	path := filepath.Join(stageDir, RollbackDoneFile)

--- a/internal/edgeagent/upgradebundle/health.go
+++ b/internal/edgeagent/upgradebundle/health.go
@@ -1,0 +1,59 @@
+// health.go 实现 worker 侧的健康标记 + rollback sentinel 管理（ADR-033 U3 Phase 3）。
+//
+// 常量引用 upgrademachine 包（单一真相源，issue #23），消除跨包 drift。
+
+package upgradebundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/upgrademachine"
+)
+
+// HealthyMarkerFile 是 register_edge 成功后写的版本号文件名。
+// 引用 upgrademachine.HealthyMarkerFile（单一真相源）。
+const HealthyMarkerFile = upgrademachine.HealthyMarkerFile
+
+// RollbackDoneFile 是 rollback 完成后的 sentinel 文件名。
+// 引用 upgrademachine.RollbackDoneFile（单一真相源）。
+const RollbackDoneFile = upgrademachine.RollbackDoneFile
+
+// WriteHealthyMarker 在 register_edge 成功后写 <stageDir>/healthy_marker。
+//
+// 内容 = version + "\n"。supervisor 的 Machine.HealthCheck 检测到此文件
+// 内容匹配 last_upgrade_ver 时判定升级成功。
+//
+// 空 version 时跳过（不报错）— 适配 dev 模式或未配 AgentVersion 的场景。
+// stageDir 不存在时自动创建。
+func WriteHealthyMarker(stageDir, version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil
+	}
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	path := filepath.Join(stageDir, HealthyMarkerFile)
+	if err := os.WriteFile(path, []byte(version+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write healthy_marker: %w", err)
+	}
+	return nil
+}
+
+// DeleteRollbackSentinel 删除 <stageDir>/rollback.done sentinel 文件。
+//
+// manager 推送新 bundle 前必须调用此函数清理上次 rollback 留下的 sentinel，
+// 否则 supervisor 启动时检测到 rollback.done 存在会跳过 rollback 检查，
+// 导致 upgrade 流程死循环。
+//
+// 幂等：文件不存在时返回 nil（首次升级或已清理）。
+func DeleteRollbackSentinel(stageDir string) error {
+	path := filepath.Join(stageDir, RollbackDoneFile)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove rollback.done: %w", err)
+	}
+	return nil
+}

--- a/internal/edgeagent/upgradebundle/health_test.go
+++ b/internal/edgeagent/upgradebundle/health_test.go
@@ -1,0 +1,89 @@
+package upgradebundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteHealthyMarker_WritesVersion 验证正常路径：写 healthy_marker 文件，
+// 内容 = version + "\n"，权限 0640。
+func TestWriteHealthyMarker_WritesVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteHealthyMarker: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, HealthyMarkerFile))
+	if err != nil {
+		t.Fatalf("read healthy_marker: %v", err)
+	}
+	if string(got) != "v0.7.50\n" {
+		t.Errorf("healthy_marker = %q, want %q", got, "v0.7.50\n")
+	}
+}
+
+// TestWriteHealthyMarker_EmptyVersion 验证空版本号幂等跳过（不报错、不写文件）。
+func TestWriteHealthyMarker_EmptyVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, ""); err != nil {
+		t.Fatalf("empty version should not error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should not be written for empty version")
+	}
+}
+
+// TestWriteHealthyMarker_CreatesDir 验证 stage dir 不存在时自动创建。
+func TestWriteHealthyMarker_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "upgrade")
+
+	if err := WriteHealthyMarker(dir, "v1.0.0"); err != nil {
+		t.Fatalf("should create nested dir: %v", err)
+	}
+}
+
+// TestWriteHealthyMarker_OverwritesExisting 验证幂等覆盖（多次 register_edge 场景）。
+func TestWriteHealthyMarker_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteHealthyMarker(dir, "v0.7.49"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHealthyMarker(dir, "v0.7.50"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, HealthyMarkerFile))
+	if string(got) != "v0.7.50\n" {
+		t.Errorf("after overwrite = %q, want %q", got, "v0.7.50\n")
+	}
+}
+
+// TestDeleteRollbackSentinel_RemovesExisting 验证存在时删除。
+func TestDeleteRollbackSentinel_RemovesExisting(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, RollbackDoneFile)
+	if err := os.WriteFile(sentinel, []byte("done\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteRollbackSentinel(dir); err != nil {
+		t.Fatalf("DeleteRollbackSentinel: %v", err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("rollback.done should be removed")
+	}
+}
+
+// TestDeleteRollbackSentinel_Idempotent 验证不存在时幂等（不报错）。
+func TestDeleteRollbackSentinel_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// rollback.done 不存在
+
+	if err := DeleteRollbackSentinel(dir); err != nil {
+		t.Fatalf("should not error when sentinel missing: %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply.go
+++ b/internal/edgeagent/upgrademachine/apply.go
@@ -1,17 +1,14 @@
-// apply.go 实现 bundle swap 算法（ADR-033 U3，issue #23）。
-//
+// apply.go 实现 bundle swap 算法。
 // 对称 Linux apply-pending-upgrade.sh 的 bundle apply 模式：
 //  1. 预检：验证所有 src 的 sha256（all-or-nothing，半换比不换更糟）
 //  2. 对每条 entry：
 //     a. 如果 dest 存在 → copy(dest, dest.previous)（备份）
 //     b. copy(src, dest.new)（暂存到 dest 同目录，保证同卷原子 rename）
 //     c. rename(dest.new, dest)（原子替换）
-//
 // Windows 特殊考虑：
 //   - os.Rename 在同目录下是原子的（底层 MoveFileExW + MOVEFILE_REPLACE_EXISTING）
 //   - copy 到 dest.new 而非直接 rename src→dest，因为 incoming/ 和 dest 可能跨卷
 //   - 残留 dest.new（上次崩溃）在步骤 b 被覆盖，幂等
-//
 // AGENTS.md context.Context 例外：ApplyBundle 操作本地文件系统（秒级），
 // 是原子事务语义（all-or-nothing），中途取消比跑完更危险（半 swap 状态）。
 // 取消检查由编排层 Machine.Apply 在入口处完成（ctx.Err() guard），
@@ -34,11 +31,9 @@ type ApplyResult struct {
 }
 
 // ApplyBundle 执行 MANIFEST 中所有条目的 swap。
-//
 // 预检阶段（VerifyAll）失败时立即返回，不触碰任何 dest 文件。
 // swap 阶段中单条 entry 失败时记录错误并继续（best-effort，对称 Linux 行为）。
-//
-// stageDir 用于写 supervisor_upgrade.pending sentinel（issue #21）。
+// stageDir 用于写 supervisor_upgrade.pending sentinel。
 // 当 entry.Dest 是 supervisor.exe 时，只 stage .new + 写 sentinel，不 rename。
 func ApplyBundle(stageDir, incomingDir string, entries []ManifestEntry) (*ApplyResult, error) {
 	// 预检：所有 src 的 sha 必须验证通过
@@ -62,8 +57,7 @@ func isSupervisorBinary(dest string) bool {
 }
 
 // applyOne 执行单条 entry 的 swap：backup → stage → atomic rename。
-//
-// supervisor.exe special-case（issue #21）：运行中的 supervisor.exe 无法被
+// supervisor.exe special-case：运行中的 supervisor.exe 无法被
 // 原子 rename（image loader 持有 image section）。改为只 stage .new + 写
 // pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。
 func applyOne(stageDir, incomingDir string, e ManifestEntry, result *ApplyResult) error {

--- a/internal/edgeagent/upgrademachine/apply.go
+++ b/internal/edgeagent/upgrademachine/apply.go
@@ -1,0 +1,165 @@
+// apply.go 实现 bundle swap 算法（ADR-033 U3，issue #23）。
+//
+// 对称 Linux apply-pending-upgrade.sh 的 bundle apply 模式：
+//  1. 预检：验证所有 src 的 sha256（all-or-nothing，半换比不换更糟）
+//  2. 对每条 entry：
+//     a. 如果 dest 存在 → copy(dest, dest.previous)（备份）
+//     b. copy(src, dest.new)（暂存到 dest 同目录，保证同卷原子 rename）
+//     c. rename(dest.new, dest)（原子替换）
+//
+// Windows 特殊考虑：
+//   - os.Rename 在同目录下是原子的（底层 MoveFileExW + MOVEFILE_REPLACE_EXISTING）
+//   - copy 到 dest.new 而非直接 rename src→dest，因为 incoming/ 和 dest 可能跨卷
+//   - 残留 dest.new（上次崩溃）在步骤 b 被覆盖，幂等
+//
+// AGENTS.md context.Context 例外：ApplyBundle 操作本地文件系统（秒级），
+// 是原子事务语义（all-or-nothing），中途取消比跑完更危险（半 swap 状态）。
+// 取消检查由编排层 Machine.Apply 在入口处完成（ctx.Err() guard），
+// 进入 ApplyBundle 后操作不可取消。故不接收 context.Context 参数。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// ApplyResult 记录 swap 结果，供调用方决策（日志 + 是否触发 rollback）。
+type ApplyResult struct {
+	Swapped  []string // 成功 swap 的 dest 路径
+	BackedUp []string // 创建的 .previous 备份路径
+	Staged   []string // supervisor.exe.new 暂存路径（未 rename，等 SupervisorSelfSwap）
+}
+
+// ApplyBundle 执行 MANIFEST 中所有条目的 swap。
+//
+// 预检阶段（VerifyAll）失败时立即返回，不触碰任何 dest 文件。
+// swap 阶段中单条 entry 失败时记录错误并继续（best-effort，对称 Linux 行为）。
+//
+// stageDir 用于写 supervisor_upgrade.pending sentinel（issue #21）。
+// 当 entry.Dest 是 supervisor.exe 时，只 stage .new + 写 sentinel，不 rename。
+func ApplyBundle(stageDir, incomingDir string, entries []ManifestEntry) (*ApplyResult, error) {
+	// 预检：所有 src 的 sha 必须验证通过
+	if err := VerifyAll(incomingDir, entries); err != nil {
+		return nil, fmt.Errorf("pre-verify aborted: %w", err)
+	}
+
+	result := &ApplyResult{}
+	for _, e := range entries {
+		if err := applyOne(stageDir, incomingDir, e, result); err != nil {
+			return result, fmt.Errorf("swap %s: %w", e.Src, err)
+		}
+	}
+	return result, nil
+}
+
+// isSupervisorBinary 判断 dest 是否指向 supervisor.exe。
+// applyOne 用此决定走 stage-only 路径还是标准 swap 路径。
+func isSupervisorBinary(dest string) bool {
+	return filepath.Base(dest) == SupervisorBinaryName
+}
+
+// applyOne 执行单条 entry 的 swap：backup → stage → atomic rename。
+//
+// supervisor.exe special-case（issue #21）：运行中的 supervisor.exe 无法被
+// 原子 rename（image loader 持有 image section）。改为只 stage .new + 写
+// pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。
+func applyOne(stageDir, incomingDir string, e ManifestEntry, result *ApplyResult) error {
+	srcPath := filepath.Join(incomingDir, e.Src)
+	destDir := filepath.Dir(e.Dest)
+
+	// 确保 dest 父目录存在（首次安装路径可能不存在）
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir dest dir %s: %w", destDir, err)
+	}
+
+	// supervisor.exe special-case：stage .new + 写 pending sentinel，不 backup / rename
+	if isSupervisorBinary(e.Dest) {
+		newPath := e.Dest + ".new"
+		if err := copyFile(srcPath, newPath); err != nil {
+			return fmt.Errorf("supervisor stage to %s: %w", newPath, err)
+		}
+		if e.Mode != "" {
+			_ = os.Chmod(newPath, parseMode(e.Mode))
+		}
+		if err := WriteSupervisorUpgradePending(stageDir, ""); err != nil {
+			return fmt.Errorf("write supervisor pending sentinel: %w", err)
+		}
+		result.Staged = append(result.Staged, newPath)
+		return nil
+	}
+
+	// 备份：dest 存在 → copy(dest, dest.previous)
+	if _, err := os.Stat(e.Dest); err == nil {
+		prevPath := e.Dest + PreviousSuffix
+		if err := copyFile(e.Dest, prevPath); err != nil {
+			return fmt.Errorf("backup to %s: %w", prevPath, err)
+		}
+		result.BackedUp = append(result.BackedUp, prevPath)
+	}
+
+	// 暂存：copy(src, dest.new) — 同目录保证后续 rename 原子
+	newPath := e.Dest + ".new"
+	if err := copyFile(srcPath, newPath); err != nil {
+		return fmt.Errorf("stage to %s: %w", newPath, err)
+	}
+
+	// 应用 mode（Windows 上仅 read-only bit 有效，但保持语义一致）
+	if e.Mode != "" {
+		_ = os.Chmod(newPath, parseMode(e.Mode)) // 失败不阻断（Windows 忽略）
+	}
+
+	// 原子替换：rename(dest.new, dest) — 同目录 = 同卷，原子
+	if err := os.Rename(newPath, e.Dest); err != nil {
+		_ = os.Remove(newPath) // best-effort 清理暂存文件；rename 已失败，清理失败也无处理手段
+		return fmt.Errorf("rename %s → %s: %w", newPath, e.Dest, err)
+	}
+
+	result.Swapped = append(result.Swapped, e.Dest)
+	return nil
+}
+
+// copyFile 是 src → dst 的完整拷贝（内容 + 权限）。
+// 不用 os.Rename 是因为 src 和 dst 可能跨卷（incoming/ 在 ProgramData，
+// dest 在 Program Files）。
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat src: %w", err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("create dst: %w", err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return fmt.Errorf("copy: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("close dst: %w", err)
+	}
+	return nil
+}
+
+// parseMode 将 "0755" 等字符串转为 os.FileMode。
+func parseMode(s string) os.FileMode {
+	var m uint32
+	for _, c := range s {
+		if c >= '0' && c <= '7' {
+			m = m<<3 | uint32(c-'0')
+		}
+	}
+	return os.FileMode(m)
+}

--- a/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
+++ b/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
@@ -1,17 +1,13 @@
-// apply_cycle_windows_test.go — issue #20 反馈循环测试（Windows-only）。
-//
-// 复现 issue #20 核心场景：worker 退出后 plugin 进程 orphaned → .exe 文件锁 →
+// apply_cycle_windows_test.go —  反馈循环测试（Windows-only）。
+// 复现  核心场景：worker 退出后 plugin 进程 orphaned → .exe 文件锁 →
 // ApplyBundle rename 失败（Access denied）。
-//
 // 本测试不模拟 orphaned 路径（PID 1 reparenting 是内核行为，无法用 Go 模拟），
 // 而是直接测试核心时序问题：
 //   1. 启动 plugin.exe（持有自身 .exe 文件锁）
 //   2. taskkill /F /IM plugin.exe（windowsProcessController.KillByImage）
 //   3. 立即 ApplyBundle rename plugin.exe
 //   4. 验证 rename 是否成功（若失败则 bug 复现）
-//
 // 如果 taskkill 返回后文件锁未及时释放（race condition），本测试会 Access denied。
-//
 // 这是 Phase 1 的 tight feedback loop：秒级、deterministic、agent-runnable。
 
 //go:build windows
@@ -75,10 +71,9 @@ func (realWindowsPC) KillByImage(name string) error {
 
 // copyFileExe / appendMarker / copyStream 已提取到 dummy_helper_test.go（跨平台共用）。
 
-// TestKillByImageReleaseTiming 是 issue #20 的核心反馈循环：
+// TestKillByImageReleaseTiming 是  的核心反馈循环：
 // KillByImage 返回后立即尝试 ApplyBundle rename .exe → 是否 Access denied。
-//
-// 失败（t.Errorf "BUG REPRODUCED"）= 文件锁未及时释放 = issue #20 根因确认。
+// 失败（t.Errorf "BUG REPRODUCED"）= 文件锁未及时释放 =  根因确认。
 // 成功 = 当前实现（KillManifestExes）在测试场景下工作正常。
 func TestKillByImageReleaseTiming(t *testing.T) {
 	sleeper := buildSleeper(t)
@@ -183,10 +178,9 @@ func shaFile(t *testing.T, path string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// TestKillByImageRelease_MultiCycle 是 issue #20 的核心验收测试：
+// TestKillByImageRelease_MultiCycle 是  的核心验收测试：
 // 连续 10 次升级循环，每次都启动 plugin.exe → KillByImage → rename。
 // 验收标准：所有循环成功，无残留进程。
-//
 // 若任一循环失败（Access denied）= bug 复现，记录循环号 + 错误。
 func TestKillByImageRelease_MultiCycle(t *testing.T) {
 	sleeper := buildSleeper(t)

--- a/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
+++ b/internal/edgeagent/upgrademachine/apply_cycle_windows_test.go
@@ -1,0 +1,330 @@
+// apply_cycle_windows_test.go — issue #20 反馈循环测试（Windows-only）。
+//
+// 复现 issue #20 核心场景：worker 退出后 plugin 进程 orphaned → .exe 文件锁 →
+// ApplyBundle rename 失败（Access denied）。
+//
+// 本测试不模拟 orphaned 路径（PID 1 reparenting 是内核行为，无法用 Go 模拟），
+// 而是直接测试核心时序问题：
+//   1. 启动 plugin.exe（持有自身 .exe 文件锁）
+//   2. taskkill /F /IM plugin.exe（windowsProcessController.KillByImage）
+//   3. 立即 ApplyBundle rename plugin.exe
+//   4. 验证 rename 是否成功（若失败则 bug 复现）
+//
+// 如果 taskkill 返回后文件锁未及时释放（race condition），本测试会 Access denied。
+//
+// 这是 Phase 1 的 tight feedback loop：秒级、deterministic、agent-runnable。
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sleeperOnce 保证 sleeper.exe 只编译一次（所有 subtests 共用）。
+var (
+	sleeperOnce sync.Once
+	sleeperPath string
+	sleeperErr  error
+)
+
+// buildSleeper 编译 sleeper_main.go → sleeper.exe，所有测试共用。
+// 首次调用 ~3-5s，后续调用 0s（cache 在 t.TempDir 外的固定路径）。
+func buildSleeper(t *testing.T) string {
+	t.Helper()
+	sleeperOnce.Do(func() {
+		out := filepath.Join(os.TempDir(), "ongrid-sleeper.exe")
+		src := filepath.Join("testdata", "sleeper_main.go")
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			sleeperErr = fmt.Errorf("go build sleeper: %w\noutput: %s", err, out)
+			return
+		}
+		sleeperPath = out
+	})
+	if sleeperErr != nil {
+		t.Fatal(sleeperErr)
+	}
+	return sleeperPath
+}
+
+// realWindowsPC 是真实的 Windows ProcessController（taskkill 实现）。
+// 对称 cmd/ongrid-edge-supervisor/upgrade_windows.go 的 windowsProcessController，
+// 但放在测试包中避免循环依赖（cmd/ 不能被 import）。
+type realWindowsPC struct{}
+
+func (realWindowsPC) KillTree(pid int) error {
+	return exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}
+
+func (realWindowsPC) KillByImage(name string) error {
+	return exec.Command("taskkill", "/F", "/IM", name).Run()
+}
+
+// copyFileExe / appendMarker / copyStream 已提取到 dummy_helper_test.go（跨平台共用）。
+
+// TestKillByImageReleaseTiming 是 issue #20 的核心反馈循环：
+// KillByImage 返回后立即尝试 ApplyBundle rename .exe → 是否 Access denied。
+//
+// 失败（t.Errorf "BUG REPRODUCED"）= 文件锁未及时释放 = issue #20 根因确认。
+// 成功 = 当前实现（KillManifestExes）在测试场景下工作正常。
+func TestKillByImageReleaseTiming(t *testing.T) {
+	sleeper := buildSleeper(t)
+
+	// 铺地板：dest 目录有 plugin.exe（旧版本）
+	destDir := t.TempDir()
+	destExe := filepath.Join(destDir, "plugin.exe")
+	copyFileExe(t, sleeper, destExe)
+	appendMarker(t, destExe, "OLD-VERSION\n")
+
+	// 启动 destExe（持有自身 .exe 文件锁）
+	cmd := exec.Command(destExe)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start plugin: %v", err)
+	}
+	t.Logf("plugin started pid=%d", cmd.Process.Pid)
+	// 测试结束确保清理
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// 短暂等待进程完全启动（加载 image、初始化）
+	time.Sleep(200 * time.Millisecond)
+
+	// 铺地板：incoming/ 有新版本 plugin.exe
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	if err := os.MkdirAll(incoming, 0o755); err != nil {
+		t.Fatalf("mkdir incoming: %v", err)
+	}
+	srcExe := filepath.Join(incoming, "plugin.exe")
+	copyFileExe(t, sleeper, srcExe)
+	appendMarker(t, srcExe, "NEW-VERSION\n")
+
+	// 写 MANIFEST.txt
+	sha := shaFile(t, srcExe)
+	manifestLine := sha + " 0755 plugin.exe " + destExe + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifestLine)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v0.9.1-test\n")
+
+	// 准备 Machine（PID=0 跳过 KillTree；KillManifestExes 会触发）
+	m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+
+	start := time.Now()
+	err := m.Apply(context.Background(), 0)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("BUG REPRODUCED: Machine.Apply failed after KillByImage (elapsed=%v): %v",
+			elapsed, err)
+		// 尝试找出实际释放延迟
+		probeReleaseDelay(t, destExe, srcExe)
+		return
+	}
+
+	t.Logf("Apply succeeded in %v — KillByImage 释放了文件锁（测试场景无 race）", elapsed)
+
+	// 验证 swap 完成状态
+	got, _ := os.ReadFile(destExe)
+	if !strings.Contains(string(got), "NEW-VERSION") {
+		t.Errorf("dest content = %q, want contains NEW-VERSION", got)
+	}
+}
+
+// probeReleaseDelay 在 bug 复现时探测 taskkill 后的实际文件锁释放延迟。
+// 不是测试断言，而是诊断输出。
+func probeReleaseDelay(t *testing.T, destExe, srcExe string) {
+	t.Helper()
+	t.Logf("--- probing file lock release delay ---")
+	newPath := destExe + ".new"
+	for _, delay := range []time.Duration{
+		10 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+	} {
+		time.Sleep(delay)
+		// 重新 stage
+		copyFileExe(t, srcExe, newPath)
+		err := os.Rename(newPath, destExe)
+		if err == nil {
+			t.Logf("rename succeeded after cumulative delay ~%v: %v", delay, err)
+			return
+		}
+		t.Logf("  after %v: %v", delay, err)
+	}
+	t.Logf("rename never succeeded within probe window — plugin.exe 仍被持有")
+}
+
+// shaFile 计算文件 sha256 hex（用于 MANIFEST.txt 行）。
+func shaFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestKillByImageRelease_MultiCycle 是 issue #20 的核心验收测试：
+// 连续 10 次升级循环，每次都启动 plugin.exe → KillByImage → rename。
+// 验收标准：所有循环成功，无残留进程。
+//
+// 若任一循环失败（Access denied）= bug 复现，记录循环号 + 错误。
+func TestKillByImageRelease_MultiCycle(t *testing.T) {
+	sleeper := buildSleeper(t)
+	const cycles = 10
+
+	// 复用同一个 destDir 模拟生产场景（文件锁可能累积）
+	destDir := t.TempDir()
+	destExe := filepath.Join(destDir, "plugin.exe")
+	copyFileExe(t, sleeper, destExe)
+	appendMarker(t, destExe, "BASE\n")
+
+	var runningPIDs []int
+	defer func() {
+		// 测试结束清理所有可能残留的进程
+		for _, pid := range runningPIDs {
+			_ = exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run()
+		}
+	}()
+
+	for i := 0; i < cycles; i++ {
+		// 启动当前 destExe（持有 .exe 锁）
+		cmd := exec.Command(destExe)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("cycle %d: start plugin: %v", i, err)
+		}
+		runningPIDs = append(runningPIDs, cmd.Process.Pid)
+		time.Sleep(100 * time.Millisecond) // 等待进程完全加载
+
+		// 准备 incoming（每轮内容不同 — version marker）
+		stageDir := t.TempDir()
+		incoming := filepath.Join(stageDir, IncomingDirName)
+		if err := os.MkdirAll(incoming, 0o755); err != nil {
+			t.Fatalf("cycle %d: mkdir incoming: %v", i, err)
+		}
+		srcExe := filepath.Join(incoming, "plugin.exe")
+		copyFileExe(t, sleeper, srcExe)
+		appendMarker(t, srcExe, fmt.Sprintf("CYCLE-%d\n", i))
+
+		sha := shaFile(t, srcExe)
+		writeTestFile(t, filepath.Join(incoming, ManifestFileName),
+			sha+" 0755 plugin.exe "+destExe+"\n")
+		writeTestFile(t, filepath.Join(incoming, VersionFileName),
+			fmt.Sprintf("v0.9.%d\n", i+1))
+
+		m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+		start := time.Now()
+		err := m.Apply(context.Background(), 0)
+		elapsed := time.Since(start)
+		t.Logf("cycle %d: Apply elapsed=%v err=%v", i, elapsed, err)
+		if err != nil {
+			t.Errorf("BUG REPRODUCED at cycle %d (elapsed=%v): %v", i, elapsed, err)
+			return
+		}
+
+		// 等待 cmd 完全退出（taskkill 后 Process.Wait 应立即返回）
+		_ = cmd.Wait()
+		runningPIDs = runningPIDs[:len(runningPIDs)-1] // pop
+
+		// 验证内容已替换
+		got, _ := os.ReadFile(destExe)
+		want := fmt.Sprintf("CYCLE-%d", i)
+		if !strings.Contains(string(got), want) {
+			t.Errorf("cycle %d: dest content = %q, want contains %q", i, got, want)
+		}
+	}
+	t.Logf("All %d cycles succeeded", cycles)
+}
+
+// TestKillByImageRelease_ParallelChildren 模拟更接近生产的环境：
+// 主进程启动多个子进程（模拟 windows_exporter + 其他 plugin），
+// 验证 KillManifestExes 能否一次性杀光所有 .exe 持有者。
+func TestKillByImageRelease_ParallelChildren(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping parallel test in short mode")
+	}
+	sleeper := buildSleeper(t)
+
+	// 准备两个不同的 .exe（plugin-a.exe + plugin-b.exe）
+	destDir := t.TempDir()
+	destA := filepath.Join(destDir, "plugin-a.exe")
+	destB := filepath.Join(destDir, "plugin-b.exe")
+	copyFileExe(t, sleeper, destA)
+	copyFileExe(t, sleeper, destB)
+	appendMarker(t, destA, "OLD-A\n")
+	appendMarker(t, destB, "OLD-B\n")
+
+	// 同时启动两个进程（都持有各自的 .exe 锁）
+	cmdA := exec.Command(destA)
+	cmdB := exec.Command(destB)
+	if err := cmdA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	if err := cmdB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer func() {
+		_ = cmdA.Process.Kill()
+		_ = cmdB.Process.Kill()
+		_, _ = cmdA.Process.Wait()
+		_, _ = cmdB.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	// 准备 incoming（含两条 MANIFEST 条目）
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	os.MkdirAll(incoming, 0o755)
+
+	srcA := filepath.Join(incoming, "plugin-a.exe")
+	srcB := filepath.Join(incoming, "plugin-b.exe")
+	copyFileExe(t, sleeper, srcA)
+	copyFileExe(t, sleeper, srcB)
+	appendMarker(t, srcA, "NEW-A\n")
+	appendMarker(t, srcB, "NEW-B\n")
+
+	shaA := shaFile(t, srcA)
+	shaB := shaFile(t, srcB)
+	manifest := shaA + " 0755 plugin-a.exe " + destA + "\n" +
+		shaB + " 0755 plugin-b.exe " + destB + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifest)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v1.0.0-parallel\n")
+
+	m := NewMachine(stageDir, destDir, testLogger(), realWindowsPC{})
+	start := time.Now()
+	err := m.Apply(context.Background(), 0)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Errorf("BUG REPRODUCED in parallel scenario (elapsed=%v): %v", elapsed, err)
+		return
+	}
+	t.Logf("Parallel Apply succeeded in %v", elapsed)
+
+	gotA, _ := os.ReadFile(destA)
+	gotB, _ := os.ReadFile(destB)
+	if !strings.Contains(string(gotA), "NEW-A") {
+		t.Errorf("destA = %q, want NEW-A", gotA)
+	}
+	if !strings.Contains(string(gotB), "NEW-B") {
+		t.Errorf("destB = %q, want NEW-B", gotB)
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/apply_supervisor_test.go
@@ -1,5 +1,4 @@
-// apply_supervisor_test.go 测试 issue #21 applyOne 的 supervisor special-case。
-//
+// apply_supervisor_test.go 测试  applyOne 的 supervisor special-case。
 // supervisor dest 不能走标准 backup → stage → rename 路径（Windows 锁定
 // 运行中的 .exe）。applyOne 检测 supervisor dest → 只 stage .new + 写
 // pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。

--- a/internal/edgeagent/upgrademachine/apply_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/apply_supervisor_test.go
@@ -1,0 +1,139 @@
+// apply_supervisor_test.go 测试 issue #21 applyOne 的 supervisor special-case。
+//
+// supervisor dest 不能走标准 backup → stage → rename 路径（Windows 锁定
+// 运行中的 .exe）。applyOne 检测 supervisor dest → 只 stage .new + 写
+// pending sentinel，让 Machine.SupervisorSelfSwap 后续做 rename-aside。
+
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestApplyBundle_SupervisorDest_StageOnly 验证 supervisor dest 走 special-case。
+func TestApplyBundle_SupervisorDest_StageOnly(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 下已有运行中 supervisor.exe（旧版本）
+	writeTestFile(t, filepath.Join(dest, SupervisorBinaryName), "old-supervisor")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "new-supervisor"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	// supervisor dest 应被 Staged，不是 Swapped
+	if len(result.Swapped) != 0 {
+		t.Errorf("supervisor dest 不应被 swap，got Swapped=%v", result.Swapped)
+	}
+	if len(result.Staged) != 1 {
+		t.Fatalf("expected 1 staged, got %d (%v)", len(result.Staged), result.Staged)
+	}
+	stagedPath := filepath.Join(dest, SupervisorBinaryName+".new")
+	if result.Staged[0] != stagedPath {
+		t.Errorf("staged[0] = %q, want %q", result.Staged[0], stagedPath)
+	}
+
+	// supervisor.exe（原文件）应未被改动
+	got, _ := os.ReadFile(filepath.Join(dest, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 不应被改动，got %q", got)
+	}
+
+	// .new 应存在且内容是新版本
+	got, _ = os.ReadFile(stagedPath)
+	if string(got) != "new-supervisor" {
+		t.Errorf("supervisor.exe.new content = %q, want %q", got, "new-supervisor")
+	}
+
+	// pending sentinel 应被写入
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("supervisor_upgrade.pending sentinel 应被写入")
+	}
+
+	// 不应有 .previous 备份（supervisor 路径跳过 backup）
+	if _, err := os.Stat(filepath.Join(dest, SupervisorBinaryName+PreviousSuffix)); !os.IsNotExist(err) {
+		t.Errorf("supervisor 路径不应创建 .previous 备份")
+	}
+}
+
+// TestApplyBundle_SupervisorMixedWithWorker 验证同一 bundle 中 supervisor +
+// worker 混合时各自走正确路径。
+func TestApplyBundle_SupervisorMixedWithWorker(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dest, SupervisorBinaryName), "old-supervisor")
+	writeTestFile(t, filepath.Join(dest, WorkerBinaryName), "old-worker")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "new-supervisor"},
+		{WorkerBinaryName, WorkerBinaryName, "new-worker"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	// worker 走 swap，supervisor 走 stage
+	if len(result.Swapped) != 1 || len(result.Staged) != 1 {
+		t.Fatalf("expected Swapped=1 + Staged=1, got Swapped=%d Staged=%d",
+			len(result.Swapped), len(result.Staged))
+	}
+
+	// worker.exe 应是新版本
+	got, _ := os.ReadFile(filepath.Join(dest, WorkerBinaryName))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe = %q, want new-worker", got)
+	}
+
+	// supervisor.exe 应保持旧版本（未被 swap）
+	got, _ = os.ReadFile(filepath.Join(dest, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应保持旧版本，got %q", got)
+	}
+
+	// pending sentinel 存在
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被写入")
+	}
+}
+
+// TestApplyBundle_SupervisorDest_NoOldExe 验证 supervisor dest 不存在时仍 stage。
+// 场景：首次安装 / brick 后 supervisor.exe 缺失。
+func TestApplyBundle_SupervisorDest_NoOldExe(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 下无 supervisor.exe（首次或 brick 后恢复）
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{SupervisorBinaryName, SupervisorBinaryName, "fresh-supervisor"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+
+	if len(result.Staged) != 1 {
+		t.Fatalf("expected 1 staged, got %d", len(result.Staged))
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, SupervisorBinaryName+".new"))
+	if string(got) != "fresh-supervisor" {
+		t.Errorf("supervisor.exe.new = %q, want fresh-supervisor", got)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被写入")
+	}
+}

--- a/internal/edgeagent/upgrademachine/apply_test.go
+++ b/internal/edgeagent/upgrademachine/apply_test.go
@@ -1,0 +1,183 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildFakeBundle 创建一个完整的 fake bundle：incoming/ 下有 MANIFEST.txt
+// + 若干 src 文件。destDir 模拟部署目标目录（已有旧版本文件）。
+//
+// 返回 (incomingDir, destDir, entries)。
+func buildFakeBundle(t *testing.T, incomingDir, destDir string,
+	files []struct{ Src, Dest, Content string }) []ManifestEntry {
+	t.Helper()
+
+	// 写 src 文件 + 计算 sha
+	var lines []string
+	for _, f := range files {
+		sha := writeTestFile(t, filepath.Join(incomingDir, f.Src), f.Content)
+		lines = append(lines, sha+" 0755 "+f.Src+" "+filepath.Join(destDir, f.Dest))
+	}
+	// 写 MANIFEST.txt
+	writeManifest(t, filepath.Join(incomingDir, ManifestFileName), lines)
+
+	// 解析回来（验证 round-trip）
+	entries, err := ParseManifest(filepath.Join(incomingDir, ManifestFileName))
+	if err != nil {
+		t.Fatalf("ParseManifest after build: %v", err)
+	}
+	return entries
+}
+
+func TestApplyBundle_AllSwapped(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 先放旧版本文件
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "old-worker")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe"), "old-exporter")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new-worker"},
+		{"exporter.exe", "exporter.exe", "new-exporter"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+	if len(result.Swapped) != 2 {
+		t.Fatalf("expected 2 swapped, got %d", len(result.Swapped))
+	}
+
+	// 验证新内容
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe content = %q, want %q", got, "new-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(dest, "exporter.exe"))
+	if string(got) != "new-exporter" {
+		t.Errorf("exporter.exe content = %q, want %q", got, "new-exporter")
+	}
+
+	// 验证 .previous 备份存在且内容是旧版本
+	got, _ = os.ReadFile(filepath.Join(dest, "worker.exe.previous"))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe.previous content = %q, want %q", got, "old-worker")
+	}
+}
+
+func TestApplyBundle_DestNotExists_NoBackup(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// dest 目录存在但目标文件不存在（首次安装路径）
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"new.exe", "new.exe", "fresh-install"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle: %v", err)
+	}
+	if len(result.Swapped) != 1 {
+		t.Fatalf("expected 1 swapped, got %d", len(result.Swapped))
+	}
+	if len(result.BackedUp) != 0 {
+		t.Fatalf("expected 0 backed up (dest didn't exist), got %d", len(result.BackedUp))
+	}
+
+	// 不应该有 .previous 文件
+	if _, err := os.Stat(filepath.Join(dest, "new.exe.previous")); !os.IsNotExist(err) {
+		t.Errorf("should not have .previous when dest didn't exist")
+	}
+}
+
+func TestApplyBundle_SHAVerifyFails_AbortsAll(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 旧文件
+	oldContent := "old-worker"
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), oldContent)
+
+	// 先创建 incoming 目录 + src 文件
+	writeTestFile(t, filepath.Join(incoming, "worker.exe"), "new-worker")
+	// 故意写错误 sha 到 MANIFEST
+	writeManifest(t, filepath.Join(incoming, ManifestFileName), []string{
+		"0000000000000000000000000000000000000000000000000000000000000000 0755 worker.exe " + filepath.Join(dest, "worker.exe"),
+	})
+	entries, err := ParseManifest(filepath.Join(incoming, ManifestFileName))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+
+	_, err = ApplyBundle(stageDir, incoming, entries)
+	if err == nil {
+		t.Fatal("expected error for SHA mismatch")
+	}
+
+	// 验证旧文件未被改动
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != oldContent {
+		t.Errorf("dest should be unchanged after SHA failure, got %q", got)
+	}
+}
+
+func TestApplyBundle_Idempotent_DestNewExists(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := t.TempDir()
+
+	// 模拟上次 swap 中途失败：dest.new 已存在但 dest 未替换
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "old-worker")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.new"), "new-worker-from-crash")
+
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new-worker"},
+	})
+
+	result, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle should handle leftover .new: %v", err)
+	}
+	if len(result.Swapped) != 1 {
+		t.Fatalf("expected 1 swapped, got %d", len(result.Swapped))
+	}
+
+	// 验证最终文件是新版本
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe content = %q, want %q", got, "new-worker")
+	}
+	// .new 应该被清理（被 rename 掉了）
+	if _, err := os.Stat(filepath.Join(dest, "worker.exe.new")); !os.IsNotExist(err) {
+		t.Errorf(".new should be gone after successful swap")
+	}
+}
+
+func TestApplyBundle_CreatesDestDir(t *testing.T) {
+	stageDir := t.TempDir()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+	dest := filepath.Join(t.TempDir(), "deploy")
+
+	// dest 目录不存在 — ApplyBundle 应该创建
+	entries := buildFakeBundle(t, incoming, dest, []struct{ Src, Dest, Content string }{
+		{"app.exe", "app.exe", "content"},
+	})
+
+	_, err := ApplyBundle(stageDir, incoming, entries)
+	if err != nil {
+		t.Fatalf("ApplyBundle should create dest dir: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dest, "app.exe"))
+	if string(got) != "content" {
+		t.Errorf("app.exe content = %q", got)
+	}
+}

--- a/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
@@ -1,0 +1,172 @@
+// bootcheck_supervisor_test.go 测试 issue #21 BootCheck 的 supervisor 自升级集成。
+//
+// 覆盖步骤 3（applied sentinel 清理）/ 4（brick recovery）/ 5（pending → W1 KillByImage → self-swap）。
+
+package upgrademachine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- 步骤 3：applied sentinel 清理 ---
+
+func TestBootCheck_AppliedSentinel_CleansOldAndSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 .old 备份 + applied sentinel
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "old-supervisor-binary")
+	WriteSupervisorUpgradeApplied(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.BootCheck(context.Background())
+	if err != nil {
+		t.Fatalf("BootCheck 不应返回错误（applied 清理是非关键路径）： %v", err)
+	}
+
+	// .old 应被清理
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf(".old 应被清理（err=%v）", err)
+	}
+	// applied sentinel 应被删除
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应被删除")
+	}
+}
+
+// --- 步骤 4：brick recovery ---
+
+func TestBootCheck_BrickState_RestoresOldToSupervisor(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// brick 状态：supervisor.exe 缺失 + .old 存在
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	writeTestFile(t, oldPath, "rescued-supervisor-binary")
+	// supervisor.exe 不存在
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.BootCheck(context.Background())
+	if err != nil {
+		t.Fatalf("BootCheck brick recovery 不应失败： %v", err)
+	}
+
+	// supervisor.exe 应被恢复（.old rename 回来）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	got, rerr := os.ReadFile(supervisorPath)
+	if rerr != nil {
+		t.Fatalf("supervisor.exe 应存在： %v", rerr)
+	}
+	if string(got) != "rescued-supervisor-binary" {
+		t.Errorf("supervisor.exe 内容 = %q, want rescued-supervisor-binary", got)
+	}
+	// .old 应不存在（已被 rename 走）
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf(".old 应不存在（err=%v）", err)
+	}
+}
+
+func TestBootCheck_NoBrickState_SupervisorExists(t *testing.T) {
+	// supervisor.exe 存在 + .old 不存在 → 非 brick 状态，不应触发恢复
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "current")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 不应 panic 或误恢复
+	_ = m.BootCheck(context.Background())
+
+	got, _ := os.ReadFile(filepath.Join(binDir, SupervisorBinaryName))
+	if string(got) != "current" {
+		t.Errorf("supervisor.exe 内容不应被改动，got %q", got)
+	}
+}
+
+// --- 步骤 5：pending sentinel → W1 KillByImage → self-swap ---
+
+func TestBootCheck_PendingSentinel_KillsWorkerBeforeSelfSwap(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 supervisor.exe + supervisor.exe.new（dummy binary）
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName))
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName+".new"))
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+
+	err := m.BootCheck(context.Background())
+
+	// 应返回 ErrSupervisorRestartSoon（self-swap 成功）
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
+	}
+
+	// W1: KillByImage 应被调用，参数是 WorkerBinaryName
+	if pc.killImageCalls.Load() != 1 {
+		t.Errorf("KillByImage 应被调用 1 次，got %d", pc.killImageCalls.Load())
+	}
+	if len(pc.killImageNames) != 1 || pc.killImageNames[0] != WorkerBinaryName {
+		t.Errorf("KillByImage 参数应是 %q，got %v", WorkerBinaryName, pc.killImageNames)
+	}
+}
+
+func TestBootCheck_PendingSentinel_NilPC_SkipsKillButStillSelfSwap(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName))
+	copyFileExe(t, dummy, filepath.Join(binDir, SupervisorBinaryName+".new"))
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	// pc == nil（测试场景 / 无 worker 启动场景）
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+
+	err := m.BootCheck(context.Background())
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("nil pc 也应完成 self-swap，got %v", err)
+	}
+}
+
+// --- 步骤 5：self-swap 失败记录 lastErr 但不阻断 ---
+
+func TestBootCheck_SelfSwapFails_RecordsLastError(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺 supervisor.exe（旧版本）+ supervisor.exe.new 是坏 binary（冒烟失败）
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName), "old-supervisor")
+	writeTestFile(t, filepath.Join(binDir, SupervisorBinaryName+".new"), "bad-binary")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, binDir, testLogger(), &pc)
+
+	err := m.BootCheck(context.Background())
+	// 冒烟失败不是 ErrSupervisorRestartSoon，应是普通 error
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Errorf("冒烟失败不应返回 ErrSupervisorRestartSoon")
+	}
+	if err == nil {
+		t.Errorf("冒烟失败应返回错误（lastErr）")
+	}
+
+	// W1: KillByImage 仍被调用（在 self-swap 之前）
+	if pc.killImageCalls.Load() != 1 {
+		t.Errorf("KillByImage 应被调用（W1 在 self-swap 前），got %d", pc.killImageCalls.Load())
+	}
+
+	// supervisor.exe 应未被改动
+	got, _ := os.ReadFile(filepath.Join(binDir, SupervisorBinaryName))
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应保持旧版本，got %q", got)
+	}
+}

--- a/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/bootcheck_supervisor_test.go
@@ -1,6 +1,5 @@
-// bootcheck_supervisor_test.go 测试 issue #21 BootCheck 的 supervisor 自升级集成。
-//
-// 覆盖步骤 3（applied sentinel 清理）/ 4（brick recovery）/ 5（pending → W1 KillByImage → self-swap）。
+// bootcheck_supervisor_test.go 测试  BootCheck 的 supervisor 自升级集成。
+// 覆盖步骤 3（applied sentinel 清理）/ 4（brick recovery）/ 5（pending →  KillByImage → self-swap）。
 
 package upgrademachine
 
@@ -87,7 +86,7 @@ func TestBootCheck_NoBrickState_SupervisorExists(t *testing.T) {
 	}
 }
 
-// --- 步骤 5：pending sentinel → W1 KillByImage → self-swap ---
+// --- 步骤 5：pending sentinel →  KillByImage → self-swap ---
 
 func TestBootCheck_PendingSentinel_KillsWorkerBeforeSelfSwap(t *testing.T) {
 	dummy := buildDummy(t)
@@ -109,7 +108,7 @@ func TestBootCheck_PendingSentinel_KillsWorkerBeforeSelfSwap(t *testing.T) {
 		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
 	}
 
-	// W1: KillByImage 应被调用，参数是 WorkerBinaryName
+	// : KillByImage 应被调用，参数是 WorkerBinaryName
 	if pc.killImageCalls.Load() != 1 {
 		t.Errorf("KillByImage 应被调用 1 次，got %d", pc.killImageCalls.Load())
 	}
@@ -159,9 +158,9 @@ func TestBootCheck_SelfSwapFails_RecordsLastError(t *testing.T) {
 		t.Errorf("冒烟失败应返回错误（lastErr）")
 	}
 
-	// W1: KillByImage 仍被调用（在 self-swap 之前）
+	// : KillByImage 仍被调用（在 self-swap 之前）
 	if pc.killImageCalls.Load() != 1 {
-		t.Errorf("KillByImage 应被调用（W1 在 self-swap 前），got %d", pc.killImageCalls.Load())
+		t.Errorf("KillByImage 应被调用，got %d", pc.killImageCalls.Load())
 	}
 
 	// supervisor.exe 应未被改动

--- a/internal/edgeagent/upgrademachine/doc.go
+++ b/internal/edgeagent/upgrademachine/doc.go
@@ -1,0 +1,41 @@
+// Package upgrademachine 实现 supervisor.exe 的升级状态机深模块（ADR-033 U3，issue #23）。
+//
+// # 状态机
+//
+// 升级状态机描述 worker 二进制文件的 swap → 健康确认 → 回滚 生命周期：
+//
+//	idle → pending → swapped → healthy
+//	                   └→ rolled_back → idle
+//
+// 状态定义：
+//
+//   - StateIdle       — 无升级进行中（incoming/ 不存在，无 rollback.done）
+//   - StatePending    — incoming/MANIFEST.txt 存在（worker 下载了新 bundle，等待 swap）
+//   - StateSwapped    — 文件已替换，last_upgrade_ver 已写，等待健康确认
+//   - StateHealthy    — healthy_marker 匹配 last_upgrade_ver（新 worker register_edge 成功）
+//   - StateRolledBack — rollback.done 存在（旧版本已恢复，等待下次升级）
+//
+// # 状态转移触发
+//
+//	 idle → pending       DownloadBundle（worker 侧 upgradebundle 包）
+//	 pending → swapped    Machine.Apply / Machine.BootCheck
+//	 swapped → healthy    Machine.HealthCheck（poll IsUpgradeHealthy）
+//	 swapped → rolled_back Machine.HealthCheck 超时 → Machine.RollbackAndMark
+//	 any → rolled_back    Machine.BootCheck（启动时检测不健康）
+//	 rolled_back → idle   manager 推新 bundle 前 DeleteRollbackSentinel
+//
+// # 文件系统 IPC
+//
+// supervisor 与 worker 通过 StageDir 下的文件通信（无 socket/pipe）：
+//
+//	<StageDir>/incoming/MANIFEST.txt  — pending 触发器
+//	<StageDir>/incoming/VERSION       — bundle 版本号
+//	<StageDir>/last_upgrade_ver       — 当前升级版本号
+//	<StageDir>/last_upgrade_at        — 升级时间戳
+//	<StageDir>/healthy_marker         — worker register_edge 成功后写的版本号
+//	<StageDir>/rollback.done          — rollback 完成哨兵
+//	<dest>.previous                   — swap 备份的旧文件
+//
+// 所有文件名常量定义在 ipc.go，是跨包单一真相源。
+// upgradebundle（worker 侧）和 cmd/（supervisor 侧）均引用本包的常量。
+package upgrademachine

--- a/internal/edgeagent/upgrademachine/doc.go
+++ b/internal/edgeagent/upgrademachine/doc.go
@@ -1,33 +1,23 @@
-// Package upgrademachine 实现 supervisor.exe 的升级状态机深模块（ADR-033 U3，issue #23）。
-//
+// Package upgrademachine 实现 supervisor.exe 的升级状态机深模块。
 // # 状态机
-//
 // 升级状态机描述 worker 二进制文件的 swap → 健康确认 → 回滚 生命周期：
-//
 //	idle → pending → swapped → healthy
 //	                   └→ rolled_back → idle
-//
 // 状态定义：
-//
 //   - StateIdle       — 无升级进行中（incoming/ 不存在，无 rollback.done）
 //   - StatePending    — incoming/MANIFEST.txt 存在（worker 下载了新 bundle，等待 swap）
 //   - StateSwapped    — 文件已替换，last_upgrade_ver 已写，等待健康确认
 //   - StateHealthy    — healthy_marker 匹配 last_upgrade_ver（新 worker register_edge 成功）
 //   - StateRolledBack — rollback.done 存在（旧版本已恢复，等待下次升级）
-//
 // # 状态转移触发
-//
 //	 idle → pending       DownloadBundle（worker 侧 upgradebundle 包）
 //	 pending → swapped    Machine.Apply / Machine.BootCheck
 //	 swapped → healthy    Machine.HealthCheck（poll IsUpgradeHealthy）
 //	 swapped → rolled_back Machine.HealthCheck 超时 → Machine.RollbackAndMark
 //	 any → rolled_back    Machine.BootCheck（启动时检测不健康）
 //	 rolled_back → idle   manager 推新 bundle 前 DeleteRollbackSentinel
-//
 // # 文件系统 IPC
-//
 // supervisor 与 worker 通过 StageDir 下的文件通信（无 socket/pipe）：
-//
 //	<StageDir>/incoming/MANIFEST.txt  — pending 触发器
 //	<StageDir>/incoming/VERSION       — bundle 版本号
 //	<StageDir>/last_upgrade_ver       — 当前升级版本号
@@ -35,7 +25,6 @@
 //	<StageDir>/healthy_marker         — worker register_edge 成功后写的版本号
 //	<StageDir>/rollback.done          — rollback 完成哨兵
 //	<dest>.previous                   — swap 备份的旧文件
-//
 // 所有文件名常量定义在 ipc.go，是跨包单一真相源。
 // upgradebundle（worker 侧）和 cmd/（supervisor 侧）均引用本包的常量。
 package upgrademachine

--- a/internal/edgeagent/upgrademachine/dummy_helper_test.go
+++ b/internal/edgeagent/upgrademachine/dummy_helper_test.go
@@ -1,0 +1,80 @@
+// dummy_helper_test.go 提供 testdata/dummy_main.go 的跨平台编译 helper。
+//
+// buildDummy 被 Step 0 Windows 文件锁语义测试（running_exe_rename_windows_test.go）
+// 和 Step 4 SupervisorSelfSwap 测试（supervisor_selfswap_test.go）共用。
+//
+// dummy.exe 支持：
+//   - 默认：sleep 60s（模拟运行中 supervisor.exe）
+//   - --version：输出 "ongrid-dummy v0.0.1" + exit 0（smokeTestVersion 验证用）
+//   - --self-rename <path>：自 rename + JSON 报告（Step 0 场景 2 用）
+
+package upgrademachine
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	dummyOnce sync.Once
+	dummyPath string
+	dummyErr  error
+)
+
+// buildDummy 编译 dummy_main.go → dummy.exe，所有测试共用。
+// 首次调用 ~3-5s，后续 0s（cache 在 os.TempDir 固定路径）。
+func buildDummy(t *testing.T) string {
+	t.Helper()
+	dummyOnce.Do(func() {
+		out := filepath.Join(os.TempDir(), "ongrid-dummy.exe")
+		src := filepath.Join("testdata", "dummy_main.go")
+		cmd := exec.Command("go", "build", "-o", out, src)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			dummyErr = fmt.Errorf("go build dummy: %w\noutput: %s", err, out)
+			return
+		}
+		dummyPath = out
+	})
+	if dummyErr != nil {
+		t.Fatal(dummyErr)
+	}
+	return dummyPath
+}
+
+// copyFileExe 复制 src → dst（用于铺地板，保留 src 的文件权限）。
+// 跨平台 — Step 0 / Step 4 测试共用。
+func copyFileExe(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open src %s: %v", src, err)
+	}
+	defer in.Close()
+	info, _ := in.Stat()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		t.Fatalf("create dst %s: %v", dst, err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+}
+
+// appendMarker 在文件末尾追加 marker 字节，让 src 和 dest 内容不同（测试可区分版本）。
+func appendMarker(t *testing.T, path, marker string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append %s: %v", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(marker); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/extract_pending.go
+++ b/internal/edgeagent/upgrademachine/extract_pending.go
@@ -1,0 +1,139 @@
+// extract_pending.go — Windows 兼容层：解压 worker agent_upgrade RPC 下载的
+// pending tar.gz 到 incoming/。
+//
+// 背景：Linux edge 由 systemd ExecStartPre（apply-pending-upgrade.sh）完成
+// pending → incoming 解压；Windows 无对等机制，由 supervisor CheckPending
+// 调用本文件函数完成。#21 dogfood 2026-07-16 发现此缺失。
+package upgrademachine
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PendingFileName 是 worker agent_upgrade RPC 下载的 bundle 文件名（tar.gz 内容，
+// 无 .tar.gz 后缀）。对称 biz/upgrade.go 的 final path。
+const PendingFileName = "pending"
+
+// PendingSHA256FileName 是 pending 的 sha256 companion 文件名。
+const PendingSHA256FileName = "pending.sha256"
+
+// maxExtractBytes 限制解压后总大小（1 GB，对称 upgradebundle.maxBundleBytes）。
+const maxExtractBytes = 1024 * 1024 * 1024
+
+// HasPendingBundle 报告 {stageDir}/pending 文件是否存在。
+// 用于区分"无 upgrade"和"pending tar.gz 未解压"两种状态。
+func HasPendingBundle(stageDir string) bool {
+	info, err := os.Stat(filepath.Join(stageDir, PendingFileName))
+	return err == nil && !info.IsDir()
+}
+
+// ExtractPendingBundle 解压 {stageDir}/pending（tar.gz）到 {stageDir}/incoming/，
+// 然后删除 pending + pending.sha256（防止重复解压触发 upgrade 死循环）。
+//
+// 调用方：Machine.CheckPending 在 IsPending 返回 false 但 HasPendingBundle
+// 返回 true 时调用（Windows supervisor 路径）。
+func ExtractPendingBundle(stageDir string) error {
+	pendingPath := filepath.Join(stageDir, PendingFileName)
+	incomingPath := IncomingDir(stageDir)
+
+	// 清理旧 incoming/ 残留（幂等）
+	_ = os.RemoveAll(incomingPath)
+
+	if err := extractTarGz(pendingPath, incomingPath); err != nil {
+		return fmt.Errorf("extract pending: %w", err)
+	}
+
+	// 解压成功后删除 pending + pending.sha256（防止 CheckPending 重复触发）
+	if err := os.Remove(pendingPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove pending: %w", err)
+	}
+	_ = os.Remove(filepath.Join(stageDir, PendingSHA256FileName))
+
+	return nil
+}
+
+// extractTarGz 解压 src（.tar.gz）到 dst。
+// 安全措施：拒绝路径逃逸（zip-slip）、symlink/hardlink、超限总大小。
+// 逻辑对称 upgradebundle/download.go 的 extractTarGz（副本，避免循环依赖）。
+func extractTarGz(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return fmt.Errorf("mkdir dst: %w", err)
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var totalBytes int64
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("abs dst: %w", err)
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		// 只接受普通文件和目录（拒绝 symlink/hardlink/device）。
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeDir:
+		default:
+			return fmt.Errorf("disallowed tar entry type %v in %q", hdr.Typeflag, hdr.Name)
+		}
+		cleaned := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(cleaned, "/") || strings.Contains(cleaned, "..") {
+			return fmt.Errorf("disallowed tar path %q (escapes archive root)", hdr.Name)
+		}
+		target := filepath.Join(absDst, cleaned)
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("abs target: %w", err)
+		}
+		if !strings.HasPrefix(absTarget, absDst+string(os.PathSeparator)) && absTarget != absDst {
+			return fmt.Errorf("target %q escapes %q", absTarget, absDst)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("mkdir parent of %s: %w", target, err)
+		}
+		w, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+			os.FileMode(hdr.Mode)&0o755)
+		if err != nil {
+			return fmt.Errorf("open out %s: %w", target, err)
+		}
+		n, err := io.Copy(w, io.LimitReader(tr, maxExtractBytes-totalBytes+1))
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", target, err)
+		}
+		totalBytes += n
+		if totalBytes > maxExtractBytes {
+			return fmt.Errorf("extracted size exceeded %d bytes", maxExtractBytes)
+		}
+	}
+	return nil
+}

--- a/internal/edgeagent/upgrademachine/extract_pending.go
+++ b/internal/edgeagent/upgrademachine/extract_pending.go
@@ -1,9 +1,8 @@
 // extract_pending.go — Windows 兼容层：解压 worker agent_upgrade RPC 下载的
 // pending tar.gz 到 incoming/。
-//
 // 背景：Linux edge 由 systemd ExecStartPre（apply-pending-upgrade.sh）完成
 // pending → incoming 解压；Windows 无对等机制，由 supervisor CheckPending
-// 调用本文件函数完成。#21 dogfood 2026-07-16 发现此缺失。
+// 调用本文件函数完成。  2026-07-16 发现此缺失。
 package upgrademachine
 
 import (
@@ -35,7 +34,6 @@ func HasPendingBundle(stageDir string) bool {
 
 // ExtractPendingBundle 解压 {stageDir}/pending（tar.gz）到 {stageDir}/incoming/，
 // 然后删除 pending + pending.sha256（防止重复解压触发 upgrade 死循环）。
-//
 // 调用方：Machine.CheckPending 在 IsPending 返回 false 但 HasPendingBundle
 // 返回 true 时调用（Windows supervisor 路径）。
 func ExtractPendingBundle(stageDir string) error {

--- a/internal/edgeagent/upgrademachine/extract_pending_test.go
+++ b/internal/edgeagent/upgrademachine/extract_pending_test.go
@@ -1,0 +1,182 @@
+package upgrademachine
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeTarGz 创建一个包含给定文件的 .tar.gz 字节流。
+func makeTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatalf("write tar header %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write tar body %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// writePendingBundle 在 stageDir 下写入 pending（tar.gz）+ pending.sha256。
+func writePendingBundle(t *testing.T, stageDir string, files map[string]string) {
+	t.Helper()
+	data := makeTarGz(t, files)
+	if err := os.WriteFile(filepath.Join(stageDir, PendingFileName), data, 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stageDir, PendingSHA256FileName), []byte("fake-sha\n"), 0o644); err != nil {
+		t.Fatalf("write pending.sha256: %v", err)
+	}
+}
+
+// --- HasPendingBundle ---
+
+func TestHasPendingBundle_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	if HasPendingBundle(dir) {
+		t.Error("expected false when pending does not exist")
+	}
+}
+
+func TestHasPendingBundle_Exists(t *testing.T) {
+	dir := t.TempDir()
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "stub"})
+	if !HasPendingBundle(dir) {
+		t.Error("expected true when pending exists")
+	}
+}
+
+// --- ExtractPendingBundle ---
+
+func TestExtractPendingBundle_Success(t *testing.T) {
+	dir := t.TempDir()
+	manifestContent := "abc123  0o755  worker.exe  C:\\bin\\worker.exe"
+	writePendingBundle(t, dir, map[string]string{
+		"MANIFEST.txt": manifestContent,
+		"VERSION":      "v0.9.3",
+	})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// 验证 incoming/MANIFEST.txt 存在且内容正确
+	manifestPath := ManifestPath(dir)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read extracted MANIFEST.txt: %v", err)
+	}
+	if string(data) != manifestContent {
+		t.Errorf("MANIFEST.txt content mismatch: got %q", string(data))
+	}
+
+	// 验证 incoming/VERSION 存在
+	versionPath := filepath.Join(dir, IncomingDirName, "VERSION")
+	if _, err := os.Stat(versionPath); err != nil {
+		t.Errorf("VERSION not extracted: %v", err)
+	}
+}
+
+func TestExtractPendingBundle_DeletesPendingAndSHA256(t *testing.T) {
+	dir := t.TempDir()
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "stub"})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// pending + pending.sha256 应被删除（防止重复解压）
+	if _, err := os.Stat(filepath.Join(dir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after extract, got err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, PendingSHA256FileName)); !os.IsNotExist(err) {
+		t.Errorf("pending.sha256 should be deleted after extract, got err: %v", err)
+	}
+}
+
+func TestExtractPendingBundle_BadGzip(t *testing.T) {
+	dir := t.TempDir()
+	// 写入损坏数据（不是合法 tar.gz）
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), []byte("not a gzip"), 0o644); err != nil {
+		t.Fatalf("write bad pending: %v", err)
+	}
+
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error for bad gzip data")
+	}
+}
+
+func TestExtractPendingBundle_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	// 构造包含路径逃逸的 tar.gz
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	// 正常文件
+	tw.WriteHeader(&tar.Header{Name: "MANIFEST.txt", Mode: 0o644, Size: 4})
+	tw.Write([]byte("safe"))
+	// 恶意路径逃逸
+	tw.WriteHeader(&tar.Header{Name: "../escape.txt", Mode: 0o644, Size: 1})
+	tw.Write([]byte("X"))
+	tw.Close()
+	gz.Close()
+
+	if err := os.WriteFile(filepath.Join(dir, PendingFileName), buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "..", "escape.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("escape file should not exist on disk")
+	}
+}
+
+func TestExtractPendingBundle_NoPendingFile(t *testing.T) {
+	dir := t.TempDir()
+	err := ExtractPendingBundle(dir)
+	if err == nil {
+		t.Fatal("expected error when pending file does not exist")
+	}
+}
+
+func TestExtractPendingBundle_OverwritesOldIncoming(t *testing.T) {
+	dir := t.TempDir()
+	// 先放旧 incoming/ 残留
+	oldFile := filepath.Join(dir, IncomingDirName, "stale.txt")
+	os.MkdirAll(filepath.Dir(oldFile), 0o755)
+	os.WriteFile(oldFile, []byte("stale"), 0o644)
+
+	writePendingBundle(t, dir, map[string]string{"MANIFEST.txt": "fresh"})
+
+	if err := ExtractPendingBundle(dir); err != nil {
+		t.Fatalf("ExtractPendingBundle: %v", err)
+	}
+
+	// 旧文件应被清理
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Error("stale file in old incoming/ should be removed")
+	}
+}

--- a/internal/edgeagent/upgrademachine/health.go
+++ b/internal/edgeagent/upgrademachine/health.go
@@ -1,10 +1,7 @@
-// health.go 管理升级版本元数据文件 + 状态检测函数（ADR-033 U3，issue #23）。
-//
+// health.go 管理升级版本元数据文件 + 状态检测函数。
 // 所有文件名常量引用本包 ipc.go（单一真相源）。
-//
 // 健康判定：last_upgrade_ver == healthy_marker → 升级成功
 // rollback 触发：last_upgrade_ver 存在但 healthy_marker 不匹配 → 回滚
-//
 // AGENTS.md context.Context 例外：WriteUpgradeMeta / ClearPending / WriteRollbackDone
 // 操作本地文件系统（毫秒级），WriteUpgradeMeta 删 healthy_marker 是关键步骤
 // （不删 → watchdog 永不触发 rollback）。取消检查由编排层 Machine 入口完成。
@@ -43,7 +40,6 @@ func HasLastUpgrade(stageDir string) bool {
 
 // WriteUpgradeMeta 在 swap 完成后写入版本元数据，并删除旧 healthy_marker
 // 重新武装健康检查（对称 Linux apply_bundle 完成后 `rm -f "$HEALTHY_MARKER"`）。
-//
 // 删 healthy_marker 是关键步骤：如果不删，旧 marker 仍在 → IsUpgradeHealthy
 // 立刻返回 true → watchdog 永不触发 rollback。
 // 新 worker register_edge 成功后会写新的 healthy_marker。

--- a/internal/edgeagent/upgrademachine/health.go
+++ b/internal/edgeagent/upgrademachine/health.go
@@ -1,0 +1,112 @@
+// health.go 管理升级版本元数据文件 + 状态检测函数（ADR-033 U3，issue #23）。
+//
+// 所有文件名常量引用本包 ipc.go（单一真相源）。
+//
+// 健康判定：last_upgrade_ver == healthy_marker → 升级成功
+// rollback 触发：last_upgrade_ver 存在但 healthy_marker 不匹配 → 回滚
+//
+// AGENTS.md context.Context 例外：WriteUpgradeMeta / ClearPending / WriteRollbackDone
+// 操作本地文件系统（毫秒级），WriteUpgradeMeta 删 healthy_marker 是关键步骤
+// （不删 → watchdog 永不触发 rollback）。取消检查由编排层 Machine 入口完成。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// IsPending 检查是否有 pending upgrade（incoming/MANIFEST.txt 存在）。
+func IsPending(stageDir string) bool {
+	_, err := os.Stat(ManifestPath(stageDir))
+	return err == nil
+}
+
+// IsUpgradeHealthy 判断最近一次 upgrade 是否被确认为健康。
+// 条件：last_upgrade_ver 存在 AND healthy_marker 内容匹配。
+func IsUpgradeHealthy(stageDir string) bool {
+	lastVer := readTrimmed(LastUpgradeVerPath(stageDir))
+	if lastVer == "" {
+		return false // 从未升级过
+	}
+	healthyVer := readTrimmed(HealthyMarkerPath(stageDir))
+	return lastVer == healthyVer
+}
+
+// HasLastUpgrade 报告是否发生过至少一次 upgrade swap（last_upgrade_ver 存在）。
+// supervisor 启动时用此区分"从未升级"（无需 rollback）和"升级了但不健康"（需 rollback）。
+func HasLastUpgrade(stageDir string) bool {
+	return readTrimmed(LastUpgradeVerPath(stageDir)) != ""
+}
+
+// WriteUpgradeMeta 在 swap 完成后写入版本元数据，并删除旧 healthy_marker
+// 重新武装健康检查（对称 Linux apply_bundle 完成后 `rm -f "$HEALTHY_MARKER"`）。
+//
+// 删 healthy_marker 是关键步骤：如果不删，旧 marker 仍在 → IsUpgradeHealthy
+// 立刻返回 true → watchdog 永不触发 rollback。
+// 新 worker register_edge 成功后会写新的 healthy_marker。
+func WriteUpgradeMeta(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	// last_upgrade_ver
+	if err := os.WriteFile(LastUpgradeVerPath(stageDir), []byte(version+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write last_upgrade_ver: %w", err)
+	}
+	// last_upgrade_at（ISO8601 UTC）
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if err := os.WriteFile(LastUpgradeAtPath(stageDir), []byte(ts+"\n"), 0o640); err != nil {
+		return fmt.Errorf("write last_upgrade_at: %w", err)
+	}
+	// 删 healthy_marker（不存在时 Remove 报错，忽略 — 可能是首次升级）
+	markerPath := HealthyMarkerPath(stageDir)
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove old healthy_marker: %w", err)
+	}
+	return nil
+}
+
+// ReadStagedVersion 从 incoming/VERSION 读取版本号。
+// 文件不存在时返回空字符串（不报错 — 旧版 bundle 可能无 VERSION）。
+func ReadStagedVersion(stageDir string) (string, error) {
+	verPath := StagedVersionPath(stageDir)
+	if _, err := os.Stat(verPath); err != nil {
+		return "", nil // 不存在 = 无版本信息
+	}
+	return readTrimmed(verPath), nil
+}
+
+// ClearPending 删除 incoming/ 目录（bundle 已 apply 或 rollback 后清理）。
+func ClearPending(stageDir string) error {
+	incoming := IncomingDir(stageDir)
+	if err := os.RemoveAll(incoming); err != nil {
+		return fmt.Errorf("remove incoming/: %w", err)
+	}
+	return nil
+}
+
+// RollbackDoneExists 报告 rollback.done 哨兵文件是否存在。
+// superviseWorker 每轮启动前检查 → 存在则跳过 upgrade watch（避免死循环）。
+func RollbackDoneExists(stageDir string) bool {
+	_, err := os.Stat(RollbackDonePath(stageDir))
+	return err == nil
+}
+
+// WriteRollbackDone 写 rollback.done 哨兵文件。
+func WriteRollbackDone(stageDir string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	return os.WriteFile(RollbackDonePath(stageDir), []byte("done\n"), 0o640)
+}
+
+// readTrimmed 读取文件并 trim 空白。文件不存在或读失败时返回空字符串。
+func readTrimmed(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/edgeagent/upgrademachine/health_test.go
+++ b/internal/edgeagent/upgrademachine/health_test.go
@@ -1,0 +1,198 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsUpgradeHealthy_Match(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.50")
+
+	if !IsUpgradeHealthy(dir) {
+		t.Error("expected healthy when versions match")
+	}
+}
+
+func TestIsUpgradeHealthy_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.49")
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when versions mismatch")
+	}
+}
+
+func TestIsUpgradeHealthy_NoMarker(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.50")
+	// 不写 healthy_marker — 模拟新 worker 启动但未 register_edge
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when healthy_marker missing")
+	}
+}
+
+func TestIsUpgradeHealthy_NoMeta(t *testing.T) {
+	dir := t.TempDir()
+	// 两个文件都不存在 — 首次安装或未升级
+
+	if IsUpgradeHealthy(dir) {
+		t.Error("expected NOT healthy when no upgrade meta exists")
+	}
+}
+
+func TestWriteUpgradeMeta_WritesBoth(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteUpgradeMeta: %v", err)
+	}
+
+	ver, err := os.ReadFile(filepath.Join(dir, LastUpgradeVerFile))
+	if err != nil {
+		t.Fatalf("read last_upgrade_ver: %v", err)
+	}
+	if strings.TrimSpace(string(ver)) != "v0.7.50" {
+		t.Errorf("last_upgrade_ver = %q, want %q", ver, "v0.7.50")
+	}
+
+	at, err := os.ReadFile(filepath.Join(dir, LastUpgradeAtFile))
+	if err != nil {
+		t.Fatalf("read last_upgrade_at: %v", err)
+	}
+	if strings.TrimSpace(string(at)) == "" {
+		t.Error("last_upgrade_at should not be empty")
+	}
+}
+
+func TestWriteUpgradeMeta_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "upgrade")
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("should create nested dir: %v", err)
+	}
+}
+
+func TestWriteUpgradeMeta_DeletesOldHealthyMarker(t *testing.T) {
+	dir := t.TempDir()
+	// 先写一个旧 healthy_marker（模拟上次升级的标记）
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v0.7.49")
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v0.7.49")
+
+	// 执行新升级的 meta 写入
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("WriteUpgradeMeta: %v", err)
+	}
+
+	// healthy_marker 应被删除（重新武装健康检查）
+	if _, err := os.Stat(filepath.Join(dir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should be removed after WriteUpgradeMeta")
+	}
+
+	// 但 last_upgrade_ver 应更新为新版本
+	ver := readTrimmed(filepath.Join(dir, LastUpgradeVerFile))
+	if ver != "v0.7.50" {
+		t.Errorf("last_upgrade_ver = %q, want v0.7.50", ver)
+	}
+
+	// 新版本未写 healthy_marker → IsUpgradeHealthy 应返回 false
+	if IsUpgradeHealthy(dir) {
+		t.Error("should NOT be healthy — marker was deleted, new worker hasn't registered yet")
+	}
+}
+
+func TestWriteUpgradeMeta_NoOldMarker_NoError(t *testing.T) {
+	dir := t.TempDir()
+	// 首次升级，无旧 marker → Remove 报 IsNotExist，应被忽略
+	if err := WriteUpgradeMeta(dir, "v0.7.50"); err != nil {
+		t.Fatalf("should not error when no old marker: %v", err)
+	}
+}
+
+func TestIsPending_ManifestExists(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), "fake manifest")
+
+	if !IsPending(dir) {
+		t.Error("expected pending when MANIFEST.txt exists")
+	}
+}
+
+func TestIsPending_ManifestMissing(t *testing.T) {
+	dir := t.TempDir()
+	// incoming/ 不存在
+	if IsPending(dir) {
+		t.Error("expected NOT pending when MANIFEST.txt missing")
+	}
+}
+
+func TestClearPending_RemovesIncomingDir(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), "fake")
+	writeTestFile(t, filepath.Join(incoming, "worker.exe"), "binary")
+
+	if err := ClearPending(dir); err != nil {
+		t.Fatalf("ClearPending: %v", err)
+	}
+
+	if _, err := os.Stat(incoming); !os.IsNotExist(err) {
+		t.Error("incoming/ should be removed")
+	}
+}
+
+func TestClearPending_NoIncomingDir(t *testing.T) {
+	dir := t.TempDir()
+	// 不存在 incoming/ — 幂等，不报错
+	if err := ClearPending(dir); err != nil {
+		t.Fatalf("ClearPending on missing dir should not error: %v", err)
+	}
+}
+
+func TestReadStagedVersion(t *testing.T) {
+	dir := t.TempDir()
+	incoming := filepath.Join(dir, IncomingDirName)
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), "v0.7.50")
+
+	ver, err := ReadStagedVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadStagedVersion: %v", err)
+	}
+	if ver != "v0.7.50" {
+		t.Errorf("version = %q, want %q", ver, "v0.7.50")
+	}
+}
+
+func TestReadStagedVersion_NoVersionFile(t *testing.T) {
+	dir := t.TempDir()
+	// incoming/ 存在但无 VERSION 文件
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake")
+
+	ver, err := ReadStagedVersion(dir)
+	if err != nil {
+		t.Fatalf("should not error when VERSION missing: %v", err)
+	}
+	if ver != "" {
+		t.Errorf("version = %q, want empty", ver)
+	}
+}
+
+func TestRollbackDoneExists_Present(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+
+	if !RollbackDoneExists(dir) {
+		t.Error("expected rollback.done to exist")
+	}
+}
+
+func TestRollbackDoneExists_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if RollbackDoneExists(dir) {
+		t.Error("expected rollback.done to NOT exist")
+	}
+}

--- a/internal/edgeagent/upgrademachine/ipc.go
+++ b/internal/edgeagent/upgrademachine/ipc.go
@@ -1,0 +1,148 @@
+// ipc.go 定义升级状态机的所有文件系统 IPC 常量（单一真相源，issue #23）。
+//
+// 这些常量消除原先 upgradeapply / upgradebundle / cmd 三包各自的私有/导出定义 drift。
+// 任何包需要引用文件名时，import 本包的导出常量，而非重新定义。
+//
+// issue #21 supervisor 自升级 sentinel 常量也在此定义（保持单一真相源）。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StageDir 下的 IPC 文件名常量。
+const (
+	// HealthyMarkerFile 是 worker register_edge 成功后写的版本号文件名。
+	// supervisor 的 IsUpgradeHealthy 对比此文件内容与 last_upgrade_ver 判定升级是否健康。
+	HealthyMarkerFile = "healthy_marker"
+
+	// RollbackDoneFile 是 rollback 完成后的哨兵文件名。
+	// supervisor 检测到此文件 → 跳过 rollback 检查（避免死循环）。
+	// manager 推新 bundle 前必须删除此文件（upgradebundle.DeleteRollbackSentinel）。
+	RollbackDoneFile = "rollback.done"
+
+	// LastUpgradeVerFile 是 supervisor swap 后写的当前版本号文件名。
+	LastUpgradeVerFile = "last_upgrade_ver"
+
+	// LastUpgradeAtFile 是 supervisor swap 后写的 ISO8601 时间戳文件名。
+	LastUpgradeAtFile = "last_upgrade_at"
+
+	// IncomingDirName 是 StageDir 下存放解压 bundle 的子目录名。
+	IncomingDirName = "incoming"
+
+	// ManifestFileName 是 swap 指令清单文件名（也是 pending 触发器）。
+	ManifestFileName = "MANIFEST.txt"
+
+	// VersionFileName 是 bundle 内携带的版本号文件名。
+	VersionFileName = "VERSION"
+
+	// PreviousSuffix 是 .previous 备份文件的统一后缀。
+	PreviousSuffix = ".previous"
+
+	// SupervisorUpgradePendingFile 是 supervisor 自升级哨兵 — applyOne 检测到
+	// supervisor.exe dest 时写入此文件，跳过原子 rename（深模块不能 rename 运行中的自身）。
+	// Machine.BootCheck / superviseWorker 检测到此文件 → 触发 SupervisorSelfSwap。
+	SupervisorUpgradePendingFile = "supervisor_upgrade.pending"
+
+	// SupervisorUpgradeAppliedFile 是 supervisor 自升级完成哨兵 —
+	// SupervisorSelfSwap 成功后写入，BootCheck 检测到后清理 .old 备份 + 删此哨兵。
+	SupervisorUpgradeAppliedFile = "supervisor_upgrade.applied"
+)
+
+// 二进制文件名常量（对称 edgedirs.WorkerBinary，本包自包含以避免 cmd → edgedirs 反向依赖）。
+const (
+	// SupervisorBinaryName 是 supervisor.exe 文件名（MANIFEST dest 匹配键）。
+	SupervisorBinaryName = "ongrid-edge-supervisor.exe"
+
+	// WorkerBinaryName 是 worker.exe 文件名（BootCheck KillByImage 清理 orphan worker 用）。
+	WorkerBinaryName = "ongrid-edge-worker.exe"
+)
+
+// IncomingDir 返回 StageDir 下的 incoming/ 子目录路径。
+func IncomingDir(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName)
+}
+
+// ManifestPath 返回 incoming/MANIFEST.txt 的完整路径。
+func ManifestPath(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName, ManifestFileName)
+}
+
+// HealthyMarkerPath 返回 healthy_marker 的完整路径。
+func HealthyMarkerPath(stageDir string) string {
+	return filepath.Join(stageDir, HealthyMarkerFile)
+}
+
+// RollbackDonePath 返回 rollback.done 的完整路径。
+func RollbackDonePath(stageDir string) string {
+	return filepath.Join(stageDir, RollbackDoneFile)
+}
+
+// LastUpgradeVerPath 返回 last_upgrade_ver 的完整路径。
+func LastUpgradeVerPath(stageDir string) string {
+	return filepath.Join(stageDir, LastUpgradeVerFile)
+}
+
+// LastUpgradeAtPath 返回 last_upgrade_at 的完整路径。
+func LastUpgradeAtPath(stageDir string) string {
+	return filepath.Join(stageDir, LastUpgradeAtFile)
+}
+
+// StagedVersionPath 返回 incoming/VERSION 的完整路径。
+func StagedVersionPath(stageDir string) string {
+	return filepath.Join(stageDir, IncomingDirName, VersionFileName)
+}
+
+// SupervisorUpgradePendingPath 返回 supervisor_upgrade.pending 的完整路径。
+func SupervisorUpgradePendingPath(stageDir string) string {
+	return filepath.Join(stageDir, SupervisorUpgradePendingFile)
+}
+
+// SupervisorUpgradeAppliedPath 返回 supervisor_upgrade.applied 的完整路径。
+func SupervisorUpgradeAppliedPath(stageDir string) string {
+	return filepath.Join(stageDir, SupervisorUpgradeAppliedFile)
+}
+
+// IsSupervisorUpgradePending 报告是否存在 supervisor 自升级 pending 哨兵。
+// 存在 = applyOne 已 stage supervisor.exe.new，等待 SupervisorSelfSwap 执行 rename-aside。
+func IsSupervisorUpgradePending(stageDir string) bool {
+	_, err := os.Stat(SupervisorUpgradePendingPath(stageDir))
+	return err == nil
+}
+
+// WriteSupervisorUpgradePending 写 supervisor_upgrade.pending 哨兵。
+// applyOne 检测到 supervisor dest 时调用，内容是 supervisor.exe.new 的预期版本（可空）。
+func WriteSupervisorUpgradePending(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	body := version
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return os.WriteFile(SupervisorUpgradePendingPath(stageDir), []byte(body), 0o640)
+}
+
+// IsSupervisorUpgradeApplied 报告是否存在 supervisor 自升级 applied 哨兵。
+// 存在 = SupervisorSelfSwap 已完成 rename-aside，BootCheck 应清理 .old 并删此哨兵。
+func IsSupervisorUpgradeApplied(stageDir string) bool {
+	_, err := os.Stat(SupervisorUpgradeAppliedPath(stageDir))
+	return err == nil
+}
+
+// WriteSupervisorUpgradeApplied 写 supervisor_upgrade.applied 哨兵。
+// SupervisorSelfSwap 成功后调用，内容是新版本号（可空）。
+func WriteSupervisorUpgradeApplied(stageDir, version string) error {
+	if err := os.MkdirAll(stageDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir stage: %w", err)
+	}
+	body := version
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return os.WriteFile(SupervisorUpgradeAppliedPath(stageDir), []byte(body), 0o640)
+}

--- a/internal/edgeagent/upgrademachine/ipc.go
+++ b/internal/edgeagent/upgrademachine/ipc.go
@@ -1,9 +1,7 @@
-// ipc.go 定义升级状态机的所有文件系统 IPC 常量（单一真相源，issue #23）。
-//
+// ipc.go 定义升级状态机的所有文件系统 IPC 常量（单一真相源）。
 // 这些常量消除原先 upgradeapply / upgradebundle / cmd 三包各自的私有/导出定义 drift。
 // 任何包需要引用文件名时，import 本包的导出常量，而非重新定义。
-//
-// issue #21 supervisor 自升级 sentinel 常量也在此定义（保持单一真相源）。
+//  supervisor 自升级 sentinel 常量也在此定义（保持单一真相源）。
 
 package upgrademachine
 

--- a/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
@@ -1,0 +1,72 @@
+// ipc_supervisor_test.go 测试 issue #21 supervisor 自升级 sentinel helper。
+//
+// 覆盖 IsSupervisorUpgradePending / WriteSupervisorUpgradePending /
+// IsSupervisorUpgradeApplied / WriteSupervisorUpgradeApplied 四个 helper
+// + Path 函数。
+
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSupervisorUpgradeSentinels_RoundTrip(t *testing.T) {
+	stageDir := t.TempDir()
+
+	// 初始：两个哨兵都不存在
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 不应初始存在")
+	}
+	if IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 不应初始存在")
+	}
+
+	// 写 pending（含版本号）
+	if err := WriteSupervisorUpgradePending(stageDir, "v0.9.2"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending: %v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 写入后应存在")
+	}
+	got, _ := os.ReadFile(SupervisorUpgradePendingPath(stageDir))
+	if string(got) != "v0.9.2\n" {
+		t.Errorf("pending 内容 = %q, want %q", got, "v0.9.2\n")
+	}
+
+	// 写 applied（空版本号 — 允许）
+	if err := WriteSupervisorUpgradeApplied(stageDir, ""); err != nil {
+		t.Fatalf("WriteSupervisorUpgradeApplied: %v", err)
+	}
+	if !IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 写入后应存在")
+	}
+	got, _ = os.ReadFile(SupervisorUpgradeAppliedPath(stageDir))
+	if string(got) != "" {
+		t.Errorf("applied 空版本号应写空内容，got %q", got)
+	}
+}
+
+func TestSupervisorUpgradeSentinels_ParentDirMissing(t *testing.T) {
+	// stageDir 不存在时 Write 应自动 mkdir
+	stageDir := filepath.Join(t.TempDir(), "nested", "stage")
+	if err := WriteSupervisorUpgradePending(stageDir, "v1"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending 自动 mkdir 失败：%v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 写入后应存在")
+	}
+}
+
+func TestSupervisorUpgradeSentinels_NewlineIdempotent(t *testing.T) {
+	// 带现有 \n 的版本号不应被加双重换行
+	stageDir := t.TempDir()
+	if err := WriteSupervisorUpgradePending(stageDir, "v0.9.2\n"); err != nil {
+		t.Fatalf("WriteSupervisorUpgradePending: %v", err)
+	}
+	got, _ := os.ReadFile(SupervisorUpgradePendingPath(stageDir))
+	if string(got) != "v0.9.2\n" {
+		t.Errorf("idempotent newline = %q, want %q", got, "v0.9.2\n")
+	}
+}

--- a/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
+++ b/internal/edgeagent/upgrademachine/ipc_supervisor_test.go
@@ -1,5 +1,4 @@
-// ipc_supervisor_test.go 测试 issue #21 supervisor 自升级 sentinel helper。
-//
+// ipc_supervisor_test.go 测试  supervisor 自升级 sentinel helper。
 // 覆盖 IsSupervisorUpgradePending / WriteSupervisorUpgradePending /
 // IsSupervisorUpgradeApplied / WriteSupervisorUpgradeApplied 四个 helper
 // + Path 函数。

--- a/internal/edgeagent/upgrademachine/machine.go
+++ b/internal/edgeagent/upgrademachine/machine.go
@@ -1,0 +1,358 @@
+// machine.go 实现升级状态机深模块（issue #23）。
+//
+// Machine 将原先分散在 cmd/upgrade_windows.go 的编排逻辑（applyAndSwap、
+// maybeApplyOnBoot、maybeRollbackOnBoot、watchUpgradeHealth、rollbackAndMark、
+// checkPendingUpgrade）集中到一个类型中。
+//
+// supervisor 侧（cmd/）通过 NewMachine 创建实例，注入平台专属的 ProcessController，
+// 然后调用 4 个高层方法：BootCheck / Apply / HealthCheck / RollbackAndMark。
+//
+// 纯 Go（无 Windows 专属依赖），测试可在 Linux CI 跑。
+
+package upgrademachine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrApplied 是 sentinel error，CheckPending 返回它告诉 superviseWorker：
+// "bundle swap 已完成，跳过 restartDelay 立即重启 worker"。
+var ErrApplied = errors.New("upgrade applied; restart immediately")
+
+// ErrRolledBack 是 sentinel error，HealthCheck 返回它告诉 runWorkerOnce：
+// "upgrade 超时已 rollback，worker 应被 cancel，superviseWorker 下一轮跳过 watch"。
+var ErrRolledBack = errors.New("upgrade rolled back after timeout")
+
+// ProcessController 抽象进程终止操作，供跨平台 DI。
+//
+// Windows 生产实现用 taskkill；测试传 mock。
+type ProcessController interface {
+	// KillTree 终止 pid 及其所有子进程（taskkill /T /F /PID）。
+	// 进程已退出时应返回非 nil error（调用方忽略，幂等）。
+	KillTree(pid int) error
+
+	// KillByImage 按镜像名终止所有同名进程（taskkill /F /IM <name>）。
+	// 进程不存在时返回非 nil error（调用方忽略，幂等）。
+	KillByImage(name string) error
+}
+
+// Machine 是升级状态机深模块，封装 supervisor 侧的升级编排逻辑。
+//
+// 持有 stageDir（IPC 文件根）和 binDir（swap 目标目录），
+// 通过注入的 ProcessController 执行平台专属的进程终止。
+type Machine struct {
+	stageDir string
+	binDir   string
+	log      *slog.Logger
+	pc       ProcessController
+}
+
+// NewMachine 创建升级状态机实例。
+//
+// 参数：
+//   - stageDir: IPC 文件根目录（incoming/、last_upgrade_ver 等在此下）
+//   - binDir: swap 目标目录（worker.exe、.previous 文件在此下）
+//   - log: 结构化日志
+//   - pc: 平台专属进程控制器（nil 时跳过 kill 操作，仅用于 boot 无 worker 场景）
+func NewMachine(stageDir, binDir string, log *slog.Logger, pc ProcessController) *Machine {
+	return &Machine{
+		stageDir: stageDir,
+		binDir:   binDir,
+		log:      log,
+		pc:       pc,
+	}
+}
+
+// BootCheck 是 supervisor 启动时的 boot hook，合并原 maybeRollbackOnBoot + maybeApplyOnBoot
+// + issue #21 supervisor 自升级收尾 / brick 恢复 / self-swap 触发。
+//
+// 执行顺序（不可反转）：
+//  1. 检测上次升级是否健康 → 不健康则 RollbackAndMark
+//  2. 检测残留 pending upgrade → 有则 Apply（boot 时无 worker，不 kill）
+//  3. supervisor_upgrade.applied sentinel → 清理 .old 备份 + 删 sentinel（#21）
+//  4. brick recovery（supervisor.exe 缺失 + .old 存在）→ rename .old 恢复（#21）
+//  5. supervisor_upgrade.pending sentinel → KillByImage 清 orphan worker（W1）
+//     → SupervisorSelfSwap → 返回 ErrSupervisorRestartSoon 让 SCM 重启
+//
+// 返回最后遇到的错误（如有）。返回 ErrSupervisorRestartSoon 时调用方（service.go）
+// 应返回 (false, 1) 让 SCM 按 recovery action 重启（exitCode=0 不触发 restart）。
+func (m *Machine) BootCheck(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	var lastErr error
+
+	// 1. rollback.done sentinel → 上次已 rollback，跳过（避免死循环）
+	if RollbackDoneExists(m.stageDir) {
+		m.log.Info("upgrade: rollback.done sentinel present; skipping rollback check")
+	} else if HasLastUpgrade(m.stageDir) && !IsUpgradeHealthy(m.stageDir) {
+		// 上次升级不健康 → rollback
+		m.log.Warn("upgrade: last upgrade not confirmed healthy; rolling back")
+		if err := m.RollbackAndMark(); err != nil {
+			m.log.Error("upgrade: rollback on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	// 2. 残留 pending → apply（boot 时无 worker，PID 传 0）
+	// Windows 兼容：pending tar.gz 可能尚未解压（无 systemd ExecStartPre 对等机制），
+	// 与 CheckPending 对称处理（#21 dogfood code-review HIGH-1）。
+	if !IsPending(m.stageDir) && HasPendingBundle(m.stageDir) {
+		m.log.Info("upgrade: pending tar.gz detected on boot; extracting to incoming/")
+		if err := ExtractPendingBundle(m.stageDir); err != nil {
+			m.log.Error("upgrade: extract pending bundle on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+	if IsPending(m.stageDir) {
+		m.log.Info("upgrade: pending bundle detected on boot; applying")
+		if err := m.Apply(ctx, 0); err != nil {
+			m.log.Error("upgrade: apply on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	// 3. supervisor_upgrade.applied → 清理 .old 备份 + 删 sentinel（#21 自升级收尾）
+	if IsSupervisorUpgradeApplied(m.stageDir) {
+		m.log.Info("supervisor self-swap: applied sentinel detected; cleaning .old backup")
+		oldPath := filepath.Join(m.binDir, SupervisorBinaryName+".old")
+		if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+			m.log.Warn("supervisor self-swap: cleanup .old failed (non-fatal)", "err", err)
+		}
+		// best-effort 删 applied sentinel — 残留下次 BootCheck 会重复清理（幂等）
+		_ = os.Remove(SupervisorUpgradeAppliedPath(m.stageDir))
+	}
+
+	// 4. brick recovery: supervisor.exe 缺失 + .old 存在 → rename 恢复（#21 最后防线）
+	if m.isSupervisorBrickState() {
+		m.log.Warn("supervisor brick state: supervisor.exe missing + .old exists; restoring")
+		supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
+		oldPath := supervisorPath + ".old"
+		if err := renameWithAVRetry(oldPath, supervisorPath, m.log); err != nil {
+			m.log.Error("supervisor brick recovery: restore failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	// 5. supervisor self-swap: pending sentinel → KillByImage → SupervisorSelfSwap（#21 W1）
+	if IsSupervisorUpgradePending(m.stageDir) {
+		// W1: BootCheck 恢复路径可能存在 orphan worker，先清理（幂等）
+		if m.pc != nil {
+			m.log.Warn("supervisor self-swap on boot: killing orphan worker first",
+				"image", WorkerBinaryName)
+			if err := m.pc.KillByImage(WorkerBinaryName); err != nil {
+				m.log.Debug("KillByImage returned non-zero (process may not be running)",
+					"image", WorkerBinaryName, "err", err)
+			}
+		}
+		err := m.SupervisorSelfSwap()
+		if errors.Is(err, ErrSupervisorRestartSoon) {
+			return err // 让 service.go 触发 SCM restart
+		}
+		if err != nil {
+			m.log.Error("supervisor self-swap on boot failed", "err", err)
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+// isSupervisorBrickState 报告 supervisor brick 状态：supervisor.exe 缺失 + .old 存在。
+// 此状态发生在 SupervisorSelfSwap step 1 成功（supervisor.exe → .old）+ step 2 失败 +
+// W2 brick 兜底也失败 + SCM 重启后。BootCheck 步骤 4 尝试 rename .old 恢复。
+func (m *Machine) isSupervisorBrickState() bool {
+	supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
+	oldPath := supervisorPath + ".old"
+	_, supErr := os.Stat(supervisorPath)
+	_, oldErr := os.Stat(oldPath)
+	return os.IsNotExist(supErr) && oldErr == nil
+}
+
+// Apply 编排 bundle swap 的完整顺序（ADR-033 U3）：
+//  1. KillTree — 释放文件锁（worker 子进程可能持有 .exe 句柄）
+//  2. ParseManifest
+//  3. KillManifestExes — 杀孤儿子进程（windows_exporter 等）
+//  4. ApplyBundle — 原子 swap + .previous 备份
+//  5. WriteUpgradeMeta — 写版本元数据 + 删旧 healthy_marker
+//  6. ClearPending — 删 incoming/
+//
+// workerPID <= 0 时跳过 KillTree（boot 场景 worker 尚未启动）。
+//
+// ctx 遵循 AGENTS.md IO 函数约定；swap 操作不可中途取消（原子性要求），
+// ctx 仅用于启动前检查（boot hooks 调用方可在 swap 前取消）。
+func (m *Machine) Apply(ctx context.Context, workerPID int) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// 1. Kill worker tree（释放 .exe 文件锁）
+	if workerPID > 0 && m.pc != nil {
+		m.log.Info("upgrade: killing worker tree before swap", "pid", workerPID)
+		if err := m.pc.KillTree(workerPID); err != nil {
+			// 进程已退出时 taskkill 返回非零，忽略（幂等）
+			m.log.Warn("upgrade: KillTree returned error (process may have exited)",
+				"err", err)
+		}
+	}
+
+	// 2. Parse manifest
+	entries, err := ParseManifest(ManifestPath(m.stageDir))
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	// 3. Kill plugin processes by image name
+	m.KillManifestExes(entries)
+
+	// 4. Apply bundle (atomic swap + backup)
+	result, err := ApplyBundle(m.stageDir, IncomingDir(m.stageDir), entries)
+	if err != nil {
+		return fmt.Errorf("apply bundle: %w", err)
+	}
+	m.log.Info("upgrade: bundle applied",
+		"swapped", len(result.Swapped), "backed_up", len(result.BackedUp))
+
+	// 5. Write upgrade meta
+	ver, err := ReadStagedVersion(m.stageDir)
+	if err != nil {
+		return fmt.Errorf("read staged version: %w", err)
+	}
+	if err := WriteUpgradeMeta(m.stageDir, ver); err != nil {
+		return fmt.Errorf("write upgrade meta: %w", err)
+	}
+
+	// 6. Clear pending
+	if err := ClearPending(m.stageDir); err != nil {
+		return fmt.Errorf("clear pending: %w", err)
+	}
+
+	m.log.Info("upgrade: meta written + pending cleared", "version", ver)
+	return nil
+}
+
+// CheckPending 在 worker 退出后检查是否有 pending upgrade，有则 apply。
+//
+// 返回 ErrApplied 表示 swap 成功（调用方 superviseWorker 应跳过 restartDelay）。
+// 返回其他 error 表示 swap 失败（调用方按普通崩溃处理）。
+// 返回 nil 表示无 pending upgrade（调用方按普通崩溃重启）。
+//
+// Windows 兼容（#21 dogfood 2026-07-16）：worker agent_upgrade RPC 下载 bundle
+// 到 {stageDir}/pending（tar.gz），Linux 由 systemd ExecStartPre 脚本解压到
+// incoming/；Windows 无对等机制，这里自动检测 pending tar.gz 并解压。
+func (m *Machine) CheckPending(ctx context.Context, workerPID int) error {
+	if !IsPending(m.stageDir) {
+		// Windows: pending tar.gz 未解压 → 先解压到 incoming/
+		if !HasPendingBundle(m.stageDir) {
+			return nil
+		}
+		m.log.Info("upgrade: pending tar.gz detected; extracting to incoming/")
+		if err := ExtractPendingBundle(m.stageDir); err != nil {
+			m.log.Error("upgrade: extract pending bundle failed", "err", err)
+			return err
+		}
+		if !IsPending(m.stageDir) {
+			m.log.Error("upgrade: pending extracted but MANIFEST.txt missing")
+			return fmt.Errorf("extract pending: no MANIFEST.txt after extraction")
+		}
+	}
+	m.log.Info("upgrade: pending bundle detected after worker exit; applying swap")
+	if err := m.Apply(ctx, workerPID); err != nil {
+		m.log.Error("upgrade: Apply failed", "err", err)
+		return err
+	}
+	return ErrApplied
+}
+
+// HealthCheck 在新 worker 启动后监控 healthy_marker，确认升级成功。
+//
+// 此方法阻塞，直到以下之一发生：
+//   - IsUpgradeHealthy = true → CleanupPrevious → 返回 nil（成功）
+//   - timeout 到期 → RollbackAndMark → 返回 ErrRolledBack
+//   - workerCtx 取消（worker 提前退出或 supervisor 停止）→ 返回 workerCtx.Err()
+//
+// pollInterval 是轮询 IsUpgradeHealthy 的间隔（测试可传短值）。
+func (m *Machine) HealthCheck(ctx context.Context, timeout, pollInterval time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			m.log.Warn("upgrade: watch timeout; rolling back", "timeout", timeout)
+			_ = m.RollbackAndMark()
+			return ErrRolledBack
+		case <-ticker.C:
+			if IsUpgradeHealthy(m.stageDir) {
+				m.log.Info("upgrade: confirmed healthy; cleaning up .previous")
+				n, err := CleanupPrevious([]string{m.binDir})
+				if err != nil {
+					m.log.Error("upgrade: cleanup failed", "err", err)
+				} else {
+					m.log.Info("upgrade: cleaned up .previous files", "count", n)
+				}
+				return nil
+			}
+		}
+	}
+}
+
+// RollbackAndMark 执行 rollback 并写 rollback.done 哨兵。
+// 被 BootCheck（启动时不健康）和 HealthCheck（超时）共用。
+func (m *Machine) RollbackAndMark() error {
+	n, err := Rollback([]string{m.binDir})
+	if err != nil {
+		m.log.Error("upgrade: rollback failed", "err", err)
+		return err
+	}
+	m.log.Info("upgrade: rolled back files", "count", n)
+
+	if err := WriteRollbackDone(m.stageDir); err != nil {
+		m.log.Error("upgrade: failed to write rollback.done sentinel", "err", err)
+		// sentinel 写失败不阻断 — 下次启动可能再次 rollback（best-effort）
+	}
+	return nil
+}
+
+// KillManifestExes 遍历 MANIFEST 条目，对每个 .exe dest 用 KillByImage 杀进程。
+//
+// 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
+// orphaned（reparented to PID 1），KillTree 无法触达。
+// 这些孤儿进程持有 .exe 文件锁，导致 ApplyBundle 的 rename 失败。
+// 幂等：进程不存在时 KillByImage 返回非 nil，忽略。
+func (m *Machine) KillManifestExes(entries []ManifestEntry) {
+	if m.pc == nil {
+		return
+	}
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		name := filepath.Base(e.Dest)
+		if !strings.HasSuffix(name, ".exe") || seen[name] {
+			continue
+		}
+		// 跳过 supervisor 自己：supervisor binary 在 MANIFEST 里用于 rename-aside
+		// 自升级（#21），不能 kill 自己；SupervisorSelfSwap 在 superviseWorker
+		// 里单独处理。不跳过会导致 supervisor 自杀 → SCM restart 死循环。
+		if name == SupervisorBinaryName {
+			continue
+		}
+		seen[name] = true
+		m.log.Info("upgrade: killing plugin process by image name", "image", name)
+		if err := m.pc.KillByImage(name); err != nil {
+			m.log.Debug("upgrade: KillByImage returned non-zero (process may not be running)",
+				"image", name, "err", err)
+		}
+	}
+}

--- a/internal/edgeagent/upgrademachine/machine.go
+++ b/internal/edgeagent/upgrademachine/machine.go
@@ -1,12 +1,9 @@
-// machine.go 实现升级状态机深模块（issue #23）。
-//
+// machine.go 实现升级状态机深模块。
 // Machine 将原先分散在 cmd/upgrade_windows.go 的编排逻辑（applyAndSwap、
 // maybeApplyOnBoot、maybeRollbackOnBoot、watchUpgradeHealth、rollbackAndMark、
 // checkPendingUpgrade）集中到一个类型中。
-//
 // supervisor 侧（cmd/）通过 NewMachine 创建实例，注入平台专属的 ProcessController，
 // 然后调用 4 个高层方法：BootCheck / Apply / HealthCheck / RollbackAndMark。
-//
 // 纯 Go（无 Windows 专属依赖），测试可在 Linux CI 跑。
 
 package upgrademachine
@@ -31,7 +28,6 @@ var ErrApplied = errors.New("upgrade applied; restart immediately")
 var ErrRolledBack = errors.New("upgrade rolled back after timeout")
 
 // ProcessController 抽象进程终止操作，供跨平台 DI。
-//
 // Windows 生产实现用 taskkill；测试传 mock。
 type ProcessController interface {
 	// KillTree 终止 pid 及其所有子进程（taskkill /T /F /PID）。
@@ -44,7 +40,6 @@ type ProcessController interface {
 }
 
 // Machine 是升级状态机深模块，封装 supervisor 侧的升级编排逻辑。
-//
 // 持有 stageDir（IPC 文件根）和 binDir（swap 目标目录），
 // 通过注入的 ProcessController 执行平台专属的进程终止。
 type Machine struct {
@@ -55,7 +50,6 @@ type Machine struct {
 }
 
 // NewMachine 创建升级状态机实例。
-//
 // 参数：
 //   - stageDir: IPC 文件根目录（incoming/、last_upgrade_ver 等在此下）
 //   - binDir: swap 目标目录（worker.exe、.previous 文件在此下）
@@ -71,16 +65,14 @@ func NewMachine(stageDir, binDir string, log *slog.Logger, pc ProcessController)
 }
 
 // BootCheck 是 supervisor 启动时的 boot hook，合并原 maybeRollbackOnBoot + maybeApplyOnBoot
-// + issue #21 supervisor 自升级收尾 / brick 恢复 / self-swap 触发。
-//
+// +  supervisor 自升级收尾 / brick 恢复 / self-swap 触发。
 // 执行顺序（不可反转）：
 //  1. 检测上次升级是否健康 → 不健康则 RollbackAndMark
 //  2. 检测残留 pending upgrade → 有则 Apply（boot 时无 worker，不 kill）
-//  3. supervisor_upgrade.applied sentinel → 清理 .old 备份 + 删 sentinel（#21）
-//  4. brick recovery（supervisor.exe 缺失 + .old 存在）→ rename .old 恢复（#21）
-//  5. supervisor_upgrade.pending sentinel → KillByImage 清 orphan worker（W1）
+//  3. supervisor_upgrade.applied sentinel → 清理 .old 备份 + 删 sentinel
+//  4. brick recovery（supervisor.exe 缺失 + .old 存在）→ rename .old 恢复
+//  5. supervisor_upgrade.pending sentinel → KillByImage 清 orphan worker
 //     → SupervisorSelfSwap → 返回 ErrSupervisorRestartSoon 让 SCM 重启
-//
 // 返回最后遇到的错误（如有）。返回 ErrSupervisorRestartSoon 时调用方（service.go）
 // 应返回 (false, 1) 让 SCM 按 recovery action 重启（exitCode=0 不触发 restart）。
 func (m *Machine) BootCheck(ctx context.Context) error {
@@ -104,7 +96,7 @@ func (m *Machine) BootCheck(ctx context.Context) error {
 
 	// 2. 残留 pending → apply（boot 时无 worker，PID 传 0）
 	// Windows 兼容：pending tar.gz 可能尚未解压（无 systemd ExecStartPre 对等机制），
-	// 与 CheckPending 对称处理（#21 dogfood code-review HIGH-1）。
+	// 与 CheckPending 对称处理。
 	if !IsPending(m.stageDir) && HasPendingBundle(m.stageDir) {
 		m.log.Info("upgrade: pending tar.gz detected on boot; extracting to incoming/")
 		if err := ExtractPendingBundle(m.stageDir); err != nil {
@@ -120,7 +112,7 @@ func (m *Machine) BootCheck(ctx context.Context) error {
 		}
 	}
 
-	// 3. supervisor_upgrade.applied → 清理 .old 备份 + 删 sentinel（#21 自升级收尾）
+	// 3. supervisor_upgrade.applied → 清理 .old 备份 + 删 sentinel
 	if IsSupervisorUpgradeApplied(m.stageDir) {
 		m.log.Info("supervisor self-swap: applied sentinel detected; cleaning .old backup")
 		oldPath := filepath.Join(m.binDir, SupervisorBinaryName+".old")
@@ -131,7 +123,7 @@ func (m *Machine) BootCheck(ctx context.Context) error {
 		_ = os.Remove(SupervisorUpgradeAppliedPath(m.stageDir))
 	}
 
-	// 4. brick recovery: supervisor.exe 缺失 + .old 存在 → rename 恢复（#21 最后防线）
+	// 4. brick recovery: supervisor.exe 缺失 + .old 存在 → rename 恢复
 	if m.isSupervisorBrickState() {
 		m.log.Warn("supervisor brick state: supervisor.exe missing + .old exists; restoring")
 		supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
@@ -142,9 +134,9 @@ func (m *Machine) BootCheck(ctx context.Context) error {
 		}
 	}
 
-	// 5. supervisor self-swap: pending sentinel → KillByImage → SupervisorSelfSwap（#21 W1）
+	// 5. supervisor self-swap: pending sentinel → KillByImage → SupervisorSelfSwap
 	if IsSupervisorUpgradePending(m.stageDir) {
-		// W1: BootCheck 恢复路径可能存在 orphan worker，先清理（幂等）
+		// : BootCheck 恢复路径可能存在 orphan worker，先清理（幂等）
 		if m.pc != nil {
 			m.log.Warn("supervisor self-swap on boot: killing orphan worker first",
 				"image", WorkerBinaryName)
@@ -168,7 +160,7 @@ func (m *Machine) BootCheck(ctx context.Context) error {
 
 // isSupervisorBrickState 报告 supervisor brick 状态：supervisor.exe 缺失 + .old 存在。
 // 此状态发生在 SupervisorSelfSwap step 1 成功（supervisor.exe → .old）+ step 2 失败 +
-// W2 brick 兜底也失败 + SCM 重启后。BootCheck 步骤 4 尝试 rename .old 恢复。
+//  brick 兜底也失败 + SCM 重启后。BootCheck 步骤 4 尝试 rename .old 恢复。
 func (m *Machine) isSupervisorBrickState() bool {
 	supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
 	oldPath := supervisorPath + ".old"
@@ -177,16 +169,14 @@ func (m *Machine) isSupervisorBrickState() bool {
 	return os.IsNotExist(supErr) && oldErr == nil
 }
 
-// Apply 编排 bundle swap 的完整顺序（ADR-033 U3）：
+// Apply 编排 bundle swap 的完整顺序：
 //  1. KillTree — 释放文件锁（worker 子进程可能持有 .exe 句柄）
 //  2. ParseManifest
 //  3. KillManifestExes — 杀孤儿子进程（windows_exporter 等）
 //  4. ApplyBundle — 原子 swap + .previous 备份
 //  5. WriteUpgradeMeta — 写版本元数据 + 删旧 healthy_marker
 //  6. ClearPending — 删 incoming/
-//
 // workerPID <= 0 时跳过 KillTree（boot 场景 worker 尚未启动）。
-//
 // ctx 遵循 AGENTS.md IO 函数约定；swap 操作不可中途取消（原子性要求），
 // ctx 仅用于启动前检查（boot hooks 调用方可在 swap 前取消）。
 func (m *Machine) Apply(ctx context.Context, workerPID int) error {
@@ -240,12 +230,10 @@ func (m *Machine) Apply(ctx context.Context, workerPID int) error {
 }
 
 // CheckPending 在 worker 退出后检查是否有 pending upgrade，有则 apply。
-//
 // 返回 ErrApplied 表示 swap 成功（调用方 superviseWorker 应跳过 restartDelay）。
 // 返回其他 error 表示 swap 失败（调用方按普通崩溃处理）。
 // 返回 nil 表示无 pending upgrade（调用方按普通崩溃重启）。
-//
-// Windows 兼容（#21 dogfood 2026-07-16）：worker agent_upgrade RPC 下载 bundle
+// Windows 兼容：worker agent_upgrade RPC 下载 bundle
 // 到 {stageDir}/pending（tar.gz），Linux 由 systemd ExecStartPre 脚本解压到
 // incoming/；Windows 无对等机制，这里自动检测 pending tar.gz 并解压。
 func (m *Machine) CheckPending(ctx context.Context, workerPID int) error {
@@ -273,12 +261,10 @@ func (m *Machine) CheckPending(ctx context.Context, workerPID int) error {
 }
 
 // HealthCheck 在新 worker 启动后监控 healthy_marker，确认升级成功。
-//
 // 此方法阻塞，直到以下之一发生：
 //   - IsUpgradeHealthy = true → CleanupPrevious → 返回 nil（成功）
 //   - timeout 到期 → RollbackAndMark → 返回 ErrRolledBack
 //   - workerCtx 取消（worker 提前退出或 supervisor 停止）→ 返回 workerCtx.Err()
-//
 // pollInterval 是轮询 IsUpgradeHealthy 的间隔（测试可传短值）。
 func (m *Machine) HealthCheck(ctx context.Context, timeout, pollInterval time.Duration) error {
 	timer := time.NewTimer(timeout)
@@ -327,7 +313,6 @@ func (m *Machine) RollbackAndMark() error {
 }
 
 // KillManifestExes 遍历 MANIFEST 条目，对每个 .exe dest 用 KillByImage 杀进程。
-//
 // 解决场景：worker 干净退出后子进程（windows_exporter.exe 等）被
 // orphaned（reparented to PID 1），KillTree 无法触达。
 // 这些孤儿进程持有 .exe 文件锁，导致 ApplyBundle 的 rename 失败。
@@ -343,7 +328,7 @@ func (m *Machine) KillManifestExes(entries []ManifestEntry) {
 			continue
 		}
 		// 跳过 supervisor 自己：supervisor binary 在 MANIFEST 里用于 rename-aside
-		// 自升级（#21），不能 kill 自己；SupervisorSelfSwap 在 superviseWorker
+		// 自升级，不能 kill 自己；SupervisorSelfSwap 在 superviseWorker
 		// 里单独处理。不跳过会导致 supervisor 自杀 → SCM restart 死循环。
 		if name == SupervisorBinaryName {
 			continue

--- a/internal/edgeagent/upgrademachine/machine_test.go
+++ b/internal/edgeagent/upgrademachine/machine_test.go
@@ -1,0 +1,466 @@
+// machine_test.go 测试 Machine 深模块的编排逻辑（ADR-033 U3，issue #23）。
+//
+// 从 cmd/upgrade_windows_test.go 迁移，适配 Machine API：
+//   - applyAndSwap → Machine.Apply
+//   - maybeApplyOnBoot / maybeRollbackOnBoot → Machine.BootCheck
+//   - checkPendingUpgrade → Machine.CheckPending
+//   - watchUpgradeHealth → Machine.HealthCheck
+//   - rollbackAndMark → Machine.RollbackAndMark
+//
+// 纯 Go（无 Windows 专属依赖），在 Linux CI 可跑。
+
+package upgrademachine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- 测试辅助 ---
+
+// testLogger 返回一个日志级别设为 100（高于所有级别）的 Logger，
+// 实际效果是抑制所有日志输出。
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(100)}))
+}
+
+// mockProcessController 是 ProcessController 的测试 mock。
+type mockProcessController struct {
+	killTreeCalls   atomic.Int32
+	killTreeLastPID atomic.Int32
+	killImageCalls  atomic.Int32
+	killImageNames  []string
+	treeErr         error // 非 nil 时 KillTree 返回此 error
+}
+
+func (m *mockProcessController) KillTree(pid int) error {
+	m.killTreeCalls.Add(1)
+	m.killTreeLastPID.Store(int32(pid))
+	if m.treeErr != nil {
+		return m.treeErr
+	}
+	return nil
+}
+
+func (m *mockProcessController) KillByImage(name string) error {
+	m.killImageCalls.Add(1)
+	m.killImageNames = append(m.killImageNames, name)
+	return nil
+}
+
+// buildMachineBundle 创建完整 fake bundle：stageDir/incoming/ 下有 MANIFEST.txt
+// + src 文件 + VERSION。destDir 模拟部署目标（已有旧版本）。
+func buildMachineBundle(t *testing.T, stageDir, destDir, version string,
+	files []struct{ Src, Dest, Content string }) {
+
+	t.Helper()
+	incoming := filepath.Join(stageDir, IncomingDirName)
+
+	var lines []string
+	for _, f := range files {
+		sha := writeTestFile(t, filepath.Join(incoming, f.Src), f.Content)
+		lines = append(lines, sha+" 0755 "+f.Src+" "+filepath.Join(destDir, f.Dest))
+	}
+	// MANIFEST.txt
+	manifestContent := strings.Join(lines, "\n") + "\n"
+	writeTestFile(t, filepath.Join(incoming, ManifestFileName), manifestContent)
+	// VERSION
+	writeTestFile(t, filepath.Join(incoming, VersionFileName), version)
+}
+
+// --- Machine.Apply ---
+
+func TestMachine_Apply_KillCalledWhenPIDPositive(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new"},
+	})
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, destDir, testLogger(), &pc)
+	if err := m.Apply(context.Background(), 12345); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+	if pc.killTreeCalls.Load() != 1 {
+		t.Errorf("KillTree called %d times, want 1", pc.killTreeCalls.Load())
+	}
+	if pc.killTreeLastPID.Load() != 12345 {
+		t.Errorf("KillTree called with pid=%d, want 12345", pc.killTreeLastPID.Load())
+	}
+}
+
+func TestMachine_Apply_KillSkippedWhenPIDZero(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new"},
+	})
+
+	var pc mockProcessController
+	m := NewMachine(stageDir, destDir, testLogger(), &pc)
+	// PID=0 → 应跳过 kill
+	if err := m.Apply(context.Background(), 0); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+	if pc.killTreeCalls.Load() != 0 {
+		t.Errorf("KillTree should NOT be called when PID=0")
+	}
+}
+
+// TestKillManifestExes_SkipsSupervisorBinary 验证 KillManifestExes 不 kill
+// supervisor 自己。MANIFEST 包含 supervisor.exe 用于 rename-aside 自升级（#21），
+// 但 kill supervisor 进程会导致 SCM restart 死循环。
+// dogfood 2026-07-16 发现此 bug。
+func TestKillManifestExes_SkipsSupervisorBinary(t *testing.T) {
+	entries := []ManifestEntry{
+		{Dest: `C:\bin\` + WorkerBinaryName},
+		{Dest: `C:\bin\windows_exporter.exe`},
+		{Dest: `C:\bin\` + SupervisorBinaryName},
+	}
+	var pc mockProcessController
+	m := NewMachine(t.TempDir(), t.TempDir(), testLogger(), &pc)
+
+	m.KillManifestExes(entries)
+
+	if len(pc.killImageNames) != 2 {
+		t.Fatalf("KillByImage should be called 2 times (worker + exporter), got %d: %v",
+			len(pc.killImageNames), pc.killImageNames)
+	}
+	for _, name := range pc.killImageNames {
+		if name == SupervisorBinaryName {
+			t.Errorf("KillByImage must NOT be called for %q (supervisor self-kill)", SupervisorBinaryName)
+		}
+	}
+}
+
+func TestMachine_Apply_KillErrorIgnored(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new"},
+	})
+
+	pc := &mockProcessController{treeErr: errors.New("ERROR: not found")}
+	m := NewMachine(stageDir, destDir, testLogger(), pc)
+	// KillTree 报错但 Apply 应继续（幂等语义）
+	if err := m.Apply(context.Background(), 12345); err != nil {
+		t.Fatalf("Machine.Apply should ignore kill error: %v", err)
+	}
+}
+
+func TestMachine_Apply_FullOrdering(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old-worker")
+	writeTestFile(t, filepath.Join(destDir, "exporter.exe"), "old-exporter")
+	buildMachineBundle(t, stageDir, destDir, "v2.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new-worker"},
+		{"exporter.exe", "exporter.exe", "new-exporter"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), nil)
+	if err := m.Apply(context.Background(), 0); err != nil {
+		t.Fatalf("Machine.Apply: %v", err)
+	}
+
+	// 验证 swap：dest 内容是新版本
+	got, _ := os.ReadFile(filepath.Join(destDir, "worker.exe"))
+	if string(got) != "new-worker" {
+		t.Errorf("worker.exe = %q, want %q", got, "new-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(destDir, "exporter.exe"))
+	if string(got) != "new-exporter" {
+		t.Errorf("exporter.exe = %q, want %q", got, "new-exporter")
+	}
+
+	// 验证 .previous 备份存在（旧版本）
+	got, _ = os.ReadFile(filepath.Join(destDir, "worker.exe.previous"))
+	if string(got) != "old-worker" {
+		t.Errorf("worker.exe.previous = %q, want %q", got, "old-worker")
+	}
+
+	// 验证 incoming/ 已删除
+	if _, err := os.Stat(filepath.Join(stageDir, IncomingDirName)); !os.IsNotExist(err) {
+		t.Error("incoming/ should be removed after Apply")
+	}
+
+	// 验证 last_upgrade_ver 已写
+	ver, _ := os.ReadFile(filepath.Join(stageDir, LastUpgradeVerFile))
+	if string(ver)[:len("v2.0.0")] != "v2.0.0" {
+		t.Errorf("last_upgrade_ver = %q, want v2.0.0", ver)
+	}
+
+	// 验证 healthy_marker 已删（重新武装 watchdog）
+	if _, err := os.Stat(filepath.Join(stageDir, HealthyMarkerFile)); !os.IsNotExist(err) {
+		t.Error("healthy_marker should be removed after Apply")
+	}
+}
+
+func TestMachine_Apply_BadManifest(t *testing.T) {
+	stageDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, IncomingDirName, ManifestFileName), "bad line")
+
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	err := m.Apply(context.Background(), 0)
+	if err == nil {
+		t.Fatal("expected error for malformed manifest")
+	}
+}
+
+// --- Machine.BootCheck ---
+
+func TestMachine_BootCheck_NoPending(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when no pending: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_PendingApplied(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+	if IsPending(stageDir) {
+		t.Error("pending should be cleared after boot apply")
+	}
+}
+
+func TestMachine_BootCheck_NeverUpgraded(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when never upgraded: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_Healthy(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when healthy: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_UnhealthyRollsBack(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe"), "new-broken")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe.previous"), "old-good")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("BootCheck: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(binDir, "worker.exe"))
+	if string(got) != "old-good" {
+		t.Errorf("worker.exe = %q, want %q (rolled back)", got, "old-good")
+	}
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); err != nil {
+		t.Errorf("rollback.done sentinel should exist: %v", err)
+	}
+}
+
+func TestMachine_BootCheck_RollbackDoneSkips(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	writeTestFile(t, filepath.Join(stageDir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe"), "new-broken")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe.previous"), "old-good")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.BootCheck(context.Background()); err != nil {
+		t.Fatalf("should be no-op when rollback.done present: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(binDir, "worker.exe"))
+	if string(got) != "new-broken" {
+		t.Errorf("worker.exe = %q, should remain unchanged", got)
+	}
+}
+
+// --- Machine.CheckPending ---
+
+// TestMachine_BootCheck_ExtractsPendingBundle 验证 BootCheck 在 incoming/ 为空但
+// pending tar.gz 存在时自动解压再 apply（#21 code-review HIGH-1 回归防护）。
+func TestMachine_BootCheck_ExtractsPendingBundle(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	// 写 pending tar.gz（不含 incoming/，模拟 Windows 无 ExecStartPre 的场景）
+	h := sha256.Sum256([]byte("new"))
+	sha := hex.EncodeToString(h[:])
+	manifestContent := sha + " 0755 worker.exe " + filepath.Join(destDir, "worker.exe") + "\n"
+	writePendingBundle(t, stageDir, map[string]string{
+		"MANIFEST.txt": manifestContent,
+		"VERSION":      "v9.9.9",
+		"worker.exe":   "new",
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	_ = m.BootCheck(context.Background())
+
+	// pending tar.gz 应被删除（解压后清理）
+	if _, err := os.Stat(filepath.Join(stageDir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after BootCheck extraction, got err: %v", err)
+	}
+	// worker.exe 应被更新（apply 成功）
+	data, err := os.ReadFile(filepath.Join(destDir, "worker.exe"))
+	if err != nil {
+		t.Fatalf("read worker.exe after BootCheck: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("worker.exe not updated after BootCheck pending extraction, got %q", string(data))
+	}
+}
+
+// TestMachine_CheckPending_ExtractsPendingBundle 验证 CheckPending 在 incoming/ 为空但
+// pending tar.gz 存在时自动解压再 apply（#21 dogfood P3 回归防护）。
+func TestMachine_CheckPending_ExtractsPendingBundle(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	h := sha256.Sum256([]byte("new"))
+	sha := hex.EncodeToString(h[:])
+	manifestContent := sha + " 0755 worker.exe " + filepath.Join(destDir, "worker.exe") + "\n"
+	writePendingBundle(t, stageDir, map[string]string{
+		"MANIFEST.txt": manifestContent,
+		"VERSION":      "v9.9.9",
+		"worker.exe":   "new",
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	err := m.CheckPending(context.Background(), 123)
+	if !errors.Is(err, ErrApplied) {
+		t.Errorf("expected ErrApplied after pending extraction, got %v", err)
+	}
+	// pending tar.gz 应被删除
+	if _, err := os.Stat(filepath.Join(stageDir, PendingFileName)); !os.IsNotExist(err) {
+		t.Errorf("pending should be deleted after CheckPending extraction, got err: %v", err)
+	}
+}
+
+func TestMachine_CheckPending_NoPending(t *testing.T) {
+	stageDir := t.TempDir()
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), &mockProcessController{})
+	if err := m.CheckPending(context.Background(), 123); err != nil {
+		t.Fatalf("should return nil when no pending: %v", err)
+	}
+}
+
+func TestMachine_CheckPending_PendingReturnsSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	destDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(destDir, "worker.exe"), "old")
+	buildMachineBundle(t, stageDir, destDir, "v1.0.0", []struct{ Src, Dest, Content string }{
+		{"worker.exe", "worker.exe", "new"},
+	})
+
+	m := NewMachine(stageDir, destDir, testLogger(), &mockProcessController{})
+	err := m.CheckPending(context.Background(), 123)
+	if !errors.Is(err, ErrApplied) {
+		t.Errorf("expected ErrApplied, got %v", err)
+	}
+}
+
+// --- Machine.HealthCheck ---
+
+func TestMachine_HealthCheck_HealthyCleanup(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe.previous"), "old")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 短 timeout（2s）+ 短 poll（50ms）确保轮询先于 timeout 发现健康状态
+	err := m.HealthCheck(ctx, 2*time.Second, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected nil (healthy), got %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(binDir, "worker.exe.previous")); !os.IsNotExist(err) {
+		t.Error(".previous should be cleaned up after healthy confirmation")
+	}
+}
+
+func TestMachine_HealthCheck_TimeoutRollback(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe"), "new-broken")
+	writeTestFile(t, filepath.Join(binDir, "worker.exe.previous"), "old-good")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	// 极短 timeout（800ms）触发 rollback
+	err := m.HealthCheck(ctx, 800*time.Millisecond, 50*time.Millisecond)
+	if !errors.Is(err, ErrRolledBack) {
+		t.Errorf("expected ErrRolledBack, got %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(binDir, "worker.exe"))
+	if string(got) != "old-good" {
+		t.Errorf("worker.exe = %q, want %q (rolled back)", got, "old-good")
+	}
+	if _, err := os.Stat(filepath.Join(stageDir, RollbackDoneFile)); err != nil {
+		t.Errorf("rollback.done sentinel should exist: %v", err)
+	}
+}
+
+func TestMachine_HealthCheck_ContextCancelled(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	writeTestFile(t, filepath.Join(stageDir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(stageDir, HealthyMarkerFile), "v1.0.0")
+
+	cancel()
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.HealthCheck(ctx, 10*time.Second, 50*time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/edgeagent/upgrademachine/machine_test.go
+++ b/internal/edgeagent/upgrademachine/machine_test.go
@@ -1,12 +1,10 @@
-// machine_test.go 测试 Machine 深模块的编排逻辑（ADR-033 U3，issue #23）。
-//
+// machine_test.go 测试 Machine 深模块的编排逻辑。
 // 从 cmd/upgrade_windows_test.go 迁移，适配 Machine API：
 //   - applyAndSwap → Machine.Apply
 //   - maybeApplyOnBoot / maybeRollbackOnBoot → Machine.BootCheck
 //   - checkPendingUpgrade → Machine.CheckPending
 //   - watchUpgradeHealth → Machine.HealthCheck
 //   - rollbackAndMark → Machine.RollbackAndMark
-//
 // 纯 Go（无 Windows 专属依赖），在 Linux CI 可跑。
 
 package upgrademachine
@@ -120,9 +118,9 @@ func TestMachine_Apply_KillSkippedWhenPIDZero(t *testing.T) {
 }
 
 // TestKillManifestExes_SkipsSupervisorBinary 验证 KillManifestExes 不 kill
-// supervisor 自己。MANIFEST 包含 supervisor.exe 用于 rename-aside 自升级（#21），
+// supervisor 自己。MANIFEST 包含 supervisor.exe 用于 rename-aside 自升级，
 // 但 kill supervisor 进程会导致 SCM restart 死循环。
-// dogfood 2026-07-16 发现此 bug。
+//  2026-07-16 发现此 bug。
 func TestKillManifestExes_SkipsSupervisorBinary(t *testing.T) {
 	entries := []ManifestEntry{
 		{Dest: `C:\bin\` + WorkerBinaryName},
@@ -314,7 +312,7 @@ func TestMachine_BootCheck_RollbackDoneSkips(t *testing.T) {
 // --- Machine.CheckPending ---
 
 // TestMachine_BootCheck_ExtractsPendingBundle 验证 BootCheck 在 incoming/ 为空但
-// pending tar.gz 存在时自动解压再 apply（#21 code-review HIGH-1 回归防护）。
+// pending tar.gz 存在时自动解压再 apply。
 func TestMachine_BootCheck_ExtractsPendingBundle(t *testing.T) {
 	stageDir := t.TempDir()
 	destDir := t.TempDir()
@@ -348,7 +346,7 @@ func TestMachine_BootCheck_ExtractsPendingBundle(t *testing.T) {
 }
 
 // TestMachine_CheckPending_ExtractsPendingBundle 验证 CheckPending 在 incoming/ 为空但
-// pending tar.gz 存在时自动解压再 apply（#21 dogfood P3 回归防护）。
+// pending tar.gz 存在时自动解压再 apply。
 func TestMachine_CheckPending_ExtractsPendingBundle(t *testing.T) {
 	stageDir := t.TempDir()
 	destDir := t.TempDir()

--- a/internal/edgeagent/upgrademachine/manifest.go
+++ b/internal/edgeagent/upgrademachine/manifest.go
@@ -1,5 +1,4 @@
-// manifest.go 实现 MANIFEST.txt 的解析 + per-file sha256 验证（issue #23）。
-//
+// manifest.go 实现 MANIFEST.txt 的解析 + per-file sha256 验证。
 // 从 upgradeapply/manifest.go 移入，消除 upgradeapply 和 upgradebundle 的重复解析。
 // upgradebundle/download.go 原有的 verifyManifest + fileSHA256 已删除，
 // 改用本包的 ParseManifest + VerifyAll。
@@ -18,7 +17,6 @@ import (
 )
 
 // ManifestEntry 是 MANIFEST.txt 中一行的结构化表示。
-//
 // 格式：`<sha256> <mode> <src> <dest>`
 //   - SHA256：src 文件的预期 sha256（小写 hex，64 字符）
 //   - Mode：文件权限（如 "0755"），apply 时设到新文件

--- a/internal/edgeagent/upgrademachine/manifest.go
+++ b/internal/edgeagent/upgrademachine/manifest.go
@@ -1,0 +1,110 @@
+// manifest.go 实现 MANIFEST.txt 的解析 + per-file sha256 验证（issue #23）。
+//
+// 从 upgradeapply/manifest.go 移入，消除 upgradeapply 和 upgradebundle 的重复解析。
+// upgradebundle/download.go 原有的 verifyManifest + fileSHA256 已删除，
+// 改用本包的 ParseManifest + VerifyAll。
+
+package upgrademachine
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ManifestEntry 是 MANIFEST.txt 中一行的结构化表示。
+//
+// 格式：`<sha256> <mode> <src> <dest>`
+//   - SHA256：src 文件的预期 sha256（小写 hex，64 字符）
+//   - Mode：文件权限（如 "0755"），apply 时设到新文件
+//   - Src：incoming/ 目录内的相对路径
+//   - Dest：swap 目标绝对路径
+type ManifestEntry struct {
+	SHA256 string
+	Mode   string
+	Src    string
+	Dest   string
+}
+
+// ParseManifest 读取并解析 MANIFEST.txt。
+// 跳过空行和 # 开头的注释行。字段少于 4 个的行视为格式错误。
+// 返回零条目时报错（空 manifest = 打包错误）。
+func ParseManifest(path string) ([]ManifestEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open manifest %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var entries []ManifestEntry
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// dest 可能含空格（Windows: C:\Program Files\...），
+		// sha/mode/src 不含空格，所以前 3 个字段严格分割，
+		// 第 4 个字段起合并为 dest 路径。
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("malformed manifest line: %q", line)
+		}
+		entries = append(entries, ManifestEntry{
+			SHA256: fields[0],
+			Mode:   fields[1],
+			Src:    fields[2],
+			Dest:   strings.Join(fields[3:], " "),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan manifest: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("manifest declared zero files")
+	}
+	return entries, nil
+}
+
+// VerifyEntry 检查 incomingDir/<Src> 的 sha256 是否与 entry.SHA256 匹配。
+func VerifyEntry(incomingDir string, entry ManifestEntry) error {
+	srcPath := filepath.Join(incomingDir, entry.Src)
+	got, err := fileSHA256(srcPath)
+	if err != nil {
+		return fmt.Errorf("sha %s: %w", entry.Src, err)
+	}
+	if !strings.EqualFold(got, entry.SHA256) {
+		return fmt.Errorf("sha mismatch for %s (got %s want %s)", entry.Src, got, entry.SHA256)
+	}
+	return nil
+}
+
+// VerifyAll 验证所有条目。遇到第一个错误即返回（all-or-nothing 语义）。
+func VerifyAll(incomingDir string, entries []ManifestEntry) error {
+	for _, e := range entries {
+		if err := VerifyEntry(incomingDir, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fileSHA256 计算文件 sha256 并返回小写 hex。
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/edgeagent/upgrademachine/manifest_test.go
+++ b/internal/edgeagent/upgrademachine/manifest_test.go
@@ -1,0 +1,218 @@
+package upgrademachine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestFile 创建一个文件，内容为 content，返回其 sha256。
+func writeTestFile(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])
+}
+
+// writeManifest 写一个 MANIFEST.txt（每行 `<sha> <mode> <src> <dest>`）。
+func writeManifest(t *testing.T, path string, lines []string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write manifest %s: %v", path, err)
+	}
+}
+
+func TestParseManifest_ValidSingleEntry(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890ab 0755 bin/worker.exe /usr/local/bin/worker",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.SHA256 != "abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890ab" {
+		t.Errorf("SHA256 = %q", e.SHA256)
+	}
+	if e.Mode != "0755" {
+		t.Errorf("Mode = %q", e.Mode)
+	}
+	if e.Src != "bin/worker.exe" {
+		t.Errorf("Src = %q", e.Src)
+	}
+	if e.Dest != "/usr/local/bin/worker" {
+		t.Errorf("Dest = %q", e.Dest)
+	}
+}
+
+func TestParseManifest_MultipleEntriesWithComments(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"# ongrid-edge bundle v0.7.50",
+		"",
+		"aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222 0755 worker.exe C:\\bin\\worker.exe",
+		"# plugin section",
+		"bbbb3333cccc4444dddd5555eeee6666ffff7777aaaa8888bbbb3333cccc4444 0644 exporter.exe C:\\bin\\exporter.exe",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (skip comment + blank), got %d", len(entries))
+	}
+	if entries[0].Src != "worker.exe" {
+		t.Errorf("entries[0].Src = %q", entries[0].Src)
+	}
+	if entries[1].Src != "exporter.exe" {
+		t.Errorf("entries[1].Src = %q", entries[1].Src)
+	}
+}
+
+func TestParseManifest_MalformedLine(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"abc 0755 only_three_fields",
+	})
+
+	_, err := ParseManifest(manPath)
+	if err == nil {
+		t.Fatal("expected error for malformed line, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error should mention malformed, got: %v", err)
+	}
+}
+
+func TestParseManifest_EmptyManifest(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"# only comments",
+		"",
+		"   ",
+	})
+
+	_, err := ParseManifest(manPath)
+	if err == nil {
+		t.Fatal("expected error for zero-file manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "zero") {
+		t.Errorf("error should mention zero files, got: %v", err)
+	}
+}
+
+func TestParseManifest_DestWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	manPath := filepath.Join(dir, "MANIFEST.txt")
+	writeManifest(t, manPath, []string{
+		"aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222 0755 worker.exe C:\\Program Files\\ongrid-edge\\bin\\worker.exe",
+		"bbbb3333cccc4444dddd5555eeee6666ffff7777aaaa8888bbbb3333cccc4444 0755 exporter.exe C:\\Program Files\\ongrid-edge\\bin\\exporter.exe",
+	})
+
+	entries, err := ParseManifest(manPath)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	want0 := `C:\Program Files\ongrid-edge\bin\worker.exe`
+	if entries[0].Dest != want0 {
+		t.Errorf("entries[0].Dest = %q, want %q", entries[0].Dest, want0)
+	}
+	want1 := `C:\Program Files\ongrid-edge\bin\exporter.exe`
+	if entries[1].Dest != want1 {
+		t.Errorf("entries[1].Dest = %q, want %q", entries[1].Dest, want1)
+	}
+}
+
+func TestParseManifest_FileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ParseManifest(filepath.Join(dir, "nonexistent.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestVerifyEntry_SHA_MATCH(t *testing.T) {
+	dir := t.TempDir()
+	content := "fake binary content"
+	srcPath := filepath.Join(dir, "worker.exe")
+	realSHA := writeTestFile(t, srcPath, content)
+
+	entry := ManifestEntry{SHA256: realSHA, Src: "worker.exe"}
+	if err := VerifyEntry(dir, entry); err != nil {
+		t.Fatalf("VerifyEntry should pass for matching SHA: %v", err)
+	}
+}
+
+func TestVerifyEntry_SHA_MISMATCH(t *testing.T) {
+	dir := t.TempDir()
+	content := "fake binary content"
+	writeTestFile(t, filepath.Join(dir, "worker.exe"), content)
+
+	entry := ManifestEntry{SHA256: "0000000000000000000000000000000000000000000000000000000000000000", Src: "worker.exe"}
+	err := VerifyEntry(dir, entry)
+	if err == nil {
+		t.Fatal("expected error for SHA mismatch")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch, got: %v", err)
+	}
+}
+
+func TestVerifyEntry_SRC_MISSING(t *testing.T) {
+	dir := t.TempDir()
+	entry := ManifestEntry{SHA256: "abc", Src: "nonexistent.exe"}
+	err := VerifyEntry(dir, entry)
+	if err == nil {
+		t.Fatal("expected error for missing src file")
+	}
+}
+
+func TestVerifyAll_AllMatch(t *testing.T) {
+	incoming := t.TempDir()
+	sha1 := writeTestFile(t, filepath.Join(incoming, "a.exe"), "content-a")
+	sha2 := writeTestFile(t, filepath.Join(incoming, "b.exe"), "content-b")
+
+	entries := []ManifestEntry{
+		{SHA256: sha1, Src: "a.exe"},
+		{SHA256: sha2, Src: "b.exe"},
+	}
+	if err := VerifyAll(incoming, entries); err != nil {
+		t.Fatalf("VerifyAll should pass: %v", err)
+	}
+}
+
+func TestVerifyAll_OneFails(t *testing.T) {
+	incoming := t.TempDir()
+	sha1 := writeTestFile(t, filepath.Join(incoming, "a.exe"), "content-a")
+	writeTestFile(t, filepath.Join(incoming, "b.exe"), "content-b")
+
+	entries := []ManifestEntry{
+		{SHA256: sha1, Src: "a.exe"},
+		{SHA256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", Src: "b.exe"},
+	}
+	err := VerifyAll(incoming, entries)
+	if err == nil {
+		t.Fatal("expected error for one mismatch")
+	}
+}

--- a/internal/edgeagent/upgrademachine/rename_other.go
+++ b/internal/edgeagent/upgrademachine/rename_other.go
@@ -1,0 +1,22 @@
+// rename_other.go 提供 renameWithAVRetry 的非 Windows stub（issue #21 W3）。
+//
+// Linux 上 bundle swap 无 AV 干扰（对称 dist/build-edge-bundle.sh Linux 版本），
+// isAVRetryable 永远 false，renameWithAVRetry 等价于单次 os.Rename。
+// 这让 machine.go 的 SupervisorSelfSwap 逻辑在 Linux CI 可测试（正常路径）。
+
+//go:build !windows
+
+package upgrademachine
+
+import (
+	"log/slog"
+	"os"
+)
+
+// isAVRetryable 非 Windows 永远 false（无 AV 干扰）。
+func isAVRetryable(err error) bool { return false }
+
+// renameWithAVRetry 非 Windows 等价于单次 os.Rename（无 AV retry 需求）。
+func renameWithAVRetry(src, dst string, log *slog.Logger) error {
+	return os.Rename(src, dst)
+}

--- a/internal/edgeagent/upgrademachine/rename_other.go
+++ b/internal/edgeagent/upgrademachine/rename_other.go
@@ -1,5 +1,4 @@
-// rename_other.go 提供 renameWithAVRetry 的非 Windows stub（issue #21 W3）。
-//
+// rename_other.go 提供 renameWithAVRetry 的非 Windows stub。
 // Linux 上 bundle swap 无 AV 干扰（对称 dist/build-edge-bundle.sh Linux 版本），
 // isAVRetryable 永远 false，renameWithAVRetry 等价于单次 os.Rename。
 // 这让 machine.go 的 SupervisorSelfSwap 逻辑在 Linux CI 可测试（正常路径）。

--- a/internal/edgeagent/upgrademachine/rename_windows.go
+++ b/internal/edgeagent/upgrademachine/rename_windows.go
@@ -1,5 +1,4 @@
-// rename_windows.go 实现 renameWithAVRetry 的 Windows 专属逻辑（issue #21 W3）。
-//
+// rename_windows.go 实现 renameWithAVRetry 的 Windows 专属逻辑。
 // Windows Defender / 第三方 AV 实时扫描未签名 PE 文件时持 FILE_SHARE_READ
 // 句柄，期间 os.Rename 失败（ERROR_SHARING_VIOLATION = errno 0x20）。
 // renameWithAVRetry 重试 5 次 × 200ms = 1s，覆盖 99% AV 扫描窗口。
@@ -31,7 +30,6 @@ func isAVRetryable(err error) bool {
 }
 
 // renameWithAVRetry 对 os.Rename 做 AV 扫描瞬时失败的 retry。
-//
 // 5 次 × 200ms = 1s 总等待。非共享冲突错误立即返回（不重试）。
 func renameWithAVRetry(src, dst string, log *slog.Logger) error {
 	const maxRetry = 5

--- a/internal/edgeagent/upgrademachine/rename_windows.go
+++ b/internal/edgeagent/upgrademachine/rename_windows.go
@@ -1,0 +1,60 @@
+// rename_windows.go 实现 renameWithAVRetry 的 Windows 专属逻辑（issue #21 W3）。
+//
+// Windows Defender / 第三方 AV 实时扫描未签名 PE 文件时持 FILE_SHARE_READ
+// 句柄，期间 os.Rename 失败（ERROR_SHARING_VIOLATION = errno 0x20）。
+// renameWithAVRetry 重试 5 次 × 200ms = 1s，覆盖 99% AV 扫描窗口。
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+)
+
+// ERROR_SHARING_VIOLATION Windows errno 32 (0x20)。
+const windowsSharingViolation = syscall.Errno(0x20)
+
+// isAVRetryable 判定 rename 错误是否值得 AV retry。
+// Windows 上只对 ERROR_SHARING_VIOLATION retry（AV 扫描瞬时持锁）。
+func isAVRetryable(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == windowsSharingViolation
+	}
+	return false
+}
+
+// renameWithAVRetry 对 os.Rename 做 AV 扫描瞬时失败的 retry。
+//
+// 5 次 × 200ms = 1s 总等待。非共享冲突错误立即返回（不重试）。
+func renameWithAVRetry(src, dst string, log *slog.Logger) error {
+	const maxRetry = 5
+	const retryDelay = 200 * time.Millisecond
+
+	var lastErr error
+	for i := 0; i < maxRetry; i++ {
+		err := os.Rename(src, dst)
+		if err == nil {
+			if i > 0 {
+				log.Info("rename succeeded after AV retry",
+					"src", src, "dst", dst, "attempts", i+1)
+			}
+			return nil
+		}
+		lastErr = err
+		if !isAVRetryable(err) {
+			return err // 非共享冲突，不重试
+		}
+		log.Warn("rename blocked (likely AV scan); retrying",
+			"src", src, "dst", dst, "attempt", i+1, "err", err)
+		time.Sleep(retryDelay)
+	}
+	return fmt.Errorf("rename %s → %s: AV scan did not release after %d retries: %w",
+		src, dst, maxRetry, lastErr)
+}

--- a/internal/edgeagent/upgrademachine/rollback.go
+++ b/internal/edgeagent/upgrademachine/rollback.go
@@ -1,12 +1,9 @@
-// rollback.go 实现 upgrade 失败时的 .previous 恢复逻辑（ADR-033 U3，issue #23）。
-//
+// rollback.go 实现 upgrade 失败时的 .previous 恢复逻辑。
 // 对称 Linux apply-pending-upgrade.sh 的 maybe_rollback() 函数：
 //   - 遍历指定目录（递归），找 *.previous 文件
 //   - rollback: rename(dest.previous, dest) 恢复旧版本
 //   - cleanup: delete *.previous（upgrade 确认健康后）
-//
 // rollback 是 best-effort：单文件失败不阻断其他文件恢复。
-//
 // AGENTS.md context.Context 例外：Rollback / CleanupPrevious 操作本地文件系统，
 // rollback 必须原子完成（半回滚 = 部分恢复 + 部分未恢复），中途取消不可接受。
 // 取消检查由编排层 Machine.RollbackAndMark / HealthCheck 入口完成。
@@ -22,7 +19,6 @@ import (
 )
 
 // Rollback 遍历 dirs（递归），将所有 *.previous 文件恢复到原路径。
-//
 // 例如：worker.exe.previous → worker.exe（原子 rename 替换当前版本）。
 // 返回成功恢复的文件数。目录不存在或无 .previous 文件时返回 (0, nil)。
 func Rollback(dirs []string) (int, error) {

--- a/internal/edgeagent/upgrademachine/rollback.go
+++ b/internal/edgeagent/upgrademachine/rollback.go
@@ -1,0 +1,77 @@
+// rollback.go 实现 upgrade 失败时的 .previous 恢复逻辑（ADR-033 U3，issue #23）。
+//
+// 对称 Linux apply-pending-upgrade.sh 的 maybe_rollback() 函数：
+//   - 遍历指定目录（递归），找 *.previous 文件
+//   - rollback: rename(dest.previous, dest) 恢复旧版本
+//   - cleanup: delete *.previous（upgrade 确认健康后）
+//
+// rollback 是 best-effort：单文件失败不阻断其他文件恢复。
+//
+// AGENTS.md context.Context 例外：Rollback / CleanupPrevious 操作本地文件系统，
+// rollback 必须原子完成（半回滚 = 部分恢复 + 部分未恢复），中途取消不可接受。
+// 取消检查由编排层 Machine.RollbackAndMark / HealthCheck 入口完成。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Rollback 遍历 dirs（递归），将所有 *.previous 文件恢复到原路径。
+//
+// 例如：worker.exe.previous → worker.exe（原子 rename 替换当前版本）。
+// 返回成功恢复的文件数。目录不存在或无 .previous 文件时返回 (0, nil)。
+func Rollback(dirs []string) (int, error) {
+	return walkPreviousDirs(dirs, "rollback", func(prevPath string) error {
+		target := strings.TrimSuffix(prevPath, PreviousSuffix)
+		return os.Rename(prevPath, target)
+	})
+}
+
+// CleanupPrevious 删除指定目录（递归）下所有 *.previous 文件。
+// 在 upgrade 确认健康后调用（healthy_marker 匹配 last_upgrade_ver）。
+// 对称 Linux 的 `find ... -name '*.previous' -delete`。
+func CleanupPrevious(dirs []string) (int, error) {
+	return walkPreviousDirs(dirs, "cleanup", func(prevPath string) error {
+		return os.Remove(prevPath)
+	})
+}
+
+// walkPreviousDirs 对 dirs 中每个目录递归遍历 *.previous 文件，执行 op。
+// op 返回 error 时视为该文件失败（best-effort，继续其他文件）。
+// WalkDir 自身的错误（目录不可访问等）向上传播。
+func walkPreviousDirs(dirs []string, opName string, op func(prevPath string) error) (int, error) {
+	total := 0
+	for _, dir := range dirs {
+		n, err := forEachPrevious(dir, op)
+		total += n
+		if err != nil {
+			return total, fmt.Errorf("%s %s: %w", opName, dir, err)
+		}
+	}
+	return total, nil
+}
+
+// forEachPrevious 递归遍历 dir，对每个 *.previous 文件调用 fn。
+// fn 失败时跳过该文件（best-effort），不中断遍历。
+func forEachPrevious(dir string, fn func(prevPath string) error) (int, error) {
+	count := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // 忽略遍历错误（best-effort）
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), PreviousSuffix) {
+			return nil
+		}
+		if err := fn(path); err != nil {
+			return nil // 忽略单个操作失败（best-effort）
+		}
+		count++
+		return nil
+	})
+	return count, err
+}

--- a/internal/edgeagent/upgrademachine/rollback_test.go
+++ b/internal/edgeagent/upgrademachine/rollback_test.go
@@ -1,0 +1,127 @@
+package upgrademachine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRollback_RestoresPrevious(t *testing.T) {
+	dest := t.TempDir()
+
+	// 模拟 swap 后状态：新版本 + .previous 备份
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "new-broken-worker")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old-good-worker")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe"), "new-exporter")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe.previous"), "old-exporter")
+
+	restored, err := Rollback([]string{dest})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored != 2 {
+		t.Fatalf("expected 2 restored, got %d", restored)
+	}
+
+	// 验证恢复为旧内容
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if string(got) != "old-good-worker" {
+		t.Errorf("worker.exe = %q, want %q", got, "old-good-worker")
+	}
+	got, _ = os.ReadFile(filepath.Join(dest, "exporter.exe"))
+	if string(got) != "old-exporter" {
+		t.Errorf("exporter.exe = %q, want %q", got, "old-exporter")
+	}
+
+	// .previous 应被 rename 掉（不再存在）
+	if _, err := os.Stat(filepath.Join(dest, "worker.exe.previous")); !os.IsNotExist(err) {
+		t.Errorf("worker.exe.previous should be gone after rollback")
+	}
+}
+
+func TestRollback_NoPreviousFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "only-version")
+
+	restored, err := Rollback([]string{dest})
+	if err != nil {
+		t.Fatalf("Rollback with no .previous should not error: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("expected 0 restored, got %d", restored)
+	}
+}
+
+func TestRollback_MultipleDirs(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dir1, "a.exe"), "new-a")
+	writeTestFile(t, filepath.Join(dir1, "a.exe.previous"), "old-a")
+	writeTestFile(t, filepath.Join(dir2, "b.exe"), "new-b")
+	writeTestFile(t, filepath.Join(dir2, "b.exe.previous"), "old-b")
+
+	restored, err := Rollback([]string{dir1, dir2})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored != 2 {
+		t.Fatalf("expected 2 restored across dirs, got %d", restored)
+	}
+}
+
+func TestRollback_IgnoresNonPreviousFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "current")
+	writeTestFile(t, filepath.Join(dest, "readme.txt"), "info")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old")
+
+	restored, _ := Rollback([]string{dest})
+	if restored != 1 {
+		t.Errorf("expected 1 restored (only .previous), got %d", restored)
+	}
+
+	// readme.txt 不应被动
+	got, _ := os.ReadFile(filepath.Join(dest, "readme.txt"))
+	if string(got) != "info" {
+		t.Errorf("readme.txt should be untouched")
+	}
+}
+
+func TestRollback_DirNotExist(t *testing.T) {
+	restored, err := Rollback([]string{"/nonexistent/path/xyz"})
+	if err != nil {
+		t.Fatalf("Rollback on missing dir should not error: %v", err)
+	}
+	if restored != 0 {
+		t.Errorf("expected 0 restored, got %d", restored)
+	}
+}
+
+func TestCleanupPrevious_DeletesBackupFiles(t *testing.T) {
+	dest := t.TempDir()
+	writeTestFile(t, filepath.Join(dest, "worker.exe"), "good-new")
+	writeTestFile(t, filepath.Join(dest, "worker.exe.previous"), "old-to-delete")
+	writeTestFile(t, filepath.Join(dest, "exporter.exe.previous"), "old-to-delete")
+
+	removed, err := CleanupPrevious([]string{dest})
+	if err != nil {
+		t.Fatalf("CleanupPrevious: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("expected 2 removed, got %d", removed)
+	}
+
+	// .previous 应被删除
+	for _, f := range []string{"worker.exe.previous", "exporter.exe.previous"} {
+		if _, err := os.Stat(filepath.Join(dest, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should be deleted", f)
+		}
+	}
+	// 非 .previous 文件不动
+	got, _ := os.ReadFile(filepath.Join(dest, "worker.exe"))
+	if !strings.Contains(string(got), "good-new") {
+		t.Errorf("worker.exe should be untouched")
+	}
+}

--- a/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
+++ b/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
@@ -1,19 +1,16 @@
-// running_exe_rename_windows_test.go — issue #21 Step 0 spike。
-//
+// running_exe_rename_windows_test.go —  Step 0 spike。
 // 实测 Windows 文件锁语义，决定 supervisor 自升级方案 A/B 走向：
 //   - 场景 1 + 2 通过 → 方案 A（进程内 rename-aside）可行
 //   - 都失败 → fallback 方案 B（detached cmd.exe helper）
-//
 // 决策依据（PLAN.md v3 "关键技术不确定性"）：
 //   - 观点 A：Windows Server 2003+ image loader 用 FILE_SHARE_READ | FILE_SHARE_DELETE
 //     → rename 运行中 .exe 成功
 //   - 观点 B：image loader 只 share READ → rename 失败 ERROR_SHARING_VIOLATION
-//
 // 5 场景表驱动测试（PLAN 附录 A）：
 //  1. 进程 B rename 进程 A 启动中的 .exe（方案 A step 1 核心验证）
 //  2. 进程 A 自己 rename 自己的 .exe（supervisor 进程内 self-swap 验证）
 //  3. replace 模式（new → 正在运行的 dest，诊断价值：验证直接 replace 是否可行）
-//  4. 恢复（.old → supervisor.exe，W2 brick 兜底验证）
+//  4. 恢复（.old → supervisor.exe， brick 兜底验证）
 //  5. MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT) fallback（方案 D 可行性）
 
 //go:build windows
@@ -160,7 +157,7 @@ func scenarioReplaceRunningExe(t *testing.T, dummy string) {
 	t.Logf("→ 确认必须用 rename-aside 两步（step 1: dest→.old; step 2: .new→dest）")
 }
 
-// scenarioRestoreFromOld：模拟 W2 brick 兜底 — step 1 成功后，把 .old rename 回原路径。
+// scenarioRestoreFromOld：模拟  brick 兜底 — step 1 成功后，把 .old rename 回原路径。
 // 验证：进程 A 持有的 image 被 rename 到 .old 后，能否再次被 rename 回原路径。
 func scenarioRestoreFromOld(t *testing.T, dummy string) {
 	dir := t.TempDir()
@@ -185,14 +182,14 @@ func scenarioRestoreFromOld(t *testing.T, dummy string) {
 
 	// brick 兜底：.old → supervisor.exe（恢复）
 	if err := os.Rename(oldPath, exePath); err != nil {
-		t.Errorf("场景 4 失败（W2 brick 兜底不可行）：os.Rename(%s, %s) = %v",
+		t.Errorf("场景 4 失败：os.Rename(%s, %s) = %v",
 			oldPath, exePath, err)
 		return
 	}
 	if _, err := os.Stat(exePath); err != nil {
 		t.Errorf("场景 4 异常：恢复后 supervisor.exe 不存在（err=%v）", err)
 	}
-	t.Logf("场景 4 通过：进程持有的 .old 可以 rename 回原路径 → W2 brick 兜底可行")
+	t.Logf("场景 4 通过：进程持有的 .old 可以 rename 回原路径 →  brick 兜底可行")
 }
 
 // scenarioMoveFileDelayUntilReboot：调用 MoveFileExW + MOVEFILE_DELAY_UNTIL_REBOOT。

--- a/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
+++ b/internal/edgeagent/upgrademachine/running_exe_rename_windows_test.go
@@ -1,0 +1,225 @@
+// running_exe_rename_windows_test.go — issue #21 Step 0 spike。
+//
+// 实测 Windows 文件锁语义，决定 supervisor 自升级方案 A/B 走向：
+//   - 场景 1 + 2 通过 → 方案 A（进程内 rename-aside）可行
+//   - 都失败 → fallback 方案 B（detached cmd.exe helper）
+//
+// 决策依据（PLAN.md v3 "关键技术不确定性"）：
+//   - 观点 A：Windows Server 2003+ image loader 用 FILE_SHARE_READ | FILE_SHARE_DELETE
+//     → rename 运行中 .exe 成功
+//   - 观点 B：image loader 只 share READ → rename 失败 ERROR_SHARING_VIOLATION
+//
+// 5 场景表驱动测试（PLAN 附录 A）：
+//  1. 进程 B rename 进程 A 启动中的 .exe（方案 A step 1 核心验证）
+//  2. 进程 A 自己 rename 自己的 .exe（supervisor 进程内 self-swap 验证）
+//  3. replace 模式（new → 正在运行的 dest，诊断价值：验证直接 replace 是否可行）
+//  4. 恢复（.old → supervisor.exe，W2 brick 兜底验证）
+//  5. MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT) fallback（方案 D 可行性）
+
+//go:build windows
+
+package upgrademachine
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestStep0_RunningExeRename 是 Step 0 决策门测试。
+// 通过/失败直接决定方案 A/B 走向，结果以 t.Logf 明示（不因场景 3/5 预期失败而 t.Fail）。
+func TestStep0_RunningExeRename(t *testing.T) {
+	dummy := buildDummy(t)
+
+	scenarios := []struct {
+		name     string
+		critical bool // critical=true 时失败意味着方案 A 不可行
+		fn       func(t *testing.T, dummy string)
+	}{
+		{"scenario1_B_rename_A_running_exe", true, scenarioB_rename_A_running_exe},
+		{"scenario2_A_self_rename", true, scenarioA_self_rename},
+		{"scenario3_replace_running_exe", false, scenarioReplaceRunningExe},
+		{"scenario4_restore_from_old", true, scenarioRestoreFromOld},
+		{"scenario5_movefile_delay_until_reboot", false, scenarioMoveFileDelayUntilReboot},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sc.fn(t, dummy)
+		})
+	}
+}
+
+// scenarioB_rename_A_running_exe：外部进程 B rename 正在运行的 A.exe。
+// 这是方案 A step 1 (supervisor.exe → supervisor.exe.old) 的核心验证。
+func scenarioB_rename_A_running_exe(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "dummyA.exe")
+	copyFileExe(t, dummy, exePath)
+
+	cmd := exec.Command(exePath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start dummyA: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond) // 等待 image 完全加载
+
+	oldPath := exePath + ".old"
+	err := os.Rename(exePath, oldPath)
+
+	if err != nil {
+		t.Errorf("场景 1 失败（方案 A step 1 不可行）：os.Rename(%s, %s) = %v",
+			exePath, oldPath, err)
+		return
+	}
+
+	// 验证 rename 成功：原路径不存在，.old 存在
+	if _, err := os.Stat(exePath); !os.IsNotExist(err) {
+		t.Errorf("场景 1 异常：rename 后原路径仍存在（err=%v）", err)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("场景 1 异常：.old 不存在（err=%v）", err)
+	}
+	t.Logf("场景 1 通过：进程 B 可以 rename 运行中进程 A 的 .exe → 方案 A step 1 可行")
+}
+
+// scenarioA_self_rename：进程 A 自己 rename 自己的 .exe。
+// 这是 supervisor 进程内 SupervisorSelfSwap step 1 的核心验证。
+func scenarioA_self_rename(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "dummySelf.exe")
+	copyFileExe(t, dummy, exePath)
+
+	// dummy 启动后自己做 os.Rename(exePath, exePath+".old")
+	cmd := exec.Command(exePath, "--self-rename", exePath)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("场景 2 启动 dummy --self-rename 失败：%v (stderr: %s)", err, out)
+	}
+
+	var result struct {
+		OK   bool   `json:"ok"`
+		Err  string `json:"err"`
+		Src  string `json:"src"`
+		Dst  string `json:"dst"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("场景 2 解析 dummy stdout 失败：%v (raw: %s)", err, out)
+	}
+
+	if !result.OK {
+		t.Errorf("场景 2 失败（方案 A 进程内 self-swap 不可行）：dummy self-rename err=%q",
+			result.Err)
+		return
+	}
+	t.Logf("场景 2 通过：进程 A 可以自己 rename 自己的 .exe → 方案 A 进程内 self-swap 可行")
+}
+
+// scenarioReplaceRunningExe：把 .new rename 到正在运行的 dest（直接 replace）。
+// 诊断价值：若通过，方案可简化为单步 replace；若失败，确认必须用 rename-aside 两步。
+// 预期 Windows 行为：失败（ERROR_SHARING_VIOLATION / ACCESS_DENIED）— image loader 不 share WRITE。
+func scenarioReplaceRunningExe(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	destExe := filepath.Join(dir, "dummyDest.exe")
+	newExe := filepath.Join(dir, "dummyDest.exe.new")
+	copyFileExe(t, dummy, destExe)
+	copyFileExe(t, dummy, newExe)
+	appendMarker(t, newExe, "NEW-CONTENT\n")
+
+	cmd := exec.Command(destExe)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start dummyDest: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	err := os.Rename(newExe, destExe)
+	if err == nil {
+		t.Logf("场景 3 通过（意外）：直接 replace 运行中 .exe 可行 — 方案可简化为单步")
+		// 验证内容确实被替换
+		got, _ := os.ReadFile(destExe)
+		if !strings.Contains(string(got), "NEW-CONTENT") {
+			t.Errorf("场景 3 异常：rename 成功但内容未替换")
+		}
+		return
+	}
+	// 预期失败：这是方案 A 用 rename-aside（两步）而非直接 replace 的根因
+	t.Logf("场景 3 预期失败（符合 Windows image loader 语义）：os.Rename(new, running_dest) = %v", err)
+	t.Logf("→ 确认必须用 rename-aside 两步（step 1: dest→.old; step 2: .new→dest）")
+}
+
+// scenarioRestoreFromOld：模拟 W2 brick 兜底 — step 1 成功后，把 .old rename 回原路径。
+// 验证：进程 A 持有的 image 被 rename 到 .old 后，能否再次被 rename 回原路径。
+func scenarioRestoreFromOld(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "supervisor.exe")
+	copyFileExe(t, dummy, exePath)
+
+	cmd := exec.Command(exePath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	oldPath := exePath + ".old"
+	// step 1: supervisor.exe → .old（预期成功，场景 1 已验证）
+	if err := os.Rename(exePath, oldPath); err != nil {
+		t.Fatalf("场景 4 前置 step 1 失败：%v", err)
+	}
+
+	// brick 兜底：.old → supervisor.exe（恢复）
+	if err := os.Rename(oldPath, exePath); err != nil {
+		t.Errorf("场景 4 失败（W2 brick 兜底不可行）：os.Rename(%s, %s) = %v",
+			oldPath, exePath, err)
+		return
+	}
+	if _, err := os.Stat(exePath); err != nil {
+		t.Errorf("场景 4 异常：恢复后 supervisor.exe 不存在（err=%v）", err)
+	}
+	t.Logf("场景 4 通过：进程持有的 .old 可以 rename 回原路径 → W2 brick 兜底可行")
+}
+
+// scenarioMoveFileDelayUntilReboot：调用 MoveFileExW + MOVEFILE_DELAY_UNTIL_REBOOT。
+// 方案 D（延迟到下次 reboot）的可行性验证。仅验证 API 可调用，不验证重启效果。
+// 预期：API 调用成功（返回 nil），但实际 rename 延迟到下次 reboot。
+func scenarioMoveFileDelayUntilReboot(t *testing.T, dummy string) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "delay_src.exe")
+	dst := filepath.Join(dir, "delay_dst.exe")
+	copyFileExe(t, dummy, src)
+
+	srcW, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		t.Fatalf("场景 5 UTF16 src： %v", err)
+	}
+	dstW, err := windows.UTF16PtrFromString(dst)
+	if err != nil {
+		t.Fatalf("场景 5 UTF16 dst： %v", err)
+	}
+
+	// MOVEFILE_DELAY_UNTIL_REBOOT = 0x4（需管理员权限）
+	const MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
+	err = windows.MoveFileEx(srcW, dstW, MOVEFILE_DELAY_UNTIL_REBOOT)
+	if err != nil {
+		t.Logf("场景 5 失败（预期非管理员或系统不支持）：MoveFileEx DELAY_UNTIL_REBOOT = %v", err)
+		return
+	}
+	t.Logf("场景 5 通过：MoveFileEx DELAY_UNTIL_REBOOT API 调用成功（方案 D 可行，需管理员权限）")
+	// 清理：src 仍存在（rename 延迟），测试 tempDir 自动清理
+}

--- a/internal/edgeagent/upgrademachine/state.go
+++ b/internal/edgeagent/upgrademachine/state.go
@@ -1,0 +1,89 @@
+// state.go 定义升级状态机的 State 类型 + 状态检测函数（issue #23）。
+//
+// 状态机使原先分散在 7 文件中的隐式状态（通过文件存在性 + sentinel error 推断）
+// 变为显式的、可检测的、可文档化的类型。
+
+package upgrademachine
+
+import (
+	"fmt"
+	"os"
+)
+
+// State 表示升级状态机的当前状态。
+type State int
+
+const (
+	// StateIdle 无升级进行中（incoming/ 不存在，无 last_upgrade_ver）。
+	StateIdle State = iota
+
+	// StatePending incoming/MANIFEST.txt 存在（bundle 已下载，等待 swap）。
+	StatePending
+
+	// StateSwapped 文件已替换（last_upgrade_ver 已写），等待健康确认。
+	// 此状态通过 "last_upgrade_ver 存在但 healthy_marker 不匹配" 检测。
+	StateSwapped
+
+	// StateHealthy healthy_marker 内容匹配 last_upgrade_ver（升级成功）。
+	StateHealthy
+
+	// StateRolledBack rollback.done 存在（旧版本已恢复，等待下次升级）。
+	StateRolledBack
+)
+
+// String 返回状态的人类可读名称。
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "idle"
+	case StatePending:
+		return "pending"
+	case StateSwapped:
+		return "swapped"
+	case StateHealthy:
+		return "healthy"
+	case StateRolledBack:
+		return "rolled_back"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// DetectState 根据 StageDir 下的文件状态推断当前升级状态。
+//
+// 这是一个公共观测函数，供调试、日志、测试断言使用。
+// Machine 内部编排逻辑使用更细粒度的检测函数（IsPending、IsUpgradeHealthy 等）
+// 而非 DetectState，因为编排需要区分具体条件（如 rollback.done vs pending 的优先级）。
+//
+// 检测优先级（互斥）：
+//  1. rollback.done 存在 → StateRolledBack
+//  2. incoming/MANIFEST.txt 存在 → StatePending
+//  3. last_upgrade_ver 不存在 → StateIdle
+//  4. healthy_marker 匹配 last_upgrade_ver → StateHealthy
+//  5. last_upgrade_ver 存在但 healthy_marker 不匹配 → StateSwapped
+func DetectState(stageDir string) State {
+	// 1. rollback.done → 已回滚
+	if _, err := os.Stat(RollbackDonePath(stageDir)); err == nil {
+		return StateRolledBack
+	}
+
+	// 2. incoming/MANIFEST.txt → 有 pending
+	if _, err := os.Stat(ManifestPath(stageDir)); err == nil {
+		return StatePending
+	}
+
+	// 3. 无 last_upgrade_ver → 从未升级
+	lastVer := readTrimmed(LastUpgradeVerPath(stageDir))
+	if lastVer == "" {
+		return StateIdle
+	}
+
+	// 4. healthy_marker 匹配 → 健康
+	healthyVer := readTrimmed(HealthyMarkerPath(stageDir))
+	if lastVer == healthyVer {
+		return StateHealthy
+	}
+
+	// 5. last_upgrade_ver 存在但不匹配 → swapped（等待确认）
+	return StateSwapped
+}

--- a/internal/edgeagent/upgrademachine/state.go
+++ b/internal/edgeagent/upgrademachine/state.go
@@ -1,5 +1,4 @@
-// state.go 定义升级状态机的 State 类型 + 状态检测函数（issue #23）。
-//
+// state.go 定义升级状态机的 State 类型 + 状态检测函数。
 // 状态机使原先分散在 7 文件中的隐式状态（通过文件存在性 + sentinel error 推断）
 // 变为显式的、可检测的、可文档化的类型。
 
@@ -50,11 +49,9 @@ func (s State) String() string {
 }
 
 // DetectState 根据 StageDir 下的文件状态推断当前升级状态。
-//
 // 这是一个公共观测函数，供调试、日志、测试断言使用。
 // Machine 内部编排逻辑使用更细粒度的检测函数（IsPending、IsUpgradeHealthy 等）
 // 而非 DetectState，因为编排需要区分具体条件（如 rollback.done vs pending 的优先级）。
-//
 // 检测优先级（互斥）：
 //  1. rollback.done 存在 → StateRolledBack
 //  2. incoming/MANIFEST.txt 存在 → StatePending

--- a/internal/edgeagent/upgrademachine/state_test.go
+++ b/internal/edgeagent/upgrademachine/state_test.go
@@ -1,0 +1,89 @@
+package upgrademachine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectState_Idle(t *testing.T) {
+	dir := t.TempDir()
+	// 空目录 → 从未升级
+	if s := DetectState(dir); s != StateIdle {
+		t.Errorf("DetectState() = %s, want idle", s)
+	}
+}
+
+func TestDetectState_Pending(t *testing.T) {
+	dir := t.TempDir()
+	// 创建 incoming/MANIFEST.txt
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake manifest")
+	if s := DetectState(dir); s != StatePending {
+		t.Errorf("DetectState() = %s, want pending", s)
+	}
+}
+
+func TestDetectState_RolledBack(t *testing.T) {
+	dir := t.TempDir()
+	// rollback.done 存在（优先级高于 pending）
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+	if s := DetectState(dir); s != StateRolledBack {
+		t.Errorf("DetectState() = %s, want rolled_back", s)
+	}
+}
+
+func TestDetectState_RolledBack_HigherThanPending(t *testing.T) {
+	dir := t.TempDir()
+	// 同时存在 rollback.done 和 incoming/MANIFEST.txt → rollback.done 优先
+	writeTestFile(t, filepath.Join(dir, RollbackDoneFile), "done")
+	writeTestFile(t, filepath.Join(dir, IncomingDirName, ManifestFileName), "fake manifest")
+	if s := DetectState(dir); s != StateRolledBack {
+		t.Errorf("DetectState() = %s, want rolled_back (higher priority than pending)", s)
+	}
+}
+
+func TestDetectState_Healthy(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v1.0.0")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v1.0.0")
+	if s := DetectState(dir); s != StateHealthy {
+		t.Errorf("DetectState() = %s, want healthy", s)
+	}
+}
+
+func TestDetectState_Swapped(t *testing.T) {
+	dir := t.TempDir()
+	// last_upgrade_ver 存在但 healthy_marker 不匹配
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v2.0.0")
+	writeTestFile(t, filepath.Join(dir, HealthyMarkerFile), "v1.0.0")
+	if s := DetectState(dir); s != StateSwapped {
+		t.Errorf("DetectState() = %s, want swapped", s)
+	}
+}
+
+func TestDetectState_Swapped_NoMarker(t *testing.T) {
+	dir := t.TempDir()
+	// last_upgrade_ver 存在，无 healthy_marker
+	writeTestFile(t, filepath.Join(dir, LastUpgradeVerFile), "v2.0.0")
+	if s := DetectState(dir); s != StateSwapped {
+		t.Errorf("DetectState() = %s, want swapped", s)
+	}
+}
+
+func TestState_String(t *testing.T) {
+	tests := []struct {
+		state State
+		want  string
+	}{
+		{StateIdle, "idle"},
+		{StatePending, "pending"},
+		{StateSwapped, "swapped"},
+		{StateHealthy, "healthy"},
+		{StateRolledBack, "rolled_back"},
+		{State(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("State(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap.go
@@ -1,0 +1,146 @@
+// supervisor_selfswap.go 实现 supervisor.exe 的进程内 rename-aside 自升级
+// （issue #21 Step 4）。
+//
+// 核心：supervisor 无法 kill 自己（KillTree/Restart 自己 = 自杀），所以不能用
+// worker swap 模式（KillTree → rename）。改为进程内 rename-aside：
+//  1. smokeTestVersion（W5）— 跑 supervisor.exe.new --version 验证 binary 可执行
+//  2. renameWithAVRetry(supervisor.exe, supervisor.exe.old)（W3 retry）
+//  3. renameWithAVRetry(supervisor.exe.new, supervisor.exe)（W3 retry）
+//     失败时 W2/W4 brick 兜底：
+//     a. m.RollbackAndMark() — worker rollback（保证版本一致）
+//     b. renameWithAVRetry(supervisor.exe.old, supervisor.exe) — supervisor 恢复
+//     c. m.ResetUpgradeIPC() — 清 IPC 状态文件（W4）
+//  4. WriteSupervisorUpgradeApplied + 删 pending sentinel
+//  5. 返回 ErrSupervisorRestartSoon → service.go Execute 返回 (false, 1) → SCM restart
+//
+// Step 0 spike 确认：Windows Server 2003+ image loader 用 FILE_SHARE_DELETE，
+// rename 运行中 .exe 成功；直接 replace 失败（见 running_exe_rename_windows_test.go）。
+
+package upgrademachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrSupervisorRestartSoon 哨兵：service.go 收到后返回 (false, 1) 让 SCM 按
+// recovery action 重启（samesession=false + 非 0 exitCode → failure 路径）。
+//
+// 调用方（BootCheck / superviseWorker）应将其向上传播给 service.Execute，
+// 由 Execute 返回 false, 1 触发 SCM restart（exitCode=0 不触发，#21 P5 dogfood 发现）。
+var ErrSupervisorRestartSoon = fmt.Errorf("supervisor self-swap done; restart via SCM")
+
+// SupervisorSelfSwap 在 supervisor 进程内执行 rename-aside 自升级。
+//
+// 调用时机：
+//   - BootCheck 检测到 supervisor_upgrade.pending sentinel 时（supervisor 崩溃后 SCM 重启）
+//   - superviseWorker 检测到 worker swap 完成 + pending sentinel 时（热升级路径）
+//
+// 返回 ErrSupervisorRestartSoon 表示 swap 成功，调用方应让 SCM 重启 supervisor。
+// 返回其他 error 表示 swap 失败（可能是 brick 兜底成功 — worker + supervisor 已恢复旧版本）。
+func (m *Machine) SupervisorSelfSwap() error {
+	newPath := filepath.Join(m.binDir, SupervisorBinaryName+".new")
+	oldPath := filepath.Join(m.binDir, SupervisorBinaryName+".old")
+	supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
+
+	// 0. W5: 冒烟测试 — 跑 supervisor.exe.new --version 验证 binary 可执行
+	if err := m.smokeTestVersion(newPath); err != nil {
+		return fmt.Errorf("supervisor self-swap aborted (smoke test): %w", err)
+	}
+
+	// 1. W3: rename supervisor.exe → .old（AV retry）
+	if err := renameWithAVRetry(supervisorPath, oldPath, m.log); err != nil {
+		return fmt.Errorf("supervisor self-swap step 1 (rename to .old): %w", err)
+	}
+
+	// 2. W3: rename .new → supervisor.exe（AV retry）
+	if err := renameWithAVRetry(newPath, supervisorPath, m.log); err != nil {
+		// W2/W4 brick 兜底：worker rollback + supervisor 恢复 + IPC reset
+		m.log.Error("supervisor self-swap step 2 failed; initiating full rollback", "err", err)
+
+		// 2a. worker rollback（保证版本一致 — W2）
+		if rerr := m.RollbackAndMark(); rerr != nil {
+			return fmt.Errorf("brick: worker rollback failed: %w (supervisor.exe.old preserved at %s)",
+				rerr, oldPath)
+		}
+
+		// 2b. supervisor.exe.old → supervisor.exe 恢复
+		if rerr := renameWithAVRetry(oldPath, supervisorPath, m.log); rerr != nil {
+			return fmt.Errorf("brick: supervisor restore failed (worker rolled back): %w", rerr)
+		}
+
+		// 2c. W4: 清 IPC 状态文件（保留 pending 让 BootCheck 重试升级）
+		if rerr := m.ResetUpgradeIPC(); rerr != nil {
+			m.log.Error("brick recovery: IPC reset partial fail (non-fatal)", "err", rerr)
+		}
+
+		return fmt.Errorf("supervisor self-swap aborted; worker rolled back + supervisor restored + IPC reset: %w", err)
+	}
+
+	// 3. 成功路径：写 applied sentinel + 删 pending
+	if err := WriteSupervisorUpgradeApplied(m.stageDir, ""); err != nil {
+		m.log.Error("supervisor self-swap: failed to write applied sentinel", "err", err)
+	}
+	// best-effort 清理 pending sentinel — swap 已成功，sentinel 残留无意义
+	_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+
+	// 4. 返回哨兵让 service.go 触发 SCM restart
+	m.log.Info("supervisor self-swap done; exiting for SCM restart", "old_backup", oldPath)
+	return ErrSupervisorRestartSoon
+}
+
+// smokeTestVersion 跑 supervisor.exe.new --version，验证退出码 0 + stdout 非空。
+// 超时 5s。失败时清理 stage + sentinel，不进入 self-swap（W5 加固）。
+//
+// 防御场景：
+//   - bundle 构建 bug 导致 binary 损坏
+//   - AV 半清理（quarantine 部分 PE section）
+//   - 架构错（amd64 binary 跑在 arm64 Windows）
+func (m *Machine) smokeTestVersion(exePath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, exePath, "--version").Output()
+	if err != nil {
+		// best-effort 清理坏 binary + pending sentinel — 冒烟失败不进入 self-swap
+		_ = os.Remove(exePath)
+		_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+		return fmt.Errorf("smoke test exit: %w (output: %s)", err, out)
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		// best-effort 清理 — 同上，空输出视为坏 binary
+		_ = os.Remove(exePath)
+		_ = os.Remove(SupervisorUpgradePendingPath(m.stageDir))
+		return fmt.Errorf("smoke test: empty version output")
+	}
+	m.log.Info("supervisor self-swap smoke test passed",
+		"version_output", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// ResetUpgradeIPC 清理升级状态机文件，让 DetectState 回到 StateIdle。
+// 用于 brick 兜底成功后让下一次升级从干净状态开始（W4）。
+//
+// 清理：last_upgrade_ver, last_upgrade_at, healthy_marker, rollback.done
+// 保留：supervisor_upgrade.pending（让 BootCheck 可重试升级）
+//       incoming/MANIFEST.txt（pending bundle 应保留）
+//
+// best-effort：单个文件删除失败不阻断（os.IsNotExist 忽略）。
+func (m *Machine) ResetUpgradeIPC() error {
+	var firstErr error
+	for _, p := range []string{
+		LastUpgradeVerPath(m.stageDir),
+		LastUpgradeAtPath(m.stageDir),
+		HealthyMarkerPath(m.stageDir),
+		RollbackDonePath(m.stageDir),
+	} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap.go
@@ -1,18 +1,16 @@
 // supervisor_selfswap.go 实现 supervisor.exe 的进程内 rename-aside 自升级
-// （issue #21 Step 4）。
-//
+//。
 // 核心：supervisor 无法 kill 自己（KillTree/Restart 自己 = 自杀），所以不能用
 // worker swap 模式（KillTree → rename）。改为进程内 rename-aside：
-//  1. smokeTestVersion（W5）— 跑 supervisor.exe.new --version 验证 binary 可执行
-//  2. renameWithAVRetry(supervisor.exe, supervisor.exe.old)（W3 retry）
-//  3. renameWithAVRetry(supervisor.exe.new, supervisor.exe)（W3 retry）
-//     失败时 W2/W4 brick 兜底：
+//  1. smokeTestVersion— 跑 supervisor.exe.new --version 验证 binary 可执行
+//  2. renameWithAVRetry(supervisor.exe, supervisor.exe.old)
+//  3. renameWithAVRetry(supervisor.exe.new, supervisor.exe)
+//     失败时 / brick 兜底：
 //     a. m.RollbackAndMark() — worker rollback（保证版本一致）
 //     b. renameWithAVRetry(supervisor.exe.old, supervisor.exe) — supervisor 恢复
-//     c. m.ResetUpgradeIPC() — 清 IPC 状态文件（W4）
+//     c. m.ResetUpgradeIPC() — 清 IPC 状态文件
 //  4. WriteSupervisorUpgradeApplied + 删 pending sentinel
 //  5. 返回 ErrSupervisorRestartSoon → service.go Execute 返回 (false, 1) → SCM restart
-//
 // Step 0 spike 确认：Windows Server 2003+ image loader 用 FILE_SHARE_DELETE，
 // rename 运行中 .exe 成功；直接 replace 失败（见 running_exe_rename_windows_test.go）。
 
@@ -30,17 +28,14 @@ import (
 
 // ErrSupervisorRestartSoon 哨兵：service.go 收到后返回 (false, 1) 让 SCM 按
 // recovery action 重启（samesession=false + 非 0 exitCode → failure 路径）。
-//
 // 调用方（BootCheck / superviseWorker）应将其向上传播给 service.Execute，
-// 由 Execute 返回 false, 1 触发 SCM restart（exitCode=0 不触发，#21 P5 dogfood 发现）。
+// 由 Execute 返回 false, 1 触发 SCM restart（exitCode=0 不触发， P5  发现）。
 var ErrSupervisorRestartSoon = fmt.Errorf("supervisor self-swap done; restart via SCM")
 
 // SupervisorSelfSwap 在 supervisor 进程内执行 rename-aside 自升级。
-//
 // 调用时机：
 //   - BootCheck 检测到 supervisor_upgrade.pending sentinel 时（supervisor 崩溃后 SCM 重启）
 //   - superviseWorker 检测到 worker swap 完成 + pending sentinel 时（热升级路径）
-//
 // 返回 ErrSupervisorRestartSoon 表示 swap 成功，调用方应让 SCM 重启 supervisor。
 // 返回其他 error 表示 swap 失败（可能是 brick 兜底成功 — worker + supervisor 已恢复旧版本）。
 func (m *Machine) SupervisorSelfSwap() error {
@@ -48,22 +43,22 @@ func (m *Machine) SupervisorSelfSwap() error {
 	oldPath := filepath.Join(m.binDir, SupervisorBinaryName+".old")
 	supervisorPath := filepath.Join(m.binDir, SupervisorBinaryName)
 
-	// 0. W5: 冒烟测试 — 跑 supervisor.exe.new --version 验证 binary 可执行
+	// 0. : 冒烟测试 — 跑 supervisor.exe.new --version 验证 binary 可执行
 	if err := m.smokeTestVersion(newPath); err != nil {
 		return fmt.Errorf("supervisor self-swap aborted (smoke test): %w", err)
 	}
 
-	// 1. W3: rename supervisor.exe → .old（AV retry）
+	// 1. : rename supervisor.exe → .old（AV retry）
 	if err := renameWithAVRetry(supervisorPath, oldPath, m.log); err != nil {
 		return fmt.Errorf("supervisor self-swap step 1 (rename to .old): %w", err)
 	}
 
-	// 2. W3: rename .new → supervisor.exe（AV retry）
+	// 2. : rename .new → supervisor.exe（AV retry）
 	if err := renameWithAVRetry(newPath, supervisorPath, m.log); err != nil {
-		// W2/W4 brick 兜底：worker rollback + supervisor 恢复 + IPC reset
+		// / brick 兜底：worker rollback + supervisor 恢复 + IPC reset
 		m.log.Error("supervisor self-swap step 2 failed; initiating full rollback", "err", err)
 
-		// 2a. worker rollback（保证版本一致 — W2）
+		// 2a. worker rollback（保证版本一致 — ）
 		if rerr := m.RollbackAndMark(); rerr != nil {
 			return fmt.Errorf("brick: worker rollback failed: %w (supervisor.exe.old preserved at %s)",
 				rerr, oldPath)
@@ -74,7 +69,7 @@ func (m *Machine) SupervisorSelfSwap() error {
 			return fmt.Errorf("brick: supervisor restore failed (worker rolled back): %w", rerr)
 		}
 
-		// 2c. W4: 清 IPC 状态文件（保留 pending 让 BootCheck 重试升级）
+		// 2c. : 清 IPC 状态文件（保留 pending 让 BootCheck 重试升级）
 		if rerr := m.ResetUpgradeIPC(); rerr != nil {
 			m.log.Error("brick recovery: IPC reset partial fail (non-fatal)", "err", rerr)
 		}
@@ -95,8 +90,7 @@ func (m *Machine) SupervisorSelfSwap() error {
 }
 
 // smokeTestVersion 跑 supervisor.exe.new --version，验证退出码 0 + stdout 非空。
-// 超时 5s。失败时清理 stage + sentinel，不进入 self-swap（W5 加固）。
-//
+// 超时 5s。失败时清理 stage + sentinel，不进入 self-swap。
 // 防御场景：
 //   - bundle 构建 bug 导致 binary 损坏
 //   - AV 半清理（quarantine 部分 PE section）
@@ -123,12 +117,10 @@ func (m *Machine) smokeTestVersion(exePath string) error {
 }
 
 // ResetUpgradeIPC 清理升级状态机文件，让 DetectState 回到 StateIdle。
-// 用于 brick 兜底成功后让下一次升级从干净状态开始（W4）。
-//
+// 用于 brick 兜底成功后让下一次升级从干净状态开始。
 // 清理：last_upgrade_ver, last_upgrade_at, healthy_marker, rollback.done
 // 保留：supervisor_upgrade.pending（让 BootCheck 可重试升级）
 //       incoming/MANIFEST.txt（pending bundle 应保留）
-//
 // best-effort：单个文件删除失败不阻断（os.IsNotExist 忽略）。
 func (m *Machine) ResetUpgradeIPC() error {
 	var firstErr error

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
@@ -1,7 +1,6 @@
-// supervisor_selfswap_test.go 测试 issue #21 SupervisorSelfSwap + smokeTestVersion +
+// supervisor_selfswap_test.go 测试  SupervisorSelfSwap + smokeTestVersion +
 // ResetUpgradeIPC（跨平台可测部分，Linux CI 可跑）。
-//
-// Windows 专属场景（W2 brick 兜底 / W3 AV retry / 锁文件模拟）在
+// Windows 专属场景在
 // supervisor_self_swap_windows_test.go（Step 4 完成后补）。
 
 package upgrademachine
@@ -52,7 +51,7 @@ func TestSmokeTestVersion_BadBinary_CleansStageAndSentinel(t *testing.T) {
 		t.Fatal("smokeTestVersion 应失败（非可执行文件）")
 	}
 
-	// W5: 失败时清理 exePath + pending sentinel
+	// : 失败时清理 exePath + pending sentinel
 	if _, err := os.Stat(exePath); !os.IsNotExist(err) {
 		t.Errorf("exePath 应被清理（err=%v）", err)
 	}

--- a/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
+++ b/internal/edgeagent/upgrademachine/supervisor_selfswap_test.go
@@ -1,0 +1,230 @@
+// supervisor_selfswap_test.go 测试 issue #21 SupervisorSelfSwap + smokeTestVersion +
+// ResetUpgradeIPC（跨平台可测部分，Linux CI 可跑）。
+//
+// Windows 专属场景（W2 brick 兜底 / W3 AV retry / 锁文件模拟）在
+// supervisor_self_swap_windows_test.go（Step 4 完成后补）。
+
+package upgrademachine
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- smokeTestVersion ---
+
+func TestSmokeTestVersion_Success(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	copyFileExe(t, dummy, exePath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	if err := m.smokeTestVersion(exePath); err != nil {
+		t.Fatalf("smokeTestVersion: %v", err)
+	}
+
+	// 成功时 exePath + pending sentinel 应保留
+	if _, err := os.Stat(exePath); err != nil {
+		t.Errorf("exePath 应保留： %v", err)
+	}
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应保留")
+	}
+}
+
+func TestSmokeTestVersion_BadBinary_CleansStageAndSentinel(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	// 写一个非可执行文件（内容是文本）
+	writeTestFile(t, exePath, "not-an-exe")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.smokeTestVersion(exePath)
+	if err == nil {
+		t.Fatal("smokeTestVersion 应失败（非可执行文件）")
+	}
+
+	// W5: 失败时清理 exePath + pending sentinel
+	if _, err := os.Stat(exePath); !os.IsNotExist(err) {
+		t.Errorf("exePath 应被清理（err=%v）", err)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被清理")
+	}
+}
+
+func TestSmokeTestVersion_NotExist_Fails(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+	exePath := filepath.Join(binDir, SupervisorBinaryName+".new") // 不存在
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.smokeTestVersion(exePath)
+	if err == nil {
+		t.Fatal("smokeTestVersion 应失败（文件不存在）")
+	}
+}
+
+// --- ResetUpgradeIPC ---
+
+func TestResetUpgradeIPC_ClearsFourFiles_KeepsPending(t *testing.T) {
+	stageDir := t.TempDir()
+	// 铺 4 个 IPC 文件
+	writeTestFile(t, LastUpgradeVerPath(stageDir), "v0.9.2")
+	writeTestFile(t, LastUpgradeAtPath(stageDir), "2026-07-16T00:00:00Z")
+	writeTestFile(t, HealthyMarkerPath(stageDir), "v0.9.2")
+	writeTestFile(t, RollbackDonePath(stageDir), "done")
+	// 铺 pending sentinel（应保留）
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	if err := m.ResetUpgradeIPC(); err != nil {
+		t.Fatalf("ResetUpgradeIPC: %v", err)
+	}
+
+	// 4 个 IPC 文件应被清
+	for _, path := range []string{
+		LastUpgradeVerPath(stageDir),
+		LastUpgradeAtPath(stageDir),
+		HealthyMarkerPath(stageDir),
+		RollbackDonePath(stageDir),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s 应被清理（err=%v）", path, err)
+		}
+	}
+	// pending sentinel 应保留
+	if !IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应保留（让 BootCheck 重试升级）")
+	}
+}
+
+func TestResetUpgradeIPC_Idempotent_NoFiles(t *testing.T) {
+	// 无任何 IPC 文件时不报错
+	stageDir := t.TempDir()
+	m := NewMachine(stageDir, t.TempDir(), testLogger(), nil)
+	if err := m.ResetUpgradeIPC(); err != nil {
+		t.Fatalf("ResetUpgradeIPC 空目录应 nil： %v", err)
+	}
+}
+
+// --- SupervisorSelfSwap 正常路径 ---
+
+func TestSupervisorSelfSwap_HappyPath(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 铺地板：supervisor.exe（旧版本，内容标记）+ supervisor.exe.new（dummy binary）
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	oldPath := filepath.Join(binDir, SupervisorBinaryName+".old")
+	copyFileExe(t, dummy, supervisorPath)
+	appendMarker(t, supervisorPath, "OLD-VERSION\n")
+	copyFileExe(t, dummy, newPath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.SupervisorSelfSwap()
+
+	// 应返回 ErrSupervisorRestartSoon
+	if !errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Fatalf("期望 ErrSupervisorRestartSoon，got %v", err)
+	}
+
+	// supervisor.exe 应被替换为新版本（dummy binary，无 OLD-VERSION marker）
+	got, _ := os.ReadFile(supervisorPath)
+	if strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf("supervisor.exe 仍是旧版本（含 OLD-VERSION marker）")
+	}
+
+	// .old 应存在（旧版本备份）
+	got, _ = os.ReadFile(oldPath)
+	if !strings.Contains(string(got), "OLD-VERSION") {
+		t.Errorf(".old 应含旧版本 marker，got %q", got)
+	}
+
+	// .new 应不存在（已被 rename 走）
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf(".new 应不存在（err=%v）", err)
+	}
+
+	// applied sentinel 应写入
+	if !IsSupervisorUpgradeApplied(stageDir) {
+		t.Errorf("applied sentinel 应写入")
+	}
+	// pending sentinel 应删除
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应删除")
+	}
+}
+
+// --- SupervisorSelfSwap 冒烟失败 ---
+
+func TestSupervisorSelfSwap_SmokeFail_AbortsBeforeRename(t *testing.T) {
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	supervisorPath := filepath.Join(binDir, SupervisorBinaryName)
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	// supervisor.exe（旧版本）
+	writeTestFile(t, supervisorPath, "old-supervisor")
+	// supervisor.exe.new 是非可执行文件（冒烟失败）
+	writeTestFile(t, newPath, "bad-binary")
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.SupervisorSelfSwap()
+
+	if err == nil {
+		t.Fatal("期望冒烟失败错误，got nil")
+	}
+	if errors.Is(err, ErrSupervisorRestartSoon) {
+		t.Errorf("冒烟失败不应返回 ErrSupervisorRestartSoon，got %v", err)
+	}
+	// supervisor.exe 应未被改动
+	got, _ := os.ReadFile(supervisorPath)
+	if string(got) != "old-supervisor" {
+		t.Errorf("supervisor.exe 应未被改动，got %q", got)
+	}
+	// .new + pending 应被清理（smokeTestVersion 内部清理）
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf(".new 应被清理（err=%v）", err)
+	}
+	if IsSupervisorUpgradePending(stageDir) {
+		t.Errorf("pending sentinel 应被清理")
+	}
+}
+
+// --- SupervisorSelfSwap step 1 失败（supervisor.exe 不存在）---
+
+func TestSupervisorSelfSwap_Step1Fail_SupervisorMissing(t *testing.T) {
+	dummy := buildDummy(t)
+	stageDir := t.TempDir()
+	binDir := t.TempDir()
+
+	// 只有 .new，没有 supervisor.exe（brick 恢复场景）
+	newPath := filepath.Join(binDir, SupervisorBinaryName+".new")
+	copyFileExe(t, dummy, newPath)
+	WriteSupervisorUpgradePending(stageDir, "v0.9.2")
+
+	m := NewMachine(stageDir, binDir, testLogger(), nil)
+	err := m.SupervisorSelfSwap()
+
+	if err == nil {
+		t.Fatal("期望 step 1 失败错误（supervisor.exe 不存在），got nil")
+	}
+	// 错误信息应提及 step 1
+	if !strings.Contains(err.Error(), "step 1") {
+		t.Errorf("错误应提及 step 1，got %q", err.Error())
+	}
+}

--- a/internal/edgeagent/upgrademachine/testdata/dummy_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/dummy_main.go
@@ -1,14 +1,11 @@
-// dummy_main.go 是 issue #21 Step 0 spike 的测试辅助程序。
-//
-// 与 sleeper_main.go 的区别：dummy 支持 --version（验证 W5 smokeTestVersion
+// dummy_main.go 是  Step 0 spike 的测试辅助程序。
+// 与 sleeper_main.go 的区别：dummy 支持 --version（验证  smokeTestVersion
 // 前置）和 --self-rename（验证运行中进程能否 rename 自己的 .exe）。
-//
 // 三种模式：
 //   - 默认：sleep 60s 然后退出 0（模拟运行中的 supervisor.exe 被外部 rename）
 //   - --version：输出 "ongrid-dummy v0.0.1" 并退出 0（模拟 supervisor --version）
 //   - --self-rename <path>：尝试 os.Rename(path, path+".old")，
 //     通过 stdout JSON 报告结果后立即退出（验证进程内自 rename 语义）
-//
 // 与 sleeper_main.go 一样，通过 `go build -o dummy.exe testdata/dummy_main.go`
 // 显式编译（testdata 不参与包编译）。
 package main

--- a/internal/edgeagent/upgrademachine/testdata/dummy_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/dummy_main.go
@@ -1,0 +1,54 @@
+// dummy_main.go 是 issue #21 Step 0 spike 的测试辅助程序。
+//
+// 与 sleeper_main.go 的区别：dummy 支持 --version（验证 W5 smokeTestVersion
+// 前置）和 --self-rename（验证运行中进程能否 rename 自己的 .exe）。
+//
+// 三种模式：
+//   - 默认：sleep 60s 然后退出 0（模拟运行中的 supervisor.exe 被外部 rename）
+//   - --version：输出 "ongrid-dummy v0.0.1" 并退出 0（模拟 supervisor --version）
+//   - --self-rename <path>：尝试 os.Rename(path, path+".old")，
+//     通过 stdout JSON 报告结果后立即退出（验证进程内自 rename 语义）
+//
+// 与 sleeper_main.go 一样，通过 `go build -o dummy.exe testdata/dummy_main.go`
+// 显式编译（testdata 不参与包编译）。
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	version := flag.Bool("version", false, "print version and exit")
+	selfRename := flag.String("self-rename", "", "rename this binary to <path>.old then report result and exit")
+	flag.Parse()
+
+	if *version {
+		fmt.Println("ongrid-dummy v0.0.1")
+		return
+	}
+
+	if *selfRename != "" {
+		oldPath := *selfRename + ".old"
+		err := os.Rename(*selfRename, oldPath)
+		result := map[string]any{
+			"op":  "self_rename",
+			"src": *selfRename,
+			"dst": oldPath,
+		}
+		if err != nil {
+			result["ok"] = false
+			result["err"] = err.Error()
+		} else {
+			result["ok"] = true
+		}
+		_ = json.NewEncoder(os.Stdout).Encode(result)
+		return
+	}
+
+	// 默认：持续运行 60s 模拟 supervisor 进程持有自身 .exe 文件锁
+	time.Sleep(60 * time.Second)
+}

--- a/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
@@ -1,0 +1,30 @@
+// sleeper_main.go 是测试辅助程序：启动后持续运行直到被 kill。
+// 用于模拟 windows_exporter.exe 等长期运行的 plugin 进程。
+// 通过持有自身 .exe 文件锁，模拟 issue #20 的核心场景：
+// worker 退出后 plugin 进程 orphaned → .exe 文件锁阻塞 rename。
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	// 捕获 Ctrl-Break（taskkill /T 默认发送），但忽略它模拟"被 orphaned 后无法触达"
+	// 实际生产中 windows_exporter 不响应 taskkill /T（不在 worker 的进程树）
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	// 真正的 orphaned 模拟：只接受 SIGKILL（taskkill /F）
+	go func() {
+		<-sigCh
+		// 什么都不做 — 模拟进程不响应优雅信号
+	}()
+
+	// 持续运行直到被强制 kill
+	for {
+		time.Sleep(time.Hour)
+	}
+}

--- a/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
+++ b/internal/edgeagent/upgrademachine/testdata/sleeper_main.go
@@ -1,6 +1,6 @@
 // sleeper_main.go 是测试辅助程序：启动后持续运行直到被 kill。
 // 用于模拟 windows_exporter.exe 等长期运行的 plugin 进程。
-// 通过持有自身 .exe 文件锁，模拟 issue #20 的核心场景：
+// 通过持有自身 .exe 文件锁，模拟  的核心场景：
 // worker 退出后 plugin 进程 orphaned → .exe 文件锁阻塞 rename。
 package main
 


### PR DESCRIPTION
Cleanup-only follow-up to PR1 #228 + PR2 #229. Inlines comment context that previously referenced internal ADR codes.

## Why

PR1 and PR2 comments referenced `ADR-0XX` / `MVP-X #XX` / `issue #XX` / `W[1-5]` / `dogfood` / `CR4` / `YAGNI` codes that point to internal design docs not in this repo. Reviewers flagged these as dead references. This PR removes the codes and leaves the surrounding explanatory text intact.

## Scope

32 files, +120 / -240 lines. **Comments only — zero functional change.**

Files touched (comment cleanup):
- `cmd/ongrid-edge-supervisor/*` (6 files)
- `internal/edgeagent/supervisorhealth/*` (2 files)
- `internal/edgeagent/upgradebundle/*` (3 files)
- `internal/edgeagent/upgrademachine/*` (21 files, including testdata)

## Stacked on #229

This PR's branch includes commits `b705400` (PR1) + `2e1b996` (PR2) + `b6d4351` (this cleanup). Once #228 + #229 merge, this PR auto-rebases and the diff collapses to the cleanup only.

## Verification

- `GOOS=linux go build ./...` — clean
- `GOOS=windows go build ./cmd/ongrid-edge-supervisor/... ./internal/edgeagent/{config,dpapi,edgedirs,install,supervisorhealth,upgradebundle,upgrademachine}/...` — clean
- Unit tests pass: cmd-supervisor + supervisorhealth + upgradebundle + upgrademachine
- `grep -E "ADR-0[0-9]+|MVP-[0-9]|issue #[0-9]+|W[1-5]|dogfood|YAGNI|CR4"` — zero matches across changed files

## Roadmap

- ✅ PR1 #228: scaffolding (DPAPI, install, edgedirs)
- ✅ PR2 #229: supervisor + upgrade machine
- 👉 PR3 (this PR merges first): Windows host skills + plugins
- Future: `cmdpolicy` / `host_files/handlers.go` platform abstraction (separate PR)