### PR TITLE
fix(skill): tail_file test uses OS-specific absolute path

### DIFF
--- a/internal/skill/builtin/tail_file_test.go
+++ b/internal/skill/builtin/tail_file_test.go
@@ -110,8 +110,10 @@ func TestTailFile_Execute_InvalidParams(t *testing.T) {
 }
 
 func TestTailFile_Execute_NotFound(t *testing.T) {
+	// 用 os.TempDir 拼路径，保证跨平台绝对路径（Windows 上 /tmp/... 不是 absolute）
+	notExistPath := filepath.Join(os.TempDir(), "this-file-does-not-exist-ongrid-test")
 	params, _ := json.Marshal(map[string]any{
-		"path": "/tmp/this-file-does-not-exist-ongrid-test",
+		"path": notExistPath,
 	})
 	out, err := (TailFile{}).Execute(context.Background(), params)
 	if err != nil {


### PR DESCRIPTION
Cross-platform fix for `TestTailFile_Execute_NotFound`. Independent of the Windows edge PR chain (#228 / #229 / #230).

## Problem

The test hardcoded `/tmp/this-file-does-not-exist-ongrid-test` as a non-existent absolute path. On Windows `/tmp/...` is not absolute (Windows requires a `C:\`-style drive prefix), so `filepath.IsAbs` returns false, the test gets `"path must be absolute"` instead of the expected file-not-found error, **FAIL on Windows**.

## Fix

Use `filepath.Join(os.TempDir(), "...")`:

- Linux/macOS: `/tmp/this-file-does-not-exist-ongrid-test`
- Windows: `C:\Users\<user>\AppData\Local\Temp\this-file-does-not-exist-ongrid-test`

Both satisfy `filepath.IsAbs`, preserving the original test intent.

## Scope

1 file, 3 insertions / 1 deletion. Test-only change, no production code touched.

## Verification

- `go test -run TestTailFile_Execute_NotFound ./internal/skill/builtin/` passes on Windows
- Full `go test ./internal/skill/builtin/` passes

## Why independent PR

Discovered while running PR3 Windows tests, but the bug and fix are platform-wide (not Windows-edge specific). Keeping it independent lets it merge quickly without waiting for the Windows edge chain (which will take 1-2 months to review).

## Contribution

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md