### PR TITLE
feat(k8s): separate telemetry data plane from controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh
+        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
 
       - name: Verify Compose image routing
         run: make verify-compose-images
@@ -116,48 +116,4 @@ jobs:
         run: make test-release-package
 
       - name: Lint and render Kubernetes chart
-        run: |
-          helm lint deploy/kubernetes/ongrid-edge \
-            --set-string manager.publicURL=https://manager.example:8443 \
-            --set-string manager.tunnelAddr=manager.example:40012 \
-            --set-string enrollment.clusterID=1 \
-            --set-string enrollment.controllerBootstrapToken=controller-token \
-            --set-string enrollment.nodeBootstrapToken=node-token
-          make package-k8s-chart
-          helm template ongrid-edge bin/k8s/ongrid-edge.tgz \
-            --namespace ongrid-system \
-            --set-string manager.publicURL=https://manager.example:8443 \
-            --set-string manager.tunnelAddr=manager.example:40012 \
-            --set-string enrollment.clusterID=1 \
-            --set-string enrollment.controllerBootstrapToken=controller-token \
-            --set-string enrollment.nodeBootstrapToken=node-token \
-            >/tmp/ongrid-edge.yaml
-          grep -q 'type: Recreate' /tmp/ongrid-edge.yaml
-          ! grep -q 'kubernetes.io/arch:' /tmp/ongrid-edge.yaml
-          image_ref="$(make --no-print-directory k8s-edge-image-ref)"
-          expected_image="image: \"${image_ref}\""
-          test "$(grep -F -c "$expected_image" /tmp/ongrid-edge.yaml)" -eq 3
-          grep -q 'k8s-inventory-full-sync-interval: "10m"' /tmp/ongrid-edge.yaml
-          grep -q 'k8s-metrics-timeout: "15s"' /tmp/ongrid-edge.yaml
-          grep -q 'k8s-metrics-push-timeout: "30s"' /tmp/ongrid-edge.yaml
-          grep -q 'k8s-metrics-sample-limit: "250000"' /tmp/ongrid-edge.yaml
-          grep -q 'k8s-metrics-batch-sample-limit: "10000"' /tmp/ongrid-edge.yaml
-          grep -q 'k8s-metrics-batch-byte-limit: "4194304"' /tmp/ongrid-edge.yaml
-          grep -q 'name: ONGRID_K8S_METRICS_TIMEOUT' /tmp/ongrid-edge.yaml
-          grep -q 'name: ONGRID_K8S_METRICS_PUSH_TIMEOUT' /tmp/ongrid-edge.yaml
-          grep -q 'name: ONGRID_K8S_METRICS_SAMPLE_LIMIT' /tmp/ongrid-edge.yaml
-          grep -q 'name: ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT' /tmp/ongrid-edge.yaml
-          grep -q 'name: ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT' /tmp/ongrid-edge.yaml
-          grep -q 'hostNetwork: true' /tmp/ongrid-edge.yaml
-          grep -q 'name: install-host-runtime' /tmp/ongrid-edge.yaml
-          grep -q -- '- install-k8s-host-runtime' /tmp/ongrid-edge.yaml
-          grep -A16 'name: install-host-runtime' /tmp/ongrid-edge.yaml | grep -q 'memory: 128Mi'
-          grep -q -- '- enter-k8s-host' /tmp/ongrid-edge.yaml
-          test "$(grep -F -c 'mountPath: /host/root' /tmp/ongrid-edge.yaml)" -eq 2
-          grep -q 'mountPropagation: HostToContainer' /tmp/ongrid-edge.yaml
-          grep -A1 'name: ONGRID_EDGE_COLLECTOR_MODE' /tmp/ongrid-edge.yaml | grep -q 'value: "off"'
-          grep -q 'add: \["CHOWN", "DAC_OVERRIDE", "FOWNER"\]' /tmp/ongrid-edge.yaml
-          grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"\]' /tmp/ongrid-edge.yaml
-          ! grep -q 'SYS_ADMIN\|SYS_PTRACE' /tmp/ongrid-edge.yaml
-          ! grep -q 'privileged: true' /tmp/ongrid-edge.yaml
-          ! grep -q 'supplementalGroups:' /tmp/ongrid-edge.yaml
+        run: make test-k8s-chart

--- a/Makefile
+++ b/Makefile
@@ -571,7 +571,7 @@ build-edge-bundle: ## [release] 打 ADR-024 edge upgrade bundle 到 dist/out/edg
 		bash dist/build-edge-bundle.sh $(VERSION) $$arch $(OUT)/edge-bundles; \
 	done
 
-.PHONY: package-k8s-chart publish-k8s-chart test-publish-k8s-chart
+.PHONY: package-k8s-chart publish-k8s-chart test-k8s-chart test-publish-k8s-chart
 package-k8s-chart: ## [dev/release] 打 Kubernetes Helm chart 到 bin/k8s/ongrid-edge.tgz
 	@mkdir -p bin/k8s
 	@rm -f bin/k8s/registry-setup.sh
@@ -585,6 +585,9 @@ publish-k8s-chart: package-k8s-chart ## [release] 发布 Kubernetes Helm chart �
 		"$(K8S_CHART_PUSH_TARGET)" \
 		"$(CNB_HELM_REGISTRY)" \
 		"$(CNB_HELM_USERNAME)"
+
+test-k8s-chart: package-k8s-chart ## [test] 校验 Kubernetes Helm Chart 的兼容、拆分、暂停与非法配置
+	bash scripts/test-k8s-chart.sh deploy/kubernetes/ongrid-edge $(K8S_CHART_PACKAGE) $(K8S_EDGE_IMAGE_REF)
 
 test-publish-k8s-chart: ## [test] 校验 Helm Chart 幂等发布
 	bash scripts/test-publish-helm-chart.sh

--- a/cmd/ongrid-edge/k8s_credentials.go
+++ b/cmd/ongrid-edge/k8s_credentials.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -127,7 +128,72 @@ func storeK8sCredential(ctx context.Context, info *tunnel.KubernetesInfo, out k8
 	if err != nil {
 		return fmt.Errorf("marshal k8s stored credential: %w", err)
 	}
+	if info.Role == "controller" && out.Telemetry != nil {
+		if out.Telemetry.ClusterID != info.ClusterID || out.Telemetry.AccessKey == "" || out.Telemetry.SecretKey == "" {
+			return fmt.Errorf("kubernetes telemetry credential does not match controller cluster")
+		}
+		telemetry := *out.Telemetry
+		applyManagerTelemetryTLS(&telemetry, out.ManagerPublicURL)
+		telemetryClient := *client
+		if secretName := strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")); secretName != "" {
+			telemetryClient.secretName = secretName
+		}
+		if err := telemetryClient.patchDataKeys(ctx, telemetrySecretData(telemetry)); err != nil {
+			return err
+		}
+	}
 	return client.patchDataKey(ctx, k8sCredentialKey(info), payload)
+}
+
+func storeK8sTelemetryConfig(ctx context.Context, info *tunnel.KubernetesInfo, telemetry k8sTelemetryConfig) error {
+	if info == nil || info.Role != "controller" || telemetry.ClusterID != info.ClusterID || telemetry.AccessKey == "" || telemetry.SecretKey == "" {
+		return fmt.Errorf("invalid kubernetes telemetry configuration")
+	}
+	client, err := newK8sSecretClient(info)
+	if err != nil {
+		return err
+	}
+	if client == nil {
+		return fmt.Errorf("kubernetes credential secret client is unavailable")
+	}
+	if secretName := strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")); secretName != "" {
+		client.secretName = secretName
+	}
+	desired := telemetrySecretData(telemetry)
+	current, found, err := client.getData(ctx)
+	if err != nil {
+		return err
+	}
+	if found && dataContainsValues(current, desired) {
+		return nil
+	}
+	return client.patchDataKeys(ctx, desired)
+}
+
+func loadK8sTelemetryCredential(ctx context.Context, info *tunnel.KubernetesInfo) (string, string, bool, error) {
+	if info == nil || info.Role != "controller" {
+		return "", "", false, fmt.Errorf("invalid kubernetes controller identity")
+	}
+	client, err := newK8sSecretClient(info)
+	if err != nil {
+		return "", "", false, err
+	}
+	if client == nil {
+		return "", "", false, fmt.Errorf("kubernetes credential secret client is unavailable")
+	}
+	if secretName := strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")); secretName != "" {
+		client.secretName = secretName
+	}
+	data, found, err := client.getData(ctx)
+	if err != nil {
+		return "", "", false, err
+	}
+	accessKey := data["telemetry-access-key"]
+	secretKey := data["telemetry-secret-key"]
+	if !found || len(accessKey) == 0 || len(secretKey) == 0 {
+		return "", "", false, nil
+	}
+	return strings.TrimSpace(string(accessKey)), strings.TrimSpace(string(secretKey)), true, nil
 }
 
 func loadStoredK8sCredentialFile(cfg *config.Config, info *tunnel.KubernetesInfo, filePath string, log *slog.Logger) (bool, error) {
@@ -296,6 +362,18 @@ func newK8sSecretClient(info *tunnel.KubernetesInfo) (*k8sSecretClient, error) {
 }
 
 func (c *k8sSecretClient) getDataKey(ctx context.Context, key string) ([]byte, bool, error) {
+	data, found, err := c.getData(ctx)
+	if err != nil || !found {
+		return nil, false, err
+	}
+	raw, ok := data[key]
+	if !ok || len(raw) == 0 {
+		return nil, false, nil
+	}
+	return raw, true, nil
+}
+
+func (c *k8sSecretClient) getData(ctx context.Context) (map[string][]byte, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.secretURL(), nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("new k8s secret get request: %w", err)
@@ -319,22 +397,28 @@ func (c *k8sSecretClient) getDataKey(ctx context.Context, key string) ([]byte, b
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, false, fmt.Errorf("decode k8s credential secret: %w", err)
 	}
-	encoded, ok := out.Data[key]
-	if !ok || encoded == "" {
-		return nil, false, nil
+	data := make(map[string][]byte, len(out.Data))
+	for key, encoded := range out.Data {
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, false, fmt.Errorf("decode k8s credential data %q: %w", key, err)
+		}
+		data[key] = raw
 	}
-	raw, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return nil, false, fmt.Errorf("decode k8s credential data %q: %w", key, err)
-	}
-	return raw, true, nil
+	return data, true, nil
 }
 
 func (c *k8sSecretClient) patchDataKey(ctx context.Context, key string, raw []byte) error {
+	return c.patchDataKeys(ctx, map[string][]byte{key: raw})
+}
+
+func (c *k8sSecretClient) patchDataKeys(ctx context.Context, values map[string][]byte) error {
+	encoded := make(map[string]string, len(values))
+	for key, raw := range values {
+		encoded[key] = base64.StdEncoding.EncodeToString(raw)
+	}
 	patch := map[string]map[string]string{
-		"data": {
-			key: base64.StdEncoding.EncodeToString(raw),
-		},
+		"data": encoded,
 	}
 	payload, err := json.Marshal(patch)
 	if err != nil {
@@ -356,6 +440,49 @@ func (c *k8sSecretClient) patchDataKey(ctx context.Context, key string, raw []by
 		return fmt.Errorf("patch k8s credential secret failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
+}
+
+func telemetrySecretData(in k8sTelemetryConfig) map[string][]byte {
+	return map[string][]byte{
+		"telemetry-cluster-id":                []byte(strconv.FormatUint(in.ClusterID, 10)),
+		"telemetry-access-key":                []byte(in.AccessKey),
+		"telemetry-secret-key":                []byte(in.SecretKey),
+		"telemetry-traces-endpoint":           []byte(in.TracesEndpoint),
+		"telemetry-logs-endpoint":             []byte(in.LogsEndpoint),
+		"telemetry-remote-write-endpoint":     []byte(in.RemoteWriteEndpoint),
+		"telemetry-remote-write-bearer":       []byte(in.RemoteWriteBearer),
+		"telemetry-remote-write-basic-user":   []byte(in.RemoteWriteBasicUser),
+		"telemetry-remote-write-basic-pass":   []byte(in.RemoteWriteBasicPass),
+		"telemetry-remote-write-tls-insecure": []byte(strconv.FormatBool(in.RemoteWriteTLSInsecure)),
+		"telemetry-remote-write-ca.pem":       []byte(in.RemoteWriteTLSCAPEM),
+	}
+}
+
+func dataContainsValues(current, desired map[string][]byte) bool {
+	for key, want := range desired {
+		got, ok := current[key]
+		if !ok || !bytes.Equal(got, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// applyManagerTelemetryTLS carries the controller's explicit trust choice to
+// remote_write only when that endpoint is served by the same Manager origin.
+// An external backend keeps the TLS policy resolved by Manager.
+func applyManagerTelemetryTLS(in *k8sTelemetryConfig, managerURL string) {
+	if in == nil || !parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false) {
+		return
+	}
+	manager, managerErr := url.Parse(strings.TrimSpace(managerURL))
+	target, targetErr := url.Parse(strings.TrimSpace(in.RemoteWriteEndpoint))
+	if managerErr != nil || targetErr != nil || manager.Scheme == "" || manager.Host == "" {
+		return
+	}
+	if strings.EqualFold(manager.Scheme, target.Scheme) && strings.EqualFold(manager.Host, target.Host) {
+		in.RemoteWriteTLSInsecure = true
+	}
 }
 
 func (c *k8sSecretClient) secretURL() string {

--- a/cmd/ongrid-edge/k8s_credentials.go
+++ b/cmd/ongrid-edge/k8s_credentials.go
@@ -448,7 +448,15 @@ func telemetrySecretData(in k8sTelemetryConfig) map[string][]byte {
 		"telemetry-access-key":                []byte(in.AccessKey),
 		"telemetry-secret-key":                []byte(in.SecretKey),
 		"telemetry-traces-endpoint":           []byte(in.TracesEndpoint),
+		"telemetry-traces-auth-mode":          []byte(in.TracesAuthMode),
+		"telemetry-traces-basic-user":         []byte(in.TracesBasicUser),
+		"telemetry-traces-basic-pass":         []byte(in.TracesBasicPass),
+		"telemetry-traces-tls-insecure":       []byte(strconv.FormatBool(in.TracesTLSInsecure)),
 		"telemetry-logs-endpoint":             []byte(in.LogsEndpoint),
+		"telemetry-logs-auth-mode":            []byte(in.LogsAuthMode),
+		"telemetry-logs-basic-user":           []byte(in.LogsBasicUser),
+		"telemetry-logs-basic-pass":           []byte(in.LogsBasicPass),
+		"telemetry-logs-tls-insecure":         []byte(strconv.FormatBool(in.LogsTLSInsecure)),
 		"telemetry-remote-write-endpoint":     []byte(in.RemoteWriteEndpoint),
 		"telemetry-remote-write-bearer":       []byte(in.RemoteWriteBearer),
 		"telemetry-remote-write-basic-user":   []byte(in.RemoteWriteBasicUser),
@@ -469,18 +477,27 @@ func dataContainsValues(current, desired map[string][]byte) bool {
 }
 
 // applyManagerTelemetryTLS carries the controller's explicit trust choice to
-// remote_write only when that endpoint is served by the same Manager origin.
-// An external backend keeps the TLS policy resolved by Manager.
+// Manager-origin signals only. External backends keep the TLS policy resolved
+// by Manager from their integration settings.
 func applyManagerTelemetryTLS(in *k8sTelemetryConfig, managerURL string) {
 	if in == nil || !parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false) {
 		return
 	}
 	manager, managerErr := url.Parse(strings.TrimSpace(managerURL))
-	target, targetErr := url.Parse(strings.TrimSpace(in.RemoteWriteEndpoint))
-	if managerErr != nil || targetErr != nil || manager.Scheme == "" || manager.Host == "" {
+	if managerErr != nil || manager.Scheme == "" || manager.Host == "" {
 		return
 	}
-	if strings.EqualFold(manager.Scheme, target.Scheme) && strings.EqualFold(manager.Host, target.Host) {
+	sameOrigin := func(raw string) bool {
+		target, err := url.Parse(strings.TrimSpace(raw))
+		return err == nil && strings.EqualFold(manager.Scheme, target.Scheme) && strings.EqualFold(manager.Host, target.Host)
+	}
+	if sameOrigin(in.TracesEndpoint) {
+		in.TracesTLSInsecure = true
+	}
+	if sameOrigin(in.LogsEndpoint) {
+		in.LogsTLSInsecure = true
+	}
+	if sameOrigin(in.RemoteWriteEndpoint) {
 		in.RemoteWriteTLSInsecure = true
 	}
 }

--- a/cmd/ongrid-edge/k8s_credentials_test.go
+++ b/cmd/ongrid-edge/k8s_credentials_test.go
@@ -65,6 +65,31 @@ func TestK8sCredentialFileRoundTrip(t *testing.T) {
 	}
 }
 
+func TestControllerCredentialFileDoesNotContainTelemetryCredential(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "controller-credential.json")
+	info := &tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}
+	out := k8sEnrollResponse{
+		EdgeID:    9,
+		AccessKey: "controller-access",
+		SecretKey: "controller-secret",
+		Telemetry: &k8sTelemetryConfig{
+			ClusterID: 7,
+			AccessKey: "kt_access",
+			SecretKey: "ks_secret",
+		},
+	}
+	if err := storeK8sCredentialFile(info, out, &config.Config{}, filePath); err != nil {
+		t.Fatalf("storeK8sCredentialFile: %v", err)
+	}
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("read controller credential: %v", err)
+	}
+	if strings.Contains(string(raw), "kt_access") || strings.Contains(string(raw), "ks_secret") || strings.Contains(string(raw), "telemetry") {
+		t.Fatalf("controller credential contains telemetry data: %s", raw)
+	}
+}
+
 func TestK8sCredentialFileRejectsDifferentNode(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "node-credential.json")
 	info := &tunnel.KubernetesInfo{ClusterID: 7, Role: "node", NodeName: "worker-a"}
@@ -74,6 +99,73 @@ func TestK8sCredentialFileRejectsDifferentNode(t *testing.T) {
 	loaded, err := loadStoredK8sCredentialFile(&config.Config{}, &tunnel.KubernetesInfo{ClusterID: 7, Role: "node", NodeName: "worker-b"}, filePath, nil)
 	if err == nil || loaded {
 		t.Fatalf("loaded=%v err=%v, want node mismatch", loaded, err)
+	}
+}
+
+func TestTelemetrySecretDataContainsOnlyPublishedDataPlaneFields(t *testing.T) {
+	in := k8sTelemetryConfig{
+		ClusterID:              7,
+		AccessKey:              "kt_access",
+		SecretKey:              "ks_secret",
+		TracesEndpoint:         "https://manager.example/v1/traces",
+		LogsEndpoint:           "https://manager.example/loki/api/v1/push",
+		RemoteWriteEndpoint:    "https://manager.example/prometheus/api/v1/write",
+		RemoteWriteBasicUser:   "kt_access",
+		RemoteWriteBasicPass:   "ks_secret",
+		RemoteWriteTLSInsecure: true,
+		RemoteWriteTLSCAPEM:    "test-ca",
+	}
+	got := telemetrySecretData(in)
+	wants := map[string]string{
+		"telemetry-cluster-id":                "7",
+		"telemetry-access-key":                "kt_access",
+		"telemetry-secret-key":                "ks_secret",
+		"telemetry-traces-endpoint":           "https://manager.example/v1/traces",
+		"telemetry-logs-endpoint":             "https://manager.example/loki/api/v1/push",
+		"telemetry-remote-write-endpoint":     "https://manager.example/prometheus/api/v1/write",
+		"telemetry-remote-write-basic-user":   "kt_access",
+		"telemetry-remote-write-basic-pass":   "ks_secret",
+		"telemetry-remote-write-tls-insecure": "true",
+		"telemetry-remote-write-ca.pem":       "test-ca",
+	}
+	for key, want := range wants {
+		if value := string(got[key]); value != want {
+			t.Fatalf("%s = %q, want %q", key, value, want)
+		}
+	}
+	if _, ok := got["controller"]; ok {
+		t.Fatal("telemetry Secret must not contain the controller credential document")
+	}
+}
+
+func TestApplyManagerTelemetryTLSIsOriginScoped(t *testing.T) {
+	t.Setenv("ONGRID_K8S_ENROLL_TLS_INSECURE", "true")
+	managerTarget := k8sTelemetryConfig{RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write"}
+	applyManagerTelemetryTLS(&managerTarget, "https://manager.example")
+	if !managerTarget.RemoteWriteTLSInsecure {
+		t.Fatal("manager-origin remote_write did not inherit the explicit manager TLS setting")
+	}
+
+	externalTarget := k8sTelemetryConfig{RemoteWriteEndpoint: "https://metrics.example/api/v1/write"}
+	applyManagerTelemetryTLS(&externalTarget, "https://manager.example")
+	if externalTarget.RemoteWriteTLSInsecure {
+		t.Fatal("external remote_write must not inherit the manager TLS setting")
+	}
+}
+
+func TestDataContainsValuesRequiresProjectedEmptyKeys(t *testing.T) {
+	desired := map[string][]byte{
+		"endpoint": []byte("https://metrics.example/write"),
+		"bearer":   {},
+	}
+	if dataContainsValues(map[string][]byte{"endpoint": []byte("https://metrics.example/write")}, desired) {
+		t.Fatal("missing empty key must still trigger a Secret patch for volume projection")
+	}
+	if !dataContainsValues(map[string][]byte{
+		"endpoint": []byte("https://metrics.example/write"),
+		"bearer":   {},
+	}, desired) {
+		t.Fatal("matching Secret data was not recognized")
 	}
 }
 
@@ -130,5 +222,46 @@ func TestK8sSecretClientDataKeyRoundTrip(t *testing.T) {
 	}
 	if string(decoded) != `{"access_key":"new"}` {
 		t.Fatalf("patched credential = %q", string(decoded))
+	}
+}
+
+func TestRefreshK8sTelemetryConfigPreservesCurrentCredentialProof(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/internal/k8s/telemetry-config" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "controller-access" || pass != "controller-secret" {
+			t.Fatalf("controller auth = %q/%q, ok=%v", user, pass, ok)
+		}
+		var proof map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&proof); err != nil {
+			t.Fatalf("decode credential proof: %v", err)
+		}
+		if proof["access_key"] != "kt_current" || proof["secret_key"] != "ks_current" {
+			t.Fatalf("credential proof = %#v", proof)
+		}
+		if err := json.NewEncoder(w).Encode(k8sTelemetryConfig{
+			ClusterID:           7,
+			AccessKey:           proof["access_key"],
+			SecretKey:           proof["secret_key"],
+			TracesEndpoint:      "https://manager.example/v1/traces",
+			LogsEndpoint:        "https://manager.example/loki/api/v1/push",
+			RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write",
+		}); err != nil {
+			t.Fatalf("encode telemetry config: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	out, err := refreshK8sTelemetryConfig(context.Background(), &config.Config{Edge: config.EdgeConfig{
+		AccessKey: "controller-access",
+		SecretKey: "controller-secret",
+	}}, server.URL, "kt_current", "ks_current")
+	if err != nil {
+		t.Fatalf("refreshK8sTelemetryConfig: %v", err)
+	}
+	if out.AccessKey != "kt_current" || out.SecretKey != "ks_current" {
+		t.Fatalf("refreshed credential = %#v", out)
 	}
 }

--- a/cmd/ongrid-edge/k8s_credentials_test.go
+++ b/cmd/ongrid-edge/k8s_credentials_test.go
@@ -108,7 +108,12 @@ func TestTelemetrySecretDataContainsOnlyPublishedDataPlaneFields(t *testing.T) {
 		AccessKey:              "kt_access",
 		SecretKey:              "ks_secret",
 		TracesEndpoint:         "https://manager.example/v1/traces",
+		TracesAuthMode:         telemetrySignalAuthTelemetry,
+		TracesTLSInsecure:      true,
 		LogsEndpoint:           "https://manager.example/loki/api/v1/push",
+		LogsAuthMode:           telemetrySignalAuthBackend,
+		LogsBasicUser:          "loki-user",
+		LogsBasicPass:          "loki-pass",
 		RemoteWriteEndpoint:    "https://manager.example/prometheus/api/v1/write",
 		RemoteWriteBasicUser:   "kt_access",
 		RemoteWriteBasicPass:   "ks_secret",
@@ -121,7 +126,12 @@ func TestTelemetrySecretDataContainsOnlyPublishedDataPlaneFields(t *testing.T) {
 		"telemetry-access-key":                "kt_access",
 		"telemetry-secret-key":                "ks_secret",
 		"telemetry-traces-endpoint":           "https://manager.example/v1/traces",
+		"telemetry-traces-auth-mode":          telemetrySignalAuthTelemetry,
+		"telemetry-traces-tls-insecure":       "true",
 		"telemetry-logs-endpoint":             "https://manager.example/loki/api/v1/push",
+		"telemetry-logs-auth-mode":            telemetrySignalAuthBackend,
+		"telemetry-logs-basic-user":           "loki-user",
+		"telemetry-logs-basic-pass":           "loki-pass",
 		"telemetry-remote-write-endpoint":     "https://manager.example/prometheus/api/v1/write",
 		"telemetry-remote-write-basic-user":   "kt_access",
 		"telemetry-remote-write-basic-pass":   "ks_secret",
@@ -140,16 +150,24 @@ func TestTelemetrySecretDataContainsOnlyPublishedDataPlaneFields(t *testing.T) {
 
 func TestApplyManagerTelemetryTLSIsOriginScoped(t *testing.T) {
 	t.Setenv("ONGRID_K8S_ENROLL_TLS_INSECURE", "true")
-	managerTarget := k8sTelemetryConfig{RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write"}
+	managerTarget := k8sTelemetryConfig{
+		TracesEndpoint:      "https://manager.example/v1/traces",
+		LogsEndpoint:        "https://manager.example/loki/api/v1/push",
+		RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write",
+	}
 	applyManagerTelemetryTLS(&managerTarget, "https://manager.example")
-	if !managerTarget.RemoteWriteTLSInsecure {
-		t.Fatal("manager-origin remote_write did not inherit the explicit manager TLS setting")
+	if !managerTarget.TracesTLSInsecure || !managerTarget.LogsTLSInsecure || !managerTarget.RemoteWriteTLSInsecure {
+		t.Fatalf("manager-origin signals did not inherit the explicit manager TLS setting: %#v", managerTarget)
 	}
 
-	externalTarget := k8sTelemetryConfig{RemoteWriteEndpoint: "https://metrics.example/api/v1/write"}
+	externalTarget := k8sTelemetryConfig{
+		TracesEndpoint:      "https://tempo.example/v1/traces",
+		LogsEndpoint:        "https://loki.example/loki/api/v1/push",
+		RemoteWriteEndpoint: "https://metrics.example/api/v1/write",
+	}
 	applyManagerTelemetryTLS(&externalTarget, "https://manager.example")
-	if externalTarget.RemoteWriteTLSInsecure {
-		t.Fatal("external remote_write must not inherit the manager TLS setting")
+	if externalTarget.TracesTLSInsecure || externalTarget.LogsTLSInsecure || externalTarget.RemoteWriteTLSInsecure {
+		t.Fatalf("external signals inherited the manager TLS setting: %#v", externalTarget)
 	}
 }
 

--- a/cmd/ongrid-edge/k8s_data_plane.go
+++ b/cmd/ongrid-edge/k8s_data_plane.go
@@ -1,0 +1,435 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+
+	edgek8s "github.com/ongridio/ongrid/internal/edgeagent/k8s"
+	edgeplugins "github.com/ongridio/ongrid/internal/edgeagent/plugins"
+	edgeplugintraces "github.com/ongridio/ongrid/internal/edgeagent/plugins/traces"
+	"github.com/ongridio/ongrid/internal/pkg/httpserver"
+	"github.com/ongridio/ongrid/internal/pkg/prom"
+	"github.com/ongridio/ongrid/internal/pkg/promauth"
+	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
+)
+
+const defaultK8sTelemetrySecretDir = "/var/run/ongrid-telemetry"
+
+func runK8sDataPlaneMode(ctx context.Context, mode string, log *slog.Logger) (bool, error) {
+	switch strings.TrimSpace(mode) {
+	case "k8s-telemetry-gateway":
+		return true, runK8sTelemetryGateway(ctx, log)
+	case "k8s-metrics-scraper":
+		return true, runK8sMetricsScraper(ctx, log)
+	default:
+		return false, nil
+	}
+}
+
+func runK8sTelemetryGateway(ctx context.Context, log *slog.Logger) error {
+	binDir := envOr("ONGRID_EDGE_PLUGIN_BIN_DIR", "/usr/local/lib/ongrid-edge")
+	workDir := envOr("ONGRID_EDGE_PLUGIN_WORK_DIR", "/var/lib/ongrid-edge/plugins")
+	plugin := edgeplugintraces.New(binDir, workDir, log.With(slog.String("comp", "telemetry-gateway")))
+	supervisor := edgeplugins.NewSupervisor(edgeplugins.SupervisorOpts{
+		Fetcher:        &k8sTelemetryGatewayFetcher{dir: telemetrySecretDir()},
+		ReloadInterval: parseDurationEnv("ONGRID_K8S_TELEMETRY_RELOAD_INTERVAL", 10*time.Second),
+		Log:            log,
+	})
+	supervisor.Register(plugin)
+
+	registry := prom.NewRegistry()
+	collectorHealthClient := &http.Client{Timeout: 500 * time.Millisecond}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error { return supervisor.Run(groupCtx) })
+	group.Go(func() error {
+		return runDataPlaneDiagnostics(groupCtx, registry, func() bool {
+			for _, snapshot := range supervisor.HealthSnapshots() {
+				if snapshot.Name == edgeplugintraces.Name {
+					return snapshot.State == edgeplugins.StateRunning && collectorHealthReady(groupCtx, collectorHealthClient)
+				}
+			}
+			return false
+		}, log)
+	})
+	log.Info("kubernetes telemetry gateway mode started; tunnel and inventory are disabled")
+	return group.Wait()
+}
+
+func collectorHealthReady(ctx context.Context, client *http.Client) bool {
+	if client == nil {
+		return false
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:13133/", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() /* Best-effort cleanup after a readiness probe. */ }()
+	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+}
+
+func runK8sMetricsScraper(ctx context.Context, log *slog.Logger) error {
+	dir := telemetrySecretDir()
+	config, err := waitForRemoteWriteFiles(ctx, dir)
+	if err != nil {
+		return err
+	}
+	pushTimeout := parseDurationEnv("ONGRID_K8S_METRICS_PUSH_TIMEOUT", 30*time.Second)
+	writer := &telemetryRemoteWriteWriter{dir: dir, timeout: pushTimeout, log: log}
+	if _, err := writer.clientFor(config); err != nil {
+		return fmt.Errorf("build k8s metrics remote_write client: %w", err)
+	}
+	registry := prom.NewRegistry()
+	scraper, err := edgek8s.NewRemoteWriteScraper(writer, edgek8s.RemoteWriteScraperConfig{
+		ClusterID:        config.clusterID,
+		Endpoint:         strings.TrimSpace(os.Getenv("ONGRID_K8S_METRICS_ENDPOINT")),
+		Interval:         parseDurationEnv("ONGRID_K8S_METRICS_INTERVAL", 30*time.Second),
+		Timeout:          parseDurationEnv("ONGRID_K8S_METRICS_TIMEOUT", 15*time.Second),
+		PushTimeout:      pushTimeout,
+		SampleLimit:      parseIntEnv("ONGRID_K8S_METRICS_SAMPLE_LIMIT", 250000),
+		BatchSampleLimit: parseIntEnv("ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT", 10000),
+		BatchByteLimit:   parseIntEnv("ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT", 4<<20),
+		MaxRetries:       parseIntEnv("ONGRID_K8S_METRICS_MAX_RETRIES", 3),
+		RetryBackoff:     parseDurationEnv("ONGRID_K8S_METRICS_RETRY_BACKOFF", 500*time.Millisecond),
+	}, log.With(slog.String("comp", "k8s-metrics-scraper")), registry)
+	if err != nil {
+		return err
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error { return scraper.Run(groupCtx) })
+	group.Go(func() error { return runDataPlaneDiagnostics(groupCtx, registry, func() bool { return true }, log) })
+	log.Info("kubernetes metrics scraper mode started; tunnel and inventory are disabled",
+		slog.Uint64("cluster_id", config.clusterID),
+	)
+	return group.Wait()
+}
+
+func runDataPlaneDiagnostics(ctx context.Context, registry *prometheus.Registry, ready func() bool, log *slog.Logger) error {
+	router := chi.NewRouter()
+	router.Handle("/metrics", prom.Handler(registry))
+	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("ok")); err != nil {
+			log.Debug("write data-plane health response", slog.Any("err", err))
+		}
+	})
+	router.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if ready == nil || !ready() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("ready")); err != nil {
+			log.Debug("write data-plane readiness response", slog.Any("err", err))
+		}
+	})
+	addr := envOr("ONGRID_EDGE_METRICS_ADDR", edgeMetricsAddr)
+	return httpserver.New(addr, router, log.With(slog.String("listener", "data-plane-diagnostics"))).Start(ctx)
+}
+
+type k8sTelemetryGatewayFetcher struct {
+	dir string
+}
+
+func (f *k8sTelemetryGatewayFetcher) Fetch(ctx context.Context) (map[string]edgeplugins.PluginConfig, error) {
+	files, err := readTelemetryFiles(ctx, f.dir)
+	if err != nil {
+		return nil, err
+	}
+	if files.tracesEndpoint == "" || files.logsEndpoint == "" || files.remoteWriteEndpoint == "" {
+		return nil, errors.New("kubernetes telemetry endpoints are not ready")
+	}
+	spec := map[string]interface{}{
+		"grpc_endpoint":                     "0.0.0.0:4317",
+		"http_endpoint":                     "0.0.0.0:4318",
+		"omit_device_id":                    true,
+		"enable_k8sattributes":              true,
+		"enable_logs":                       true,
+		"enable_metrics":                    true,
+		"logs_endpoint":                     files.logsEndpoint,
+		"metrics_remote_write_endpoint":     files.remoteWriteEndpoint,
+		"metrics_remote_write_auth_user":    files.remoteWriteBasicUser,
+		"metrics_remote_write_auth_pass":    files.remoteWriteBasicPass,
+		"metrics_remote_write_bearer":       files.remoteWriteBearer,
+		"metrics_remote_write_tls_insecure": files.remoteWriteTLSInsecure,
+		"bounded_pipelines":                 true,
+		"memory_limit_mib":                  parseIntEnv("ONGRID_K8S_GATEWAY_MEMORY_LIMIT_MIB", 768),
+		"memory_spike_limit_mib":            parseIntEnv("ONGRID_K8S_GATEWAY_MEMORY_SPIKE_LIMIT_MIB", 128),
+		"batch_send_size":                   parseIntEnv("ONGRID_K8S_GATEWAY_BATCH_SIZE", 2048),
+		"batch_max_size":                    parseIntEnv("ONGRID_K8S_GATEWAY_BATCH_MAX_SIZE", 4096),
+		"queue_size":                        parseIntEnv("ONGRID_K8S_GATEWAY_QUEUE_SIZE", 512),
+		"collector_metrics_endpoint":        "0.0.0.0:8888",
+		"tls_insecure_skip_verify":          parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false),
+		"extra_attrs": map[string]interface{}{
+			"cluster_id":        strconv.FormatUint(files.clusterID, 10),
+			"telemetry_gateway": "kubernetes",
+			"gateway_namespace": strings.TrimSpace(os.Getenv("ONGRID_K8S_POD_NAMESPACE")),
+		},
+	}
+	if files.remoteWriteCAPath != "" {
+		spec["metrics_remote_write_ca_file"] = files.remoteWriteCAPath
+		spec["metrics_remote_write_ca_checksum"] = fmt.Sprintf("%x", files.remoteWriteCAHash)
+	}
+	return map[string]edgeplugins.PluginConfig{
+		edgeplugintraces.Name: {
+			Enabled:  true,
+			Endpoint: files.tracesEndpoint,
+			AuthUser: files.accessKey,
+			AuthPass: files.secretKey,
+			Spec:     spec,
+		},
+	}, nil
+}
+
+type telemetryFiles struct {
+	clusterID              uint64
+	accessKey              string
+	secretKey              string
+	tracesEndpoint         string
+	logsEndpoint           string
+	remoteWriteEndpoint    string
+	remoteWriteBearer      string
+	remoteWriteBasicUser   string
+	remoteWriteBasicPass   string
+	remoteWriteTLSInsecure bool
+	remoteWriteCAPath      string
+	remoteWriteCAHash      [32]byte
+}
+
+func readTelemetryFiles(ctx context.Context, dir string) (telemetryFiles, error) {
+	files, err := readRemoteWriteFiles(ctx, dir)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	accessKey, err := readTelemetryFile(ctx, dir, "telemetry-access-key", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	secretKey, err := readTelemetryFile(ctx, dir, "telemetry-secret-key", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	tracesEndpoint, err := readTelemetryFile(ctx, dir, "telemetry-traces-endpoint", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	logsEndpoint, err := readTelemetryFile(ctx, dir, "telemetry-logs-endpoint", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	if err := validateTelemetryEndpoint("traces", tracesEndpoint); err != nil {
+		return telemetryFiles{}, err
+	}
+	if err := validateTelemetryEndpoint("logs", logsEndpoint); err != nil {
+		return telemetryFiles{}, err
+	}
+	files.accessKey = accessKey
+	files.secretKey = secretKey
+	files.tracesEndpoint = tracesEndpoint
+	files.logsEndpoint = logsEndpoint
+	return files, nil
+}
+
+// readRemoteWriteFiles is the intentionally narrow Metrics Scraper view of
+// the telemetry Secret. It does not require or read the Loki/Tempo ingest
+// identity, so the scraper volume can project only its write target fields.
+func readRemoteWriteFiles(ctx context.Context, dir string) (telemetryFiles, error) {
+	if err := ctx.Err(); err != nil {
+		return telemetryFiles{}, err
+	}
+	clusterRaw, err := readTelemetryFile(ctx, dir, "telemetry-cluster-id", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	clusterID, err := strconv.ParseUint(clusterRaw, 10, 64)
+	if err != nil || clusterID == 0 {
+		return telemetryFiles{}, fmt.Errorf("parse telemetry cluster id")
+	}
+	remoteWriteEndpoint, err := readTelemetryFile(ctx, dir, "telemetry-remote-write-endpoint", true)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	if err := validateTelemetryEndpoint("remote_write", remoteWriteEndpoint); err != nil {
+		return telemetryFiles{}, err
+	}
+	remoteWriteBearer, err := readTelemetryFile(ctx, dir, "telemetry-remote-write-bearer", false)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	remoteWriteBasicUser, err := readTelemetryFile(ctx, dir, "telemetry-remote-write-basic-user", false)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	remoteWriteBasicPass, err := readTelemetryFile(ctx, dir, "telemetry-remote-write-basic-pass", false)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	if (remoteWriteBasicUser == "") != (remoteWriteBasicPass == "") {
+		return telemetryFiles{}, errors.New("kubernetes telemetry remote_write basic auth requires both username and password")
+	}
+	tlsRaw, err := readTelemetryFile(ctx, dir, "telemetry-remote-write-tls-insecure", false)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	tlsInsecure := false
+	if tlsRaw != "" {
+		tlsInsecure, err = strconv.ParseBool(tlsRaw)
+		if err != nil {
+			return telemetryFiles{}, fmt.Errorf("parse kubernetes telemetry remote_write TLS setting: %w", err)
+		}
+	}
+	caPath := filepath.Join(dir, "telemetry-remote-write-ca.pem")
+	caRaw, caErr := os.ReadFile(caPath)
+	var caHash [32]byte
+	if errors.Is(caErr, os.ErrNotExist) || (caErr == nil && len(caRaw) == 0) {
+		caPath = ""
+	} else if caErr != nil {
+		return telemetryFiles{}, fmt.Errorf("read kubernetes telemetry remote_write CA: %w", caErr)
+	} else {
+		caHash = sha256.Sum256(caRaw)
+	}
+	return telemetryFiles{
+		clusterID:              clusterID,
+		remoteWriteEndpoint:    remoteWriteEndpoint,
+		remoteWriteBearer:      remoteWriteBearer,
+		remoteWriteBasicUser:   remoteWriteBasicUser,
+		remoteWriteBasicPass:   remoteWriteBasicPass,
+		remoteWriteTLSInsecure: tlsInsecure,
+		remoteWriteCAPath:      caPath,
+		remoteWriteCAHash:      caHash,
+	}, nil
+}
+
+func validateTelemetryEndpoint(name, raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse kubernetes telemetry %s endpoint: %w", name, err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return fmt.Errorf("kubernetes telemetry %s endpoint must be an absolute HTTP(S) URL", name)
+	}
+	return nil
+}
+
+func readTelemetryFile(ctx context.Context, dir, name string, required bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		if !required && errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read kubernetes telemetry config %s: %w", name, err)
+	}
+	value := strings.TrimSpace(string(raw))
+	if required && value == "" {
+		return "", fmt.Errorf("kubernetes telemetry config %s is empty", name)
+	}
+	return value, nil
+}
+
+func waitForRemoteWriteFiles(ctx context.Context, dir string) (telemetryFiles, error) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		config, err := readRemoteWriteFiles(ctx, dir)
+		if err == nil {
+			return config, nil
+		}
+		select {
+		case <-ctx.Done():
+			return telemetryFiles{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+type telemetryRemoteWriteWriter struct {
+	dir     string
+	timeout time.Duration
+	log     *slog.Logger
+
+	mu          sync.Mutex
+	configured  bool
+	fingerprint [32]byte
+	writer      *pkgpromwrite.Client
+	httpClient  *http.Client
+}
+
+func (w *telemetryRemoteWriteWriter) Write(ctx context.Context, samples []pkgpromwrite.Sample) error {
+	files, err := readRemoteWriteFiles(ctx, w.dir)
+	if err != nil {
+		return err
+	}
+	writer, err := w.clientFor(files)
+	if err != nil {
+		return err
+	}
+	return writer.Write(ctx, samples)
+}
+
+func (w *telemetryRemoteWriteWriter) clientFor(files telemetryFiles) (*pkgpromwrite.Client, error) {
+	fingerprint := remoteWriteFingerprint(files)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.configured && fingerprint == w.fingerprint && w.writer != nil {
+		return w.writer, nil
+	}
+	auth := promauth.NewStaticResolver(promauth.Config{
+		BearerToken:   files.remoteWriteBearer,
+		BasicUser:     files.remoteWriteBasicUser,
+		BasicPassword: files.remoteWriteBasicPass,
+	})
+	httpClient, err := promauth.BuildClient(promauth.TLSConfig{
+		Insecure: files.remoteWriteTLSInsecure,
+		CAPath:   files.remoteWriteCAPath,
+	}, auth, w.timeout)
+	if err != nil {
+		return nil, fmt.Errorf("reload remote_write transport: %w", err)
+	}
+	writer := pkgpromwrite.NewWithWriteURLAndHTTPClient(files.remoteWriteEndpoint, httpClient, w.log)
+	oldHTTPClient := w.httpClient
+	w.writer = writer
+	w.httpClient = httpClient
+	w.fingerprint = fingerprint
+	w.configured = true
+	if oldHTTPClient != nil {
+		oldHTTPClient.CloseIdleConnections()
+	}
+	return writer, nil
+}
+
+func remoteWriteFingerprint(files telemetryFiles) [32]byte {
+	return sha256.Sum256([]byte(strings.Join([]string{
+		files.remoteWriteEndpoint,
+		files.remoteWriteBearer,
+		files.remoteWriteBasicUser,
+		files.remoteWriteBasicPass,
+		strconv.FormatBool(files.remoteWriteTLSInsecure),
+		string(files.remoteWriteCAHash[:]),
+	}, "\x00")))
+}
+
+func telemetrySecretDir() string {
+	return envOr("ONGRID_K8S_TELEMETRY_SECRET_DIR", defaultK8sTelemetrySecretDir)
+}

--- a/cmd/ongrid-edge/k8s_data_plane.go
+++ b/cmd/ongrid-edge/k8s_data_plane.go
@@ -30,6 +30,11 @@ import (
 
 const defaultK8sTelemetrySecretDir = "/var/run/ongrid-telemetry"
 
+const (
+	telemetrySignalAuthTelemetry = "telemetry"
+	telemetrySignalAuthBackend   = "backend"
+)
+
 func runK8sDataPlaneMode(ctx context.Context, mode string, log *slog.Logger) (bool, error) {
 	switch strings.TrimSpace(mode) {
 	case "k8s-telemetry-gateway":
@@ -101,6 +106,7 @@ func runK8sMetricsScraper(ctx context.Context, log *slog.Logger) error {
 	scraper, err := edgek8s.NewRemoteWriteScraper(writer, edgek8s.RemoteWriteScraperConfig{
 		ClusterID:        config.clusterID,
 		Endpoint:         strings.TrimSpace(os.Getenv("ONGRID_K8S_METRICS_ENDPOINT")),
+		DiscoverApps:     parseBoolEnv("ONGRID_K8S_APP_METRICS_DISCOVERY", false),
 		Interval:         parseDurationEnv("ONGRID_K8S_METRICS_INTERVAL", 30*time.Second),
 		Timeout:          parseDurationEnv("ONGRID_K8S_METRICS_TIMEOUT", 15*time.Second),
 		PushTimeout:      pushTimeout,
@@ -116,7 +122,7 @@ func runK8sMetricsScraper(ctx context.Context, log *slog.Logger) error {
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error { return scraper.Run(groupCtx) })
-	group.Go(func() error { return runDataPlaneDiagnostics(groupCtx, registry, func() bool { return true }, log) })
+	group.Go(func() error { return runDataPlaneDiagnostics(groupCtx, registry, scraper.Ready, log) })
 	log.Info("kubernetes metrics scraper mode started; tunnel and inventory are disabled",
 		slog.Uint64("cluster_id", config.clusterID),
 	)
@@ -166,6 +172,10 @@ func (f *k8sTelemetryGatewayFetcher) Fetch(ctx context.Context) (map[string]edge
 		"enable_logs":                       true,
 		"enable_metrics":                    true,
 		"logs_endpoint":                     files.logsEndpoint,
+		"logs_auth_override":                true,
+		"logs_auth_user":                    files.logsAuthUser,
+		"logs_auth_pass":                    files.logsAuthPass,
+		"logs_tls_insecure_skip_verify":     files.logsTLSInsecure,
 		"metrics_remote_write_endpoint":     files.remoteWriteEndpoint,
 		"metrics_remote_write_auth_user":    files.remoteWriteBasicUser,
 		"metrics_remote_write_auth_pass":    files.remoteWriteBasicPass,
@@ -178,7 +188,7 @@ func (f *k8sTelemetryGatewayFetcher) Fetch(ctx context.Context) (map[string]edge
 		"batch_max_size":                    parseIntEnv("ONGRID_K8S_GATEWAY_BATCH_MAX_SIZE", 4096),
 		"queue_size":                        parseIntEnv("ONGRID_K8S_GATEWAY_QUEUE_SIZE", 512),
 		"collector_metrics_endpoint":        "0.0.0.0:8888",
-		"tls_insecure_skip_verify":          parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false),
+		"tls_insecure_skip_verify":          files.tracesTLSInsecure,
 		"extra_attrs": map[string]interface{}{
 			"cluster_id":        strconv.FormatUint(files.clusterID, 10),
 			"telemetry_gateway": "kubernetes",
@@ -193,8 +203,8 @@ func (f *k8sTelemetryGatewayFetcher) Fetch(ctx context.Context) (map[string]edge
 		edgeplugintraces.Name: {
 			Enabled:  true,
 			Endpoint: files.tracesEndpoint,
-			AuthUser: files.accessKey,
-			AuthPass: files.secretKey,
+			AuthUser: files.tracesAuthUser,
+			AuthPass: files.tracesAuthPass,
 			Spec:     spec,
 		},
 	}, nil
@@ -205,7 +215,13 @@ type telemetryFiles struct {
 	accessKey              string
 	secretKey              string
 	tracesEndpoint         string
+	tracesAuthUser         string
+	tracesAuthPass         string
+	tracesTLSInsecure      bool
 	logsEndpoint           string
+	logsAuthUser           string
+	logsAuthPass           string
+	logsTLSInsecure        bool
 	remoteWriteEndpoint    string
 	remoteWriteBearer      string
 	remoteWriteBasicUser   string
@@ -242,11 +258,74 @@ func readTelemetryFiles(ctx context.Context, dir string) (telemetryFiles, error)
 	if err := validateTelemetryEndpoint("logs", logsEndpoint); err != nil {
 		return telemetryFiles{}, err
 	}
+	tracesAuth, err := readTelemetrySignalAuth(ctx, dir, "traces", accessKey, secretKey)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
+	logsAuth, err := readTelemetrySignalAuth(ctx, dir, "logs", accessKey, secretKey)
+	if err != nil {
+		return telemetryFiles{}, err
+	}
 	files.accessKey = accessKey
 	files.secretKey = secretKey
 	files.tracesEndpoint = tracesEndpoint
+	files.tracesAuthUser = tracesAuth.user
+	files.tracesAuthPass = tracesAuth.password
+	files.tracesTLSInsecure = tracesAuth.tlsInsecure
 	files.logsEndpoint = logsEndpoint
+	files.logsAuthUser = logsAuth.user
+	files.logsAuthPass = logsAuth.password
+	files.logsTLSInsecure = logsAuth.tlsInsecure
 	return files, nil
+}
+
+type telemetrySignalAuth struct {
+	user        string
+	password    string
+	tlsInsecure bool
+}
+
+func readTelemetrySignalAuth(ctx context.Context, dir, signal, accessKey, secretKey string) (telemetrySignalAuth, error) {
+	prefix := "telemetry-" + signal + "-"
+	mode, err := readTelemetryFile(ctx, dir, prefix+"auth-mode", false)
+	if err != nil {
+		return telemetrySignalAuth{}, err
+	}
+	// Secrets created before per-signal auth was introduced used the shared
+	// telemetry credential. Treat a missing mode as that legacy contract.
+	if mode == "" {
+		mode = telemetrySignalAuthTelemetry
+	}
+	user, err := readTelemetryFile(ctx, dir, prefix+"basic-user", false)
+	if err != nil {
+		return telemetrySignalAuth{}, err
+	}
+	password, err := readTelemetryFile(ctx, dir, prefix+"basic-pass", false)
+	if err != nil {
+		return telemetrySignalAuth{}, err
+	}
+	tlsRaw, err := readTelemetryFile(ctx, dir, prefix+"tls-insecure", false)
+	if err != nil {
+		return telemetrySignalAuth{}, err
+	}
+	tlsInsecure := parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false)
+	if tlsRaw != "" {
+		tlsInsecure, err = strconv.ParseBool(tlsRaw)
+		if err != nil {
+			return telemetrySignalAuth{}, fmt.Errorf("parse kubernetes telemetry %s TLS setting: %w", signal, err)
+		}
+	}
+	switch mode {
+	case telemetrySignalAuthTelemetry:
+		return telemetrySignalAuth{user: accessKey, password: secretKey, tlsInsecure: tlsInsecure}, nil
+	case telemetrySignalAuthBackend:
+		if (user == "") != (password == "") {
+			return telemetrySignalAuth{}, fmt.Errorf("kubernetes telemetry %s basic auth requires both username and password", signal)
+		}
+		return telemetrySignalAuth{user: user, password: password, tlsInsecure: tlsInsecure}, nil
+	default:
+		return telemetrySignalAuth{}, fmt.Errorf("unsupported kubernetes telemetry %s auth mode %q", signal, mode)
+	}
 }
 
 // readRemoteWriteFiles is the intentionally narrow Metrics Scraper view of

--- a/cmd/ongrid-edge/k8s_data_plane_test.go
+++ b/cmd/ongrid-edge/k8s_data_plane_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	edgeplugintraces "github.com/ongridio/ongrid/internal/edgeagent/plugins/traces"
+	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
+)
+
+func TestK8sTelemetryGatewayFetcherBuildsStandaloneConfig(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"telemetry-cluster-id":                "7",
+		"telemetry-access-key":                "kt_access",
+		"telemetry-secret-key":                "ks_secret",
+		"telemetry-traces-endpoint":           "https://manager.example/v1/traces",
+		"telemetry-logs-endpoint":             "https://manager.example/loki/api/v1/push",
+		"telemetry-remote-write-endpoint":     "https://manager.example/prometheus/api/v1/write",
+		"telemetry-remote-write-basic-user":   "kt_access",
+		"telemetry-remote-write-basic-pass":   "ks_secret",
+		"telemetry-remote-write-tls-insecure": "true",
+		"telemetry-remote-write-ca.pem":       "test-ca",
+	}
+	for name, value := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	configs, err := (&k8sTelemetryGatewayFetcher{dir: dir}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	cfg, ok := configs[edgeplugintraces.Name]
+	if !ok {
+		t.Fatalf("traces config missing: %#v", configs)
+	}
+	if cfg.EdgeID != 0 || cfg.Endpoint != files["telemetry-traces-endpoint"] || cfg.AuthUser != "kt_access" || cfg.AuthPass != "ks_secret" {
+		t.Fatalf("gateway identity config = %#v", cfg)
+	}
+	for key, want := range map[string]any{
+		"omit_device_id":                true,
+		"enable_k8sattributes":          true,
+		"enable_logs":                   true,
+		"enable_metrics":                true,
+		"bounded_pipelines":             true,
+		"metrics_remote_write_endpoint": files["telemetry-remote-write-endpoint"],
+	} {
+		if got := cfg.Spec[key]; got != want {
+			t.Fatalf("spec[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+	if cfg.Spec["metrics_remote_write_ca_file"] != filepath.Join(dir, "telemetry-remote-write-ca.pem") {
+		t.Fatalf("CA path = %#v", cfg.Spec["metrics_remote_write_ca_file"])
+	}
+	if cfg.Spec["metrics_remote_write_ca_checksum"] == "" {
+		t.Fatal("CA checksum is empty; projected CA changes would not reload the Collector")
+	}
+}
+
+func TestTelemetryRemoteWriteWriterReloadsProjectedConfig(t *testing.T) {
+	authA := make(chan string, 1)
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authA <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer serverA.Close()
+	authB := make(chan string, 1)
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authB <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer serverB.Close()
+
+	dir := t.TempDir()
+	writeConfig := func(endpoint, user, pass string) {
+		t.Helper()
+		for name, value := range map[string]string{
+			"telemetry-cluster-id":                "7",
+			"telemetry-remote-write-endpoint":     endpoint,
+			"telemetry-remote-write-basic-user":   user,
+			"telemetry-remote-write-basic-pass":   pass,
+			"telemetry-remote-write-tls-insecure": "false",
+		} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0600); err != nil {
+				t.Fatalf("write %s: %v", name, err)
+			}
+		}
+	}
+	writeConfig(serverA.URL, "writer-a", "secret-a")
+	writer := &telemetryRemoteWriteWriter{dir: dir, log: nil}
+	samples := []pkgpromwrite.Sample{{
+		Labels: []pkgpromwrite.Label{{Name: "__name__", Value: "up"}},
+		Value:  1,
+		TsMs:   1,
+	}}
+	if err := writer.Write(context.Background(), samples); err != nil {
+		t.Fatalf("first Write() error = %v", err)
+	}
+	if got := <-authA; got != "Basic d3JpdGVyLWE6c2VjcmV0LWE=" {
+		t.Fatalf("first Authorization = %q", got)
+	}
+
+	writeConfig(serverB.URL, "writer-b", "secret-b")
+	if err := writer.Write(context.Background(), samples); err != nil {
+		t.Fatalf("reloaded Write() error = %v", err)
+	}
+	if got := <-authB; got != "Basic d3JpdGVyLWI6c2VjcmV0LWI=" {
+		t.Fatalf("reloaded Authorization = %q", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "telemetry-remote-write-ca.pem"), []byte("invalid-ca"), 0600); err != nil {
+		t.Fatalf("write invalid CA: %v", err)
+	}
+	if err := writer.Write(context.Background(), samples); err == nil || !strings.Contains(err.Error(), "contained no valid certificates") {
+		t.Fatalf("Write() after CA change error = %v", err)
+	}
+}
+
+func TestReadTelemetryFilesRejectsMissingWriteEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	for name, value := range map[string]string{
+		"telemetry-cluster-id": "7",
+		"telemetry-access-key": "kt_access",
+		"telemetry-secret-key": "ks_secret",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if _, err := readTelemetryFiles(context.Background(), dir); err == nil {
+		t.Fatal("readTelemetryFiles() error = nil, want missing remote_write endpoint")
+	}
+}
+
+func TestReadRemoteWriteFilesDoesNotRequireGatewayCredentials(t *testing.T) {
+	dir := t.TempDir()
+	for name, value := range map[string]string{
+		"telemetry-cluster-id":                "7",
+		"telemetry-remote-write-endpoint":     "https://metrics.example/api/v1/write",
+		"telemetry-remote-write-basic-user":   "writer",
+		"telemetry-remote-write-basic-pass":   "secret",
+		"telemetry-remote-write-tls-insecure": "false",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	got, err := readRemoteWriteFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("readRemoteWriteFiles() error = %v", err)
+	}
+	if got.clusterID != 7 || got.remoteWriteEndpoint != "https://metrics.example/api/v1/write" || got.remoteWriteBasicUser != "writer" {
+		t.Fatalf("remote write config = %#v", got)
+	}
+	if got.accessKey != "" || got.secretKey != "" || got.tracesEndpoint != "" || got.logsEndpoint != "" {
+		t.Fatalf("scraper loaded gateway-only fields: %#v", got)
+	}
+}

--- a/cmd/ongrid-edge/k8s_data_plane_test.go
+++ b/cmd/ongrid-edge/k8s_data_plane_test.go
@@ -123,6 +123,47 @@ func TestTelemetryRemoteWriteWriterReloadsProjectedConfig(t *testing.T) {
 	}
 }
 
+func TestK8sTelemetryGatewayFetcherUsesIndependentBackendAuth(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"telemetry-cluster-id":                "7",
+		"telemetry-access-key":                "kt_access",
+		"telemetry-secret-key":                "ks_secret",
+		"telemetry-traces-endpoint":           "https://tempo.example/v1/traces",
+		"telemetry-traces-auth-mode":          telemetrySignalAuthBackend,
+		"telemetry-traces-basic-user":         "tempo-user",
+		"telemetry-traces-basic-pass":         "tempo-pass",
+		"telemetry-traces-tls-insecure":       "true",
+		"telemetry-logs-endpoint":             "https://loki.example/loki/api/v1/push",
+		"telemetry-logs-auth-mode":            telemetrySignalAuthBackend,
+		"telemetry-logs-tls-insecure":         "false",
+		"telemetry-remote-write-endpoint":     "https://metrics.example/api/v1/write",
+		"telemetry-remote-write-basic-user":   "metrics-user",
+		"telemetry-remote-write-basic-pass":   "metrics-pass",
+		"telemetry-remote-write-tls-insecure": "false",
+	}
+	for name, value := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(value), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	configs, err := (&k8sTelemetryGatewayFetcher{dir: dir}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	cfg := configs[edgeplugintraces.Name]
+	if cfg.AuthUser != "tempo-user" || cfg.AuthPass != "tempo-pass" {
+		t.Fatalf("trace auth = %q/%q", cfg.AuthUser, cfg.AuthPass)
+	}
+	if cfg.Spec["logs_auth_override"] != true || cfg.Spec["logs_auth_user"] != "" || cfg.Spec["logs_auth_pass"] != "" {
+		t.Fatalf("log auth spec = %#v", cfg.Spec)
+	}
+	if cfg.Spec["tls_insecure_skip_verify"] != true || cfg.Spec["logs_tls_insecure_skip_verify"] != false {
+		t.Fatalf("signal TLS spec = %#v", cfg.Spec)
+	}
+}
+
 func TestReadTelemetryFilesRejectsMissingWriteEndpoint(t *testing.T) {
 	dir := t.TempDir()
 	for name, value := range map[string]string{

--- a/cmd/ongrid-edge/k8s_upgrade.go
+++ b/cmd/ongrid-edge/k8s_upgrade.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	edgek8s "github.com/ongridio/ongrid/internal/edgeagent/k8s"
+)
+
+func runK8sUpgradeCommand(ctx context.Context, args []string) (bool, error) {
+	if len(args) == 0 || args[0] != "prepare-k8s-upgrade" {
+		return false, nil
+	}
+	flags := flag.NewFlagSet("prepare-k8s-upgrade", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	namespace := flags.String("namespace", "", "release namespace")
+	controller := flags.String("controller", "", "controller Deployment name")
+	metricsScraper := flags.String("metrics-scraper", "", "metrics scraper Deployment name")
+	gatewayMode := flags.String("gateway-mode", "", "target telemetry gateway mode")
+	metricsMode := flags.String("metrics-mode", "", "target Kubernetes metrics mode")
+	timeout := flags.Duration("timeout", 8*time.Minute, "preparation timeout")
+	if err := flags.Parse(args[1:]); err != nil {
+		return true, fmt.Errorf("parse prepare-k8s-upgrade arguments: %w", err)
+	}
+	if flags.NArg() != 0 {
+		return true, fmt.Errorf("prepare-k8s-upgrade: unexpected arguments %q", strings.Join(flags.Args(), " "))
+	}
+	if *timeout <= 0 {
+		return true, fmt.Errorf("prepare-k8s-upgrade: timeout must be positive")
+	}
+	prepareCtx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	return true, edgek8s.PrepareUpgrade(prepareCtx, edgek8s.UpgradePreparationConfig{
+		Namespace:                *namespace,
+		ControllerDeployment:     *controller,
+		MetricsScraperDeployment: *metricsScraper,
+		TargetGatewayMode:        *gatewayMode,
+		TargetMetricsMode:        *metricsMode,
+	})
+}

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -102,6 +102,14 @@ func main() {
 
 	rootCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+	if handled, err := runK8sDataPlaneMode(rootCtx, strings.TrimSpace(os.Getenv("ONGRID_EDGE_MODE")), log); handled {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Error("kubernetes data plane stopped with error", slog.Any("err", err))
+			os.Exit(1)
+		}
+		log.Info("kubernetes data plane shutdown complete")
+		return
+	}
 
 	k8sInfo, err := ensureK8sEnrollment(rootCtx, cfg, log)
 	if err != nil {
@@ -120,6 +128,9 @@ func main() {
 	})
 
 	eg, egCtx := errgroup.WithContext(rootCtx)
+	if isK8sController(k8sInfo) && strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")) != "" {
+		eg.Go(func() error { return runK8sTelemetryConfigSync(egCtx, cfg, k8sInfo, log) })
+	}
 
 	// Build the collector based on configured mode.
 	collector, scraperRunner, err := buildCollector(egCtx, cfg, log, eg)
@@ -461,14 +472,29 @@ type k8sEnrollRequest struct {
 }
 
 type k8sEnrollResponse struct {
-	ClusterID        uint64 `json:"cluster_id"`
-	Role             string `json:"role"`
-	Mode             string `json:"mode"`
-	EdgeID           uint64 `json:"edge_id"`
-	AccessKey        string `json:"access_key"`
-	SecretKey        string `json:"secret_key"`
-	CloudAddr        string `json:"cloud_addr,omitempty"`
-	ManagerPublicURL string `json:"manager_public_url,omitempty"`
+	ClusterID        uint64              `json:"cluster_id"`
+	Role             string              `json:"role"`
+	Mode             string              `json:"mode"`
+	EdgeID           uint64              `json:"edge_id"`
+	AccessKey        string              `json:"access_key"`
+	SecretKey        string              `json:"secret_key"`
+	CloudAddr        string              `json:"cloud_addr,omitempty"`
+	ManagerPublicURL string              `json:"manager_public_url,omitempty"`
+	Telemetry        *k8sTelemetryConfig `json:"telemetry,omitempty"`
+}
+
+type k8sTelemetryConfig struct {
+	ClusterID              uint64 `json:"cluster_id"`
+	AccessKey              string `json:"access_key"`
+	SecretKey              string `json:"secret_key"`
+	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
+	LogsEndpoint           string `json:"logs_endpoint,omitempty"`
+	RemoteWriteEndpoint    string `json:"remote_write_endpoint,omitempty"`
+	RemoteWriteBearer      string `json:"remote_write_bearer,omitempty"`
+	RemoteWriteBasicUser   string `json:"remote_write_basic_user,omitempty"`
+	RemoteWriteBasicPass   string `json:"remote_write_basic_pass,omitempty"`
+	RemoteWriteTLSInsecure bool   `json:"remote_write_tls_insecure,omitempty"`
+	RemoteWriteTLSCAPEM    string `json:"remote_write_tls_ca_pem,omitempty"`
 }
 
 func ensureK8sEnrollment(ctx context.Context, cfg *config.Config, log *slog.Logger) (*tunnel.KubernetesInfo, error) {
@@ -516,6 +542,15 @@ func ensureK8sEnrollment(ctx context.Context, cfg *config.Config, log *slog.Logg
 		log.Warn("load kubernetes edge credentials failed; falling back to bootstrap enrollment", slog.Any("err", err))
 	}
 	if loaded {
+		if isK8sController(info) && strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")) != "" {
+			refreshErr := refreshAndStoreK8sTelemetryConfig(ctx, cfg, info)
+			if refreshErr != nil {
+				if parseBoolEnv("ONGRID_K8S_TELEMETRY_REQUIRED", false) {
+					return nil, fmt.Errorf("refresh required kubernetes telemetry config: %w", refreshErr)
+				}
+				log.Warn("refresh kubernetes telemetry config failed; control plane will continue", slog.Any("err", refreshErr))
+			}
+		}
 		return info, nil
 	}
 	if bootstrapToken == "" {
@@ -555,12 +590,7 @@ func ensureK8sEnrollment(ctx context.Context, cfg *config.Config, log *slog.Logg
 	}
 	req.Header.Set("Authorization", "Bearer "+bootstrapToken)
 	req.Header.Set("Content-Type", "application/json")
-	hc := &http.Client{Timeout: 30 * time.Second}
-	if strings.EqualFold(os.Getenv("ONGRID_K8S_ENROLL_TLS_INSECURE"), "true") {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}
-		hc.Transport = transport
-	}
+	hc := k8sManagerHTTPClient()
 	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("k8s enroll request: %w", err)
@@ -597,6 +627,99 @@ func ensureK8sEnrollment(ctx context.Context, cfg *config.Config, log *slog.Logg
 		slog.String("role", info.Role),
 	)
 	return info, nil
+}
+
+func refreshK8sTelemetryConfig(ctx context.Context, cfg *config.Config, managerURL, currentAccessKey, currentSecretKey string) (*k8sTelemetryConfig, error) {
+	if managerURL == "" {
+		return nil, fmt.Errorf("manager public URL is required")
+	}
+	endpoint, err := url.JoinPath(managerURL, "/internal/k8s/telemetry-config")
+	if err != nil {
+		return nil, fmt.Errorf("build k8s telemetry config URL: %w", err)
+	}
+	payload, err := json.Marshal(map[string]string{
+		"access_key": currentAccessKey,
+		"secret_key": currentSecretKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal k8s telemetry config request: %w", err)
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("new k8s telemetry config request: %w", err)
+	}
+	req.SetBasicAuth(cfg.Edge.AccessKey, cfg.Edge.SecretKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := k8sManagerHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("k8s telemetry config request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if readErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("k8s telemetry config failed: status=%d", resp.StatusCode),
+				fmt.Errorf("read k8s telemetry config error response: %w", readErr),
+			)
+		}
+		return nil, fmt.Errorf("k8s telemetry config failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out k8sTelemetryConfig
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode k8s telemetry config: %w", err)
+	}
+	if out.ClusterID == 0 || out.AccessKey == "" || out.SecretKey == "" {
+		return nil, fmt.Errorf("k8s telemetry config response is incomplete")
+	}
+	applyManagerTelemetryTLS(&out, managerURL)
+	return &out, nil
+}
+
+func refreshAndStoreK8sTelemetryConfig(ctx context.Context, cfg *config.Config, info *tunnel.KubernetesInfo) error {
+	accessKey, secretKey, _, err := loadK8sTelemetryCredential(ctx, info)
+	if err != nil {
+		return err
+	}
+	managerURL := strings.TrimRight(envOr("ONGRID_MANAGER_PUBLIC_URL", cfg.PublicURL), "/")
+	telemetry, err := refreshK8sTelemetryConfig(ctx, cfg, managerURL, accessKey, secretKey)
+	if err != nil {
+		return err
+	}
+	if err := storeK8sTelemetryConfig(ctx, info, *telemetry); err != nil {
+		return fmt.Errorf("store kubernetes telemetry config: %w", err)
+	}
+	return nil
+}
+
+func runK8sTelemetryConfigSync(ctx context.Context, cfg *config.Config, info *tunnel.KubernetesInfo, log *slog.Logger) error {
+	interval := parseDurationEnv("ONGRID_K8S_TELEMETRY_CONFIG_REFRESH_INTERVAL", time.Minute)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := refreshAndStoreK8sTelemetryConfig(ctx, cfg, info); err != nil {
+				log.Warn("refresh kubernetes telemetry config failed; keeping previous Secret data", slog.Any("err", err))
+				continue
+			}
+			log.Debug("kubernetes telemetry config refreshed")
+		}
+	}
+}
+
+func k8sManagerHTTPClient() *http.Client {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if strings.EqualFold(os.Getenv("ONGRID_K8S_ENROLL_TLS_INSECURE"), "true") {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}
+		hc.Transport = transport
+	}
+	return hc
 }
 
 func defaultK8sRole(edgeMode string) string {

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -495,7 +495,15 @@ type k8sTelemetryConfig struct {
 	AccessKey              string `json:"access_key"`
 	SecretKey              string `json:"secret_key"`
 	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
+	TracesAuthMode         string `json:"traces_auth_mode,omitempty"`
+	TracesBasicUser        string `json:"traces_basic_user,omitempty"`
+	TracesBasicPass        string `json:"traces_basic_pass,omitempty"`
+	TracesTLSInsecure      bool   `json:"traces_tls_insecure,omitempty"`
 	LogsEndpoint           string `json:"logs_endpoint,omitempty"`
+	LogsAuthMode           string `json:"logs_auth_mode,omitempty"`
+	LogsBasicUser          string `json:"logs_basic_user,omitempty"`
+	LogsBasicPass          string `json:"logs_basic_pass,omitempty"`
+	LogsTLSInsecure        bool   `json:"logs_tls_insecure,omitempty"`
 	RemoteWriteEndpoint    string `json:"remote_write_endpoint,omitempty"`
 	RemoteWriteBearer      string `json:"remote_write_bearer,omitempty"`
 	RemoteWriteBasicUser   string `json:"remote_write_basic_user,omitempty"`

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -69,6 +69,13 @@ func main() {
 		}
 		return
 	}
+	if handled, err := runK8sUpgradeCommand(context.Background(), os.Args[1:]); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "kubernetes upgrade preparation: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// Print-and-exit flags before anything that can fail (config load,
 	// env access). install.sh and operators rely on `ongrid-edge --version`

--- a/cmd/ongrid/k8s_telemetry_target_test.go
+++ b/cmd/ongrid/k8s_telemetry_target_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+type staticTelemetryBackendResolver struct {
+	url         string
+	user        string
+	password    string
+	tlsInsecure bool
+}
+
+func (r staticTelemetryBackendResolver) URL(context.Context) string { return r.url }
+
+func (r staticTelemetryBackendResolver) Auth(context.Context) (string, string) {
+	return r.user, r.password
+}
+
+func (r staticTelemetryBackendResolver) TLSInsecure(context.Context) bool {
+	return r.tlsInsecure
+}
+
+func TestPluginEndpointResolverPublishesExternalSignalSettings(t *testing.T) {
+	resolver := pluginEndpointResolver{
+		publicURL: "https://manager.example",
+		loki: staticTelemetryBackendResolver{
+			url:         "https://loki.example",
+			user:        "loki-user",
+			password:    "loki-pass",
+			tlsInsecure: true,
+		},
+		tempo: staticTelemetryBackendResolver{
+			url:      "https://tempo.example/v1/traces",
+			user:     "tempo-user",
+			password: "tempo-pass",
+		},
+	}
+
+	logs, err := resolver.ResolveTelemetryTarget(context.Background(), "logs")
+	if err != nil {
+		t.Fatalf("resolve logs: %v", err)
+	}
+	if logs.Endpoint != "https://loki.example/loki/api/v1/push" || logs.BasicUser != "loki-user" || logs.BasicPassword != "loki-pass" || !logs.TLSInsecure || logs.UseTelemetryCredential {
+		t.Fatalf("logs target = %#v", logs)
+	}
+	traces, err := resolver.ResolveTelemetryTarget(context.Background(), "traces")
+	if err != nil {
+		t.Fatalf("resolve traces: %v", err)
+	}
+	if traces.Endpoint != "https://tempo.example/v1/traces" || traces.BasicUser != "tempo-user" || traces.BasicPassword != "tempo-pass" || traces.TLSInsecure || traces.UseTelemetryCredential {
+		t.Fatalf("traces target = %#v", traces)
+	}
+}
+
+func TestPluginEndpointResolverFallsBackToManagerForInternalSeeds(t *testing.T) {
+	resolver := pluginEndpointResolver{
+		publicURL: "https://manager.example/",
+		loki:      staticTelemetryBackendResolver{url: "http://loki:3100"},
+		tempo:     staticTelemetryBackendResolver{url: "http://tempo:4318"},
+	}
+
+	logs, err := resolver.ResolveTelemetryTarget(context.Background(), "logs")
+	if err != nil {
+		t.Fatalf("resolve logs: %v", err)
+	}
+	traces, err := resolver.ResolveTelemetryTarget(context.Background(), "traces")
+	if err != nil {
+		t.Fatalf("resolve traces: %v", err)
+	}
+	if logs.Endpoint != "https://manager.example/loki/api/v1/push" || !logs.UseTelemetryCredential {
+		t.Fatalf("logs target = %#v", logs)
+	}
+	if traces.Endpoint != "https://manager.example/v1/traces" || !traces.UseTelemetryCredential {
+		t.Fatalf("traces target = %#v", traces)
+	}
+}

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -404,6 +404,11 @@ func main() {
 	// exists yet, so previous admin edits survive restarts.
 	settingRepo := managersettingdata.NewRepo(db)
 	settingSvc := managerbizsetting.New(settingRepo, log.With(slog.String("comp", "setting")))
+	queryFallback := cfg.Prom.URL
+	if cfg.Prom.QueryURL != "" {
+		queryFallback = cfg.Prom.QueryURL
+	}
+	promResolver := managerbizsetting.NewPromResolver(settingSvc, queryFallback, cfg.Prom.RemoteWriteURL)
 
 	// HLD-010 audit log — append-only "who did what" trail. Built early
 	// so the auth middleware factory below can capture login attempts.
@@ -779,7 +784,13 @@ func main() {
 		EventMaxPerCluster:   cfg.K8sEventMaxPerCluster,
 		EventCleanupInterval: cfg.K8sEventCleanupInterval,
 	})
+	k8sUC.SetRemoteWriteResolver(k8sRemoteWriteResolver{
+		resolver:  promResolver,
+		prom:      cfg.Prom,
+		publicURL: cfg.PublicURL,
+	})
 	k8sSvc := managersvck8s.New(k8sUC)
+	telemetryAuthn := managerbizk8s.NewTelemetryAuthenticator(k8sRepo)
 	edgeSvc.SetManagedEdgeGuard(k8sSvc)
 	k8sHandler := managerserverk8s.NewHandler(k8sSvc)
 
@@ -848,14 +859,16 @@ func main() {
 		log.Warn("k8s: topology reconcile on boot failed", slog.Any("err", err))
 	}
 
-	// Data plane auth verify — nginx auth_request
-	// calls this endpoint to validate edge basic-auth before proxy_pass'ing
-	// /loki/api/v1/push to internal Loki. Reuses the same edge credentials
-	// that gate tunnel handshakes (edgeAuthn).
-	edgeAuthHandler := managerserveredgeauth.NewHandler(
-		edgeAuthAdapter{authn: edgeAuthn},
+	// Data plane auth verify — nginx auth_request calls the compatibility
+	// endpoint for Loki/Tempo and exact scope endpoints for controller config
+	// and Prometheus remote_write. Telemetry credentials never enter the
+	// tunnel authenticator.
+	dataPlaneAuthHandler := managerserveredgeauth.NewHandler(
+		dataPlaneAuthAdapter{edge: edgeAuthn, telemetry: telemetryAuthn},
 		log,
 	)
+	edgeOnlyAuthHandler := managerserveredgeauth.NewHandler(edgeOnlyAuthAdapter{authn: edgeAuthn}, log)
+	telemetryOnlyAuthHandler := managerserveredgeauth.NewHandler(telemetryOnlyAuthAdapter{authn: telemetryAuthn}, log)
 
 	// PR-F: MySQL fast path commented out — single source of truth is now
 	// cloud Prometheus. Edges still emit push_host_metrics for backward
@@ -931,12 +944,6 @@ func main() {
 		// when the DB rows are absent. UI saves take effect within ~5s
 		// without a manager restart — the prom clients re-resolve on each
 		// request and the round-tripper has its own 5s cache.
-		queryFallback := cfg.Prom.URL
-		if cfg.Prom.QueryURL != "" {
-			queryFallback = cfg.Prom.QueryURL
-		}
-		promResolver := managerbizsetting.NewPromResolver(settingSvc, queryFallback, cfg.Prom.RemoteWriteURL)
-
 		promHTTPClient, herr := promauth.BuildClient(
 			promauth.TLSConfig{
 				Insecure: cfg.Prom.TLSInsecure,
@@ -2216,7 +2223,9 @@ func main() {
 	// Data plane auth verify lives outside /api so nginx can reach it
 	// without JWT. Network policy (docker-internal only) is the gate;
 	// nginx must NOT proxy_pass external traffic to /internal/auth/*.
-	edgeAuthHandler.Register(mux)
+	dataPlaneAuthHandler.Register(mux)
+	edgeOnlyAuthHandler.RegisterAt(mux, "/internal/auth/edge-verify")
+	telemetryOnlyAuthHandler.RegisterAt(mux, "/internal/auth/telemetry-verify")
 	k8sHandler.RegisterInternal(mux)
 
 	// All BC HTTP lives under /api. Public iam routes (login / refresh)
@@ -2697,16 +2706,115 @@ func isEdgeReachableURL(raw string) bool {
 // returns tunnel.Session) to the narrower edgeauth.Authenticator
 // interface (which only needs the edge_id). Lives at the wiring site so
 // edgeauth doesn't import the tunnel package.
-type edgeAuthAdapter struct {
+type dataPlaneAuthAdapter struct {
+	edge      *managerbizedge.AccessKeyAuthenticator
+	telemetry *managerbizk8s.TelemetryAuthenticator
+}
+
+type edgeOnlyAuthAdapter struct {
 	authn *managerbizedge.AccessKeyAuthenticator
 }
 
-func (a edgeAuthAdapter) AuthenticateEdge(ctx context.Context, accessKey, secretKey string) (uint64, error) {
+func (a edgeOnlyAuthAdapter) AuthenticateDataPlane(ctx context.Context, accessKey, secretKey string) (managerserveredgeauth.Identity, error) {
 	sess, err := a.authn.Authenticate(ctx, accessKey, secretKey)
 	if err != nil {
-		return 0, err
+		return managerserveredgeauth.Identity{}, err
 	}
-	return sess.EdgeID, nil
+	return managerserveredgeauth.Identity{EdgeID: sess.EdgeID}, nil
+}
+
+type telemetryOnlyAuthAdapter struct {
+	authn *managerbizk8s.TelemetryAuthenticator
+}
+
+func (a telemetryOnlyAuthAdapter) AuthenticateDataPlane(ctx context.Context, accessKey, secretKey string) (managerserveredgeauth.Identity, error) {
+	clusterID, err := a.authn.Authenticate(ctx, accessKey, secretKey)
+	if err != nil {
+		return managerserveredgeauth.Identity{}, err
+	}
+	return managerserveredgeauth.Identity{ClusterID: clusterID}, nil
+}
+
+type k8sRemoteWriteResolver struct {
+	resolver  *managerbizsetting.PromResolver
+	prom      config.PromConfig
+	publicURL string
+}
+
+func (r k8sRemoteWriteResolver) ResolveRemoteWrite(ctx context.Context) (managerbizk8s.RemoteWriteTarget, error) {
+	if !r.prom.Enabled || r.resolver == nil {
+		return managerbizk8s.RemoteWriteTarget{}, nil
+	}
+	writeURL, err := r.resolver.ResolveWriteURL(ctx)
+	if err != nil {
+		return managerbizk8s.RemoteWriteTarget{}, err
+	}
+	if isEmbeddedPrometheusURL(writeURL) {
+		base := strings.TrimRight(strings.TrimSpace(r.publicURL), "/")
+		if base == "" {
+			return managerbizk8s.RemoteWriteTarget{}, nil
+		}
+		return managerbizk8s.RemoteWriteTarget{
+			Endpoint:               base + "/prometheus/api/v1/write",
+			UseTelemetryCredential: true,
+		}, nil
+	}
+	authConfig, err := r.resolver.Resolve(ctx)
+	if err != nil {
+		return managerbizk8s.RemoteWriteTarget{}, err
+	}
+	var caPEM string
+	if path := strings.TrimSpace(r.prom.TLSCAPath); path != "" {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return managerbizk8s.RemoteWriteTarget{}, fmt.Errorf("read prometheus TLS CA: %w", err)
+		}
+		caPEM = string(raw)
+	}
+	return managerbizk8s.RemoteWriteTarget{
+		Endpoint:      writeURL,
+		BearerToken:   authConfig.BearerToken,
+		BasicUser:     authConfig.BasicUser,
+		BasicPassword: authConfig.BasicPassword,
+		TLSInsecure:   r.prom.TLSInsecure,
+		TLSCAPEM:      caPEM,
+	}, nil
+}
+
+func isEmbeddedPrometheusURL(raw string) bool {
+	u, err := neturl.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "prometheus")
+}
+
+func (a dataPlaneAuthAdapter) AuthenticateDataPlane(ctx context.Context, accessKey, secretKey string) (managerserveredgeauth.Identity, error) {
+	telemetryFirst := strings.HasPrefix(accessKey, "kt_")
+	if telemetryFirst {
+		clusterID, err := a.telemetry.Authenticate(ctx, accessKey, secretKey)
+		if err == nil {
+			return managerserveredgeauth.Identity{ClusterID: clusterID}, nil
+		}
+		if !errors.Is(err, errs.ErrUnauthorized) {
+			return managerserveredgeauth.Identity{}, err
+		}
+	}
+	sess, err := a.edge.Authenticate(ctx, accessKey, secretKey)
+	if err == nil {
+		return managerserveredgeauth.Identity{EdgeID: sess.EdgeID}, nil
+	}
+	if !errors.Is(err, errs.ErrUnauthorized) {
+		return managerserveredgeauth.Identity{}, err
+	}
+	if telemetryFirst {
+		return managerserveredgeauth.Identity{}, errs.ErrUnauthorized
+	}
+	clusterID, err := a.telemetry.Authenticate(ctx, accessKey, secretKey)
+	if err != nil {
+		return managerserveredgeauth.Identity{}, err
+	}
+	return managerserveredgeauth.Identity{ClusterID: clusterID}, nil
 }
 
 // Resolve implements llm.Resolver. Empty fields tell the LLM client to

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -804,6 +804,7 @@ func main() {
 		loki:      lokiResolver,
 		tempo:     tempoResolver,
 	}
+	k8sUC.SetTelemetryTargetResolver(pluginEndpointResolver)
 	pluginConfigUC := managerbizedge.NewPluginConfigUC(pluginConfigRepo, nil, pluginEndpointResolver, log)
 
 	edgeHandler := managerserveredge.NewHandler(edgeSvc, deviceRepo, pluginConfigUC)
@@ -2625,39 +2626,72 @@ func (i k8sEdgeIdentityIssuer) DeleteEdge(ctx context.Context, edgeID uint64) er
 // overridden the seed and we should fall through to PublicURL.
 type pluginEndpointResolver struct {
 	publicURL string
-	loki      *managerbizsetting.LokiResolver
-	tempo     *managerbizsetting.TempoResolver
+	loki      telemetryBackendResolver
+	tempo     telemetryBackendResolver
+}
+
+type telemetryBackendResolver interface {
+	URL(ctx context.Context) string
+	Auth(ctx context.Context) (basicUser, basicPassword string)
+	TLSInsecure(ctx context.Context) bool
 }
 
 func (r pluginEndpointResolver) Endpoint(ctx context.Context, plugin string) string {
-	switch plugin {
+	target, err := r.ResolveTelemetryTarget(ctx, plugin)
+	if err != nil {
+		return ""
+	}
+	return target.Endpoint
+}
+
+func (r pluginEndpointResolver) ResolveTelemetryTarget(ctx context.Context, signal string) (managerbizk8s.TelemetryTarget, error) {
+	switch signal {
 	case "logs":
 		if r.loki != nil {
 			if u := edgeReachableLokiURL(r.loki.URL(ctx)); u != "" {
-				return u + "/loki/api/v1/push"
+				user, password := r.loki.Auth(ctx)
+				return managerbizk8s.TelemetryTarget{
+					Endpoint:      u + "/loki/api/v1/push",
+					BasicUser:     user,
+					BasicPassword: password,
+					TLSInsecure:   r.loki.TLSInsecure(ctx),
+				}, nil
 			}
 		}
 		if r.publicURL == "" {
-			return ""
+			return managerbizk8s.TelemetryTarget{}, nil
 		}
-		return r.publicURL + "/loki/api/v1/push"
+		return managerbizk8s.TelemetryTarget{
+			Endpoint:               strings.TrimRight(r.publicURL, "/") + "/loki/api/v1/push",
+			UseTelemetryCredential: true,
+		}, nil
 	case "traces":
 		if r.tempo != nil {
 			if u := edgeReachableTempoURL(r.tempo.URL(ctx)); u != "" {
 				// If the admin URL already includes /v1/traces (some
 				// OTLP endpoints publish the path inline), respect it.
-				if strings.HasSuffix(u, "/v1/traces") {
-					return u
+				endpoint := u
+				if !strings.HasSuffix(endpoint, "/v1/traces") {
+					endpoint += "/v1/traces"
 				}
-				return u + "/v1/traces"
+				user, password := r.tempo.Auth(ctx)
+				return managerbizk8s.TelemetryTarget{
+					Endpoint:      endpoint,
+					BasicUser:     user,
+					BasicPassword: password,
+					TLSInsecure:   r.tempo.TLSInsecure(ctx),
+				}, nil
 			}
 		}
 		if r.publicURL == "" {
-			return ""
+			return managerbizk8s.TelemetryTarget{}, nil
 		}
-		return r.publicURL + "/v1/traces"
+		return managerbizk8s.TelemetryTarget{
+			Endpoint:               strings.TrimRight(r.publicURL, "/") + "/v1/traces",
+			UseTelemetryCredential: true,
+		}, nil
 	}
-	return ""
+	return managerbizk8s.TelemetryTarget{}, nil
 }
 
 // edgeReachableLokiURL returns the URL when it looks like an

--- a/deploy/install/nginx.conf
+++ b/deploy/install/nginx.conf
@@ -132,9 +132,9 @@ http {
         }
 
         # ---- Telemetry data plane: Loki push (ADR-012 / ADR-014) ----------
-        # Edge promtail subprocesses POST log batches here with HTTP Basic
-        # auth (user = edge access_key, pass = edge secret_key). nginx
-        # auth_request validates against manager's edgeauth endpoint, then
+        # Edge promtail uses an edge credential; the Kubernetes Telemetry
+        # Gateway uses its cluster-scoped telemetry credential. nginx
+        # auth_request validates either data-plane identity, then
         # proxy_pass es to internal loki:3100 — manager Go is NOT on this
         # byte stream (ADR-014 §决策第 1 条).
         location = /loki/api/v1/push {
@@ -152,6 +152,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Edge-Id         $edge_id;
             proxy_set_header X-Scope-OrgID     ongrid;
+            proxy_set_header Authorization     "";
             proxy_set_header Connection "";
             proxy_connect_timeout 10s;
             proxy_send_timeout    60s;
@@ -169,6 +170,24 @@ http {
             proxy_set_header X-Original-URI    $request_uri;
         }
 
+        location = /__auth_edge {
+            internal;
+            proxy_pass http://ongrid_backend/internal/auth/edge-verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header X-Original-URI $request_uri;
+        }
+
+        location = /__auth_telemetry {
+            internal;
+            proxy_pass http://ongrid_backend/internal/auth/telemetry-verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header X-Original-URI $request_uri;
+        }
+
         location = /internal/k8s/enroll {
             limit_req zone=k8s_enrollment burst=500 nodelay;
             limit_req_status 429;
@@ -180,10 +199,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location = /internal/k8s/telemetry-config {
+            auth_request     /__auth_edge;
+            auth_request_set $edge_id $upstream_http_x_edge_id;
+            proxy_pass http://ongrid_backend/internal/k8s/telemetry-config;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Edge-Id         $edge_id;
+            proxy_set_header Authorization     "";
+        }
+
         # ---- Telemetry data plane: Tempo OTLP HTTP push (ADR-013/014) -----
-        # Edge otelcol-contrib subprocesses POST OTLP-HTTP trace batches
-        # here with the same edge access/secret pair used for /loki push.
-        # nginx auth_request validates against manager's edgeauth endpoint,
+        # Edge otelcol-contrib uses an edge credential; the Kubernetes
+        # Telemetry Gateway uses its cluster-scoped telemetry credential.
+        # nginx auth_request validates either data-plane identity,
         # then proxy_pass es to internal tempo:4318/v1/traces — manager Go
         # is NOT on this byte stream (ADR-014 §决策第 1 条).
         location = /v1/traces {
@@ -201,7 +233,33 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Edge-Id         $edge_id;
             proxy_set_header X-Scope-OrgID     ongrid;
+            proxy_set_header Authorization     "";
             proxy_set_header Connection "";
+            proxy_connect_timeout 10s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        # Kubernetes telemetry metrics remote_write. This exact write-only
+        # route is authenticated with the cluster telemetry credential and
+        # bypasses manager Go and the controller tunnel.
+        location = /prometheus/api/v1/write {
+            auth_request     /__auth_telemetry;
+            auth_request_set $cluster_id $upstream_http_x_cluster_id;
+
+            limit_req        zone=edge_dataplane burst=200 nodelay;
+            client_max_body_size 16M;
+
+            # Embedded Prometheus runs with --web.route-prefix=/prometheus/.
+            proxy_pass http://prometheus_backend/prometheus/api/v1/write;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Cluster-Id      $cluster_id;
+            proxy_set_header Authorization     "";
+            proxy_set_header Connection        "";
             proxy_connect_timeout 10s;
             proxy_send_timeout    60s;
             proxy_read_timeout    60s;

--- a/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
+++ b/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
@@ -27,6 +27,16 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 {{- default (printf "%s-controller" (include "ongrid-edge.fullname" .)) .Values.controller.serviceAccountName -}}
 {{- end -}}
 
+{{- define "ongrid-edge.telemetryGatewayServiceAccount" -}}
+{{- $gw := default dict .Values.telemetryGateway -}}
+{{- default (printf "%s-telemetry-gateway" (include "ongrid-edge.fullname" .)) $gw.serviceAccountName -}}
+{{- end -}}
+
+{{- define "ongrid-edge.metricsScraperServiceAccount" -}}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- default (printf "%s-metrics-scraper" (include "ongrid-edge.fullname" .)) $metrics.serviceAccountName -}}
+{{- end -}}
+
 {{- define "ongrid-edge.kubeStateMetricsName" -}}
 {{- printf "%s-kube-state-metrics" (include "ongrid-edge.fullname" .) -}}
 {{- end -}}
@@ -37,6 +47,48 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 
 {{- define "ongrid-edge.controllerCredentialSecretName" -}}
 {{- printf "%s-controller-credentials" (include "ongrid-edge.fullname" .) -}}
+{{- end -}}
+
+{{- define "ongrid-edge.telemetryCredentialSecretName" -}}
+{{- printf "%s-telemetry-credentials" (include "ongrid-edge.fullname" .) -}}
+{{- end -}}
+
+{{- define "ongrid-edge.telemetryGatewayMode" -}}
+{{- $gw := default dict .Values.telemetryGateway -}}
+{{- $mode := default "embedded" $gw.mode -}}
+{{- if and (ne $mode "embedded") (ne $mode "deployment") -}}
+{{- fail "telemetryGateway.mode must be embedded or deployment" -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}
+
+{{- define "ongrid-edge.kubernetesMetricsMode" -}}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- $mode := default "controller" $metrics.mode -}}
+{{- if and (ne $mode "controller") (ne $mode "scraper") -}}
+{{- fail "kubernetesMetrics.mode must be controller or scraper" -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}
+
+{{- define "ongrid-edge.kubernetesMetricsEnabled" -}}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- if kindIs "bool" $metrics.enabled -}}
+{{- if $metrics.enabled -}}true{{- else -}}false{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "ongrid-edge.memoryQuantityMiB" -}}
+{{- $raw := toString . -}}
+{{- if regexMatch "^[1-9][0-9]*Mi$" $raw -}}
+{{- trimSuffix "Mi" $raw -}}
+{{- else if regexMatch "^[1-9][0-9]*Gi$" $raw -}}
+{{- mul (int (trimSuffix "Gi" $raw)) 1024 -}}
+{{- else -}}
+{{- fail (printf "telemetryGateway.resources.limits.memory must be a whole Mi or Gi quantity, got %q" $raw) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "ongrid-edge.telemetryGatewayEnabled" -}}
@@ -77,9 +129,18 @@ true
 {{- end -}}
 {{- end -}}
 
+{{- define "ongrid-edge.kubernetesMetricsEndpoint" -}}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- if $metrics.endpoint -}}
+{{- $metrics.endpoint -}}
+{{- else if eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true" -}}
+{{- include "ongrid-edge.kubeStateMetricsEndpoint" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "ongrid-edge.k8sMetricsEnabled" -}}
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
-{{- if or (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- if and (eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesMetricsMode" .) "controller") (or (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true")) -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "ongrid-edge.kubeStateMetricsResources" -}}

--- a/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
+++ b/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
@@ -81,10 +81,27 @@ ongrid.io/telemetry-backend
 
 {{- define "ongrid-edge.kubernetesMetricsEnabled" -}}
 {{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- $controllerMetrics := default dict .Values.controller.metrics -}}
 {{- if kindIs "bool" $metrics.enabled -}}
 {{- if $metrics.enabled -}}true{{- else -}}false{{- end -}}
-{{- else -}}
+{{- else if or $metrics.endpoint (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" .) "true") -}}
 true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" -}}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- $app := default dict $metrics.appDiscovery -}}
+{{- $controllerMetrics := default dict .Values.controller.metrics -}}
+{{- $legacyApp := default dict $controllerMetrics.appDiscovery -}}
+{{- if kindIs "bool" $app.enabled -}}
+{{- if $app.enabled -}}true{{- else -}}false{{- end -}}
+{{- else if kindIs "bool" $legacyApp.enabled -}}
+{{- if $legacyApp.enabled -}}true{{- else -}}false{{- end -}}
+{{- else -}}
+false
 {{- end -}}
 {{- end -}}
 
@@ -162,8 +179,11 @@ true
 
 {{- define "ongrid-edge.kubernetesMetricsEndpoint" -}}
 {{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- $controllerMetrics := default dict .Values.controller.metrics -}}
 {{- if $metrics.endpoint -}}
 {{- $metrics.endpoint -}}
+{{- else if $controllerMetrics.endpoint -}}
+{{- $controllerMetrics.endpoint -}}
 {{- else if eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true" -}}
 {{- include "ongrid-edge.kubeStateMetricsEndpoint" . -}}
 {{- end -}}
@@ -171,7 +191,7 @@ true
 
 {{- define "ongrid-edge.k8sMetricsEnabled" -}}
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
-{{- if and (eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesMetricsMode" .) "controller") (or (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true")) -}}true{{- else -}}false{{- end -}}
+{{- if and (eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesMetricsMode" .) "controller") (or (default false $controllerMetrics.enabled) (eq (include "ongrid-edge.kubeStateMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" .) "true")) -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "ongrid-edge.kubeStateMetricsResources" -}}

--- a/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
+++ b/deploy/kubernetes/ongrid-edge/templates/_helpers.tpl
@@ -45,6 +45,14 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 {{- printf "%s-telemetry-gateway" (include "ongrid-edge.fullname" .) -}}
 {{- end -}}
 
+{{- define "ongrid-edge.telemetryBackendLabel" -}}
+ongrid.io/telemetry-backend
+{{- end -}}
+
+{{- define "ongrid-edge.upgradeHookServiceAccount" -}}
+{{- printf "%s-upgrade-preflight" (include "ongrid-edge.fullname" .) -}}
+{{- end -}}
+
 {{- define "ongrid-edge.controllerCredentialSecretName" -}}
 {{- printf "%s-controller-credentials" (include "ongrid-edge.fullname" .) -}}
 {{- end -}}
@@ -55,7 +63,7 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 
 {{- define "ongrid-edge.telemetryGatewayMode" -}}
 {{- $gw := default dict .Values.telemetryGateway -}}
-{{- $mode := default "embedded" $gw.mode -}}
+{{- $mode := default "deployment" $gw.mode -}}
 {{- if and (ne $mode "embedded") (ne $mode "deployment") -}}
 {{- fail "telemetryGateway.mode must be embedded or deployment" -}}
 {{- end -}}
@@ -64,7 +72,7 @@ ongrid.io/cluster-id: {{ .Values.enrollment.clusterID | quote }}
 
 {{- define "ongrid-edge.kubernetesMetricsMode" -}}
 {{- $metrics := default dict .Values.kubernetesMetrics -}}
-{{- $mode := default "controller" $metrics.mode -}}
+{{- $mode := default "scraper" $metrics.mode -}}
 {{- if and (ne $mode "controller") (ne $mode "scraper") -}}
 {{- fail "kubernetesMetrics.mode must be controller or scraper" -}}
 {{- end -}}
@@ -91,10 +99,33 @@ true
 {{- end -}}
 {{- end -}}
 
+{{- define "ongrid-edge.durationSeconds" -}}
+{{- $raw := toString . -}}
+{{- if regexMatch "^[1-9][0-9]*s$" $raw -}}
+{{- trimSuffix "s" $raw -}}
+{{- else if regexMatch "^[1-9][0-9]*m$" $raw -}}
+{{- mul (int (trimSuffix "m" $raw)) 60 -}}
+{{- else if regexMatch "^[1-9][0-9]*h$" $raw -}}
+{{- mul (int (trimSuffix "h" $raw)) 3600 -}}
+{{- else -}}
+{{- fail (printf "upgrade.migrationHook.timeout must be a whole second, minute, or hour duration, got %q" $raw) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "ongrid-edge.telemetryGatewayEnabled" -}}
 {{- $gw := default dict .Values.telemetryGateway -}}
 {{- if kindIs "bool" $gw.enabled -}}
 {{- if $gw.enabled -}}true{{- else -}}false{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "ongrid-edge.upgradeMigrationHookEnabled" -}}
+{{- $upgrade := default dict .Values.upgrade -}}
+{{- $hook := default dict $upgrade.migrationHook -}}
+{{- if kindIs "bool" $hook.enabled -}}
+{{- if $hook.enabled -}}true{{- else -}}false{{- end -}}
 {{- else -}}
 true
 {{- end -}}

--- a/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
@@ -1,7 +1,13 @@
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
+{{- $standaloneMetrics := default dict .Values.kubernetesMetrics -}}
+{{- $metricsConfig := $controllerMetrics -}}
+{{- $metricsEndpoint := include "ongrid-edge.k8sMetricsEndpoint" . -}}
+{{- if eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper" -}}
+{{- $metricsConfig = $standaloneMetrics -}}
+{{- $metricsEndpoint = include "ongrid-edge.kubernetesMetricsEndpoint" . -}}
+{{- end -}}
 {{- $appMetricsDiscovery := default dict $controllerMetrics.appDiscovery -}}
 {{- $controllerInventory := default dict .Values.controller.inventory -}}
-{{- $ksmEndpoint := include "ongrid-edge.k8sMetricsEndpoint" . -}}
 {{- if ne .Values.mode "full-node" -}}
 {{- fail (printf "unsupported mode %q; supported mode is full-node" .Values.mode) -}}
 {{- end -}}
@@ -18,11 +24,13 @@ data:
   manager-tunnel-addr: {{ required "manager.tunnelAddr is required" .Values.manager.tunnelAddr | quote }}
   k8s-inventory-watch: {{ default true $controllerInventory.watch | quote }}
   k8s-inventory-full-sync-interval: {{ default "10m" $controllerInventory.fullSyncInterval | quote }}
-  k8s-metrics-endpoint: {{ default "" $ksmEndpoint | quote }}
-  k8s-metrics-interval: {{ default "30s" $controllerMetrics.interval | quote }}
-  k8s-metrics-timeout: {{ default "15s" $controllerMetrics.timeout | quote }}
-  k8s-metrics-push-timeout: {{ default "30s" $controllerMetrics.pushTimeout | quote }}
-  k8s-metrics-sample-limit: {{ default 250000 $controllerMetrics.sampleLimit | int | quote }}
-  k8s-metrics-batch-sample-limit: {{ default 10000 $controllerMetrics.batchSampleLimit | int | quote }}
-  k8s-metrics-batch-byte-limit: {{ default 4194304 $controllerMetrics.batchByteLimit | int | quote }}
+  k8s-metrics-endpoint: {{ default "" $metricsEndpoint | quote }}
+  k8s-metrics-interval: {{ default "30s" $metricsConfig.interval | quote }}
+  k8s-metrics-timeout: {{ default "15s" $metricsConfig.timeout | quote }}
+  k8s-metrics-push-timeout: {{ default "30s" $metricsConfig.pushTimeout | quote }}
+  k8s-metrics-sample-limit: {{ default 250000 $metricsConfig.sampleLimit | int | quote }}
+  k8s-metrics-batch-sample-limit: {{ default 10000 $metricsConfig.batchSampleLimit | int | quote }}
+  k8s-metrics-batch-byte-limit: {{ default 4194304 $metricsConfig.batchByteLimit | int | quote }}
+  k8s-metrics-max-retries: {{ default 3 $standaloneMetrics.maxRetries | int | quote }}
+  k8s-metrics-retry-backoff: {{ default "500ms" $standaloneMetrics.retryBackoff | quote }}
   k8s-app-metrics-discovery: {{ default false $appMetricsDiscovery.enabled | quote }}

--- a/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/configmap.yaml
@@ -1,12 +1,22 @@
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
 {{- $standaloneMetrics := default dict .Values.kubernetesMetrics -}}
-{{- $metricsConfig := $controllerMetrics -}}
 {{- $metricsEndpoint := include "ongrid-edge.k8sMetricsEndpoint" . -}}
+{{- $metricsInterval := default "30s" $controllerMetrics.interval -}}
+{{- $metricsTimeout := default "15s" $controllerMetrics.timeout -}}
+{{- $metricsPushTimeout := default "30s" $controllerMetrics.pushTimeout -}}
+{{- $metricsSampleLimit := default 250000 $controllerMetrics.sampleLimit -}}
+{{- $metricsBatchSampleLimit := default 10000 $controllerMetrics.batchSampleLimit -}}
+{{- $metricsBatchByteLimit := default 4194304 $controllerMetrics.batchByteLimit -}}
 {{- if eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper" -}}
-{{- $metricsConfig = $standaloneMetrics -}}
 {{- $metricsEndpoint = include "ongrid-edge.kubernetesMetricsEndpoint" . -}}
+{{- $metricsInterval = default $metricsInterval $standaloneMetrics.interval -}}
+{{- $metricsTimeout = default $metricsTimeout $standaloneMetrics.timeout -}}
+{{- $metricsPushTimeout = default $metricsPushTimeout $standaloneMetrics.pushTimeout -}}
+{{- $metricsSampleLimit = default $metricsSampleLimit $standaloneMetrics.sampleLimit -}}
+{{- $metricsBatchSampleLimit = default $metricsBatchSampleLimit $standaloneMetrics.batchSampleLimit -}}
+{{- $metricsBatchByteLimit = default $metricsBatchByteLimit $standaloneMetrics.batchByteLimit -}}
 {{- end -}}
-{{- $appMetricsDiscovery := default dict $controllerMetrics.appDiscovery -}}
+{{- $appMetricsDiscoveryEnabled := include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" . -}}
 {{- $controllerInventory := default dict .Values.controller.inventory -}}
 {{- if ne .Values.mode "full-node" -}}
 {{- fail (printf "unsupported mode %q; supported mode is full-node" .Values.mode) -}}
@@ -25,12 +35,12 @@ data:
   k8s-inventory-watch: {{ default true $controllerInventory.watch | quote }}
   k8s-inventory-full-sync-interval: {{ default "10m" $controllerInventory.fullSyncInterval | quote }}
   k8s-metrics-endpoint: {{ default "" $metricsEndpoint | quote }}
-  k8s-metrics-interval: {{ default "30s" $metricsConfig.interval | quote }}
-  k8s-metrics-timeout: {{ default "15s" $metricsConfig.timeout | quote }}
-  k8s-metrics-push-timeout: {{ default "30s" $metricsConfig.pushTimeout | quote }}
-  k8s-metrics-sample-limit: {{ default 250000 $metricsConfig.sampleLimit | int | quote }}
-  k8s-metrics-batch-sample-limit: {{ default 10000 $metricsConfig.batchSampleLimit | int | quote }}
-  k8s-metrics-batch-byte-limit: {{ default 4194304 $metricsConfig.batchByteLimit | int | quote }}
+  k8s-metrics-interval: {{ $metricsInterval | quote }}
+  k8s-metrics-timeout: {{ $metricsTimeout | quote }}
+  k8s-metrics-push-timeout: {{ $metricsPushTimeout | quote }}
+  k8s-metrics-sample-limit: {{ $metricsSampleLimit | int | quote }}
+  k8s-metrics-batch-sample-limit: {{ $metricsBatchSampleLimit | int | quote }}
+  k8s-metrics-batch-byte-limit: {{ $metricsBatchByteLimit | int | quote }}
   k8s-metrics-max-retries: {{ default 3 $standaloneMetrics.maxRetries | int | quote }}
   k8s-metrics-retry-backoff: {{ default "500ms" $standaloneMetrics.retryBackoff | quote }}
-  k8s-app-metrics-discovery: {{ default false $appMetricsDiscovery.enabled | quote }}
+  k8s-app-metrics-discovery: {{ $appMetricsDiscoveryEnabled | quote }}

--- a/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- $nodeConfigChecksum := printf "%s\n%s\n%s" .Values.mode .Values.manager.publicURL .Values.manager.tunnelAddr | sha256sum -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -14,6 +15,9 @@ spec:
       app.kubernetes.io/component: node
   template:
     metadata:
+      annotations:
+        checksum/config: {{ $nodeConfigChecksum }}
+        checksum/node-bootstrap: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "ongrid-edge.labels" . | nindent 8 }}
         app.kubernetes.io/component: node

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -1,6 +1,11 @@
 {{- $controllerMetrics := default dict .Values.controller.metrics -}}
+{{- $telemetryConfig := default dict .Values.telemetryConfig -}}
 {{- $k8sMetricsEndpoint := include "ongrid-edge.k8sMetricsEndpoint" . -}}
 {{- $telemetryGatewayEnabled := eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true" -}}
+{{- $telemetryGatewayEmbedded := and $telemetryGatewayEnabled (eq (include "ongrid-edge.telemetryGatewayMode" .) "embedded") -}}
+{{- $kubernetesMetricsEnabled := eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true" -}}
+{{- $controllerMetricsMode := and $kubernetesMetricsEnabled (eq (include "ongrid-edge.kubernetesMetricsMode" .) "controller") -}}
+{{- $telemetryDataPlaneRequired := or (and $telemetryGatewayEnabled (eq (include "ongrid-edge.telemetryGatewayMode" .) "deployment")) (and $kubernetesMetricsEnabled (eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper")) -}}
 {{- if ne (int .Values.controller.replicas) 1 -}}
 {{- fail "controller.replicas must be 1 until controller leader election is implemented" -}}
 {{- end -}}
@@ -42,7 +47,7 @@ spec:
           image: {{ include "ongrid-edge.image" . | quote }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           workingDir: /
-          {{- if $telemetryGatewayEnabled }}
+          {{- if $telemetryGatewayEmbedded }}
           ports:
             - name: otlp-grpc
               containerPort: 4317
@@ -73,6 +78,12 @@ spec:
                   key: bootstrap-token
             - name: ONGRID_K8S_CREDENTIAL_SECRET
               value: {{ include "ongrid-edge.controllerCredentialSecretName" . | quote }}
+            - name: ONGRID_K8S_TELEMETRY_SECRET
+              value: {{ include "ongrid-edge.telemetryCredentialSecretName" . | quote }}
+            - name: ONGRID_K8S_TELEMETRY_REQUIRED
+              value: {{ $telemetryDataPlaneRequired | quote }}
+            - name: ONGRID_K8S_TELEMETRY_CONFIG_REFRESH_INTERVAL
+              value: {{ default "1m" $telemetryConfig.refreshInterval | quote }}
             - name: ONGRID_MANAGER_PUBLIC_URL
               valueFrom:
                 configMapKeyRef:
@@ -85,7 +96,7 @@ spec:
                   key: manager-tunnel-addr
             - name: ONGRID_K8S_ENROLL_TLS_INSECURE
               value: {{ .Values.manager.tlsInsecure | quote }}
-            {{- if $telemetryGatewayEnabled }}
+            {{- if $telemetryGatewayEmbedded }}
             - name: ONGRID_K8S_TELEMETRY_GATEWAY_ENABLED
               value: "true"
             {{- end }}
@@ -100,10 +111,14 @@ spec:
                   name: {{ include "ongrid-edge.fullname" . }}-config
                   key: k8s-inventory-full-sync-interval
             - name: ONGRID_K8S_APP_METRICS_DISCOVERY
+              {{- if $controllerMetricsMode }}
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "ongrid-edge.fullname" . }}-config
                   key: k8s-app-metrics-discovery
+              {{- else }}
+              value: "false"
+              {{- end }}
             - name: ONGRID_K8S_POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -6,6 +6,11 @@
 {{- $kubernetesMetricsEnabled := eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true" -}}
 {{- $controllerMetricsMode := and $kubernetesMetricsEnabled (eq (include "ongrid-edge.kubernetesMetricsMode" .) "controller") -}}
 {{- $telemetryDataPlaneRequired := or (and $telemetryGatewayEnabled (eq (include "ongrid-edge.telemetryGatewayMode" .) "deployment")) (and $kubernetesMetricsEnabled (eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper")) -}}
+{{- $controllerInventory := default dict .Values.controller.inventory -}}
+{{- $controllerConfigChecksum := printf "%s\n%s\n%s\n%v\n%s" .Values.mode .Values.manager.publicURL .Values.manager.tunnelAddr (default true $controllerInventory.watch) (default "10m" $controllerInventory.fullSyncInterval) | sha256sum -}}
+{{- if $controllerMetricsMode -}}
+{{- $controllerConfigChecksum = include (print $.Template.BasePath "/configmap.yaml") . | sha256sum -}}
+{{- end -}}
 {{- if ne (int .Values.controller.replicas) 1 -}}
 {{- fail "controller.replicas must be 1 until controller leader election is implemented" -}}
 {{- end -}}
@@ -28,6 +33,9 @@ spec:
       app.kubernetes.io/component: controller
   template:
     metadata:
+      annotations:
+        checksum/config: {{ $controllerConfigChecksum }}
+        checksum/controller-bootstrap: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "ongrid-edge.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         {{- include "ongrid-edge.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{ include "ongrid-edge.telemetryBackendLabel" . }}: {{ ternary "true" "false" $telemetryGatewayEmbedded | quote }}
     spec:
       serviceAccountName: {{ include "ongrid-edge.controllerServiceAccount" . }}
       {{- with .Values.image.architecture }}

--- a/deploy/kubernetes/ongrid-edge/templates/metrics-scraper-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/metrics-scraper-deployment.yaml
@@ -1,0 +1,160 @@
+{{- $mode := include "ongrid-edge.kubernetesMetricsMode" . -}}
+{{- $enabled := eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true" -}}
+{{- if and $enabled (eq $mode "scraper") }}
+{{- $metrics := default dict .Values.kubernetesMetrics -}}
+{{- $endpoint := include "ongrid-edge.kubernetesMetricsEndpoint" . -}}
+{{- if ne (int (default 1 $metrics.replicas)) 1 -}}
+{{- fail "kubernetesMetrics.replicas must be 1 until scraper leader election or target sharding is implemented" -}}
+{{- end -}}
+{{- if or (lt (int (default 3 $metrics.maxRetries)) 1) (gt (int (default 3 $metrics.maxRetries)) 10) -}}
+{{- fail "kubernetesMetrics.maxRetries must be between 1 and 10" -}}
+{{- end -}}
+{{- if not $endpoint -}}
+{{- fail "kubernetesMetrics.mode=scraper requires kubernetesMetrics.endpoint or kubeStateMetrics.enabled=true" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ongrid-edge.fullname" . }}-metrics-scraper
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-scraper
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: metrics-scraper
+  template:
+    metadata:
+      labels:
+        {{- include "ongrid-edge.labels" . | nindent 8 }}
+        app.kubernetes.io/component: metrics-scraper
+    spec:
+      serviceAccountName: {{ include "ongrid-edge.metricsScraperServiceAccount" . }}
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.image.architecture }}
+      nodeSelector:
+        kubernetes.io/arch: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurity.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurity.runAsUser }}
+        runAsGroup: {{ .Values.podSecurity.runAsGroup }}
+        fsGroup: {{ .Values.podSecurity.fsGroup }}
+      containers:
+        - name: metrics-scraper
+          image: {{ include "ongrid-edge.image" . | quote }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          workingDir: /
+          ports:
+            - name: diagnostics
+              containerPort: 9101
+              protocol: TCP
+          env:
+            - name: ONGRID_EDGE_MODE
+              value: k8s-metrics-scraper
+            - name: ONGRID_K8S_TELEMETRY_SECRET_DIR
+              value: /var/run/ongrid-telemetry
+            - name: ONGRID_K8S_METRICS_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-endpoint
+            - name: ONGRID_K8S_METRICS_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-interval
+            - name: ONGRID_K8S_METRICS_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-timeout
+            - name: ONGRID_K8S_METRICS_PUSH_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-push-timeout
+            - name: ONGRID_K8S_METRICS_SAMPLE_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-sample-limit
+            - name: ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-batch-sample-limit
+            - name: ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-batch-byte-limit
+            - name: ONGRID_K8S_METRICS_MAX_RETRIES
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-max-retries
+            - name: ONGRID_K8S_METRICS_RETRY_BACKOFF
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-metrics-retry-backoff
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: diagnostics
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: diagnostics
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: diagnostics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml $metrics.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: telemetry-credentials
+              mountPath: /var/run/ongrid-telemetry
+              readOnly: true
+      volumes:
+        - name: telemetry-credentials
+          secret:
+            secretName: {{ include "ongrid-edge.telemetryCredentialSecretName" . }}
+            items:
+              - key: telemetry-cluster-id
+                path: telemetry-cluster-id
+              - key: telemetry-remote-write-endpoint
+                path: telemetry-remote-write-endpoint
+              - key: telemetry-remote-write-bearer
+                path: telemetry-remote-write-bearer
+              - key: telemetry-remote-write-basic-user
+                path: telemetry-remote-write-basic-user
+              - key: telemetry-remote-write-basic-pass
+                path: telemetry-remote-write-basic-pass
+              - key: telemetry-remote-write-tls-insecure
+                path: telemetry-remote-write-tls-insecure
+              - key: telemetry-remote-write-ca.pem
+                path: telemetry-remote-write-ca.pem
+{{- end }}

--- a/deploy/kubernetes/ongrid-edge/templates/metrics-scraper-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/metrics-scraper-deployment.yaml
@@ -3,14 +3,15 @@
 {{- if and $enabled (eq $mode "scraper") }}
 {{- $metrics := default dict .Values.kubernetesMetrics -}}
 {{- $endpoint := include "ongrid-edge.kubernetesMetricsEndpoint" . -}}
+{{- $appDiscoveryEnabled := eq (include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" .) "true" -}}
 {{- if ne (int (default 1 $metrics.replicas)) 1 -}}
 {{- fail "kubernetesMetrics.replicas must be 1 until scraper leader election or target sharding is implemented" -}}
 {{- end -}}
 {{- if or (lt (int (default 3 $metrics.maxRetries)) 1) (gt (int (default 3 $metrics.maxRetries)) 10) -}}
 {{- fail "kubernetesMetrics.maxRetries must be between 1 and 10" -}}
 {{- end -}}
-{{- if not $endpoint -}}
-{{- fail "kubernetesMetrics.mode=scraper requires kubernetesMetrics.endpoint or kubeStateMetrics.enabled=true" -}}
+{{- if and (not $endpoint) (not $appDiscoveryEnabled) -}}
+{{- fail "kubernetesMetrics.mode=scraper requires an endpoint, kubeStateMetrics, or app discovery" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -31,12 +32,14 @@ spec:
       app.kubernetes.io/component: metrics-scraper
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "ongrid-edge.labels" . | nindent 8 }}
         app.kubernetes.io/component: metrics-scraper
     spec:
       serviceAccountName: {{ include "ongrid-edge.metricsScraperServiceAccount" . }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ $appDiscoveryEnabled }}
       terminationGracePeriodSeconds: 30
       {{- with .Values.image.architecture }}
       nodeSelector:
@@ -106,6 +109,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ongrid-edge.fullname" . }}-config
                   key: k8s-metrics-retry-backoff
+            - name: ONGRID_K8S_APP_METRICS_DISCOVERY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ongrid-edge.fullname" . }}-config
+                  key: k8s-app-metrics-discovery
           readinessProbe:
             httpGet:
               path: /readyz

--- a/deploy/kubernetes/ongrid-edge/templates/rbac.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/rbac.yaml
@@ -8,7 +8,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: [{{ include "ongrid-edge.controllerCredentialSecretName" . | quote }}]
+    resourceNames:
+      - {{ include "ongrid-edge.controllerCredentialSecretName" . | quote }}
+      - {{ include "ongrid-edge.telemetryCredentialSecretName" . | quote }}
     verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,6 +28,36 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "ongrid-edge.controllerServiceAccount" . }}
     namespace: {{ .Release.Namespace }}
+{{- if and (eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true") (eq (include "ongrid-edge.telemetryGatewayMode" .) "deployment") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ongrid-edge.fullname" . }}-telemetry-gateway
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ongrid-edge.fullname" . }}-telemetry-gateway
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ongrid-edge.fullname" . }}-telemetry-gateway
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ongrid-edge.telemetryGatewayServiceAccount" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/kubernetes/ongrid-edge/templates/rbac.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/rbac.yaml
@@ -41,6 +41,15 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
     verbs: ["get", "list", "watch"]
+  # k8sattributes follows owner references so it can derive stable workload
+  # names from incoming Pod metadata. Keep this read-only and aligned with
+  # the workload fields extracted in the rendered Collector configuration.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -56,6 +65,36 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ongrid-edge.telemetryGatewayServiceAccount" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and (eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper") (eq (include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" .) "true") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ongrid-edge.fullname" . }}-metrics-scraper-discovery
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-scraper
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ongrid-edge.fullname" . }}-metrics-scraper-discovery
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ongrid-edge.fullname" . }}-metrics-scraper-discovery
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ongrid-edge.metricsScraperServiceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 ---

--- a/deploy/kubernetes/ongrid-edge/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/serviceaccount.yaml
@@ -9,6 +9,25 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ include "ongrid-edge.telemetryGatewayServiceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ongrid-edge.metricsScraperServiceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-scraper
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: {{ include "ongrid-edge.controllerServiceAccount" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/deploy/kubernetes/ongrid-edge/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/serviceaccount.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     {{- include "ongrid-edge.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics-scraper
-automountServiceAccountToken: false
+automountServiceAccountToken: {{ and (eq (include "ongrid-edge.kubernetesMetricsEnabled" .) "true") (eq (include "ongrid-edge.kubernetesMetricsMode" .) "scraper") (eq (include "ongrid-edge.kubernetesAppMetricsDiscoveryEnabled" .) "true") }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-credentials-secret.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- $namespace := .Release.Namespace -}}
+{{- $name := include "ongrid-edge.telemetryCredentialSecretName" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-data-plane
+type: Opaque
+# Controller owns the data field. Keeping it absent prevents Helm release
+# history from copying live data-plane credentials during upgrades.

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
@@ -1,0 +1,162 @@
+{{- $enabled := eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true" -}}
+{{- $mode := include "ongrid-edge.telemetryGatewayMode" . -}}
+{{- if and $enabled (eq $mode "deployment") }}
+{{- $gw := default dict .Values.telemetryGateway -}}
+{{- $autoscaling := default dict $gw.autoscaling -}}
+{{- $memoryLimiter := default dict $gw.memoryLimiter -}}
+{{- $batch := default dict $gw.batch -}}
+{{- $replicas := int (default 2 $gw.replicas) -}}
+{{- $limitMiB := int (default 768 $memoryLimiter.limitMiB) -}}
+{{- $spikeMiB := int (default 128 $memoryLimiter.spikeLimitMiB) -}}
+{{- $sendSize := int (default 2048 $batch.sendSize) -}}
+{{- $maxSize := int (default 4096 $batch.maxSize) -}}
+{{- $queueSize := int (default 512 $gw.queueSize) -}}
+{{- $containerMemory := required "telemetryGateway.resources.limits.memory is required" $gw.resources.limits.memory -}}
+{{- $containerLimitMiB := int (include "ongrid-edge.memoryQuantityMiB" $containerMemory) -}}
+{{- if and (not (default false $autoscaling.enabled)) (lt $replicas 2) -}}
+{{- fail "telemetryGateway.replicas must be at least 2 when autoscaling is disabled" -}}
+{{- end -}}
+{{- if or (le $spikeMiB 0) (le $limitMiB $spikeMiB) -}}
+{{- fail "telemetryGateway.memoryLimiter requires 0 < spikeLimitMiB < limitMiB" -}}
+{{- end -}}
+{{- if gt (mul $limitMiB 100) (mul $containerLimitMiB 80) -}}
+{{- fail "telemetryGateway.memoryLimiter.limitMiB must be at most 80% of the container memory limit" -}}
+{{- end -}}
+{{- if or (le $sendSize 0) (lt $maxSize $sendSize) (gt $maxSize 4096) -}}
+{{- fail "telemetryGateway.batch requires 0 < sendSize <= maxSize <= 4096" -}}
+{{- end -}}
+{{- if or (le $queueSize 0) (gt $queueSize 4096) -}}
+{{- fail "telemetryGateway.queueSize must be between 1 and 4096" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ongrid-edge.telemetryGatewayName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+spec:
+  {{- if not (default false $autoscaling.enabled) }}
+  replicas: {{ $replicas }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: telemetry-gateway
+  template:
+    metadata:
+      labels:
+        {{- include "ongrid-edge.labels" . | nindent 8 }}
+        app.kubernetes.io/component: telemetry-gateway
+    spec:
+      serviceAccountName: {{ include "ongrid-edge.telemetryGatewayServiceAccount" . }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.image.architecture }}
+      nodeSelector:
+        kubernetes.io/arch: {{ . | quote }}
+      {{- end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: telemetry-gateway
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: telemetry-gateway
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurity.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurity.runAsUser }}
+        runAsGroup: {{ .Values.podSecurity.runAsGroup }}
+        fsGroup: {{ .Values.podSecurity.fsGroup }}
+      containers:
+        - name: telemetry-gateway
+          image: {{ include "ongrid-edge.image" . | quote }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          workingDir: /
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: otel-metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: diagnostics
+              containerPort: 9101
+              protocol: TCP
+          env:
+            - name: ONGRID_EDGE_MODE
+              value: k8s-telemetry-gateway
+            - name: ONGRID_K8S_TELEMETRY_SECRET_DIR
+              value: /var/run/ongrid-telemetry
+            - name: ONGRID_K8S_TELEMETRY_RELOAD_INTERVAL
+              value: {{ default "10s" $gw.reloadInterval | quote }}
+            - name: ONGRID_K8S_ENROLL_TLS_INSECURE
+              value: {{ .Values.manager.tlsInsecure | quote }}
+            - name: ONGRID_K8S_GATEWAY_MEMORY_LIMIT_MIB
+              value: {{ $limitMiB | quote }}
+            - name: ONGRID_K8S_GATEWAY_MEMORY_SPIKE_LIMIT_MIB
+              value: {{ $spikeMiB | quote }}
+            - name: ONGRID_K8S_GATEWAY_BATCH_SIZE
+              value: {{ $sendSize | quote }}
+            - name: ONGRID_K8S_GATEWAY_BATCH_MAX_SIZE
+              value: {{ $maxSize | quote }}
+            - name: ONGRID_K8S_GATEWAY_QUEUE_SIZE
+              value: {{ $queueSize | quote }}
+            - name: ONGRID_K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: diagnostics
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: diagnostics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml $gw.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: edge-state
+              mountPath: /var/lib/ongrid-edge
+            - name: telemetry-credentials
+              mountPath: /var/run/ongrid-telemetry
+              readOnly: true
+      volumes:
+        - name: edge-state
+          emptyDir: {}
+        - name: telemetry-credentials
+          secret:
+            secretName: {{ include "ongrid-edge.telemetryCredentialSecretName" . }}
+{{- end }}

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
@@ -55,6 +55,7 @@ spec:
       labels:
         {{- include "ongrid-edge.labels" . | nindent 8 }}
         app.kubernetes.io/component: telemetry-gateway
+        {{ include "ongrid-edge.telemetryBackendLabel" . }}: "true"
     spec:
       serviceAccountName: {{ include "ongrid-edge.telemetryGatewayServiceAccount" . }}
       terminationGracePeriodSeconds: 30

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
@@ -1,0 +1,73 @@
+{{- $enabled := eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true" -}}
+{{- $mode := include "ongrid-edge.telemetryGatewayMode" . -}}
+{{- if and $enabled (eq $mode "deployment") }}
+{{- $gw := default dict .Values.telemetryGateway -}}
+{{- $pdb := default dict $gw.podDisruptionBudget -}}
+{{- $autoscaling := default dict $gw.autoscaling -}}
+{{- $memoryLimiter := default dict $gw.memoryLimiter -}}
+{{- if or (not (hasKey $pdb "enabled")) $pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ongrid-edge.telemetryGatewayName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+spec:
+  minAvailable: {{ default 1 $pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: telemetry-gateway
+{{- end }}
+{{- if default false $autoscaling.enabled }}
+---
+{{- $minReplicas := int (default 2 $autoscaling.minReplicas) -}}
+{{- $maxReplicas := int (default 10 $autoscaling.maxReplicas) -}}
+{{- $targetMemory := default "600Mi" $autoscaling.targetMemoryAverageValue -}}
+{{- $targetMemoryMiB := int (include "ongrid-edge.memoryQuantityMiB" $targetMemory) -}}
+{{- $softLimitMiB := sub (int (default 768 $memoryLimiter.limitMiB)) (int (default 128 $memoryLimiter.spikeLimitMiB)) -}}
+{{- if lt $minReplicas 2 -}}
+{{- fail "telemetryGateway.autoscaling.minReplicas must be at least 2" -}}
+{{- end -}}
+{{- if lt $maxReplicas $minReplicas -}}
+{{- fail "telemetryGateway.autoscaling.maxReplicas must be greater than or equal to minReplicas" -}}
+{{- end -}}
+{{- if ge $targetMemoryMiB $softLimitMiB -}}
+{{- fail "telemetryGateway.autoscaling.targetMemoryAverageValue must be below the memory_limiter soft limit" -}}
+{{- end -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ongrid-edge.telemetryGatewayName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: telemetry-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ongrid-edge.telemetryGatewayName" . }}
+  minReplicas: {{ $minReplicas }}
+  maxReplicas: {{ $maxReplicas }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ default 300 $autoscaling.scaleDownStabilizationWindowSeconds }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ default 60 $autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: {{ $targetMemory }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
@@ -25,17 +25,46 @@ spec:
 {{- if default false $autoscaling.enabled }}
 {{- $minReplicas := int (default 2 $autoscaling.minReplicas) -}}
 {{- $maxReplicas := int (default 10 $autoscaling.maxReplicas) -}}
-{{- $targetMemory := default "600Mi" $autoscaling.targetMemoryAverageValue -}}
+{{- $targetCPU := 60 -}}
+{{- if hasKey $autoscaling "targetCPUUtilizationPercentage" -}}
+{{- $targetCPU = int $autoscaling.targetCPUUtilizationPercentage -}}
+{{- end -}}
+{{- $targetMemory := default "512Mi" $autoscaling.targetMemoryAverageValue -}}
 {{- $targetMemoryMiB := int (include "ongrid-edge.memoryQuantityMiB" $targetMemory) -}}
 {{- $softLimitMiB := sub (int (default 768 $memoryLimiter.limitMiB)) (int (default 128 $memoryLimiter.spikeLimitMiB)) -}}
+{{- $maxTargetMemoryMiB := div (mul $softLimitMiB 80) 100 -}}
+{{- $scaleDownWindow := 300 -}}
+{{- if hasKey $autoscaling "scaleDownStabilizationWindowSeconds" -}}
+{{- $scaleDownWindow = int $autoscaling.scaleDownStabilizationWindowSeconds -}}
+{{- end -}}
+{{- $scaleDownMaxPods := 1 -}}
+{{- if hasKey $autoscaling "scaleDownMaxPods" -}}
+{{- $scaleDownMaxPods = int $autoscaling.scaleDownMaxPods -}}
+{{- end -}}
+{{- $scaleDownPeriod := 60 -}}
+{{- if hasKey $autoscaling "scaleDownPeriodSeconds" -}}
+{{- $scaleDownPeriod = int $autoscaling.scaleDownPeriodSeconds -}}
+{{- end -}}
 {{- if lt $minReplicas 2 -}}
 {{- fail "telemetryGateway.autoscaling.minReplicas must be at least 2" -}}
 {{- end -}}
 {{- if lt $maxReplicas $minReplicas -}}
 {{- fail "telemetryGateway.autoscaling.maxReplicas must be greater than or equal to minReplicas" -}}
 {{- end -}}
-{{- if ge $targetMemoryMiB $softLimitMiB -}}
-{{- fail "telemetryGateway.autoscaling.targetMemoryAverageValue must be below the memory_limiter soft limit" -}}
+{{- if or (lt $targetCPU 1) (gt $targetCPU 100) -}}
+{{- fail "telemetryGateway.autoscaling.targetCPUUtilizationPercentage must be between 1 and 100" -}}
+{{- end -}}
+{{- if or (lt $targetMemoryMiB 1) (gt $targetMemoryMiB $maxTargetMemoryMiB) -}}
+{{- fail "telemetryGateway.autoscaling.targetMemoryAverageValue must be positive and at most 80% of the memory_limiter soft limit" -}}
+{{- end -}}
+{{- if or (lt $scaleDownWindow 0) (gt $scaleDownWindow 3600) -}}
+{{- fail "telemetryGateway.autoscaling.scaleDownStabilizationWindowSeconds must be between 0 and 3600" -}}
+{{- end -}}
+{{- if lt $scaleDownMaxPods 1 -}}
+{{- fail "telemetryGateway.autoscaling.scaleDownMaxPods must be at least 1" -}}
+{{- end -}}
+{{- if or (lt $scaleDownPeriod 1) (gt $scaleDownPeriod 1800) -}}
+{{- fail "telemetryGateway.autoscaling.scaleDownPeriodSeconds must be between 1 and 1800" -}}
 {{- end -}}
 ---
 apiVersion: autoscaling/v2
@@ -54,15 +83,30 @@ spec:
   minReplicas: {{ $minReplicas }}
   maxReplicas: {{ $maxReplicas }}
   behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 4
+          periodSeconds: 15
     scaleDown:
-      stabilizationWindowSeconds: {{ default 300 $autoscaling.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ $scaleDownWindow }}
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: {{ $scaleDownMaxPods }}
+          periodSeconds: {{ $scaleDownPeriod }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ default 60 $autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ $targetCPU }}
     - type: Resource
       resource:
         name: memory

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-policy.yaml
@@ -23,7 +23,6 @@ spec:
       app.kubernetes.io/component: telemetry-gateway
 {{- end }}
 {{- if default false $autoscaling.enabled }}
----
 {{- $minReplicas := int (default 2 $autoscaling.minReplicas) -}}
 {{- $maxReplicas := int (default 10 $autoscaling.maxReplicas) -}}
 {{- $targetMemory := default "600Mi" $autoscaling.targetMemoryAverageValue -}}
@@ -38,6 +37,7 @@ spec:
 {{- if ge $targetMemoryMiB $softLimitMiB -}}
 {{- fail "telemetryGateway.autoscaling.targetMemoryAverageValue must be below the memory_limiter soft limit" -}}
 {{- end -}}
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
@@ -1,6 +1,7 @@
 {{- if eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true" }}
 {{- $gw := default dict .Values.telemetryGateway -}}
 {{- $svc := default dict $gw.service -}}
+{{- $mode := include "ongrid-edge.telemetryGatewayMode" . -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,7 +15,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/component: {{ ternary "telemetry-gateway" "controller" (eq $mode "deployment") }}
   ports:
     - name: otlp-grpc
       port: {{ default 4317 $svc.grpcPort }}

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
@@ -1,7 +1,6 @@
 {{- if eq (include "ongrid-edge.telemetryGatewayEnabled" .) "true" }}
 {{- $gw := default dict .Values.telemetryGateway -}}
 {{- $svc := default dict $gw.service -}}
-{{- $mode := include "ongrid-edge.telemetryGatewayMode" . -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,7 +14,10 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "ongrid-edge.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: {{ ternary "telemetry-gateway" "controller" (eq $mode "deployment") }}
+    # The selector is stable across embedded/deployment modes. The pre-upgrade
+    # hook adds this label to a legacy embedded Controller before Helm changes
+    # the Service, then the final manifests hand it to the standalone Gateway.
+    {{ include "ongrid-edge.telemetryBackendLabel" . }}: "true"
   ports:
     - name: otlp-grpc
       port: {{ default 4317 $svc.grpcPort }}

--- a/deploy/kubernetes/ongrid-edge/templates/upgrade-preflight.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/upgrade-preflight.yaml
@@ -1,0 +1,102 @@
+{{- if and .Release.IsUpgrade (eq (include "ongrid-edge.upgradeMigrationHookEnabled" .) "true") }}
+{{- $upgrade := default dict .Values.upgrade -}}
+{{- $hook := default dict $upgrade.migrationHook -}}
+{{- $hookName := include "ongrid-edge.upgradeHookServiceAccount" . -}}
+{{- $hookAnnotations := dict "helm.sh/hook" "pre-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-preflight
+  annotations:
+    {{- toYaml (merge (dict "helm.sh/hook-weight" "-30") $hookAnnotations) | nindent 4 }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-preflight
+  annotations:
+    {{- toYaml (merge (dict "helm.sh/hook-weight" "-25") $hookAnnotations) | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - {{ printf "%s-controller" (include "ongrid-edge.fullname" .) | quote }}
+      - {{ printf "%s-metrics-scraper" (include "ongrid-edge.fullname" .) | quote }}
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-preflight
+  annotations:
+    {{- toYaml (merge (dict "helm.sh/hook-weight" "-20") $hookAnnotations) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $hookName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $hookName }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ongrid-edge.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-preflight
+  annotations:
+    {{- toYaml (merge (dict "helm.sh/hook-weight" "-10") $hookAnnotations) | nindent 4 }}
+spec:
+  backoffLimit: {{ default 1 $hook.backoffLimit }}
+  activeDeadlineSeconds: {{ include "ongrid-edge.durationSeconds" (default "8m" $hook.timeout) }}
+  template:
+    metadata:
+      labels:
+        {{- include "ongrid-edge.labels" . | nindent 8 }}
+        app.kubernetes.io/component: upgrade-preflight
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $hookName }}
+      {{- with .Values.image.architecture }}
+      nodeSelector:
+        kubernetes.io/arch: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurity.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurity.runAsUser }}
+        runAsGroup: {{ .Values.podSecurity.runAsGroup }}
+        fsGroup: {{ .Values.podSecurity.fsGroup }}
+      containers:
+        - name: prepare
+          image: {{ include "ongrid-edge.image" . | quote }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          args:
+            - prepare-k8s-upgrade
+            - --namespace={{ .Release.Namespace }}
+            - --controller={{ include "ongrid-edge.fullname" . }}-controller
+            - --metrics-scraper={{ include "ongrid-edge.fullname" . }}-metrics-scraper
+            - --gateway-mode={{ include "ongrid-edge.telemetryGatewayMode" . }}
+            - --metrics-mode={{ include "ongrid-edge.kubernetesMetricsMode" . }}
+            - --timeout={{ default "8m" $hook.timeout }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+{{- end }}

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -83,10 +83,74 @@ kubeStateMetrics:
       cpu: 200m
       memory: 256Mi
 
+telemetryConfig:
+  # Controller republishes endpoint/auth/TLS changes to the projected Secret;
+  # Gateway and Scraper then hot-reload without a rollout.
+  refreshInterval: 1m
+
+kubernetesMetrics:
+  # Compatibility default for the first rollout. Switch to scraper only after
+  # the telemetry Secret is populated.
+  mode: controller
+  # Set false for the stop-old/start-new cutover step. While false, neither the
+  # Controller nor the standalone Scraper reads kube-state-metrics.
+  enabled: true
+  # First phase is intentionally single-active; values other than 1 fail
+  # template validation when mode=scraper.
+  replicas: 1
+  serviceAccountName: ""
+  endpoint: ""
+  interval: 30s
+  timeout: 15s
+  pushTimeout: 30s
+  sampleLimit: 250000
+  batchSampleLimit: 10000
+  batchByteLimit: 4194304
+  maxRetries: 3
+  retryBackoff: 500ms
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 telemetryGateway:
   # Expose the controller OTLP receiver by default so instrumented workloads
   # can export cluster-scoped traces, logs, and metrics without extra Helm flags.
   enabled: true
+  # embedded preserves the old controller-hosted Collector for rollout and
+  # rollback. deployment creates an isolated, horizontally scalable gateway.
+  mode: embedded
+  replicas: 2
+  serviceAccountName: ""
+  reloadInterval: 10s
+  memoryLimiter:
+    limitMiB: 768
+    spikeLimitMiB: 128
+  batch:
+    sendSize: 2048
+    maxSize: 4096
+  queueSize: 512
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 60
+    # Scale before memory_limiter's 640Mi soft limit (768Mi - 128Mi spike).
+    targetMemoryAverageValue: 600Mi
+    scaleDownStabilizationWindowSeconds: 300
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   service:
     type: ClusterIP
     grpcPort: 4317

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -93,19 +93,25 @@ kubernetesMetrics:
   # standalone Scraper starts, so fresh installs and upgrades share one target.
   mode: scraper
   # Manual emergency gate. While false, neither the Controller nor the
-  # standalone Scraper reads kube-state-metrics; normal upgrades keep it true.
-  enabled: true
+  # standalone Scraper reads metrics. Null preserves legacy
+  # controller.metrics.enabled / kubeStateMetrics.enabled values on upgrade.
+  enabled: null
   # First phase is intentionally single-active; values other than 1 fail
   # template validation when mode=scraper.
   replicas: 1
   serviceAccountName: ""
-  endpoint: ""
-  interval: 30s
-  timeout: 15s
-  pushTimeout: 30s
-  sampleLimit: 250000
-  batchSampleLimit: 10000
-  batchByteLimit: 4194304
+  # Null values inherit the corresponding controller.metrics.* setting. This
+  # keeps --reset-then-reuse-values compatible with releases from before the
+  # standalone Scraper existed while allowing an explicit new value to win.
+  endpoint: null
+  interval: null
+  timeout: null
+  pushTimeout: null
+  sampleLimit: null
+  batchSampleLimit: null
+  batchByteLimit: null
+  appDiscovery:
+    enabled: null
   maxRetries: 3
   retryBackoff: 500ms
   resources:

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -163,9 +163,13 @@ telemetryGateway:
     minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 60
-    # Scale before memory_limiter's 640Mi soft limit (768Mi - 128Mi spike).
-    targetMemoryAverageValue: 600Mi
+    # Keep the target at no more than 80% of memory_limiter's 640Mi soft limit
+    # (768Mi - 128Mi spike), leaving headroom for HPA tolerance and sampling lag.
+    targetMemoryAverageValue: 512Mi
     scaleDownStabilizationWindowSeconds: 300
+    # Drain in-memory telemetry gradually after the stabilization window.
+    scaleDownMaxPods: 1
+    scaleDownPeriodSeconds: 60
   podDisruptionBudget:
     enabled: true
     minAvailable: 1

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -156,7 +156,10 @@ telemetryGateway:
       cpu: 1000m
       memory: 1Gi
   autoscaling:
-    enabled: false
+    # Requires the standard metrics.k8s.io API (normally provided by
+    # metrics-server). Disable this flag to fall back to a fixed replica count
+    # on clusters that intentionally do not expose resource metrics.
+    enabled: true
     minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 60

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -89,11 +89,11 @@ telemetryConfig:
   refreshInterval: 1m
 
 kubernetesMetrics:
-  # Compatibility default for the first rollout. Switch to scraper only after
-  # the telemetry Secret is populated.
-  mode: controller
-  # Set false for the stop-old/start-new cutover step. While false, neither the
-  # Controller nor the standalone Scraper reads kube-state-metrics.
+  # The Chart pre-upgrade hook stops a legacy Controller scrape before the
+  # standalone Scraper starts, so fresh installs and upgrades share one target.
+  mode: scraper
+  # Manual emergency gate. While false, neither the Controller nor the
+  # standalone Scraper reads kube-state-metrics; normal upgrades keep it true.
   enabled: true
   # First phase is intentionally single-active; values other than 1 fail
   # template validation when mode=scraper.
@@ -116,13 +116,22 @@ kubernetesMetrics:
       cpu: 500m
       memory: 512Mi
 
+upgrade:
+  # A pre-upgrade Helm hook performs any live hand-off that cannot be made
+  # safe by Kubernetes reconciliation order alone. Keep enabled so upgrades
+  # remain one atomic Helm command.
+  migrationHook:
+    enabled: true
+    timeout: 8m
+    backoffLimit: 1
+
 telemetryGateway:
   # Expose the controller OTLP receiver by default so instrumented workloads
   # can export cluster-scoped traces, logs, and metrics without extra Helm flags.
   enabled: true
-  # embedded preserves the old controller-hosted Collector for rollout and
-  # rollback. deployment creates an isolated, horizontally scalable gateway.
-  mode: embedded
+  # deployment is the normal isolated data plane. embedded remains an explicit
+  # rollback option and is preserved by --reset-then-reuse-values.
+  mode: deployment
   replicas: 2
   serviceAccountName: ""
   reloadInterval: 10s

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -139,9 +139,9 @@ http {
         }
 
         # ---- Telemetry data plane: Loki push (ADR-012 / ADR-014) ----------
-        # Edge promtail subprocesses POST log batches here with HTTP Basic
-        # auth (user = edge access_key, pass = edge secret_key). nginx
-        # auth_request validates against manager's edgeauth endpoint, then
+        # Edge promtail uses an edge credential; the Kubernetes Telemetry
+        # Gateway uses its cluster-scoped telemetry credential. nginx
+        # auth_request validates either data-plane identity, then
         # proxy_pass es to internal loki:3100 — manager Go is NOT on this
         # byte stream (ADR-014 §决策第 1 条).
         location = /loki/api/v1/push {
@@ -159,6 +159,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Edge-Id         $edge_id;
             proxy_set_header X-Scope-OrgID     ongrid;
+            proxy_set_header Authorization     "";
             proxy_set_header Connection "";
             proxy_connect_timeout 10s;
             proxy_send_timeout    60s;
@@ -176,6 +177,24 @@ http {
             proxy_set_header X-Original-URI    $request_uri;
         }
 
+        location = /__auth_edge {
+            internal;
+            proxy_pass http://ongrid_backend/internal/auth/edge-verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header X-Original-URI $request_uri;
+        }
+
+        location = /__auth_telemetry {
+            internal;
+            proxy_pass http://ongrid_backend/internal/auth/telemetry-verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header X-Original-URI $request_uri;
+        }
+
         location = /internal/k8s/enroll {
             limit_req zone=k8s_enrollment burst=500 nodelay;
             limit_req_status 429;
@@ -187,10 +206,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location = /internal/k8s/telemetry-config {
+            auth_request     /__auth_edge;
+            auth_request_set $edge_id $upstream_http_x_edge_id;
+            proxy_pass http://ongrid_backend/internal/k8s/telemetry-config;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Edge-Id         $edge_id;
+            proxy_set_header Authorization     "";
+        }
+
         # ---- Telemetry data plane: Tempo OTLP HTTP push (ADR-013/014) -----
-        # Edge otelcol-contrib subprocesses POST OTLP-HTTP trace batches
-        # here with the same edge access/secret pair used for /loki push.
-        # nginx auth_request validates against manager's edgeauth endpoint,
+        # Edge otelcol-contrib uses an edge credential; the Kubernetes
+        # Telemetry Gateway uses its cluster-scoped telemetry credential.
+        # nginx auth_request validates either data-plane identity,
         # then proxy_pass es to internal tempo:4318/v1/traces — manager Go
         # is NOT on this byte stream (ADR-014 §决策第 1 条).
         location = /v1/traces {
@@ -208,7 +240,33 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Edge-Id         $edge_id;
             proxy_set_header X-Scope-OrgID     ongrid;
+            proxy_set_header Authorization     "";
             proxy_set_header Connection "";
+            proxy_connect_timeout 10s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        # Kubernetes telemetry metrics remote_write. This exact write-only
+        # route is authenticated with the cluster telemetry credential and
+        # bypasses manager Go and the controller tunnel.
+        location = /prometheus/api/v1/write {
+            auth_request     /__auth_telemetry;
+            auth_request_set $cluster_id $upstream_http_x_cluster_id;
+
+            limit_req        zone=edge_dataplane burst=200 nodelay;
+            client_max_body_size 16M;
+
+            # Embedded Prometheus runs with --web.route-prefix=/prometheus/.
+            proxy_pass http://prometheus_backend/prometheus/api/v1/write;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Cluster-Id      $cluster_id;
+            proxy_set_header Authorization     "";
+            proxy_set_header Connection        "";
             proxy_connect_timeout 10s;
             proxy_send_timeout    60s;
             proxy_read_timeout    60s;

--- a/docs/adr/ADR-029-kubernetes-telemetry-data-plane-separation.md
+++ b/docs/adr/ADR-029-kubernetes-telemetry-data-plane-separation.md
@@ -1,0 +1,193 @@
+# ADR-029：拆分 Kubernetes Controller 与遥测数据面
+
+> 完整规范见 `spec/02-architecture/architecture-decision-record.md`（何时写、状态流转、评审流程）。
+
+- 状态：已接受
+- 日期：2026-07-22
+- 作者：Codex
+- 替代：不适用
+
+## 背景
+
+当前 Kubernetes `ongrid-edge-controller` 是单副本 Deployment，同时承担两类职责：
+
+1. 控制面：controller enroll/tunnel、Kubernetes inventory list/watch、实时查询和审批后的写动作；
+2. 遥测数据面：在同一个 Pod cgroup 内运行 `otelcol-contrib` 接收 traces、logs、OTLP metrics，并由 Controller 抓取 Collector Prometheus exporter 和 kube-state-metrics（KSM），再通过 controller tunnel 推送 metrics。
+
+Controller 默认内存上限为 `512Mi`。遥测吞吐、高基数时序、batch/queue、Kubernetes metadata cache 或大 KSM scrape 都会与 inventory cache 和控制面操作竞争同一个内存与 CPU 配额。Controller Pod 被 OOMKill 时，遥测、资源同步、查询和写动作会同时中断。
+
+直接增加 Controller 副本不安全：相同 controller identity 会产生 tunnel 冲突；多个副本会重复 inventory watch/upload 和 K8s action；多个副本抓同一 KSM endpoint 还会重复写入相同 Prometheus 时序。
+
+## 决策
+
+我们决定将 Kubernetes 控制面、OTLP 数据面和 KSM scrape 拆成三个独立故障域。
+
+### 1. Controller 只承担控制面职责
+
+`ongrid-edge-controller` 保持单副本和唯一 controller identity，仅负责：
+
+- controller enroll 和 controller tunnel；
+- Kubernetes inventory list/watch、缓存和同步；
+- 实时只读查询；
+- 审批后的 Kubernetes 写动作；
+- 发布数据面配置、endpoint 和凭据 Secret。
+
+Controller 不再：
+
+- 监听 OTLP 4317/4318；
+- 在自身 cgroup 内启动遥测 Collector；
+- 接收或转发业务 logs、traces、OTLP metrics；
+- 抓取 KSM；
+- 通过 controller tunnel 传输 OTLP metrics 或 KSM metrics。
+
+Controller 自身的健康检查和自监控指标不属于业务遥测数据面，仍可通过独立 `/metrics` 暴露。
+
+### 2. 多副本 Telemetry Gateway 承担 OTLP 数据面
+
+新增独立 `ongrid-edge-telemetry-gateway` Deployment：
+
+- 保留现有 telemetry Gateway Service DNS 和 4317/4318 端口；
+- 默认至少两个副本，可独立配置 HPA、PDB 和 topology spread；
+- 每条 signal pipeline 使用 memory limiter、独立 batch、有界 queue 和有界 retry；
+- traces 写入现有 Tempo 数据面入口；
+- logs 写入现有 Loki 数据面入口；
+- OTLP metrics 直接 remote_write 到当前启用的 Prometheus-compatible backend；
+- 不建立 controller tunnel，不具备 Kubernetes 写权限。
+
+Gateway 使用 cluster-scoped、仅允许数据写入的 `telemetry_ingest` credential，不复用 controller credential。
+
+### 3. 单活 Metrics Scraper 承担 KSM scrape
+
+新增独立 `ongrid-edge-metrics-scraper` Deployment：
+
+- 第一阶段固定一个副本；
+- 使用固定 KSM Service DNS 抓取 `/metrics`；
+- 复用现有增量解析、label drop、sample limit 和按样本数/字节数分批逻辑；
+- 直接 remote_write 到当前启用的 Prometheus-compatible backend；
+- 强制写入 `cluster_id` 和 `ongrid_source="k8s:kube-state-metrics"`；
+- 不建立 controller tunnel，不启动 inventory，也不需要 Kubernetes API RBAC；
+- 使用 `Recreate` 或等价无重叠更新策略，避免多个 Scraper 同时抓取同一 KSM endpoint。
+
+KSM 继续使用自己的只读 ServiceAccount list/watch Kubernetes API 并暴露资源状态指标。KSM 的对象 cache、Metrics Scraper 的解析/batch 和 Controller inventory cache 分属不同 Pod 与 cgroup。
+
+不得让每个 Telemetry Gateway 副本抓取同一 KSM endpoint。后续若要求 KSM scrape 高可用或突破单实例容量，必须先引入 Lease leader election、target allocator，或者 KSM 与 scrape target 的明确分片。
+
+### 4. 保持兼容且禁止双写
+
+保持以下兼容边界：
+
+- 业务 Pod 的 OTLP endpoint 不变；
+- Prometheus 中现有 `cluster_id`、`ongrid_source` 和业务标签语义不变；
+- 现有 K8s PromQL 和告警无需改写；
+- Gateway 和 KSM scrape 使用独立模式开关：`telemetryGateway.mode=embedded|deployment`、`kubernetesMetrics.mode=controller|scraper`；KSM 另有 `kubernetesMetrics.enabled` 迁移闸门；
+- KSM 切换必须先停止旧路径，再启动新路径；不允许 Controller 和 Metrics Scraper 同时写入同一组时序。
+
+Controller active-active、高可用 KSM scrape 和超大集群 KSM 分片不包含在本决策的第一阶段范围内。
+
+## 备选方案
+
+### 方案 A：只提高 Controller 内存上限
+
+**优点：**
+
+- 改动最小，可以快速缓解当前 OOM；
+- 不增加新的 Deployment 和凭据。
+
+**缺点：**
+
+- 只能推迟 OOM，不能隔离控制面和数据面；
+- 下游阻塞、高基数或突发流量仍可能耗尽更大的内存；
+- Controller 升级和故障仍会同时中断全部能力。
+
+**未选择原因：** 不能消除单一故障域，可作为短期止血但不能作为目标架构。
+
+### 方案 B：增加完整 Controller 副本并加入 leader election
+
+**优点：**
+
+- 单个 Deployment 同时获得一定的控制面和数据面可用性；
+- 表面上减少新增组件数量。
+
+**缺点：**
+
+- 必须解决 tunnel identity、leader 切换、非 leader 行为和 K8s action 幂等；
+- 每个副本仍保留 Collector metadata cache 和 inventory cache；
+- 控制面与遥测数据面仍共享 Pod 故障域；
+- KSM scrape 必须额外选主，否则产生重复写入。
+
+**未选择原因：** 复杂度高且没有解决控制面与数据面的资源隔离。Controller HA 应作为后续独立决策。
+
+### 方案 C：所有 Telemetry Gateway 副本都抓取 KSM
+
+**优点：**
+
+- 不新增 Metrics Scraper Deployment；
+- KSM scrape 表面上随 Gateway 副本增加。
+
+**缺点：**
+
+- 每个副本会抓取并写入相同 `cluster_id` 和标签的时序；
+- HPA 扩缩容会动态改变重复写入倍数；
+- 可能产生重复、乱序样本和错误告警。
+
+**未选择原因：** 没有 target ownership 或分片时，多副本 scrape 不具备正确性。
+
+### 方案 D：要求客户提供 OpenTelemetry Operator 或全局采集平台
+
+**优点：**
+
+- Ongrid 不必维护默认 Gateway 和 Scraper 生命周期；
+- 已有成熟观测平台的客户可以复用其能力。
+
+**缺点：**
+
+- 把版本、RBAC、升级和故障排查责任转移给客户；
+- 无法提供开箱即用的一致安装与回滚路径。
+
+**未选择原因：** 保留为高级接入方式，但不能作为默认架构。
+
+## 后果
+
+### 正面影响
+
+- 遥测吞吐和 KSM scrape 大小不再直接增长 Controller RSS；
+- Gateway OOM、扩缩容或升级不影响 inventory 和 K8s action；
+- KSM/Scraper 故障只造成 Kubernetes 状态指标缺口，不拖垮 Controller；
+- OTLP Gateway 可以按流量独立横向扩容；
+- OTLP metrics 和 KSM metrics 不再经过 controller tunnel 和 Manager 重复编解码；
+- signal queue、内存和重试边界可以分别配置和告警。
+
+### 负面影响 / 权衡
+
+- 启用目标模式后增加至少两个 Gateway Pod 和一个 Metrics Scraper Pod，集群基础资源开销上升；
+- Gateway 需要只读 Kubernetes metadata 权限，仍会产生独立 `k8sattributes` cache；
+- 第一阶段 Metrics Scraper 单活，故障或无重叠更新时可能缺失若干 scrape interval；
+- 新增数据面 Secret、credential 轮换和 remote_write 入口，运维与安全面扩大；
+- 切换顺序错误可能产生 KSM 双写或指标缺口；
+- KSM 自身的大集群对象 cache 问题没有被消除，只是被隔离。
+
+### 中性影响
+
+- Controller 第一阶段仍是单副本，控制面 HA 另行决策；
+- KSM 仍独立 list/watch Kubernetes API；
+- Loki、Tempo 和 Prometheus-compatible backend 继续作为现有数据后端；
+- 旧 embedded/controller 模式暂时保留为灰度和回滚路径。
+
+## 实现说明
+
+实现和迁移细节以 RFC-002 为准，并必须遵守以下不变量：
+
+1. `deployment` 模式下 Controller Pod 不存在 `otelcol-contrib` 进程，也不监听 4317/4318；
+2. `scraper` 模式下 Controller 不请求 KSM endpoint，controller tunnel 不出现来源为 `k8s:kube-state-metrics` 的 `push_prom_samples`；
+3. Metrics Scraper 不携带 controller credential，也不能建立 tunnel 或执行 K8s action；
+4. 任一时刻至多一个有效 KSM scrape writer；
+5. 新旧链路的 `cluster_id`、`ongrid_source` 和业务标签通过 golden test 保持一致；
+6. 新路径必须具有明确的内存、batch、queue、retry 上限和至少 30% 容量余量；
+7. 第一轮发布保持旧模式默认，完成压测、故障演练和至少 7 天灰度观察后，再调整新安装默认值。
+
+本 ADR 已接受。如需改变上述职责边界、允许多副本重复 scrape 或复用 controller credential，必须新增 ADR 替代本决策。
+
+## 相关文档
+
+- [RFC-002：Kubernetes Controller 遥测数据面拆分与弹性扩容](../rfc/RFC-002-kubernetes-controller-telemetry-scalability.md)
+- [RFC-001：Kubernetes Full-node 接入适配方案](../rfc/RFC-001-kubernetes-edge-adaptation.md)

--- a/docs/adr/ADR-029-kubernetes-telemetry-data-plane-separation.md
+++ b/docs/adr/ADR-029-kubernetes-telemetry-data-plane-separation.md
@@ -81,6 +81,7 @@ KSM 继续使用自己的只读 ServiceAccount list/watch Kubernetes API 并暴�
 - 现有 K8s PromQL 和告警无需改写；
 - Gateway 和 KSM scrape 使用独立模式开关：`telemetryGateway.mode=embedded|deployment`、`kubernetesMetrics.mode=controller|scraper`；KSM 另有 `kubernetesMetrics.enabled` 迁移闸门；
 - KSM 切换必须先停止旧路径，再启动新路径；不允许 Controller 和 Metrics Scraper 同时写入同一组时序。
+- 标准升级必须保持一条原子 Helm 命令；Chart 的幂等 pre-upgrade Hook 负责停止旧路径并等待完成，不能依赖操作者手工执行多次 release。
 
 Controller active-active、高可用 KSM scrape 和超大集群 KSM 分片不包含在本决策的第一阶段范围内。
 
@@ -183,7 +184,8 @@ Controller active-active、高可用 KSM scrape 和超大集群 KSM 分片不包
 4. 任一时刻至多一个有效 KSM scrape writer；
 5. 新旧链路的 `cluster_id`、`ongrid_source` 和业务标签通过 golden test 保持一致；
 6. 新路径必须具有明确的内存、batch、queue、retry 上限和至少 30% 容量余量；
-7. 第一轮发布保持旧模式默认，完成压测、故障演练和至少 7 天灰度观察后，再调整新安装默认值。
+7. 新安装默认使用 `deployment` + `scraper`；`embedded` + `controller` 作为显式回滚模式，并由 Helm 3.14+ 的 `--reset-then-reuse-values` 在后续升级中保留；
+8. 已完成迁移后的纯镜像升级不得再次 patch Controller 或触发额外迁移 rollout。
 
 本 ADR 已接受。如需改变上述职责边界、允许多副本重复 scrape 或复用 controller credential，必须新增 ADR 替代本决策。
 

--- a/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
+++ b/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
@@ -1,0 +1,599 @@
+# RFC-002：Kubernetes Controller 遥测数据面拆分与弹性扩容
+
+## 元信息
+
+- 状态：实施中
+- 作者：Codex
+- 日期：2026-07-22
+- 计划评审期：2026-07-23 至 2026-07-27
+- 建议实施期：2026-07-28 至 2026-08-26（含 7 天灰度观察）
+- 关联 RFC：[RFC-001：Kubernetes Full-node 接入适配方案](./RFC-001-kubernetes-edge-adaptation.md)
+- 关联 ADR：[ADR-029：拆分 Kubernetes Controller 与遥测数据面](../adr/ADR-029-kubernetes-telemetry-data-plane-separation.md)（已接受）
+
+## 摘要
+
+当前 `ongrid-edge-controller` 同时承担 Kubernetes 控制面和集群遥测数据面：
+
+- watch Kubernetes 资源、维护 inventory cache、上传快照；
+- 接收 K8s 写动作并通过唯一 controller tunnel 执行；
+- 在同一容器 cgroup 内启动 `otelcol-contrib` 子进程；
+- 接收全部 OTLP traces、logs、metrics；
+- 将 OTLP metrics 暂存在 Collector 的 Prometheus exporter，再由 Controller 抓取并经 tunnel 推送。
+- 定时抓取 kube-state-metrics（KSM）并把资源状态指标经 controller tunnel 推送。
+
+Chart 将 Controller 限制为单副本、`Recreate` 更新，默认内存上限只有 `512Mi`。当遥测吞吐或时序基数增长时，Collector 的 batch、重试队列、Kubernetes metadata cache 和 Prometheus exporter 时序共同占用内存；一旦同 Pod OOM，inventory、K8s 查询和写动作也同时中断。
+
+本 RFC 建议把遥测数据面拆成两个独立工作负载：多副本 `ongrid-edge-telemetry-gateway` 只承接业务 Pod 的 OTLP 流量；单活 `ongrid-edge-metrics-scraper` 专门抓取 KSM 并直接 remote_write。Controller 保持控制面单写语义，不再接收、抓取或转发任何 logs、traces、OTLP metrics、KSM metrics。业务 Pod 继续使用原 Service DNS，不需要修改 OTLP endpoint。
+
+## 背景与当前链路
+
+### 当前约束
+
+| 现状 | 代码或部署位置 | 影响 |
+| --- | --- | --- |
+| Controller 只允许一个副本 | `deploy/kubernetes/ongrid-edge/templates/deployment.yaml` | `controller.replicas != 1` 时 Helm 直接失败 |
+| Controller 使用 `Recreate` | 同上 | 升级期间没有可用副本 |
+| Controller 容器内存上限默认 `512Mi` | `deploy/kubernetes/ongrid-edge/values.yaml` | Go Controller 与 Collector 子进程共享同一个 cgroup 上限 |
+| Controller 进程启动 `otelcol-contrib` 子进程 | `cmd/ongrid-edge/main.go`、`internal/edgeagent/plugins/subprocess.go` | Collector OOM 会导致整个 Controller Pod 被 OOMKill |
+| 三种 OTLP signal 共用一个 Collector | `internal/edgeagent/plugins/traces/render.go` | 任一 signal 突发都可能挤压其余 signal 和控制面内存 |
+| 没有 `memory_limiter` processor | 同上 | Collector 在 Kubernetes OOMKill 前没有软拒绝和主动 GC 水位 |
+| batch 最大 16384、trace exporter queue 为 1024 | 同上 | 下游变慢时可在内存中累积大量 payload |
+| OTLP metrics 先进入 Prometheus exporter | 同上 | 高基数时序常驻 Collector 内存 |
+| Controller 再抓取 `127.0.0.1:9464/metrics` | `cmd/ongrid-edge/main.go`、`internal/edgeagent/k8s/metrics.go` | metrics 同时经过 Collector 时序缓存、文本编码、Go 解析、JSON batch 和 tunnel |
+| Controller 默认抓取 KSM Service | `deploy/kubernetes/ongrid-edge/templates/_helpers.tpl`、`internal/edgeagent/k8s/metrics.go` | KSM 指标仍进入 Controller 进程并占用 tunnel 带宽；大 scrape 会与 inventory、查询和写动作争用资源 |
+| KSM 与 Controller 分别 watch Kubernetes API | `deploy/kubernetes/ongrid-edge/templates/kube-state-metrics.yaml`、`internal/edgeagent/k8s/inventory.go` | 两者用途不同：KSM 生成状态指标，Controller 维护 inventory；拆分数据路径不消除 KSM 自身的 watch 和内存基线 |
+| inventory 保留完整快照和对象 cache | `internal/edgeagent/k8s/inventory.go`、`inventory_delta.go` | 大集群控制面本身已有与对象数量成正比的内存基线 |
+
+### 当前数据流
+
+```mermaid
+flowchart LR
+  Apps["业务 Pod"] --> Service["telemetry-gateway Service"]
+  Service --> ControllerPod["单个 Controller Pod / 512Mi cgroup"]
+  K8sAPI["Kubernetes API"] --> KSM["kube-state-metrics"]
+  KSM -->|"/metrics scrape"| ControllerPod
+  subgraph ControllerPod
+    Controller["ongrid-edge 控制面"]
+    Collector["otelcol-contrib 子进程"]
+    Cache["inventory / watch cache"]
+    PromExporter["Prometheus exporter 时序"]
+    Collector --> PromExporter
+    PromExporter --> Controller
+    Controller --> Cache
+  end
+  Collector --> Loki["Loki"]
+  Collector --> Tempo["Tempo"]
+  Controller --> Tunnel["Manager tunnel"]
+  Tunnel --> Prometheus["Prometheus remote_write"]
+```
+
+### 为什么不能直接增加 Controller 副本
+
+直接把现有 Deployment 改为多个副本不能安全解决问题：
+
+1. 所有副本会读取同一个 controller credential，建立相同 edge 身份的 tunnel session，可能互相顶替；
+2. 每个副本都会 list/watch 相同 Kubernetes 资源并上传重复 inventory；
+3. Controller RPC 和 K8s 写动作缺少 leader election，存在重复执行风险；
+4. 每个副本都会保留完整 inventory 和 `k8sattributes` cache，固定内存随副本数线性放大；
+5. 每个副本还会抓取同一个 KSM endpoint，造成重复采集和重复写入；
+6. 即使增加副本，logs、traces、metrics 仍共享同一 Collector 故障域，无法按 signal 独立限制。
+
+## 目标
+
+- 遥测流量增加时不再挤占 Controller 控制面内存。
+- Controller 不再抓取 KSM，也不再通过 tunnel 传输任何 Kubernetes metrics。
+- Telemetry Gateway 可以独立设置固定副本或 HPA，最少保持两个可用副本。
+- KSM 由独立 Metrics Scraper 单活抓取并直接 remote_write，避免多 Gateway 副本重复采集。
+- logs、traces、metrics 都有明确的内存上限、批大小、队列和拒绝指标。
+- 下游 Loki、Tempo、Prometheus 变慢或短暂不可用时，Gateway 保持有界，不因无限重试而 OOM。
+- 保持现有 Service DNS 和 OTLP 4317/4318 端口，业务 Pod 无需修改配置。
+- 保持 `cluster_id`、`ongrid_source` 和 Kubernetes metadata 等现有查询标签。
+- Gateway 和 KSM scrape 均有独立开关，可分别退回当前 embedded/controller 模式。
+- 容量方案保留至少 30% headroom，并通过可重复压测确定单副本拐点。
+
+## 非目标
+
+- 本 RFC 第一阶段不实现 Controller 控制面的多副本 active-active。
+- 本 RFC 第一阶段不实现 KSM 或 Metrics Scraper 的多副本 active-active；超大集群的 KSM 分片和 scrape target 分片作为后续阶段。
+- 不承诺下游无限期不可用时零数据丢失。
+- 不替代客户已有的 OpenTelemetry Operator 或全局 Collector 平台。
+- 不在本 RFC 中重写 inventory watch/cache；拆分后再单独评估大集群对象缓存。
+- 不用简单提高内存上限掩盖没有背压的问题。
+
+## 方案
+
+### 1. 拆分控制面和数据面
+
+新增独立的 `ongrid-edge-telemetry-gateway` 和 `ongrid-edge-metrics-scraper` Deployment：
+
+```mermaid
+flowchart LR
+  Apps["业务 Pod"] --> Service["原 telemetry-gateway Service"]
+  Service --> GW1["Gateway Pod A"]
+  Service --> GW2["Gateway Pod B"]
+  Service --> GWN["Gateway Pod N"]
+
+  GW1 --> Logs["Loki push"]
+  GW1 --> Traces["Tempo OTLP"]
+  GW1 --> Metrics["Prometheus remote_write"]
+  GW2 --> Logs
+  GW2 --> Traces
+  GW2 --> Metrics
+  GWN --> Logs
+  GWN --> Traces
+  GWN --> Metrics
+
+  K8sAPI["Kubernetes API"] --> KSM["kube-state-metrics"]
+  KSM -->|"单活 scrape"| Scraper["Metrics Scraper"]
+  Scraper --> Metrics
+
+  K8sAPI --> Controller["Controller control plane"]
+  Controller --> Manager["Manager tunnel"]
+  Controller --> Config["数据面 config / credential Secret"]
+  Config --> GW1
+  Config --> GW2
+  Config --> GWN
+  Config --> Scraper
+```
+
+职责边界：
+
+| 组件 | 保留职责 | 移除职责 |
+| --- | --- | --- |
+| Controller | enroll、controller tunnel、inventory list/watch、只读查询、审批后的 K8s 写动作、数据面配置发布 | OTLP receiver、KSM scrape、logs/traces/metrics 数据转发 |
+| Telemetry Gateway | OTLP gRPC/HTTP receiver、K8s metadata enrichment、batch、queue、retry、向观测后端导出 | KSM scrape、inventory、K8s 写动作、controller tunnel、主机能力 |
+| Metrics Scraper | 单活抓取 KSM、标签规范化、限流、batch、直接 remote_write | OTLP receiver、inventory、K8s 写动作、controller tunnel |
+| kube-state-metrics | 只读 list/watch Kubernetes 资源并暴露状态指标 | remote_write、Controller inventory、Ongrid action |
+| Node Edge | 现有节点主机采集与诊断 | 不承担集群集中式 Gateway 的控制职责 |
+
+Controller 保持 `replicas: 1`，但遥测吞吐和 KSM scrape 大小不再影响它。控制面 HA 作为后续独立阶段，通过 Kubernetes Lease leader election 实现，不与数据面扩容绑定。
+
+### 2. Gateway 运行形态
+
+复用当前 `ongrid-edge` 多架构镜像中已经打包的 `otelcol-contrib`，新增轻量的 `k8s-telemetry-gateway` 运行模式：
+
+- 不 enroll 为 controller，不建立 tunnel，不注册 K8s 写动作；
+- 从只读挂载的 Gateway Secret 加载数据面凭据和 Manager 下发的 endpoint；
+- 渲染 Collector 配置并监督子进程；
+- Secret 内容变化时有序重启 Collector，沿用当前插件 Supervisor 的配置收敛模型；
+- 对外暴露 OTLP 4317、4318 和独立的健康/指标端口。
+
+Gateway Pod 使用与 Controller 不同的 ServiceAccount。它不拥有 Kubernetes 写权限，只允许 `get/list/watch pods/namespaces/nodes` 供 `k8sattributes` enrichment 使用；如果后续证明 cluster-wide metadata cache 仍然过大，可增加只依赖应用主动上报 resource attributes 的低内存模式。
+
+### 3. Metrics Scraper 运行形态
+
+新增 `k8s-metrics-scraper` 运行模式，复用当前增量 Prometheus 文本解析、标签清理、sample limit 和按样本数/字节数分批逻辑，但把最终出口从 `push_prom_samples` tunnel RPC 改为 Prometheus remote_write：
+
+- 单独部署为 `ongrid-edge-metrics-scraper`，第一阶段固定 `replicas: 1`；
+- 不 enroll 为 controller、不建立 tunnel、不启动 inventory、不注册 K8s 查询或写动作；
+- 通过固定 KSM Service DNS 抓取 `/metrics`，不需要访问 Kubernetes API；
+- 使用专用只写凭据直接写入当前启用的 Prometheus-compatible backend；
+- 强制写入 `cluster_id` 和 `ongrid_source="k8s:kube-state-metrics"`，并禁止目标端覆盖这些系统标签；
+- 保留当前高基数标签清理规则、`250000` sample limit、`10000` samples/批和 `4MiB`/批的默认边界，最终值由压测校准；
+- 使用 `Recreate` 或等价的无重叠更新策略，保证任一时刻只有一个 scraper 抓同一 KSM endpoint。
+
+不能简单让所有 Telemetry Gateway 副本启用相同的 Prometheus receiver。Gateway 是多副本 Deployment，所有副本抓同一 KSM 会产生重复样本；第一阶段使用独立单活 Scraper，把可用性取舍限定为最多丢失若干个 scrape interval，而不是污染时序。后续如需高可用，必须引入明确的 Lease leader election、target allocator 或 KSM/scrape target 分片后再增加副本。
+
+KSM 本身继续使用独立 ServiceAccount 对 Kubernetes API 执行只读 `get/list/watch`。KSM 的对象 cache 和内存上限属于独立故障域；KSM OOM 会造成状态指标缺口，但不会拖垮 Controller、inventory 或 K8s action。
+
+### 4. 使用独立的数据面凭据
+
+不能让所有 Gateway 副本复用具备控制面能力的 controller credential。
+
+Manager 在 controller enroll 成功时额外签发 cluster-scoped 数据面 credential：
+
+- scope 固定为 `telemetry_ingest`；
+- 允许通过 nginx `auth_request` 写入 logs、traces、metrics；
+- 禁止建立 tunnel、调用工具或执行 K8s action；
+- 删除集群时同步失效；数据面凭据可独立轮换，不依赖 controller token；
+- 多个 Gateway 副本共享这一组数据面凭据，便于按集群限流与吊销。
+
+Controller 将凭据和已解析的 telemetry endpoint 写入专用 Kubernetes Secret。Gateway 只挂载 OTLP 数据面需要的字段；Metrics Scraper 只挂载 Prometheus remote_write endpoint 和写凭据，不获得 Loki、Tempo 或查询权限。状态和日志只记录 Secret 名称、版本与校验和，不记录密码。
+
+Controller 启动时及之后按 `telemetryConfig.refreshInterval`（默认 `1m`）用现有 telemetry access/secret 向 Manager 证明凭据仍有效：验证成功只刷新 endpoint、TLS 和 backend 写凭据，不轮换 live credential；Secret 缺失或证明失效时才签发新凭据。同步失败时保留 Secret 上一版并继续控制面，下一周期重试。这样既能动态传播第三方 backend 配置，也避免 Controller 重启后 Manager 立即使旧凭据失效、而 Gateway 尚未看到 Secret 投影更新所造成的短暂 401。Manager 仍只持久化 telemetry secret 的密码哈希。
+
+### 5. 四条遥测链路的目标数据流
+
+#### Traces
+
+```text
+Pod -> Gateway OTLP -> memory_limiter -> k8sattributes
+    -> resource/cluster -> batch/traces -> bounded queue -> Manager /v1/traces -> Tempo
+```
+
+继续使用现有 `/v1/traces` 数据面鉴权和 Tempo 路径。
+
+#### Logs
+
+```text
+Pod -> Gateway OTLP -> memory_limiter -> k8sattributes
+    -> resource/loki_labels -> batch/logs -> bounded queue
+    -> Manager /loki/api/v1/push -> Loki
+```
+
+继续使用现有 Loki push 数据面路径，并强制覆盖 `cluster_id` 和 `ongrid_source`，防止客户端伪造系统标签。
+
+#### OTLP Metrics
+
+```text
+Pod -> Gateway OTLP -> memory_limiter -> k8sattributes
+    -> resource/cluster -> transform/system_labels -> batch/metrics
+    -> prometheusremotewrite -> active Prometheus-compatible backend
+```
+
+OTLP Metrics 不再经过以下旧链路：
+
+```text
+Prometheus exporter -> localhost:9464 text scrape -> Go parse
+-> JSON tunnel batch -> Manager decode -> remote_write encode
+```
+
+#### kube-state-metrics
+
+```text
+Kubernetes API -> kube-state-metrics -> Metrics Scraper
+    -> streaming parse -> label drop/system labels -> bounded batch
+    -> remote_write -> active Prometheus-compatible backend
+```
+
+KSM Metrics 不再经过以下旧链路：
+
+```text
+kube-state-metrics -> Controller Go scrape -> JSON tunnel batch
+-> Manager decode -> remote_write encode
+```
+
+KSM 不是 OTLP signal，不经过多副本 Telemetry Gateway。Metrics Scraper 必须保持现有查询兼容性：强制 `cluster_id` 和 `ongrid_source="k8s:kube-state-metrics"`，保留业务指标名与非高基数标签，并继续上报 `up`、`ongrid_scrape_partial`、`ongrid_scrape_samples_accepted` 等抓取状态指标。
+
+内置 Prometheus 增加只接受 telemetry credential 的精确 remote_write 写入口；外部 Prometheus 模式由 Manager 将当前已解析的 remote_write endpoint 和必要凭据分别发布到 Gateway 与 Metrics Scraper Secret。不得把 Prometheus 查询权限一并下放给数据面 Pod。
+
+### 6. 内存、批处理与背压
+
+Collector 的每条 pipeline 第一项都必须是 `memory_limiter`。第一版建议默认值：
+
+| 配置 | 建议默认值 | 说明 |
+| --- | --- | --- |
+| Gateway container limit | `1Gi` | 与 Controller 完全隔离 |
+| `memory_limiter.limit_mib` | `768` | 给 Collector runtime、wrapper 和瞬时分配保留约 25% |
+| `memory_limiter.spike_limit_mib` | `128` | 提前触发拒绝和 GC |
+| `check_interval` | `1s` | 快于常见突发持续时间 |
+| batch timeout | `1s` | 避免低流量时长时间占用内存 |
+| batch max size | 每个 signal 独立配置，默认不超过 `4096` | 不再三种 signal 共用一个大 batch |
+| sending queue | 每个 exporter 独立、有界 | 队列满时暴露拒绝/丢弃指标，不无限增长 |
+| retry max elapsed | 默认 `5m` | 下游长期故障时停止无限占用资源 |
+
+Metrics Scraper 使用独立资源边界：
+
+| 配置 | 建议默认值 | 说明 |
+| --- | --- | --- |
+| Scraper container limit | `512Mi` | 与 Controller、Gateway、KSM 分别隔离 |
+| scrape sample limit | `250000` | 超限立即停止继续解析并上报 partial，不尝试把整个响应保存在内存 |
+| batch sample limit | `10000` | 沿用当前增量分批边界 |
+| batch byte limit | `4MiB` | 防止单次 remote_write payload 过大 |
+| scrape interval / timeout | `30s` / `15s` | scrape 不允许跨越下一周期累积 |
+| remote_write retry | 最多 `3` 次，单批总超时 `30s` | 有界重试；不能因后端长期不可用无限保留样本 |
+
+Scraper 必须逐行/增量解析 KSM exposition，不允许先构造完整 `[]PromSample`。KSM Pod 继续拥有独立的 CPU/内存 request 与 limit；压测必须同时观察 KSM cache 和 Scraper RSS，不能只验证 remote_write 成功。
+
+第一阶段只实现有界内存 queue。可选的 `file_storage` persistent queue 作为后续增强，启用前必须满足：
+
+- 使用带 `sizeLimit` 的 `emptyDir`，默认关闭；
+- 开启后将短期下游故障的队列从 heap 转移到本地临时磁盘；
+- Pod 被驱逐或节点丢失时仍可能丢失，不能宣称 durable；
+- 磁盘队列满时必须拒绝新数据并告警，不能挤满节点根盘。
+
+所有默认值必须经过压测校准。Helm 模板应校验 `memory_limiter.limit_mib` 明显低于 container memory limit，避免错误配置使 limiter 晚于 cgroup OOM 生效。
+
+### 7. 横向扩容与可用性
+
+新增 Helm values：
+
+```yaml
+telemetryConfig:
+  refreshInterval: 1m
+
+telemetryGateway:
+  mode: deployment       # embedded | deployment
+  replicas: 2
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 60
+    # 使用 AverageValue，而不是相对 memory request 的 Utilization。
+    # 默认 600Mi，先于 640Mi soft limit（768Mi - 128Mi spike）扩容。
+    targetMemoryAverageValue: 600Mi
+    scaleDownStabilizationWindowSeconds: 300
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  memoryLimiter:
+    limitMiB: 768
+    spikeLimitMiB: 128
+  queueSize: 512
+
+kubernetesMetrics:
+  mode: scraper           # controller | scraper
+  enabled: true           # 切换时先设 false 停止两条路径
+  replicas: 1             # 第一阶段必须为 1，Helm 对其他值直接失败
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+```
+
+部署约束：
+
+- 默认固定两个副本；确认集群安装了 metrics-server 后再启用 HPA；
+- HPA 最小副本数不得小于 2；
+- 内存 HPA 使用明确的 `averageValue`，不能把 limit 百分比误写成 request 利用率；
+- `PodDisruptionBudget.minAvailable: 1`；
+- 使用 `topologySpreadConstraints`，尽量分散到不同 Node/zone；
+- `RollingUpdate.maxUnavailable: 0`、`maxSurge: 1`；
+- readiness 必须同时检查 Collector receiver 和配置已加载；
+- Service 只选择 Ready Gateway Pod。
+
+Metrics Scraper 不跟随 Telemetry Gateway HPA 扩容。第一阶段 Helm 必须校验 `kubernetesMetrics.replicas == 1`，更新时不得同时运行两个会抓同一 KSM endpoint 的 Pod。若单 Scraper 达到容量拐点，应先减少无用 KSM collectors/labels，再设计 KSM shard 与 scrape target shard；不得通过无分片加副本解决。
+
+Kubernetes Service 按连接分发。OTLP gRPC 是长连接，单条高吞吐连接不会在扩容后自动拆分到多个 Pod；容量验证必须包含长连接热点场景。若真实流量由少量超大客户端构成，优先让客户端使用多个 exporter 实例或 OTLP HTTP，必要时再引入支持连接级再均衡的前置代理。
+
+### 8. 容量模型
+
+不使用“每 N 个 Pod 固定一个 Gateway”的静态猜测。先测量单副本拐点，再计算副本数：
+
+```text
+required_replicas = ceil(
+  max(
+    peak_spans_per_second / tested_spans_per_second,
+    peak_log_bytes_per_second / tested_log_bytes_per_second,
+    peak_metric_points_per_second / tested_metric_points_per_second
+  ) * 1.3
+)
+```
+
+其中单副本可用吞吐必须同时满足：
+
+- container memory P99 不超过 limit 的 70%；
+- CPU P99 不超过 request 的 70% 或已知 HPA target；
+- receiver refused 和 exporter send failed 在稳定负载下为 0；
+- export P99 latency 满足约定 SLO；
+- 下游短暂抖动不会造成持续队列增长。
+
+压测至少覆盖：
+
+1. 30 分钟稳定峰值；
+2. 5 分钟 2 倍突发；
+3. Loki、Tempo、Prometheus 分别中断 5 分钟；
+4. 同时中断三个下游 5 分钟；
+5. 删除一个 Gateway Pod；
+6. HPA 从 2 扩到最大副本并回落；
+7. 少量 OTLP gRPC 长连接产生热点；
+8. 高基数 metrics 和大日志行/大 trace payload。
+
+KSM/Scraper 使用独立容量门槛，不计入 OTLP Gateway 副本公式：
+
+- KSM 暴露的样本数不超过已验证的 sample limit，预估增长保留至少 30% headroom；
+- 单次 scrape P99 耗时不超过 interval 的 50%；
+- KSM 和 Scraper container memory P99 均不超过各自 limit 的 70%；
+- Scraper 最大 batch 不超过样本数和字节数双重边界；
+- 达到边界时必须产生 partial/limit 告警，不允许静默截断；
+- 超出单 Scraper 拐点时，以 KSM shard 数和 scrape target shard 数重新建模，不复用 OTLP HPA 公式。
+
+### 9. 可观测性和告警
+
+Gateway 必须暴露 Collector 自身指标，并由现有监控链路采集：
+
+- receiver accepted/refused spans、log records、metric points；
+- exporter sent/send failed；
+- exporter queue size/capacity；
+- process RSS、heap、CPU、GC；
+- Pod restart、OOMKilled、HPA desired/current replicas；
+- 每个 signal 的 batch size 和 export latency；
+- 配置版本、最后成功 reload 时间。
+
+Metrics Scraper 必须暴露：
+
+- KSM scrape `up`、duration、observed/accepted samples、partial 和 sample-limit exceeded；
+- remote_write 成功/失败 batch、成功/拒绝 samples、重试次数和最后成功时间；
+- process RSS、heap、CPU、GC 和 Pod restart/OOMKilled；
+- 当前 `cluster_id`、配置版本和最后成功 reload 时间；`cluster_id` 允许作为低基数 label，endpoint、错误文本和 Secret 信息禁止作为 label。
+
+新增至少以下告警并附 Runbook：
+
+| 告警 | 建议条件 |
+| --- | --- |
+| `K8sTelemetryGatewayMemoryHigh` | 10 分钟内存持续超过 limit 的 75% |
+| `K8sTelemetryGatewayRefusingData` | 任一 receiver refused 持续大于 0 |
+| `K8sTelemetryGatewayQueueNearFull` | queue 使用率持续超过 80% |
+| `K8sTelemetryGatewayExportFailure` | send failed 连续增长 5 分钟 |
+| `K8sTelemetryGatewayReplicaUnavailable` | available replicas 小于 2 |
+| `K8sTelemetryGatewayOOMKilled` | 任一 Gateway container OOMKilled |
+| `K8sMetricsScraperDown` | 连续两个 scrape interval 未成功抓取或写入 KSM metrics |
+| `K8sMetricsScrapePartial` | `ongrid_scrape_partial` 连续两个周期为 1 |
+| `K8sMetricsSampleLimitNearCapacity` | accepted samples 持续超过 sample limit 的 70% |
+| `K8sMetricsScraperMemoryHigh` | 10 分钟内存持续超过 limit 的 75% |
+| `K8sControllerInventoryLag` | 拆分后 watch lag 超过现有基线或 30 秒 |
+
+## 兼容与迁移
+
+### Feature flag
+
+`telemetryGateway.mode` 支持：
+
+- `embedded`：保持当前 Controller 内嵌 Collector，作为回滚路径；
+- `deployment`：启用独立 Gateway Deployment，Controller 不启动 Collector。
+
+`kubernetesMetrics.mode` 独立支持：
+
+- `controller`：保持当前 Controller 抓 KSM 并经 tunnel 推送，作为回滚路径；
+- `scraper`：启用独立 Metrics Scraper，Controller 不再读取 KSM endpoint，也不再发送来源为 `k8s:kube-state-metrics` 的 `push_prom_samples`。
+
+`kubernetesMetrics.enabled=false` 是无重叠切换闸门：此时 Controller 不读取 KSM endpoint，独立 Metrics Scraper 也不会创建。它只用于切换窗口，正常运行应设为 `true`。
+
+第一轮发布保持 `telemetryGateway.mode=embedded`、`kubernetesMetrics.mode=controller`，通过预发和少量集群显式启用新模式。完成压测和至少 7 天 soak 后，新安装默认改为 `deployment` + `scraper`；升级安装继续保留用户已设置的值。两个开关独立，便于分别灰度和回滚。
+
+### 无感迁移
+
+- 保留现有 `ongrid-edge-telemetry-gateway.<namespace>.svc:4317/4318`；
+- 只修改 Service selector，不要求业务 Pod 改 endpoint；
+- 新 Gateway Ready 后再让 Service 切流；
+- Controller 的 embedded Collector 在 Service 完成切流后停止；
+- 切换期间允许短暂重连，但不能同时把同一批数据广播到两套 Gateway。
+
+KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不能在一次 Helm release 中直接从 `controller` 切到 `scraper`：Kubernetes 不保证旧 Controller 与新 Scraper 的调和顺序。
+
+1. 先以兼容模式升级新版本，保持 `kubernetesMetrics.mode=controller`、`kubernetesMetrics.enabled=true`，确认 telemetry Secret 已填充；
+2. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=controller --set kubernetesMetrics.enabled=false --wait`；
+3. 确认新 Controller 已就绪、不再请求 KSM，且 tunnel 不再产生 `k8s:kube-state-metrics` batch；
+4. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.enabled=true --wait`；
+5. 等待 Metrics Scraper 首个完整 scrape 和 remote_write 成功，对比 golden labels、样本数和关键 PromQL；
+6. 迁移窗口允许缺失一个 scrape interval，但禁止两条路径同时写同一组时序。
+
+### 回滚
+
+回滚动作：
+
+1. Controller 重新启用 embedded Collector；
+2. 等待其 readiness 成功；
+3. Service selector 切回 Controller；
+4. 缩容独立 Gateway Deployment；
+5. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.enabled=false --wait`，停止 Metrics Scraper 并确认其不再抓取 KSM；
+6. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=controller --set kubernetesMetrics.enabled=true --wait`，恢复 Controller KSM scrape，并确认首个 tunnel batch 被 Manager 接受；
+7. 保留数据面 Secret，便于再次尝试。
+
+回滚不涉及数据库 schema 回退。新增 telemetry credential 可以保留或显式吊销。
+
+## 备选方案
+
+### 方案 A：只提高 Controller 内存上限
+
+例如把 `512Mi` 提高到 `2Gi`。
+
+不采用为长期方案。它只能推迟 OOM，无法隔离控制面和数据面，也没有解决无界队列、高基数 Prometheus exporter 和单点升级中断。可以作为当前生产事故的临时止血措施。
+
+### 方案 B：现有 Controller 直接增加副本并做 leader election
+
+所有副本运行完整 Controller，只有 leader 执行 inventory 和写动作，所有副本接收 telemetry。
+
+不作为首选。它仍把控制面与 Collector 放在同一故障域，并要求先解决 tunnel identity、credential、leader 切换和非 leader 行为。即使实现，`k8sattributes` 和 inventory cache 仍会在多个副本重复占用内存。后续可单独用于控制面 HA。
+
+### 方案 C：Node-local Telemetry Gateway DaemonSet
+
+每个 Node 运行一个 Gateway，并通过 `internalTrafficPolicy: Local` 接收本节点 Pod 的 telemetry。
+
+不作为第一阶段默认。它能按 Node 自然扩容并缩小 metadata cache，但会在每个 Node 固定占用资源；Node 上没有可用 Gateway 时流量直接失败，且极端热点 Node 仍无法横向拆分。可作为超大集群或严格数据本地化场景的后续模式。
+
+### 方案 D：要求客户安装 OpenTelemetry Operator
+
+完全使用客户自有 Gateway/Collector，Ongrid 只提供 exporter 配置。
+
+保留为高级接入方式，但不能作为默认方案。它把版本、RBAC、升级和故障排查责任转嫁给用户，也不解决开箱即用安装的单 Controller OOM。
+
+### 方案 E：每个 Telemetry Gateway 副本都抓取 KSM
+
+在多副本 Gateway 的 Collector 配置中加入相同 KSM Prometheus scrape target。
+
+不采用。每个副本都会独立抓取同一 endpoint 并写入相同 `cluster_id`/labels，产生重复或乱序样本；Gateway HPA 每次扩缩容还会改变重复倍数。除非先引入 target allocator、leader election 或明确分片，否则 KSM 抓取必须与 OTLP Gateway 副本数解耦。
+
+## 影响范围
+
+### 代码
+
+- `cmd/ongrid-edge`：新增 telemetry gateway 和 KSM metrics scraper 运行模式；
+- `internal/edgeagent/plugins/traces`：拆分 signal batch/queue、增加 memory limiter 和 direct remote_write；
+- `internal/edgeagent/k8s/remote_write_scraper.go`：复用增量解析和有界 batch，新增不依赖 tunnel/Kubernetes API 的 direct-remote-write 出口；Controller 仅在回滚模式启用旧抓取；
+- `internal/manager/biz/k8s`：签发/轮换数据面凭据并生成 Gateway 配置；
+- `internal/manager/server/edgeauth`：识别 credential scope；
+- `deploy/kubernetes/ongrid-edge`：新增 Gateway 与 Metrics Scraper Deployment、HPA、PDB、Secret、Service selector、互斥迁移逻辑和 values；
+- nginx：增加 telemetry-credential-authenticated metrics remote_write 精确写入口；
+- CI：增加 Gateway 与 KSM 两组新旧 mode 组合的 Helm render、单活、策略和资源校验。
+
+### 运行时
+
+- 启用目标模式后新增至少两个 Gateway Pod 和一个 Metrics Scraper Pod，集群基础资源开销增加；
+- Controller 内存显著下降，并不再随 telemetry 吞吐增长；
+- OTLP metrics 和 KSM metrics 均不再经 tunnel，减少 Controller 和 Manager 的重复编码/解码；
+- KSM 仍独立 list/watch Kubernetes API；其对象 cache 未被消除，只是与 Controller 故障域隔离；
+- 高压时 Gateway 会先拒绝或丢弃有界数据，而不是 OOM 连带控制面。
+
+### 安全
+
+- 新增数据面 credential scope；
+- Gateway ServiceAccount 不具备 K8s 写权限；
+- Gateway Secret 含 ingest 凭据，必须只挂载到 Gateway；Metrics Scraper 只挂载 remote_write 所需字段；
+- Helm 只创建不含 `data` 的 Telemetry Secret，运行时字段由 Controller 持有并更新，禁止用 `lookup` 将 live credential 复制进 Helm release 历史；
+- Metrics Scraper 使用固定 KSM Service DNS，不授予 Kubernetes API RBAC，并关闭 ServiceAccount token 自动挂载；KSM 自身继续使用只读 ServiceAccount；
+- `manager.tlsInsecure` 只允许作用于同源 Manager 写入口；第三方 remote_write 后端独立遵循其 TLS/CA 配置；
+- 外部 backend 凭据如果下发到集群，应使用单独只写账号并支持轮换。
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解 |
+| --- | --- | --- |
+| Service 切换时 endpoint 短暂为空 | telemetry 客户端重试或丢少量数据 | 新 Gateway Ready 后切 selector；SDK 配置重试 |
+| HPA 依赖 metrics-server | 无法自动扩容 | 默认固定 2 副本；安装前检查后显式启用 HPA |
+| OTLP gRPC 长连接热点 | 新副本空闲、旧副本过载 | 压测热点；鼓励多 exporter/OTLP HTTP；必要时前置代理 |
+| 每个 Gateway 都有 cluster-wide k8sattributes cache | 固定内存随副本增长 | 只提取必要字段；后续支持无 cache/Node-local 模式 |
+| 下游故障导致队列满 | 拒绝或丢数据 | memory limiter、有界内存 queue、明确告警；磁盘 queue 留作后续增强 |
+| 两条 KSM 路径迁移时重叠 | 重复或乱序样本 | 先停 Controller scrape、再启 Scraper；Helm 状态互斥；验收 remote_write 前检查旧 tunnel source 已停止 |
+| 单活 Metrics Scraper 更新或故障 | 出现若干 scrape interval 的 KSM 指标缺口 | readiness、明确告警、快速重建；第一阶段接受短缺口，HA 必须先引入选主或分片 |
+| KSM 或 Scraper 达到单实例容量上限 | partial scrape 或状态指标缺失 | 30% headroom、sample-limit 预警、精简 collectors/labels；超限后实施 KSM 与 target 分片 |
+| 数据面凭据被窃取 | 可伪造 telemetry | scope 限制、集群级限流、Secret 最小权限、支持立即吊销 |
+| metrics 直写标签与旧链路不一致 | 现有 PromQL/告警失效 | golden payload 测试，强制 `cluster_id`/`ongrid_source`，双路径对比但不同时写生产 TSDB |
+| embedded 回滚路径长期腐化 | 事故时无法回退 | CI 每次渲染并启动两种 mode；定期演练回滚 |
+
+## 实施计划
+
+| 里程碑 | 工作项 | 预计时间 | 产物 |
+| --- | --- | --- | --- |
+| M0 基线 | 补 Collector 自监控；构造三种 OTLP signal 与不同 KSM 对象/样本规模；记录 Controller、KSM、Scraper 单实例拐点 | 2 至 3 天 | `docs/ops/loadtest-<date>.md` |
+| M1 故障域拆分 | 新增 Gateway mode、Deployment、Service selector、embedded feature flag | 3 天 | 可独立部署的 Gateway |
+| M2a OTLP 数据路径 | 数据面 credential scope；logs/traces 保持路径；OTLP metrics direct remote_write | 2 至 3 天 | 三种 OTLP signal 全链路 |
+| M2b KSM 数据路径 | 新增单活 KSM Scraper、direct remote_write、独立 feature flag 和无重叠切换 | 2 至 3 天 | KSM 目标链路 |
+| M3 弹性与保护 | memory limiter、独立 batch/queue、HPA、PDB、spread、告警 | 2 天 | 容量保护和 Runbook |
+| M4a 验证 | OTLP 压测、KSM 大 scrape、下游故障、Pod kill、KSM 无重叠切换和回滚演练 | 2 至 3 天 | 验收记录 |
+| M4b 灰度 | 少量集群启用新模式并连续观察 7 天 | 7 天观察 | 默认值与推广结论 |
+
+所有任务按 1 至 3 天颗粒度拆分。M0 没有拿到基线数据前，不把建议默认值当成最终容量承诺。
+
+## 验收标准
+
+- Helm 的 Gateway `embedded/deployment` 与 KSM `controller/scraper` 组合均能 lint、render、安装和回滚；`kubernetesMetrics.enabled=false` 不渲染 Scraper 且不给 Controller 注入 KSM 配置；非法多副本 Scraper 配置渲染失败。
+- `deployment` 模式下 Controller Pod 内不再存在 `otelcol-contrib` 进程，也不监听 4317/4318。
+- `scraper` 模式下 Controller 不再请求 KSM endpoint，且 tunnel 中不再出现来源为 `k8s:kube-state-metrics` 的 `push_prom_samples`；Metrics Scraper 不建立 controller tunnel。
+- 2 倍目标峰值持续 5 分钟时 Controller 无 OOM、RSS 不随 telemetry 吞吐显著增长。
+- Gateway 在稳定峰值下内存 P99 不超过 limit 的 70%，保留至少 30% headroom。
+- 稳定峰值下三种 OTLP signal 的 receiver refused、exporter send failed 为 0。
+- 目标 KSM 规模下 Scraper 与 KSM 内存 P99 不超过各自 limit 的 70%，单次 scrape P99 不超过 interval 的 50%，稳定负载无 partial/limit exceeded。
+- 任一时刻至多一个有效 KSM scraper；切换验证不存在 Controller 与 Scraper 双写或多个 Scraper 重复抓取。
+- 任一 Gateway Pod 删除后，Service 仍有可用 endpoint，Controller inventory 和 K8s action 不受影响。
+- 删除 Metrics Scraper Pod 时 Controller inventory 和 K8s action 不受影响；Scraper 重建后在两个 scrape interval 内恢复写入并触发/恢复相应告警。
+- 任一下游中断 5 分钟时 Gateway 不 OOM；恢复后队列回落，实际丢失量有记录且不超过配置的有界容量。
+- HPA 启用时可以从 2 副本扩容并在稳定窗口后回落，scale down 不造成持续 export failure。
+- OTLP metrics 与 KSM metrics 新旧链路的 `cluster_id`、`ongrid_source` 和业务标签 golden test 一致，现有 K8s PromQL 和告警无需修改。
+- telemetry credential 无法建立 tunnel 或调用 K8s action。
+- 日志、状态 API、Pod spec 和进程参数不泄露任何 ingest/backend 密码。
+- `inventory_watch_lag_seconds` P99 不高于拆分前基线，目标不超过 30 秒。
+- 完成一次 `deployment -> embedded` 和一次 `scraper -> controller` 回滚演练并记录耗时、指标缺口与重复样本检查结果。
+
+## 已确认与待量化事项
+
+已确认：第一阶段同时支持 Manager 内置 Prometheus 和外部 Prometheus-compatible backend 的动态 endpoint/写凭据下发；HPA 默认关闭并固定两个 Gateway 副本；persistent queue 不进入第一阶段；Metrics Scraper 第一阶段单活，切换或故障允许短暂指标缺口。
+
+待通过 M0/M4 量化：峰值 spans/s、log MiB/s、OTLP metric points/s、最大 active series，以及 KSM 最大对象数/样本数。未取得基线与 2 倍峰值压测结果前，不调整新安装默认模式。
+
+## 变更记录
+
+| 日期 | 变更 | 作者 |
+| --- | --- | --- |
+| 2026-07-22 | 初稿：拆分 Controller 控制面与可横向扩展的 Telemetry Gateway | Codex |
+| 2026-07-22 | 补充 KSM 目标链路：独立单活 Metrics Scraper 直接 remote_write，禁止多 Gateway 重复抓取 | Codex |
+| 2026-07-22 | 关联 ADR-029，固化 Controller、Gateway 与 Metrics Scraper 的职责边界 | Codex |
+| 2026-07-22 | ADR 接受后启动实现；增加独立数据面凭据、部署模板、有界队列，以及 KSM 无重叠迁移闸门 | Codex |

--- a/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
+++ b/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
@@ -318,7 +318,7 @@ telemetryGateway:
 
 kubernetesMetrics:
   mode: scraper           # controller | scraper
-  enabled: true           # 切换时先设 false 停止两条路径
+  enabled: true           # 手工故障处理闸门；正常升级由 Hook 自动编排
   replicas: 1             # 第一阶段必须为 1，Helm 对其他值直接失败
   resources:
     requests:
@@ -435,38 +435,47 @@ Metrics Scraper 必须暴露：
 - `controller`：保持当前 Controller 抓 KSM 并经 tunnel 推送，作为回滚路径；
 - `scraper`：启用独立 Metrics Scraper，Controller 不再读取 KSM endpoint，也不再发送来源为 `k8s:kube-state-metrics` 的 `push_prom_samples`。
 
-`kubernetesMetrics.enabled=false` 是无重叠切换闸门：此时 Controller 不读取 KSM endpoint，独立 Metrics Scraper 也不会创建。它只用于切换窗口，正常运行应设为 `true`。
+`kubernetesMetrics.enabled=false` 是手工故障处理闸门：此时 Controller 不读取 KSM endpoint，独立 Metrics Scraper 也不会创建。正常运行和标准升级均保持 `true`，由 Chart 的 pre-upgrade Hook 自动执行无重叠交接。
 
-第一轮发布保持 `telemetryGateway.mode=embedded`、`kubernetesMetrics.mode=controller`，通过预发和少量集群显式启用新模式。完成压测和至少 7 天 soak 后，新安装默认改为 `deployment` + `scraper`；升级安装继续保留用户已设置的值。两个开关独立，便于分别灰度和回滚。
+新安装默认使用 `telemetryGateway.mode=deployment`、`kubernetesMetrics.mode=scraper`。升级要求 Helm 3.14+，使用 `--reset-then-reuse-values` 先加载新版 Chart 默认值，再覆盖旧 release 中用户显式设置的 values；旧 release 没有这两个字段时收敛到新默认。两个开关仍然独立，显式设置 `embedded` 或 `controller` 后，后续镜像升级不会强制改回新模式。
 
 ### 无感迁移
 
 - 保留现有 `ongrid-edge-telemetry-gateway.<namespace>.svc:4317/4318`；
-- 只修改 Service selector，不要求业务 Pod 改 endpoint；
-- 新 Gateway Ready 后再让 Service 切流；
-- Controller 的 embedded Collector 在 Service 完成切流后停止；
+- Service 使用稳定的 `ongrid.io/telemetry-backend=true` selector，不要求业务 Pod 改 endpoint；
+- pre-upgrade Hook 先给旧 embedded Controller 增加稳定后端标签，避免 Service selector 变更本身提前切断旧 endpoint；
+- 最终 Controller 模板显式把后端标签设为 `false` 并停止 embedded Collector，Helm 等待新 Gateway Ready；Controller Recreate 与 Gateway 首次启动之间仍允许一次短暂重连；
 - 切换期间允许短暂重连，但不能同时把同一批数据广播到两套 Gateway。
 
-KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不能在一次 Helm release 中直接从 `controller` 切到 `scraper`：Kubernetes 不保证旧 Controller 与新 Scraper 的调和顺序。
+KSM 迁移仍使用“先停旧抓取，再启新抓取”的无重叠顺序，但该顺序由同一个 Helm release 内的 pre-upgrade Hook 编排，用户只执行页面生成的一条命令：
 
-1. 先以兼容模式升级新版本，保持 `kubernetesMetrics.mode=controller`、`kubernetesMetrics.enabled=true`，确认 telemetry Secret 已填充；
-2. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=controller --set kubernetesMetrics.enabled=false --wait`；
-3. 确认新 Controller 已就绪、不再请求 KSM，且 tunnel 不再产生 `k8s:kube-state-metrics` batch；
-4. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.enabled=true --wait`；
-5. 等待 Metrics Scraper 首个完整 scrape 和 remote_write 成功，对比 golden labels、样本数和关键 PromQL；
-6. 迁移窗口允许缺失一个 scrape interval，但禁止两条路径同时写同一组时序。
+```bash
+helm upgrade ongrid-edge <chart> --version <version> --namespace <namespace> \
+  --reset-then-reuse-values <manager-overrides> \
+  --wait --wait-for-jobs --atomic --timeout 15m
+```
+
+1. Helm 创建最小权限、仅本次升级存在的 Hook ServiceAccount、Role 和 Job；
+2. Hook 检查 live Controller。若旧 Controller 仍抓 KSM，则移除其 KSM endpoint、关闭 app discovery，并等待 Recreate rollout 完成；
+3. Hook 同时给仍承接 OTLP 的旧 Controller 增加稳定 Service 后端标签；
+4. Hook 成功后 Helm 才应用最终 Controller、Gateway、Scraper、Secret 和 Service；Scraper 在 telemetry Secret 字段就绪前不会启动抓取；
+5. `--wait --wait-for-jobs` 等待工作负载健康，任一步失败由 `--atomic` 回滚整个 release；
+6. 已完成拆分的集群再次升级时，Hook 只执行 GET 检查并立即退出，不 PATCH Deployment，因此纯镜像升级不会重复迁移或额外重启 Controller。
+
+迁移窗口允许缺失一个 scrape interval，但禁止两条路径同时写同一组时序。Hook 必须保持幂等和可重试；后续复杂版本在 Hook 中增加有明确前置状态、完成状态和回滚边界的迁移步骤，页面命令保持不变。
 
 ### 回滚
 
-回滚动作：
+标准升级失败由 `--atomic` 自动恢复上一 release；进入 Helm 回滚流程后，上一版 manifest 会覆盖 pre-upgrade 对旧 Controller 的过渡 patch。手工退回兼容模式也只执行一次：
 
-1. Controller 重新启用 embedded Collector；
-2. 等待其 readiness 成功；
-3. Service selector 切回 Controller；
-4. 缩容独立 Gateway Deployment；
-5. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.enabled=false --wait`，停止 Metrics Scraper 并确认其不再抓取 KSM；
-6. 执行 `helm upgrade ... --reuse-values --set kubernetesMetrics.mode=controller --set kubernetesMetrics.enabled=true --wait`，恢复 Controller KSM scrape，并确认首个 tunnel batch 被 Manager 接受；
-7. 保留数据面 Secret，便于再次尝试。
+```bash
+helm upgrade ... --reset-then-reuse-values \
+  --set telemetryGateway.mode=embedded \
+  --set kubernetesMetrics.mode=controller \
+  --wait --wait-for-jobs --atomic --timeout 15m
+```
+
+Hook 会先停止 Metrics Scraper，最终 manifest 再恢复 Controller 的 embedded Collector 和 KSM scrape，并移除独立 Gateway。切换可能触发 OTLP 客户端短暂重连；完成后需要确认 Controller Ready、首个 KSM tunnel batch 已被 Manager 接受。数据面 Secret 可以保留，便于再次切换。
 
 回滚不涉及数据库 schema 回退。新增 telemetry credential 可以保留或显式吊销。
 
@@ -511,7 +520,7 @@ KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不�
 - `internal/edgeagent/k8s/remote_write_scraper.go`：复用增量解析和有界 batch，新增不依赖 tunnel/Kubernetes API 的 direct-remote-write 出口；Controller 仅在回滚模式启用旧抓取；
 - `internal/manager/biz/k8s`：签发/轮换数据面凭据并生成 Gateway 配置；
 - `internal/manager/server/edgeauth`：识别 credential scope；
-- `deploy/kubernetes/ongrid-edge`：新增 Gateway 与 Metrics Scraper Deployment、HPA、PDB、Secret、Service selector、互斥迁移逻辑和 values；
+- `deploy/kubernetes/ongrid-edge`：新增 Gateway 与 Metrics Scraper Deployment、HPA、PDB、Secret、稳定 Service selector、幂等 pre-upgrade Hook 和 values；
 - nginx：增加 telemetry-credential-authenticated metrics remote_write 精确写入口；
 - CI：增加 Gateway 与 KSM 两组新旧 mode 组合的 Helm render、单活、策略和资源校验。
 
@@ -537,12 +546,12 @@ KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不�
 
 | 风险 | 影响 | 缓解 |
 | --- | --- | --- |
-| Service 切换时 endpoint 短暂为空 | telemetry 客户端重试或丢少量数据 | 新 Gateway Ready 后切 selector；SDK 配置重试 |
+| Service 切换时 endpoint 短暂为空 | telemetry 客户端重试或丢少量数据 | Hook 先标记旧 Controller，Service 使用跨模式稳定 selector，Helm 等待 Gateway Ready；SDK 配置重试 |
 | HPA 依赖 metrics-server | 无法自动扩容 | 默认固定 2 副本；安装前检查后显式启用 HPA |
 | OTLP gRPC 长连接热点 | 新副本空闲、旧副本过载 | 压测热点；鼓励多 exporter/OTLP HTTP；必要时前置代理 |
 | 每个 Gateway 都有 cluster-wide k8sattributes cache | 固定内存随副本增长 | 只提取必要字段；后续支持无 cache/Node-local 模式 |
 | 下游故障导致队列满 | 拒绝或丢数据 | memory limiter、有界内存 queue、明确告警；磁盘 queue 留作后续增强 |
-| 两条 KSM 路径迁移时重叠 | 重复或乱序样本 | 先停 Controller scrape、再启 Scraper；Helm 状态互斥；验收 remote_write 前检查旧 tunnel source 已停止 |
+| 两条 KSM 路径迁移时重叠 | 重复或乱序样本 | pre-upgrade Hook 先停 Controller scrape并等待 rollout，再由同一 release 启动 Scraper；验收 remote_write 前检查旧 tunnel source 已停止 |
 | 单活 Metrics Scraper 更新或故障 | 出现若干 scrape interval 的 KSM 指标缺口 | readiness、明确告警、快速重建；第一阶段接受短缺口，HA 必须先引入选主或分片 |
 | KSM 或 Scraper 达到单实例容量上限 | partial scrape 或状态指标缺失 | 30% headroom、sample-limit 预警、精简 collectors/labels；超限后实施 KSM 与 target 分片 |
 | 数据面凭据被窃取 | 可伪造 telemetry | scope 限制、集群级限流、Secret 最小权限、支持立即吊销 |
@@ -565,7 +574,8 @@ KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不�
 
 ## 验收标准
 
-- Helm 的 Gateway `embedded/deployment` 与 KSM `controller/scraper` 组合均能 lint、render、安装和回滚；`kubernetesMetrics.enabled=false` 不渲染 Scraper 且不给 Controller 注入 KSM 配置；非法多副本 Scraper 配置渲染失败。
+- 页面生成且只需执行一条 `helm upgrade`；Gateway `embedded/deployment` 与 KSM `controller/scraper` 组合均能 lint、render、安装和回滚；`kubernetesMetrics.enabled=false` 不渲染 Scraper 且不给 Controller 注入 KSM 配置；非法多副本 Scraper 配置渲染失败。
+- 从旧模式升级时 pre-upgrade Hook 先停止 Controller KSM 路径再应用 Scraper；已经拆分后的纯镜像升级只 GET、不 PATCH，也不触发额外 Controller rollout。
 - `deployment` 模式下 Controller Pod 内不再存在 `otelcol-contrib` 进程，也不监听 4317/4318。
 - `scraper` 模式下 Controller 不再请求 KSM endpoint，且 tunnel 中不再出现来源为 `k8s:kube-state-metrics` 的 `push_prom_samples`；Metrics Scraper 不建立 controller tunnel。
 - 2 倍目标峰值持续 5 分钟时 Controller 无 OOM、RSS 不随 telemetry 吞吐显著增长。
@@ -587,7 +597,7 @@ KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不�
 
 已确认：第一阶段同时支持 Manager 内置 Prometheus 和外部 Prometheus-compatible backend 的动态 endpoint/写凭据下发；HPA 默认关闭并固定两个 Gateway 副本；persistent queue 不进入第一阶段；Metrics Scraper 第一阶段单活，切换或故障允许短暂指标缺口。
 
-待通过 M0/M4 量化：峰值 spans/s、log MiB/s、OTLP metric points/s、最大 active series，以及 KSM 最大对象数/样本数。未取得基线与 2 倍峰值压测结果前，不调整新安装默认模式。
+待通过 M0/M4 量化：峰值 spans/s、log MiB/s、OTLP metric points/s、最大 active series，以及 KSM 最大对象数/样本数。未取得基线与 2 倍峰值压测结果前，不把当前资源 requests/limits 当成最终容量承诺。
 
 ## 变更记录
 
@@ -597,3 +607,4 @@ KSM 迁移使用“先停旧抓取，再启新抓取”的无重叠顺序。不�
 | 2026-07-22 | 补充 KSM 目标链路：独立单活 Metrics Scraper 直接 remote_write，禁止多 Gateway 重复抓取 | Codex |
 | 2026-07-22 | 关联 ADR-029，固化 Controller、Gateway 与 Metrics Scraper 的职责边界 | Codex |
 | 2026-07-22 | ADR 接受后启动实现；增加独立数据面凭据、部署模板、有界队列，以及 KSM 无重叠迁移闸门 | Codex |
+| 2026-07-27 | 将多次人工切换收敛为单次原子 Helm upgrade；增加幂等 pre-upgrade Hook、稳定 Service selector 和纯镜像升级无 PATCH 保证 | Codex |

--- a/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
+++ b/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
@@ -301,9 +301,12 @@ telemetryGateway:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 60
     # 使用 AverageValue，而不是相对 memory request 的 Utilization。
-    # 默认 600Mi，先于 640Mi soft limit（768Mi - 128Mi spike）扩容。
-    targetMemoryAverageValue: 600Mi
+    # 默认 512Mi，为 640Mi soft limit（768Mi - 128Mi spike）的 80%，
+    # 给 HPA 容忍区间和指标采样/调度延迟保留余量。
+    targetMemoryAverageValue: 512Mi
     scaleDownStabilizationWindowSeconds: 300
+    scaleDownMaxPods: 1
+    scaleDownPeriodSeconds: 60
   resources:
     requests:
       cpu: 200m
@@ -335,6 +338,7 @@ kubernetesMetrics:
 - HPA 最小副本数不得小于 2；
 - HPA 开启时 Deployment manifest 不渲染 `spec.replicas`，副本数只由 HPA 持有，后续 Helm/镜像升级不得重置实时副本数；
 - 内存 HPA 使用明确的 `averageValue`，不能把 limit 百分比误写成 request 利用率；
+- 扩容显式保持 Kubernetes 的快速默认策略（每 15 秒最多增加 100% 或 4 个 Pod，取较大值）；缩容稳定 300 秒后每 60 秒最多减少 1 个 Pod，给内存队列和长连接留出排空时间；
 - `PodDisruptionBudget.minAvailable: 1`；
 - 使用 `topologySpreadConstraints`，尽量分散到不同 Node/zone；
 - `RollingUpdate.maxUnavailable: 0`、`maxSurge: 1`；
@@ -610,3 +614,4 @@ Hook 会先停止 Metrics Scraper，最终 manifest 再恢复 Controller 的 emb
 | 2026-07-22 | ADR 接受后启动实现；增加独立数据面凭据、部署模板、有界队列，以及 KSM 无重叠迁移闸门 | Codex |
 | 2026-07-27 | 将多次人工切换收敛为单次原子 Helm upgrade；增加幂等 pre-upgrade Hook、稳定 Service selector 和纯镜像升级无 PATCH 保证 | Codex |
 | 2026-07-27 | Gateway HPA 改为默认开启；HPA 独占副本数，固定副本模式保留为无 Metrics API 集群的回滚选项 | Codex |
+| 2026-07-27 | HPA 内存目标降至 soft limit 的 80%；显式保留快速扩容，并限制缩容为每分钟一个 Pod | Codex |

--- a/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
+++ b/docs/rfc/RFC-002-kubernetes-controller-telemetry-scalability.md
@@ -296,7 +296,7 @@ telemetryGateway:
   mode: deployment       # embedded | deployment
   replicas: 2
   autoscaling:
-    enabled: false
+    enabled: true
     minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 60
@@ -331,8 +331,9 @@ kubernetesMetrics:
 
 部署约束：
 
-- 默认固定两个副本；确认集群安装了 metrics-server 后再启用 HPA；
+- 默认启用 HPA，要求集群提供标准 `metrics.k8s.io` API（通常由 metrics-server 提供）；未提供该 API 的集群必须关闭 HPA 并回退到固定两个副本；
 - HPA 最小副本数不得小于 2；
+- HPA 开启时 Deployment manifest 不渲染 `spec.replicas`，副本数只由 HPA 持有，后续 Helm/镜像升级不得重置实时副本数；
 - 内存 HPA 使用明确的 `averageValue`，不能把 limit 百分比误写成 request 利用率；
 - `PodDisruptionBudget.minAvailable: 1`；
 - 使用 `topologySpreadConstraints`，尽量分散到不同 Node/zone；
@@ -547,7 +548,7 @@ Hook 会先停止 Metrics Scraper，最终 manifest 再恢复 Controller 的 emb
 | 风险 | 影响 | 缓解 |
 | --- | --- | --- |
 | Service 切换时 endpoint 短暂为空 | telemetry 客户端重试或丢少量数据 | Hook 先标记旧 Controller，Service 使用跨模式稳定 selector，Helm 等待 Gateway Ready；SDK 配置重试 |
-| HPA 依赖 metrics-server | 无法自动扩容 | 默认固定 2 副本；安装前检查后显式启用 HPA |
+| HPA 依赖 `metrics.k8s.io` | 无法自动扩容 | 部署前确认 Metrics API 可用；无该 API 的集群显式关闭 HPA，固定保持 2 副本 |
 | OTLP gRPC 长连接热点 | 新副本空闲、旧副本过载 | 压测热点；鼓励多 exporter/OTLP HTTP；必要时前置代理 |
 | 每个 Gateway 都有 cluster-wide k8sattributes cache | 固定内存随副本增长 | 只提取必要字段；后续支持无 cache/Node-local 模式 |
 | 下游故障导致队列满 | 拒绝或丢数据 | memory limiter、有界内存 queue、明确告警；磁盘 queue 留作后续增强 |
@@ -595,7 +596,7 @@ Hook 会先停止 Metrics Scraper，最终 manifest 再恢复 Controller 的 emb
 
 ## 已确认与待量化事项
 
-已确认：第一阶段同时支持 Manager 内置 Prometheus 和外部 Prometheus-compatible backend 的动态 endpoint/写凭据下发；HPA 默认关闭并固定两个 Gateway 副本；persistent queue 不进入第一阶段；Metrics Scraper 第一阶段单活，切换或故障允许短暂指标缺口。
+已确认：第一阶段同时支持 Manager 内置 Prometheus 和外部 Prometheus-compatible backend 的动态 endpoint/写凭据下发；Gateway HPA 默认开启，依赖集群提供标准 `metrics.k8s.io` API，最少保留两个副本，并允许通过 `telemetryGateway.autoscaling.enabled=false` 回退到固定副本；persistent queue 不进入第一阶段；Metrics Scraper 第一阶段单活，切换或故障允许短暂指标缺口。
 
 待通过 M0/M4 量化：峰值 spans/s、log MiB/s、OTLP metric points/s、最大 active series，以及 KSM 最大对象数/样本数。未取得基线与 2 倍峰值压测结果前，不把当前资源 requests/limits 当成最终容量承诺。
 
@@ -608,3 +609,4 @@ Hook 会先停止 Metrics Scraper，最终 manifest 再恢复 Controller 的 emb
 | 2026-07-22 | 关联 ADR-029，固化 Controller、Gateway 与 Metrics Scraper 的职责边界 | Codex |
 | 2026-07-22 | ADR 接受后启动实现；增加独立数据面凭据、部署模板、有界队列，以及 KSM 无重叠迁移闸门 | Codex |
 | 2026-07-27 | 将多次人工切换收敛为单次原子 Helm upgrade；增加幂等 pre-upgrade Hook、稳定 Service selector 和纯镜像升级无 PATCH 保证 | Codex |
+| 2026-07-27 | Gateway HPA 改为默认开启；HPA 独占副本数，固定副本模式保留为无 Metrics API 集群的回滚选项 | Codex |

--- a/internal/edgeagent/k8s/inventory.go
+++ b/internal/edgeagent/k8s/inventory.go
@@ -936,6 +936,9 @@ func (c *apiClient) watch(ctx context.Context, apiPath, resourceVersion string, 
 		if rv := eventResourceVersion(event); rv != "" {
 			latest = rv
 		}
+		if err := watchEventError(event); err != nil {
+			return latest, err
+		}
 		if onEvent != nil {
 			if err := onEvent(event); err != nil {
 				return latest, err
@@ -973,6 +976,35 @@ func eventResourceVersion(event k8sWatchEvent) string {
 		return ""
 	}
 	return strings.TrimSpace(meta.Metadata.ResourceVersion)
+}
+
+func watchEventError(event k8sWatchEvent) error {
+	if !strings.EqualFold(strings.TrimSpace(event.Type), "ERROR") {
+		return nil
+	}
+	if len(event.Object) == 0 {
+		return errors.New("kubernetes watch error event object is empty")
+	}
+	var status struct {
+		Code    int    `json:"code"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(event.Object, &status); err != nil {
+		return fmt.Errorf("decode kubernetes watch error event: %w", err)
+	}
+	reason := strings.TrimSpace(status.Reason)
+	switch {
+	case status.Code == http.StatusGone || strings.EqualFold(reason, "Expired"):
+		return errResourceExpired
+	case status.Code == http.StatusForbidden || strings.EqualFold(reason, "Forbidden"):
+		return errForbidden
+	case status.Code == http.StatusNotFound || strings.EqualFold(reason, "NotFound"):
+		return errNotFound
+	default:
+		return fmt.Errorf("kubernetes watch error event: code=%d reason=%q message=%q",
+			status.Code, reason, strings.TrimSpace(status.Message))
+	}
 }
 
 type objectMeta struct {

--- a/internal/edgeagent/k8s/inventory_watch_test.go
+++ b/internal/edgeagent/k8s/inventory_watch_test.go
@@ -2,10 +2,12 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -51,6 +53,71 @@ func TestAPIClientWatchDecodesEventsAndBookmarks(t *testing.T) {
 	}
 	if len(gotTypes) != 2 || gotTypes[0] != "ADDED" || gotTypes[1] != "BOOKMARK" {
 		t.Fatalf("event types = %v", gotTypes)
+	}
+}
+
+func TestAPIClientWatchHandlesErrorEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    string
+		wantError error
+		wantText  string
+	}{
+		{
+			name:      "expired code",
+			status:    `{"code":410,"reason":"Expired","message":"too old resource version"}`,
+			wantError: errResourceExpired,
+		},
+		{
+			name:      "expired reason",
+			status:    `{"reason":"Expired","message":"resource version compacted"}`,
+			wantError: errResourceExpired,
+		},
+		{
+			name:      "forbidden",
+			status:    `{"code":403,"reason":"Forbidden"}`,
+			wantError: errForbidden,
+		},
+		{
+			name:      "not found",
+			status:    `{"code":404,"reason":"NotFound"}`,
+			wantError: errNotFound,
+		},
+		{
+			name:     "server failure",
+			status:   `{"code":500,"reason":"InternalError","message":"temporary failure"}`,
+			wantText: `code=500`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := fmt.Fprintf(w, `{"type":"ERROR","object":%s}`+"\n", tt.status); err != nil {
+					t.Errorf("write watch response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			client := &apiClient{baseURL: srv.URL, token: "test-token", http: srv.Client()}
+			callbackCalled := false
+			latest, err := client.watch(context.Background(), "/api/v1/events", "100", func(k8sWatchEvent) error {
+				callbackCalled = true
+				return nil
+			})
+			if tt.wantError != nil && !errors.Is(err, tt.wantError) {
+				t.Fatalf("watch() error = %v, want %v", err, tt.wantError)
+			}
+			if tt.wantText != "" && (err == nil || !strings.Contains(err.Error(), tt.wantText)) {
+				t.Fatalf("watch() error = %v, want text %q", err, tt.wantText)
+			}
+			if latest != "100" {
+				t.Fatalf("latest resourceVersion = %q, want 100", latest)
+			}
+			if callbackCalled {
+				t.Fatal("watch callback called for ERROR event")
+			}
+		})
 	}
 }
 

--- a/internal/edgeagent/k8s/metrics_observer.go
+++ b/internal/edgeagent/k8s/metrics_observer.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -17,6 +18,8 @@ type metricsObserver struct {
 	scrapeLimitExceeded *prometheus.CounterVec
 	pushBatches         *prometheus.CounterVec
 	pushSamples         *prometheus.CounterVec
+	lastSuccess         *prometheus.GaugeVec
+	scrapeDuration      *prometheus.HistogramVec
 }
 
 type metricsPusherOptions struct {
@@ -49,23 +52,48 @@ func newMetricsObserver(reg prometheus.Registerer) (*metricsObserver, error) {
 	}, []string{"source"})
 	observer.pushBatches = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ongrid_edge_k8s_metrics_push_batches_total",
-		Help: "Kubernetes metrics batches sent through the edge tunnel, partitioned by result.",
+		Help: "Kubernetes metrics batches sent to the configured data-plane sink, partitioned by result.",
 	}, []string{"source", "result"})
 	observer.pushSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ongrid_edge_k8s_metrics_push_samples_total",
-		Help: "Kubernetes metrics samples sent through the edge tunnel, partitioned by result.",
+		Help: "Kubernetes metrics samples sent to the configured data-plane sink, partitioned by result.",
 	}, []string{"source", "result"})
+	observer.lastSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ongrid_edge_k8s_metrics_last_success_timestamp_seconds",
+		Help: "Unix timestamp of the last complete Kubernetes metrics scrape and data-plane write.",
+	}, []string{"source"})
+	observer.scrapeDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ongrid_edge_k8s_metrics_scrape_duration_seconds",
+		Help:    "End-to-end duration of a Kubernetes metrics scrape and data-plane write.",
+		Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30},
+	}, []string{"source"})
 	for _, collector := range []prometheus.Collector{
 		observer.scrapeSamples,
 		observer.scrapeLimitExceeded,
 		observer.pushBatches,
 		observer.pushSamples,
+		observer.lastSuccess,
+		observer.scrapeDuration,
 	} {
 		if err := reg.Register(collector); err != nil {
 			return nil, fmt.Errorf("register k8s metrics observer: %w", err)
 		}
 	}
 	return observer, nil
+}
+
+func (o *metricsObserver) observeCycle(source string, startedAt, completedAt time.Time, success bool) {
+	if o == nil || o.lastSuccess == nil || o.scrapeDuration == nil {
+		return
+	}
+	duration := completedAt.Sub(startedAt)
+	if duration < 0 {
+		duration = 0
+	}
+	o.scrapeDuration.WithLabelValues(source).Observe(duration.Seconds())
+	if success {
+		o.lastSuccess.WithLabelValues(source).Set(float64(completedAt.Unix()))
+	}
 }
 
 func (o *metricsObserver) observeScrape(source string, accepted int, limitExceeded bool) {

--- a/internal/edgeagent/k8s/remote_write_scraper.go
+++ b/internal/edgeagent/k8s/remote_write_scraper.go
@@ -1,0 +1,271 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/plugins/metricscommon"
+	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+const (
+	defaultRemoteWriteRetries = 3
+	defaultRemoteWriteBackoff = 500 * time.Millisecond
+	maxRemoteWriteRetries     = 10
+)
+
+type RemoteWriteWriter interface {
+	Write(ctx context.Context, samples []pkgpromwrite.Sample) error
+}
+
+type RemoteWriteScraperConfig struct {
+	ClusterID        uint64
+	Endpoint         string
+	Interval         time.Duration
+	Timeout          time.Duration
+	PushTimeout      time.Duration
+	SampleLimit      int
+	BatchSampleLimit int
+	BatchByteLimit   int
+	MaxRetries       int
+	RetryBackoff     time.Duration
+}
+
+// RemoteWriteScraper is the single-active KSM data plane. It has no tunnel
+// client and no Kubernetes API client; its only inputs are a fixed /metrics
+// URL and an exact remote_write writer.
+type RemoteWriteScraper struct {
+	writer  RemoteWriteWriter
+	cfg     RemoteWriteScraperConfig
+	log     *slog.Logger
+	metrics *metricsObserver
+}
+
+func NewRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfig, log *slog.Logger, registerer prometheus.Registerer) (*RemoteWriteScraper, error) {
+	if writer == nil {
+		return nil, errors.New("k8s remote write scraper: writer is required")
+	}
+	if cfg.ClusterID == 0 {
+		return nil, errors.New("k8s remote write scraper: cluster_id is required")
+	}
+	cfg.Endpoint = strings.TrimSpace(cfg.Endpoint)
+	if cfg.Endpoint == "" {
+		return nil, errors.New("k8s remote write scraper: endpoint is required")
+	}
+	if err := metricscommon.ValidateURL(cfg.Endpoint); err != nil {
+		return nil, fmt.Errorf("k8s remote write scraper endpoint: %w", err)
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultK8sMetricsInterval
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultK8sMetricsTimeout
+	}
+	if cfg.Timeout > cfg.Interval {
+		cfg.Timeout = cfg.Interval
+	}
+	if cfg.PushTimeout <= 0 {
+		cfg.PushTimeout = defaultK8sMetricsPushTimeout
+	}
+	if cfg.SampleLimit <= 0 {
+		cfg.SampleLimit = defaultK8sMetricsLimit
+	}
+	if cfg.BatchSampleLimit <= 0 {
+		cfg.BatchSampleLimit = defaultK8sMetricsBatchSampleLimit
+	}
+	if cfg.BatchByteLimit <= 0 {
+		cfg.BatchByteLimit = defaultK8sMetricsBatchByteLimit
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = defaultRemoteWriteRetries
+	}
+	if cfg.MaxRetries > maxRemoteWriteRetries {
+		cfg.MaxRetries = maxRemoteWriteRetries
+	}
+	if cfg.RetryBackoff <= 0 {
+		cfg.RetryBackoff = defaultRemoteWriteBackoff
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	observer, err := newMetricsObserver(registerer)
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteWriteScraper{writer: writer, cfg: cfg, log: log, metrics: observer}, nil
+}
+
+func (s *RemoteWriteScraper) Run(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.scrapeAndWrite(ctx)
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			s.scrapeAndWrite(ctx)
+		}
+	}
+}
+
+func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) {
+	startedAt := time.Now()
+	target := s.target()
+	batcher, err := newMetricsBatcher(0, k8sMetricsSource, s.cfg.BatchSampleLimit, s.cfg.BatchByteLimit, func(samples []tunnel.PromSample) error {
+		return s.writeWithRetry(ctx, k8sMetricsSource, samples)
+	})
+	if err != nil {
+		s.log.Error("k8s metrics batcher initialization failed", slog.Any("err", err))
+		return
+	}
+
+	scrapeCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+	stats, scrapeErr := metricscommon.ScrapeIncremental(scrapeCtx, target, func(samples []tunnel.PromSample) error {
+		batcher.Add(samples...)
+		return nil
+	})
+	cancel()
+	batcher.Flush()
+	dataStats := batcher.Stats()
+	s.metrics.observeScrape(k8sMetricsSource, stats.Accepted, stats.LimitExceeded)
+	s.metrics.observePush(k8sMetricsSource, dataStats)
+
+	partial := stats.LimitExceeded || dataStats.FailedBatches > 0 || dataStats.RejectedSamples > 0
+	if scrapeErr != nil && stats.Accepted > 0 {
+		partial = true
+	}
+	statusSamples := scrapeStatusSamples(time.Now(), "k8s", target, partial, dataStats.SuccessfulSamples, scrapeErr == nil)
+	statusStats := metricsBatchStats{}
+	if err := s.writeWithRetry(ctx, k8sMetricsSource, statusSamples); err != nil {
+		statusStats.FailedBatches = 1
+		statusStats.FailedSamples = len(statusSamples)
+		statusStats.FirstError = err
+	} else {
+		statusStats.SuccessfulBatches = 1
+		statusStats.SuccessfulSamples = len(statusSamples)
+	}
+	s.metrics.observePush(k8sMetricsSource, statusStats)
+	completedAt := time.Now()
+	s.metrics.observeCycle(k8sMetricsSource, startedAt, completedAt,
+		scrapeErr == nil && !stats.LimitExceeded && dataStats.FailedBatches == 0 && dataStats.RejectedSamples == 0 && statusStats.FailedBatches == 0,
+	)
+	s.logOutcome(target, stats, dataStats, statusStats, scrapeErr)
+}
+
+func (s *RemoteWriteScraper) writeWithRetry(ctx context.Context, source string, samples []tunnel.PromSample) error {
+	writeCtx, cancel := context.WithTimeout(ctx, s.cfg.PushTimeout)
+	defer cancel()
+	payload := buildKubernetesRemoteWriteSamples(s.cfg.ClusterID, source, samples)
+	var lastErr error
+	for attempt := 1; attempt <= s.cfg.MaxRetries; attempt++ {
+		if err := s.writer.Write(writeCtx, payload); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if attempt == s.cfg.MaxRetries {
+			break
+		}
+		delay := s.cfg.RetryBackoff * time.Duration(1<<(attempt-1))
+		if delay > 2*time.Second {
+			delay = 2 * time.Second
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-writeCtx.Done():
+			timer.Stop()
+			return errors.Join(lastErr, writeCtx.Err())
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("remote_write failed after %d attempts: %w", s.cfg.MaxRetries, lastErr)
+}
+
+func (s *RemoteWriteScraper) target() metricscommon.Target {
+	return metricscommon.Target{
+		ID:                 "kube-state-metrics",
+		Name:               "kube-state-metrics",
+		URL:                s.cfg.Endpoint,
+		Enabled:            true,
+		Interval:           s.cfg.Interval,
+		Timeout:            s.cfg.Timeout,
+		SourceLabel:        k8sMetricsSource,
+		SampleLimit:        s.cfg.SampleLimit,
+		Kind:               "kubernetes",
+		ReportScrapeStatus: true,
+		LabelDrop: []string{
+			"uid",
+			"pod_uid",
+			"container_id",
+			"image_id",
+			"id",
+			"owner_uid",
+			"controller_revision_hash",
+		},
+	}
+}
+
+func (s *RemoteWriteScraper) logOutcome(target metricscommon.Target, stats metricscommon.ScrapeStats, dataStats, statusStats metricsBatchStats, scrapeErr error) {
+	if scrapeErr != nil {
+		s.log.Warn("k8s metrics scrape failed", slog.String("endpoint", target.URL), slog.Any("err", scrapeErr))
+	}
+	if stats.LimitExceeded {
+		s.log.Warn("k8s metrics sample limit exceeded; writing bounded scrape",
+			slog.Int("observed_samples_at_least", stats.Observed),
+			slog.Int("sample_limit", target.SampleLimit),
+			slog.Int("accepted_samples", stats.Accepted),
+		)
+	}
+	if dataStats.FirstError != nil || statusStats.FirstError != nil {
+		s.log.Warn("k8s metrics remote_write partially failed",
+			slog.Int("successful_batches", dataStats.SuccessfulBatches+statusStats.SuccessfulBatches),
+			slog.Int("failed_batches", dataStats.FailedBatches+statusStats.FailedBatches),
+			slog.Any("data_error", dataStats.FirstError),
+			slog.Any("status_error", statusStats.FirstError),
+		)
+	}
+}
+
+var reservedKubernetesRemoteWriteLabels = map[string]struct{}{
+	"__name__":      {},
+	"cluster_id":    {},
+	"device_id":     {},
+	"edge_id":       {},
+	"ongrid_source": {},
+}
+
+func buildKubernetesRemoteWriteSamples(clusterID uint64, source string, samples []tunnel.PromSample) []pkgpromwrite.Sample {
+	out := make([]pkgpromwrite.Sample, 0, len(samples))
+	for _, sample := range samples {
+		labels := make([]pkgpromwrite.Label, 0, len(sample.Labels)+3)
+		labels = append(labels,
+			pkgpromwrite.Label{Name: "__name__", Value: sample.Name},
+			pkgpromwrite.Label{Name: "cluster_id", Value: strconv.FormatUint(clusterID, 10)},
+		)
+		if source != "" {
+			labels = append(labels, pkgpromwrite.Label{Name: "ongrid_source", Value: source})
+		}
+		for name, value := range sample.Labels {
+			if _, reserved := reservedKubernetesRemoteWriteLabels[name]; reserved {
+				continue
+			}
+			labels = append(labels, pkgpromwrite.Label{Name: name, Value: value})
+		}
+		sort.Slice(labels, func(i, j int) bool { return labels[i].Name < labels[j].Name })
+		out = append(out, pkgpromwrite.Sample{Labels: labels, Value: sample.Value, TsMs: sample.TsMs})
+	}
+	return out
+}

--- a/internal/edgeagent/k8s/remote_write_scraper.go
+++ b/internal/edgeagent/k8s/remote_write_scraper.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,6 +31,7 @@ type RemoteWriteWriter interface {
 type RemoteWriteScraperConfig struct {
 	ClusterID        uint64
 	Endpoint         string
+	DiscoverApps     bool
 	Interval         time.Duration
 	Timeout          time.Duration
 	PushTimeout      time.Duration
@@ -40,17 +42,24 @@ type RemoteWriteScraperConfig struct {
 	RetryBackoff     time.Duration
 }
 
-// RemoteWriteScraper is the single-active KSM data plane. It has no tunnel
-// client and no Kubernetes API client; its only inputs are a fixed /metrics
-// URL and an exact remote_write writer.
+// RemoteWriteScraper is the single-active Kubernetes metrics data plane. It
+// has no tunnel client. It scrapes the configured kube-state-metrics endpoint
+// and, when enabled, annotation-discovered application targets through a
+// read-only Kubernetes API client before writing directly to remote_write.
 type RemoteWriteScraper struct {
 	writer  RemoteWriteWriter
 	cfg     RemoteWriteScraperConfig
 	log     *slog.Logger
+	api     *apiClient
 	metrics *metricsObserver
+	ready   atomic.Bool
 }
 
 func NewRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfig, log *slog.Logger, registerer prometheus.Registerer) (*RemoteWriteScraper, error) {
+	return newRemoteWriteScraper(writer, cfg, log, registerer, nil)
+}
+
+func newRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfig, log *slog.Logger, registerer prometheus.Registerer, api *apiClient) (*RemoteWriteScraper, error) {
 	if writer == nil {
 		return nil, errors.New("k8s remote write scraper: writer is required")
 	}
@@ -58,11 +67,13 @@ func NewRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfi
 		return nil, errors.New("k8s remote write scraper: cluster_id is required")
 	}
 	cfg.Endpoint = strings.TrimSpace(cfg.Endpoint)
-	if cfg.Endpoint == "" {
-		return nil, errors.New("k8s remote write scraper: endpoint is required")
+	if cfg.Endpoint == "" && !cfg.DiscoverApps {
+		return nil, errors.New("k8s remote write scraper: endpoint or app discovery is required")
 	}
-	if err := metricscommon.ValidateURL(cfg.Endpoint); err != nil {
-		return nil, fmt.Errorf("k8s remote write scraper endpoint: %w", err)
+	if cfg.Endpoint != "" {
+		if err := metricscommon.ValidateURL(cfg.Endpoint); err != nil {
+			return nil, fmt.Errorf("k8s remote write scraper endpoint: %w", err)
+		}
 	}
 	if cfg.Interval <= 0 {
 		cfg.Interval = defaultK8sMetricsInterval
@@ -97,11 +108,26 @@ func NewRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfi
 	if log == nil {
 		log = slog.Default()
 	}
+	if cfg.DiscoverApps && api == nil {
+		var err error
+		api, err = newInClusterAPIClient()
+		if err != nil {
+			return nil, fmt.Errorf("k8s remote write scraper app discovery: %w", err)
+		}
+	}
 	observer, err := newMetricsObserver(registerer)
 	if err != nil {
 		return nil, err
 	}
-	return &RemoteWriteScraper{writer: writer, cfg: cfg, log: log, metrics: observer}, nil
+	return &RemoteWriteScraper{writer: writer, cfg: cfg, log: log, api: api, metrics: observer}, nil
+}
+
+// Ready reports whether the most recent required discovery, core scrape, and
+// remote_write cycle succeeded. Individual application endpoints report their
+// own up=0 series and do not take a healthy kube-state-metrics scraper offline.
+// It remains false until the first required cycle.
+func (s *RemoteWriteScraper) Ready() bool {
+	return s != nil && s.ready.Load()
 }
 
 func (s *RemoteWriteScraper) Run(ctx context.Context) error {
@@ -121,15 +147,98 @@ func (s *RemoteWriteScraper) Run(ctx context.Context) error {
 	}
 }
 
-func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) {
+func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) bool {
+	targets, discoveryOK := s.targets(ctx)
+	cycleOK := discoveryOK
+	hasCoreTarget := s.cfg.Endpoint != ""
+	for _, target := range targets {
+		success := s.scrapeTargetAndWrite(ctx, target)
+		isAppTarget := target.SourceLabel == k8sAppMetricsSource
+		if !success && (!hasCoreTarget || !isAppTarget) {
+			cycleOK = false
+		}
+		if hasCoreTarget && !isAppTarget {
+			// Application targets may be numerous or temporarily unavailable.
+			// Publish core readiness as soon as KSM and remote_write complete.
+			s.ready.Store(cycleOK)
+		}
+	}
+	// App-discovery-only configurations may legitimately have no annotated
+	// pods. Publish one bounded status sample so readiness still proves that
+	// both Kubernetes discovery and remote_write are usable.
+	if len(targets) == 0 && s.cfg.DiscoverApps && discoveryOK {
+		target := metricscommon.Target{
+			ID:          "app-discovery",
+			Name:        "app-discovery",
+			Enabled:     true,
+			SourceLabel: k8sAppMetricsSource,
+			Kind:        "kubernetes-app-discovery",
+		}
+		status := []tunnel.PromSample{metricscommon.ScrapeUpSample(time.Now(), "k8s_app", target, true)}
+		if err := s.writeWithRetry(ctx, k8sAppMetricsSource, status); err != nil {
+			s.log.Warn("k8s app metrics discovery status write failed", slog.Any("err", err))
+			cycleOK = false
+		}
+	}
+	if !hasCoreTarget {
+		s.ready.Store(cycleOK)
+	}
+	return cycleOK
+}
+
+func (s *RemoteWriteScraper) targets(ctx context.Context) ([]metricscommon.Target, bool) {
+	targets := make([]metricscommon.Target, 0, 1)
+	if s.cfg.Endpoint != "" {
+		targets = append(targets, s.target())
+	}
+	if !s.cfg.DiscoverApps {
+		return targets, true
+	}
+	if s.api == nil {
+		s.log.Warn("k8s app metrics discovery client is unavailable")
+		return targets, false
+	}
+	discoveryCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+	pods, err := s.api.listMetricPods(discoveryCtx, "")
+	cancel()
+	if err != nil {
+		s.log.Warn("k8s app metrics discovery failed", slog.Any("err", err))
+		return targets, false
+	}
+	appCfg := MetricsConfig{
+		Interval:    s.cfg.Interval,
+		Timeout:     s.cfg.Timeout,
+		SampleLimit: s.cfg.SampleLimit,
+	}
+	discovered := 0
+	for _, pod := range pods {
+		target, ok := appMetricsTarget(pod, appCfg)
+		if !ok {
+			continue
+		}
+		targets = append(targets, target)
+		discovered++
+	}
+	s.log.Debug("k8s app metrics discovery completed", slog.Int("targets", discovered))
+	return targets, true
+}
+
+func (s *RemoteWriteScraper) scrapeTargetAndWrite(ctx context.Context, target metricscommon.Target) bool {
 	startedAt := time.Now()
-	target := s.target()
-	batcher, err := newMetricsBatcher(0, k8sMetricsSource, s.cfg.BatchSampleLimit, s.cfg.BatchByteLimit, func(samples []tunnel.PromSample) error {
-		return s.writeWithRetry(ctx, k8sMetricsSource, samples)
+	source := strings.TrimSpace(target.SourceLabel)
+	if source == "" {
+		source = k8sMetricsSource
+	}
+	plugin := "k8s"
+	if source == k8sAppMetricsSource {
+		plugin = "k8s_app"
+	}
+	batcher, err := newMetricsBatcher(0, source, s.cfg.BatchSampleLimit, s.cfg.BatchByteLimit, func(samples []tunnel.PromSample) error {
+		return s.writeWithRetry(ctx, source, samples)
 	})
 	if err != nil {
 		s.log.Error("k8s metrics batcher initialization failed", slog.Any("err", err))
-		return
+		return false
 	}
 
 	scrapeCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
@@ -140,16 +249,16 @@ func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) {
 	cancel()
 	batcher.Flush()
 	dataStats := batcher.Stats()
-	s.metrics.observeScrape(k8sMetricsSource, stats.Accepted, stats.LimitExceeded)
-	s.metrics.observePush(k8sMetricsSource, dataStats)
+	s.metrics.observeScrape(source, stats.Accepted, stats.LimitExceeded)
+	s.metrics.observePush(source, dataStats)
 
 	partial := stats.LimitExceeded || dataStats.FailedBatches > 0 || dataStats.RejectedSamples > 0
 	if scrapeErr != nil && stats.Accepted > 0 {
 		partial = true
 	}
-	statusSamples := scrapeStatusSamples(time.Now(), "k8s", target, partial, dataStats.SuccessfulSamples, scrapeErr == nil)
+	statusSamples := scrapeStatusSamples(time.Now(), plugin, target, partial, dataStats.SuccessfulSamples, scrapeErr == nil)
 	statusStats := metricsBatchStats{}
-	if err := s.writeWithRetry(ctx, k8sMetricsSource, statusSamples); err != nil {
+	if err := s.writeWithRetry(ctx, source, statusSamples); err != nil {
 		statusStats.FailedBatches = 1
 		statusStats.FailedSamples = len(statusSamples)
 		statusStats.FirstError = err
@@ -157,12 +266,12 @@ func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) {
 		statusStats.SuccessfulBatches = 1
 		statusStats.SuccessfulSamples = len(statusSamples)
 	}
-	s.metrics.observePush(k8sMetricsSource, statusStats)
+	s.metrics.observePush(source, statusStats)
 	completedAt := time.Now()
-	s.metrics.observeCycle(k8sMetricsSource, startedAt, completedAt,
-		scrapeErr == nil && !stats.LimitExceeded && dataStats.FailedBatches == 0 && dataStats.RejectedSamples == 0 && statusStats.FailedBatches == 0,
-	)
+	success := scrapeErr == nil && !stats.LimitExceeded && dataStats.FailedBatches == 0 && dataStats.RejectedSamples == 0 && statusStats.FailedBatches == 0
+	s.metrics.observeCycle(source, startedAt, completedAt, success)
 	s.logOutcome(target, stats, dataStats, statusStats, scrapeErr)
+	return success
 }
 
 func (s *RemoteWriteScraper) writeWithRetry(ctx context.Context, source string, samples []tunnel.PromSample) error {

--- a/internal/edgeagent/k8s/remote_write_scraper.go
+++ b/internal/edgeagent/k8s/remote_write_scraper.go
@@ -122,10 +122,12 @@ func newRemoteWriteScraper(writer RemoteWriteWriter, cfg RemoteWriteScraperConfi
 	return &RemoteWriteScraper{writer: writer, cfg: cfg, log: log, api: api, metrics: observer}, nil
 }
 
-// Ready reports whether the most recent required discovery, core scrape, and
-// remote_write cycle succeeded. Individual application endpoints report their
-// own up=0 series and do not take a healthy kube-state-metrics scraper offline.
-// It remains false until the first required cycle.
+// Ready reports whether the most recent required core scrape and remote_write
+// cycle succeeded. When a core endpoint is configured, optional application
+// discovery and application endpoints degrade independently and do not take a
+// healthy kube-state-metrics scraper offline. Discovery-only configurations
+// still require discovery to succeed. It remains false until the first
+// required cycle.
 func (s *RemoteWriteScraper) Ready() bool {
 	return s != nil && s.ready.Load()
 }
@@ -149,8 +151,8 @@ func (s *RemoteWriteScraper) Run(ctx context.Context) error {
 
 func (s *RemoteWriteScraper) scrapeAndWrite(ctx context.Context) bool {
 	targets, discoveryOK := s.targets(ctx)
-	cycleOK := discoveryOK
 	hasCoreTarget := s.cfg.Endpoint != ""
+	cycleOK := discoveryOK || hasCoreTarget
 	for _, target := range targets {
 		success := s.scrapeTargetAndWrite(ctx, target)
 		isAppTarget := target.SourceLabel == k8sAppMetricsSource

--- a/internal/edgeagent/k8s/remote_write_scraper_test.go
+++ b/internal/edgeagent/k8s/remote_write_scraper_test.go
@@ -1,0 +1,131 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
+)
+
+type recordingRemoteWriteWriter struct {
+	batches [][]pkgpromwrite.Sample
+	err     error
+	calls   int
+}
+
+func (w *recordingRemoteWriteWriter) Write(_ context.Context, samples []pkgpromwrite.Sample) error {
+	w.calls++
+	if w.err != nil {
+		return w.err
+	}
+	cp := append([]pkgpromwrite.Sample(nil), samples...)
+	w.batches = append(w.batches, cp)
+	return nil
+}
+
+func TestRemoteWriteScraperPreservesKubernetesLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte(`kube_pod_status_phase{namespace="default",pod="api",phase="Running",uid="drop",cluster_id="evil",device_id="evil"} 1
+`))
+	}))
+	defer srv.Close()
+
+	writer := &recordingRemoteWriteWriter{}
+	registry := prometheus.NewRegistry()
+	scraper, err := NewRemoteWriteScraper(writer, RemoteWriteScraperConfig{
+		ClusterID:   7,
+		Endpoint:    srv.URL,
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		PushTimeout: time.Second,
+		MaxRetries:  1,
+	}, slog.Default(), registry)
+	if err != nil {
+		t.Fatalf("NewRemoteWriteScraper() error = %v", err)
+	}
+	scraper.scrapeAndWrite(context.Background())
+
+	var found *pkgpromwrite.Sample
+	for _, batch := range writer.batches {
+		for i := range batch {
+			labels := remoteWriteLabelMap(batch[i].Labels)
+			if labels["__name__"] == "kube_pod_status_phase" {
+				found = &batch[i]
+			}
+		}
+	}
+	if found == nil {
+		t.Fatal("kube_pod_status_phase was not written")
+	}
+	labels := remoteWriteLabelMap(found.Labels)
+	if labels["cluster_id"] != "7" || labels["ongrid_source"] != k8sMetricsSource {
+		t.Fatalf("system labels = %#v", labels)
+	}
+	if labels["namespace"] != "default" || labels["pod"] != "api" || labels["phase"] != "Running" {
+		t.Fatalf("business labels = %#v", labels)
+	}
+	if _, ok := labels["uid"]; ok {
+		t.Fatalf("high-cardinality uid was retained: %#v", labels)
+	}
+	if _, ok := labels["device_id"]; ok {
+		t.Fatalf("host identity was retained: %#v", labels)
+	}
+	names := make([]string, 0, len(found.Labels))
+	for _, label := range found.Labels {
+		names = append(names, label.Name)
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Fatalf("labels are not sorted: %v", names)
+	}
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	var lastSuccess float64
+	for _, family := range families {
+		if family.GetName() == "ongrid_edge_k8s_metrics_last_success_timestamp_seconds" && len(family.Metric) == 1 {
+			lastSuccess = family.Metric[0].GetGauge().GetValue()
+		}
+	}
+	if lastSuccess == 0 {
+		t.Fatal("last-success metric was not recorded")
+	}
+}
+
+func TestRemoteWriteScraperCapsRetries(t *testing.T) {
+	writer := &recordingRemoteWriteWriter{err: errors.New("backend unavailable")}
+	scraper, err := NewRemoteWriteScraper(writer, RemoteWriteScraperConfig{
+		ClusterID:    7,
+		Endpoint:     "http://kube-state-metrics.invalid/metrics",
+		PushTimeout:  time.Second,
+		MaxRetries:   1000,
+		RetryBackoff: time.Nanosecond,
+	}, slog.Default(), nil)
+	if err != nil {
+		t.Fatalf("NewRemoteWriteScraper() error = %v", err)
+	}
+	err = scraper.writeWithRetry(context.Background(), k8sMetricsSource, nil)
+	if err == nil {
+		t.Fatal("writeWithRetry() error = nil")
+	}
+	if writer.calls != maxRemoteWriteRetries {
+		t.Fatalf("writer calls = %d, want capped %d", writer.calls, maxRemoteWriteRetries)
+	}
+}
+
+func remoteWriteLabelMap(labels []pkgpromwrite.Label) map[string]string {
+	out := make(map[string]string, len(labels))
+	for _, label := range labels {
+		out[label.Name] = label.Value
+	}
+	return out
+}

--- a/internal/edgeagent/k8s/remote_write_scraper_test.go
+++ b/internal/edgeagent/k8s/remote_write_scraper_test.go
@@ -210,6 +210,39 @@ func TestRemoteWriteScraperDiscoversApplicationTargets(t *testing.T) {
 	t.Fatal("discovered application metric was not written")
 }
 
+func TestRemoteWriteScraperKeepsCoreReadyWhenAppDiscoveryFails(t *testing.T) {
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte("kube_node_info{node=\"node-a\"} 1\n"))
+	}))
+	defer metricsServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	defer apiServer.Close()
+
+	writer := &recordingRemoteWriteWriter{}
+	scraper, err := newRemoteWriteScraper(writer, RemoteWriteScraperConfig{
+		ClusterID:    7,
+		Endpoint:     metricsServer.URL,
+		DiscoverApps: true,
+		Interval:     time.Second,
+		Timeout:      time.Second,
+		PushTimeout:  time.Second,
+		MaxRetries:   1,
+	}, slog.Default(), nil, &apiClient{baseURL: apiServer.URL, http: apiServer.Client()})
+	if err != nil {
+		t.Fatalf("newRemoteWriteScraper() error = %v", err)
+	}
+	if !scraper.scrapeAndWrite(context.Background()) {
+		t.Fatal("core scrape failed when optional application discovery was unavailable")
+	}
+	if !scraper.Ready() {
+		t.Fatal("scraper was not ready after a successful core scrape")
+	}
+}
+
 func TestRemoteWriteScraperCapsRetries(t *testing.T) {
 	writer := &recordingRemoteWriteWriter{err: errors.New("backend unavailable")}
 	scraper, err := NewRemoteWriteScraper(writer, RemoteWriteScraperConfig{

--- a/internal/edgeagent/k8s/remote_write_scraper_test.go
+++ b/internal/edgeagent/k8s/remote_write_scraper_test.go
@@ -2,10 +2,12 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sort"
 	"testing"
 	"time"
@@ -53,6 +55,9 @@ func TestRemoteWriteScraperPreservesKubernetesLabels(t *testing.T) {
 		t.Fatalf("NewRemoteWriteScraper() error = %v", err)
 	}
 	scraper.scrapeAndWrite(context.Background())
+	if !scraper.Ready() {
+		t.Fatal("scraper did not become ready after a complete successful cycle")
+	}
 
 	var found *pkgpromwrite.Sample
 	for _, batch := range writer.batches {
@@ -99,6 +104,110 @@ func TestRemoteWriteScraperPreservesKubernetesLabels(t *testing.T) {
 	if lastSuccess == 0 {
 		t.Fatal("last-success metric was not recorded")
 	}
+}
+
+func TestRemoteWriteScraperReadyTracksCompleteCycle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte("kube_node_info{node=\"node-a\"} 1\n"))
+	}))
+	defer srv.Close()
+
+	writer := &recordingRemoteWriteWriter{err: errors.New("backend unavailable")}
+	scraper, err := NewRemoteWriteScraper(writer, RemoteWriteScraperConfig{
+		ClusterID:    7,
+		Endpoint:     srv.URL,
+		Interval:     time.Second,
+		Timeout:      time.Second,
+		PushTimeout:  time.Second,
+		MaxRetries:   1,
+		RetryBackoff: time.Nanosecond,
+	}, slog.Default(), nil)
+	if err != nil {
+		t.Fatalf("NewRemoteWriteScraper() error = %v", err)
+	}
+	if scraper.Ready() {
+		t.Fatal("scraper is ready before its first cycle")
+	}
+	if scraper.scrapeAndWrite(context.Background()) || scraper.Ready() {
+		t.Fatal("scraper became ready while remote_write was failing")
+	}
+
+	writer.err = nil
+	if !scraper.scrapeAndWrite(context.Background()) || !scraper.Ready() {
+		t.Fatal("scraper did not become ready after remote_write recovered")
+	}
+
+	writer.err = errors.New("backend unavailable again")
+	if scraper.scrapeAndWrite(context.Background()) || scraper.Ready() {
+		t.Fatal("scraper stayed ready after a later incomplete cycle")
+	}
+}
+
+func TestRemoteWriteScraperDiscoversApplicationTargets(t *testing.T) {
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte("app_requests_total{route=\"/ready\"} 3\n"))
+	}))
+	defer metricsServer.Close()
+	metricsURL, err := url.Parse(metricsServer.URL)
+	if err != nil {
+		t.Fatalf("parse metrics server URL: %v", err)
+	}
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/pods" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{
+				"metadata": map[string]any{
+					"name":      "api",
+					"namespace": "default",
+					"annotations": map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   metricsURL.Port(),
+					},
+				},
+				"spec":   map[string]any{"nodeName": "node-a"},
+				"status": map[string]any{"podIP": metricsURL.Hostname()},
+			}},
+		}); err != nil {
+			t.Errorf("encode pod list: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	writer := &recordingRemoteWriteWriter{}
+	scraper, err := newRemoteWriteScraper(writer, RemoteWriteScraperConfig{
+		ClusterID:    7,
+		DiscoverApps: true,
+		Interval:     time.Second,
+		Timeout:      time.Second,
+		PushTimeout:  time.Second,
+		MaxRetries:   1,
+	}, slog.Default(), nil, &apiClient{baseURL: apiServer.URL, http: apiServer.Client()})
+	if err != nil {
+		t.Fatalf("newRemoteWriteScraper() error = %v", err)
+	}
+	if !scraper.scrapeAndWrite(context.Background()) || !scraper.Ready() {
+		t.Fatal("application-only scrape cycle did not become ready")
+	}
+
+	for _, batch := range writer.batches {
+		for _, sample := range batch {
+			labels := remoteWriteLabelMap(sample.Labels)
+			if labels["__name__"] == "app_requests_total" {
+				if labels["ongrid_source"] != k8sAppMetricsSource || labels["namespace"] != "default" || labels["pod"] != "api" {
+					t.Fatalf("application labels = %#v", labels)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("discovered application metric was not written")
 }
 
 func TestRemoteWriteScraperCapsRetries(t *testing.T) {

--- a/internal/edgeagent/k8s/upgrade_prepare.go
+++ b/internal/edgeagent/k8s/upgrade_prepare.go
@@ -1,0 +1,298 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	telemetryBackendLabel                = "ongrid.io/telemetry-backend"
+	kubernetesStrategicMergePatchContent = "application/strategic-merge-patch+json"
+	defaultUpgradePollInterval           = time.Second
+)
+
+// UpgradePreparationConfig describes the live release transition performed by
+// the Helm pre-upgrade hook. The hook mutates only the two data-plane owner
+// Deployments and is safe to run repeatedly.
+type UpgradePreparationConfig struct {
+	Namespace                string
+	ControllerDeployment     string
+	MetricsScraperDeployment string
+	TargetGatewayMode        string
+	TargetMetricsMode        string
+	PollInterval             time.Duration
+}
+
+// PrepareUpgrade makes a single Helm release safe even when Kubernetes
+// reconciles the final Controller and data-plane Deployments in either order.
+// It runs before Helm applies the new manifests.
+func PrepareUpgrade(ctx context.Context, cfg UpgradePreparationConfig) error {
+	client, err := newInClusterAPIClient()
+	if err != nil {
+		return fmt.Errorf("prepare kubernetes upgrade client: %w", err)
+	}
+	return prepareUpgradeWithClient(ctx, client, cfg)
+}
+
+func prepareUpgradeWithClient(ctx context.Context, client *apiClient, cfg UpgradePreparationConfig) error {
+	if client == nil {
+		return errors.New("prepare kubernetes upgrade: api client is required")
+	}
+	cfg.Namespace = strings.TrimSpace(cfg.Namespace)
+	if cfg.Namespace == "" {
+		cfg.Namespace = strings.TrimSpace(client.namespace)
+	}
+	if cfg.Namespace == "" {
+		return errors.New("prepare kubernetes upgrade: namespace is required")
+	}
+	cfg.ControllerDeployment = strings.TrimSpace(cfg.ControllerDeployment)
+	if cfg.ControllerDeployment == "" {
+		return errors.New("prepare kubernetes upgrade: controller deployment is required")
+	}
+	cfg.MetricsScraperDeployment = strings.TrimSpace(cfg.MetricsScraperDeployment)
+	if cfg.MetricsScraperDeployment == "" {
+		return errors.New("prepare kubernetes upgrade: metrics scraper deployment is required")
+	}
+	cfg.TargetGatewayMode = strings.TrimSpace(cfg.TargetGatewayMode)
+	if cfg.TargetGatewayMode != "embedded" && cfg.TargetGatewayMode != "deployment" {
+		return fmt.Errorf("prepare kubernetes upgrade: unsupported gateway mode %q", cfg.TargetGatewayMode)
+	}
+	cfg.TargetMetricsMode = strings.TrimSpace(cfg.TargetMetricsMode)
+	if cfg.TargetMetricsMode != "controller" && cfg.TargetMetricsMode != "scraper" {
+		return fmt.Errorf("prepare kubernetes upgrade: unsupported metrics mode %q", cfg.TargetMetricsMode)
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultUpgradePollInterval
+	}
+
+	if cfg.TargetMetricsMode == "controller" {
+		if err := stopDeploymentIfPresent(ctx, client, cfg.Namespace, cfg.MetricsScraperDeployment, cfg.PollInterval); err != nil {
+			return fmt.Errorf("stop previous metrics scraper: %w", err)
+		}
+	}
+
+	controller, err := getUpgradeDeployment(ctx, client, cfg.Namespace, cfg.ControllerDeployment)
+	if err != nil {
+		return fmt.Errorf("get controller deployment: %w", err)
+	}
+	container, ok := controllerContainer(controller)
+	if !ok {
+		return fmt.Errorf("controller deployment %s/%s has no edge-controller container", cfg.Namespace, cfg.ControllerDeployment)
+	}
+
+	labels := map[string]string{}
+	envPatches := make([]map[string]any, 0, 2)
+	changed := false
+	if containerHasPort(container, "otlp-grpc") && controller.Spec.Template.Metadata.Labels[telemetryBackendLabel] != "true" {
+		// The Service switches to this stable selector in the final release.
+		// Mark the still-embedded Controller first so changing the selector does
+		// not itself disconnect the old endpoint. This is needed for both target
+		// modes when upgrading a Chart that still selected component=controller.
+		labels[telemetryBackendLabel] = "true"
+		changed = true
+	}
+	if cfg.TargetMetricsMode == "scraper" {
+		if containerHasEnv(container, "ONGRID_K8S_METRICS_ENDPOINT") {
+			envPatches = append(envPatches, map[string]any{
+				"name":   "ONGRID_K8S_METRICS_ENDPOINT",
+				"$patch": "delete",
+			})
+			changed = true
+		}
+		if value, found := containerEnvValue(container, "ONGRID_K8S_APP_METRICS_DISCOVERY"); found && value != "false" {
+			envPatches = append(envPatches, map[string]any{
+				"name":      "ONGRID_K8S_APP_METRICS_DISCOVERY",
+				"value":     "false",
+				"valueFrom": nil,
+			})
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	templatePatch := map[string]any{}
+	if len(labels) > 0 {
+		templatePatch["metadata"] = map[string]any{"labels": labels}
+	}
+	if len(envPatches) > 0 {
+		templatePatch["spec"] = map[string]any{
+			"containers": []map[string]any{{
+				"name": "edge-controller",
+				"env":  envPatches,
+			}},
+		}
+	}
+	patch := map[string]any{"spec": map[string]any{"template": templatePatch}}
+	updated, err := patchUpgradeDeployment(ctx, client, cfg.Namespace, cfg.ControllerDeployment, patch)
+	if err != nil {
+		return fmt.Errorf("prepare controller deployment: %w", err)
+	}
+	if err := waitUpgradeDeploymentReady(ctx, client, cfg.Namespace, cfg.ControllerDeployment, updated.Metadata.Generation, cfg.PollInterval); err != nil {
+		return fmt.Errorf("wait for prepared controller: %w", err)
+	}
+	return nil
+}
+
+type upgradeDeployment struct {
+	Metadata struct {
+		Generation int64 `json:"generation"`
+	} `json:"metadata"`
+	Spec struct {
+		Replicas *int `json:"replicas"`
+		Template struct {
+			Metadata struct {
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+			Spec struct {
+				Containers []upgradeContainer `json:"containers"`
+			} `json:"spec"`
+		} `json:"template"`
+	} `json:"spec"`
+	Status struct {
+		ObservedGeneration  int64 `json:"observedGeneration"`
+		UpdatedReplicas     int   `json:"updatedReplicas"`
+		ReadyReplicas       int   `json:"readyReplicas"`
+		AvailableReplicas   int   `json:"availableReplicas"`
+		UnavailableReplicas int   `json:"unavailableReplicas"`
+	} `json:"status"`
+}
+
+type upgradeContainer struct {
+	Name  string `json:"name"`
+	Ports []struct {
+		Name string `json:"name"`
+	} `json:"ports"`
+	Env []struct {
+		Name      string          `json:"name"`
+		Value     string          `json:"value"`
+		ValueFrom json.RawMessage `json:"valueFrom"`
+	} `json:"env"`
+}
+
+func controllerContainer(deployment *upgradeDeployment) (upgradeContainer, bool) {
+	if deployment == nil {
+		return upgradeContainer{}, false
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "edge-controller" {
+			return container, true
+		}
+	}
+	return upgradeContainer{}, false
+}
+
+func containerHasPort(container upgradeContainer, name string) bool {
+	for _, port := range container.Ports {
+		if port.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func containerHasEnv(container upgradeContainer, name string) bool {
+	_, found := containerEnvValue(container, name)
+	return found
+}
+
+func containerEnvValue(container upgradeContainer, name string) (string, bool) {
+	for _, env := range container.Env {
+		if env.Name == name {
+			return strings.TrimSpace(env.Value), true
+		}
+	}
+	return "", false
+}
+
+func stopDeploymentIfPresent(ctx context.Context, client *apiClient, namespace, name string, pollInterval time.Duration) error {
+	deployment, err := getUpgradeDeployment(ctx, client, namespace, name)
+	if errors.Is(err, errNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if deploymentReplicas(deployment) == 0 {
+		return nil
+	}
+	updated, err := patchUpgradeDeployment(ctx, client, namespace, name, map[string]any{
+		"spec": map[string]any{"replicas": 0},
+	})
+	if err != nil {
+		return err
+	}
+	return waitUpgradeDeploymentReady(ctx, client, namespace, name, updated.Metadata.Generation, pollInterval)
+}
+
+func getUpgradeDeployment(ctx context.Context, client *apiClient, namespace, name string) (*upgradeDeployment, error) {
+	var deployment upgradeDeployment
+	if err := client.get(ctx, deploymentAPIPath(namespace, name), &deployment); err != nil {
+		return nil, err
+	}
+	return &deployment, nil
+}
+
+func patchUpgradeDeployment(ctx context.Context, client *apiClient, namespace, name string, patch map[string]any) (*upgradeDeployment, error) {
+	body, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("marshal deployment patch: %w", err)
+	}
+	out, err := client.doRaw(ctx, http.MethodPatch, deploymentAPIPath(namespace, name), kubernetesStrategicMergePatchContent, body)
+	if err != nil {
+		return nil, err
+	}
+	var deployment upgradeDeployment
+	if err := json.Unmarshal(out, &deployment); err != nil {
+		return nil, fmt.Errorf("decode patched deployment: %w", err)
+	}
+	return &deployment, nil
+}
+
+func waitUpgradeDeploymentReady(ctx context.Context, client *apiClient, namespace, name string, generation int64, pollInterval time.Duration) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		deployment, err := getUpgradeDeployment(ctx, client, namespace, name)
+		if err != nil {
+			return err
+		}
+		if deploymentReady(deployment, generation) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("deployment %s/%s rollout: %w", namespace, name, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func deploymentReady(deployment *upgradeDeployment, generation int64) bool {
+	if deployment == nil || deployment.Status.ObservedGeneration < generation {
+		return false
+	}
+	desired := deploymentReplicas(deployment)
+	return deployment.Status.UpdatedReplicas == desired &&
+		deployment.Status.ReadyReplicas == desired &&
+		deployment.Status.AvailableReplicas == desired &&
+		deployment.Status.UnavailableReplicas == 0
+}
+
+func deploymentReplicas(deployment *upgradeDeployment) int {
+	if deployment == nil || deployment.Spec.Replicas == nil {
+		return 1
+	}
+	return *deployment.Spec.Replicas
+}
+
+func deploymentAPIPath(namespace, name string) string {
+	return "/apis/apps/v1/namespaces/" + url.PathEscape(namespace) + "/deployments/" + url.PathEscape(name)
+}

--- a/internal/edgeagent/k8s/upgrade_prepare_test.go
+++ b/internal/edgeagent/k8s/upgrade_prepare_test.go
@@ -1,0 +1,262 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPrepareUpgradeStopsLegacyControllerMetricsBeforeSplit(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	patches := make([]map[string]any, 0, 1)
+	patched := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/apis/apps/v1/namespaces/ongrid-system/deployments/ongrid-edge-controller" {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			mu.Lock()
+			isPatched := patched
+			mu.Unlock()
+			writeUpgradeDeployment(t, w, legacyUpgradeController(isPatched))
+		case http.MethodPatch:
+			if got := r.Header.Get("Content-Type"); got != kubernetesStrategicMergePatchContent {
+				t.Errorf("patch Content-Type = %q", got)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read patch: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			var patch map[string]any
+			if err := json.Unmarshal(body, &patch); err != nil {
+				t.Errorf("decode patch: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			patches = append(patches, patch)
+			patched = true
+			mu.Unlock()
+			writeUpgradeDeployment(t, w, legacyUpgradeController(true))
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := prepareUpgradeWithClient(ctx, &apiClient{baseURL: server.URL, http: server.Client()}, UpgradePreparationConfig{
+		Namespace:                "ongrid-system",
+		ControllerDeployment:     "ongrid-edge-controller",
+		MetricsScraperDeployment: "ongrid-edge-metrics-scraper",
+		TargetGatewayMode:        "deployment",
+		TargetMetricsMode:        "scraper",
+		PollInterval:             time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("prepareUpgradeWithClient() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(patches) != 1 {
+		t.Fatalf("patch count = %d, want 1", len(patches))
+	}
+	raw, err := json.Marshal(patches[0])
+	if err != nil {
+		t.Fatalf("marshal captured patch: %v", err)
+	}
+	for _, want := range []string{
+		`"ongrid.io/telemetry-backend":"true"`,
+		`"name":"ONGRID_K8S_METRICS_ENDPOINT"`,
+		`"$patch":"delete"`,
+		`"name":"ONGRID_K8S_APP_METRICS_DISCOVERY"`,
+		`"value":"false"`,
+		`"valueFrom":null`,
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("patch = %s, missing %s", raw, want)
+		}
+	}
+}
+
+func TestPrepareUpgradeAlreadySplitDoesNotPatch(t *testing.T) {
+	t.Parallel()
+
+	var patchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patchCount.Add(1)
+			http.Error(w, "image-only upgrade must not patch", http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path != "/apis/apps/v1/namespaces/ongrid-system/deployments/ongrid-edge-controller" {
+			http.NotFound(w, r)
+			return
+		}
+		writeUpgradeDeployment(t, w, splitUpgradeController())
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := prepareUpgradeWithClient(ctx, &apiClient{baseURL: server.URL, http: server.Client()}, UpgradePreparationConfig{
+		Namespace:                "ongrid-system",
+		ControllerDeployment:     "ongrid-edge-controller",
+		MetricsScraperDeployment: "ongrid-edge-metrics-scraper",
+		TargetGatewayMode:        "deployment",
+		TargetMetricsMode:        "scraper",
+		PollInterval:             time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("prepareUpgradeWithClient() error = %v", err)
+	}
+	if got := patchCount.Load(); got != 0 {
+		t.Fatalf("patch count = %d, want 0", got)
+	}
+}
+
+func TestPrepareUpgradeStopsScraperBeforeControllerRollback(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	scraperStopped := false
+	patchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apis/apps/v1/namespaces/ongrid-system/deployments/ongrid-edge-metrics-scraper":
+			mu.Lock()
+			stopped := scraperStopped
+			mu.Unlock()
+			if r.Method == http.MethodPatch {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read scraper patch: %v", err)
+				}
+				if !strings.Contains(string(body), `"replicas":0`) {
+					t.Errorf("scraper patch = %s, want replicas 0", body)
+				}
+				mu.Lock()
+				scraperStopped = true
+				patchCount++
+				stopped = true
+				mu.Unlock()
+			}
+			replicas := 1
+			generation := int64(1)
+			if stopped {
+				replicas = 0
+				generation = 2
+			}
+			writeUpgradeDeployment(t, w, upgradeDeploymentObject(generation, nil, []map[string]any{{"name": "metrics-scraper"}}, replicas))
+		case "/apis/apps/v1/namespaces/ongrid-system/deployments/ongrid-edge-controller":
+			if r.Method != http.MethodGet {
+				t.Errorf("controller method = %s, want GET", r.Method)
+			}
+			writeUpgradeDeployment(t, w, splitUpgradeController())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := prepareUpgradeWithClient(ctx, &apiClient{baseURL: server.URL, http: server.Client()}, UpgradePreparationConfig{
+		Namespace:                "ongrid-system",
+		ControllerDeployment:     "ongrid-edge-controller",
+		MetricsScraperDeployment: "ongrid-edge-metrics-scraper",
+		TargetGatewayMode:        "embedded",
+		TargetMetricsMode:        "controller",
+		PollInterval:             time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("prepareUpgradeWithClient() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !scraperStopped || patchCount != 1 {
+		t.Fatalf("scraper stopped = %v, patch count = %d; want true, 1", scraperStopped, patchCount)
+	}
+}
+
+func legacyUpgradeController(patched bool) map[string]any {
+	generation := int64(1)
+	labels := map[string]string{"app.kubernetes.io/component": "controller"}
+	env := []map[string]any{
+		{
+			"name": "ONGRID_K8S_METRICS_ENDPOINT",
+			"valueFrom": map[string]any{
+				"configMapKeyRef": map[string]string{"name": "ongrid-edge-config", "key": "k8s-metrics-endpoint"},
+			},
+		},
+		{
+			"name": "ONGRID_K8S_APP_METRICS_DISCOVERY",
+			"valueFrom": map[string]any{
+				"configMapKeyRef": map[string]string{"name": "ongrid-edge-config", "key": "k8s-app-metrics-discovery"},
+			},
+		},
+	}
+	if patched {
+		generation = 2
+		labels[telemetryBackendLabel] = "true"
+		env = []map[string]any{{"name": "ONGRID_K8S_APP_METRICS_DISCOVERY", "value": "false"}}
+	}
+	return upgradeDeploymentObject(generation, labels, []map[string]any{{
+		"name":  "edge-controller",
+		"ports": []map[string]any{{"name": "otlp-grpc"}, {"name": "otlp-http"}},
+		"env":   env,
+	}}, 1)
+}
+
+func splitUpgradeController() map[string]any {
+	return upgradeDeploymentObject(3, map[string]string{
+		"app.kubernetes.io/component": "controller",
+		telemetryBackendLabel:         "false",
+	}, []map[string]any{{
+		"name": "edge-controller",
+		"env":  []map[string]any{{"name": "ONGRID_K8S_APP_METRICS_DISCOVERY", "value": "false"}},
+	}}, 1)
+}
+
+func upgradeDeploymentObject(generation int64, labels map[string]string, containers []map[string]any, replicas int) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{"generation": generation},
+		"spec": map[string]any{
+			"replicas": replicas,
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": labels},
+				"spec":     map[string]any{"containers": containers},
+			},
+		},
+		"status": map[string]any{
+			"observedGeneration":  generation,
+			"updatedReplicas":     replicas,
+			"readyReplicas":       replicas,
+			"availableReplicas":   replicas,
+			"unavailableReplicas": 0,
+		},
+	}
+}
+
+func writeUpgradeDeployment(t *testing.T, w http.ResponseWriter, deployment map[string]any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(deployment); err != nil {
+		t.Errorf("encode deployment: %v", err)
+	}
+}

--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -40,6 +40,12 @@ receivers:
         endpoint: {{ .HTTPEndpoint }}
 
 processors:
+{{- if .BoundedPipelines }}
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: {{ .MemoryLimitMiB }}
+    spike_limit_mib: {{ .MemorySpikeMiB }}
+{{- end }}
 {{- if .K8sAttributesEnabled }}
   # Enrich gateway spans with Kubernetes resource attributes using the
   # controller ServiceAccount. Keep metadata bounded to stable ownership
@@ -105,10 +111,25 @@ processors:
         action: upsert
 {{- end }}
 
+{{- if .BoundedPipelines }}
+  batch/traces:
+    send_batch_size: {{ .BatchSendSize }}
+    timeout: 1s
+    send_batch_max_size: {{ .BatchMaxSize }}
+  batch/logs:
+    send_batch_size: {{ .BatchSendSize }}
+    timeout: 1s
+    send_batch_max_size: {{ .BatchMaxSize }}
+  batch/metrics:
+    send_batch_size: {{ .BatchSendSize }}
+    timeout: 1s
+    send_batch_max_size: {{ .BatchMaxSize }}
+{{- else }}
   batch:
     send_batch_size: 8192
     timeout: 5s
     send_batch_max_size: 16384
+{{- end }}
 
 exporters:
   otlphttp/manager:
@@ -130,7 +151,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 4
-      queue_size: 1024
+      queue_size: {{ .QueueSize }}
     retry_on_failure:
       enabled: true
       initial_interval: 1s
@@ -152,12 +173,55 @@ exporters:
       job: true
       instance: false
       level: true
+    {{- if .BoundedPipelines }}
+    sending_queue:
+      enabled: true
+      num_consumers: 4
+      queue_size: {{ .QueueSize }}
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 5m
+    {{- end }}
 {{- end }}
 {{- if .MetricsEnabled }}
+{{- if .MetricsRemoteWriteEnabled }}
+  prometheusremotewrite/manager:
+    endpoint: {{ .MetricsRemoteWriteEndpoint }}
+    {{- if .MetricsAuthHeader }}
+    headers:
+      Authorization: "{{ .MetricsAuthHeader }}"
+    {{- end }}
+    {{- if or .MetricsTLSInsecure .MetricsCAFile }}
+    tls:
+      {{- if .MetricsTLSInsecure }}
+      insecure_skip_verify: true
+      {{- end }}
+      {{- if .MetricsCAFile }}
+      ca_file: {{ .MetricsCAFile }}
+      {{- end }}
+    {{- end }}
+    resource_to_telemetry_conversion:
+      enabled: true
+    # prometheusremotewrite has its own queue implementation and rejects
+    # exporterhelper's generic sending_queue key.
+    remote_write_queue:
+      enabled: true
+      # Keep one consumer so samples for a series remain ordered.
+      num_consumers: 1
+      queue_size: {{ .QueueSize }}
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 5m
+{{- else }}
   prometheus/gateway:
     endpoint: {{ .MetricsExportEndpoint }}
     resource_to_telemetry_conversion:
       enabled: true
+{{- end }}
 {{- end }}
 
 extensions:
@@ -170,23 +234,23 @@ service:
     logs:
       level: info
     metrics:
-      address: 127.0.0.1:8888
+      address: {{ .CollectorMetricsEndpoint }}
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, batch]
+      processors: [{{ if .BoundedPipelines }}memory_limiter, {{ end }}{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, {{ if .BoundedPipelines }}batch/traces{{ else }}batch{{ end }}]
       exporters: [otlphttp/manager]
 {{- if .LogsEnabled }}
     logs:
       receivers: [otlp]
-      processors: [{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, resource/loki_labels, batch]
+      processors: [{{ if .BoundedPipelines }}memory_limiter, {{ end }}{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, resource/loki_labels, {{ if .BoundedPipelines }}batch/logs{{ else }}batch{{ end }}]
       exporters: [loki/manager]
 {{- end }}
 {{- if .MetricsEnabled }}
     metrics:
       receivers: [otlp]
-      processors: [{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, batch]
-      exporters: [prometheus/gateway]
+      processors: [{{ if .BoundedPipelines }}memory_limiter, {{ end }}{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, {{ if .BoundedPipelines }}batch/metrics{{ else }}batch{{ end }}]
+      exporters: [{{ if .MetricsRemoteWriteEnabled }}prometheusremotewrite/manager{{ else }}prometheus/gateway{{ end }}]
 {{- end }}
 `
 
@@ -229,8 +293,28 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 	}
 	metricsEnabled := boolSpec(cfg.Spec, "enable_metrics")
 	metricsExportEndpoint := stringOr(cfg.Spec, "metrics_export_endpoint", "")
-	if metricsEnabled && metricsExportEndpoint == "" {
+	metricsRemoteWriteEndpoint := stringOr(cfg.Spec, "metrics_remote_write_endpoint", "")
+	metricsRemoteWriteEnabled := metricsRemoteWriteEndpoint != ""
+	if metricsEnabled && metricsExportEndpoint == "" && !metricsRemoteWriteEnabled {
 		return nil, fmt.Errorf("traces plugin: metrics_export_endpoint required when enable_metrics=true")
+	}
+	boundedPipelines := boolSpec(cfg.Spec, "bounded_pipelines")
+	memoryLimitMiB := intSpec(cfg.Spec, "memory_limit_mib", 384)
+	memorySpikeMiB := intSpec(cfg.Spec, "memory_spike_limit_mib", 96)
+	batchSendSize := intSpec(cfg.Spec, "batch_send_size", 2048)
+	batchMaxSize := intSpec(cfg.Spec, "batch_max_size", 4096)
+	queueSize := 1024
+	if boundedPipelines {
+		queueSize = intSpec(cfg.Spec, "queue_size", 512)
+	}
+	if boundedPipelines && (memoryLimitMiB <= 0 || memorySpikeMiB <= 0 || memorySpikeMiB >= memoryLimitMiB) {
+		return nil, fmt.Errorf("traces plugin: memory limiter requires 0 < spike_limit_mib < memory_limit_mib")
+	}
+	if boundedPipelines && (batchSendSize <= 0 || batchMaxSize < batchSendSize || batchMaxSize > 4096) {
+		return nil, fmt.Errorf("traces plugin: bounded batch requires 0 < send size <= max size <= 4096")
+	}
+	if boundedPipelines && (queueSize <= 0 || queueSize > 4096) {
+		return nil, fmt.Errorf("traces plugin: bounded queue_size must be between 1 and 4096")
 	}
 
 	// Default to skip-verify because the standard install ships a self-signed
@@ -252,23 +336,40 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 			authHeader = "Bearer " + cfg.AuthPass
 		}
 	}
+	metricsAuthHeader := authHeaderFromValues(
+		stringOr(cfg.Spec, "metrics_remote_write_auth_user", ""),
+		stringOr(cfg.Spec, "metrics_remote_write_auth_pass", ""),
+		stringOr(cfg.Spec, "metrics_remote_write_bearer", ""),
+	)
 
 	// text/template ranges over maps in key-sorted order (Go 1.12+), so
 	// passing the raw map yields stable rendered output across runs.
 	data := map[string]any{
-		"EdgeID":                cfg.EdgeID,
-		"EmitDeviceID":          !omitDeviceID,
-		"GRPCEndpoint":          grpcEP,
-		"HTTPEndpoint":          httpEP,
-		"ExtraAttrs":            extra,
-		"Endpoint":              strings.TrimRight(cfg.Endpoint, "/"),
-		"AuthHeader":            authHeader,
-		"TLSInsecureSkipVerify": tlsInsecure,
-		"K8sAttributesEnabled":  k8sAttributes,
-		"LogsEnabled":           logsEnabled,
-		"LogsEndpoint":          logsEndpoint,
-		"MetricsEnabled":        metricsEnabled,
-		"MetricsExportEndpoint": metricsExportEndpoint,
+		"EdgeID":                     cfg.EdgeID,
+		"EmitDeviceID":               !omitDeviceID,
+		"GRPCEndpoint":               grpcEP,
+		"HTTPEndpoint":               httpEP,
+		"ExtraAttrs":                 extra,
+		"Endpoint":                   strings.TrimRight(cfg.Endpoint, "/"),
+		"AuthHeader":                 authHeader,
+		"TLSInsecureSkipVerify":      tlsInsecure,
+		"K8sAttributesEnabled":       k8sAttributes,
+		"LogsEnabled":                logsEnabled,
+		"LogsEndpoint":               logsEndpoint,
+		"MetricsEnabled":             metricsEnabled,
+		"MetricsExportEndpoint":      metricsExportEndpoint,
+		"MetricsRemoteWriteEnabled":  metricsRemoteWriteEnabled,
+		"MetricsRemoteWriteEndpoint": metricsRemoteWriteEndpoint,
+		"MetricsAuthHeader":          metricsAuthHeader,
+		"MetricsTLSInsecure":         boolSpec(cfg.Spec, "metrics_remote_write_tls_insecure"),
+		"MetricsCAFile":              stringOr(cfg.Spec, "metrics_remote_write_ca_file", ""),
+		"BoundedPipelines":           boundedPipelines,
+		"MemoryLimitMiB":             memoryLimitMiB,
+		"MemorySpikeMiB":             memorySpikeMiB,
+		"BatchSendSize":              batchSendSize,
+		"BatchMaxSize":               batchMaxSize,
+		"QueueSize":                  queueSize,
+		"CollectorMetricsEndpoint":   stringOr(cfg.Spec, "collector_metrics_endpoint", "127.0.0.1:8888"),
 	}
 
 	tmpl, err := template.New("otelcol").Parse(otelcolTemplate)
@@ -328,4 +429,31 @@ func stringMap(spec map[string]interface{}, key string) map[string]string {
 // basicAuth encodes user:pass in base64 for the Authorization header.
 func basicAuth(user, pass string) string {
 	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+}
+
+func authHeaderFromValues(user, pass, bearer string) string {
+	if bearer != "" {
+		return "Bearer " + bearer
+	}
+	if user != "" && pass != "" {
+		return "Basic " + basicAuth(user, pass)
+	}
+	return ""
+}
+
+func intSpec(spec map[string]interface{}, key string, fallback int) int {
+	raw, ok := spec[key]
+	if !ok {
+		return fallback
+	}
+	switch value := raw.(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return fallback
+	}
 }

--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -160,13 +160,13 @@ exporters:
 {{- if .LogsEnabled }}
   loki/manager:
     endpoint: {{ .LogsEndpoint }}
-    {{- if .TLSInsecureSkipVerify }}
+    {{- if .LogsTLSInsecureSkipVerify }}
     tls:
       insecure_skip_verify: true
     {{- end }}
-    {{- if .AuthHeader }}
+    {{- if .LogsAuthHeader }}
     headers:
-      Authorization: "{{ .AuthHeader }}"
+      Authorization: "{{ .LogsAuthHeader }}"
     {{- end }}
     default_labels_enabled:
       exporter: false
@@ -267,6 +267,9 @@ service:
 //	enable_k8sattributes : bool (default false; true for Kubernetes gateway collectors)
 //	enable_logs : bool (default false; true for Kubernetes telemetry gateway)
 //	logs_endpoint : string (required when enable_logs=true; Loki push URL)
+//	logs_auth_override : bool (use logs_auth_* instead of trace auth)
+//	logs_auth_user / logs_auth_pass / logs_auth_bearer : string
+//	logs_tls_insecure_skip_verify : bool (defaults to trace TLS policy)
 //	enable_metrics : bool (default false; true for Kubernetes telemetry gateway)
 //	metrics_export_endpoint : string (required when enable_metrics=true; local scrape endpoint)
 //
@@ -336,6 +339,20 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 			authHeader = "Bearer " + cfg.AuthPass
 		}
 	}
+	logsAuthHeader := authHeader
+	if boolSpec(cfg.Spec, "logs_auth_override") {
+		logsAuthHeader = authHeaderFromValues(
+			stringOr(cfg.Spec, "logs_auth_user", ""),
+			stringOr(cfg.Spec, "logs_auth_pass", ""),
+			stringOr(cfg.Spec, "logs_auth_bearer", ""),
+		)
+	}
+	logsTLSInsecure := tlsInsecure
+	if v, ok := cfg.Spec["logs_tls_insecure_skip_verify"]; ok {
+		if b, ok := v.(bool); ok {
+			logsTLSInsecure = b
+		}
+	}
 	metricsAuthHeader := authHeaderFromValues(
 		stringOr(cfg.Spec, "metrics_remote_write_auth_user", ""),
 		stringOr(cfg.Spec, "metrics_remote_write_auth_pass", ""),
@@ -356,6 +373,8 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 		"K8sAttributesEnabled":       k8sAttributes,
 		"LogsEnabled":                logsEnabled,
 		"LogsEndpoint":               logsEndpoint,
+		"LogsAuthHeader":             logsAuthHeader,
+		"LogsTLSInsecureSkipVerify":  logsTLSInsecure,
 		"MetricsEnabled":             metricsEnabled,
 		"MetricsExportEndpoint":      metricsExportEndpoint,
 		"MetricsRemoteWriteEnabled":  metricsRemoteWriteEnabled,

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -1,11 +1,63 @@
 package traces
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ongridio/ongrid/internal/edgeagent/plugins"
 )
+
+// TestRenderedStandaloneConfigAcceptedByCollector is an opt-in compatibility
+// check against the exact bundled otelcol-contrib version. Compatibility jobs
+// may set ONGRID_TEST_OTELCOL_BINARY; ordinary unit-test runs skip it.
+func TestRenderedStandaloneConfigAcceptedByCollector(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("ONGRID_TEST_OTELCOL_BINARY"))
+	if binary == "" {
+		t.Skip("ONGRID_TEST_OTELCOL_BINARY is not set")
+	}
+	raw, err := render(plugins.PluginConfig{
+		Enabled:  true,
+		Endpoint: "https://manager.example.com/v1/traces",
+		AuthUser: "kt_access",
+		AuthPass: "ks_secret",
+		Spec: map[string]interface{}{
+			"omit_device_id":                    true,
+			"enable_k8sattributes":              true,
+			"enable_logs":                       true,
+			"enable_metrics":                    true,
+			"logs_endpoint":                     "https://manager.example.com/loki/api/v1/push",
+			"metrics_remote_write_endpoint":     "https://manager.example.com/prometheus/api/v1/write",
+			"metrics_remote_write_auth_user":    "kt_access",
+			"metrics_remote_write_auth_pass":    "ks_secret",
+			"metrics_remote_write_tls_insecure": true,
+			"bounded_pipelines":                 true,
+			"memory_limit_mib":                  384,
+			"memory_spike_limit_mib":            96,
+			"batch_send_size":                   2048,
+			"batch_max_size":                    4096,
+			"queue_size":                        512,
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "otelcol.yaml")
+	if err := os.WriteFile(configPath, raw, 0600); err != nil {
+		t.Fatalf("write rendered config: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, "validate", "--config="+configPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("otelcol-contrib rejected rendered config: %v\n%s", err, output)
+	}
+}
 
 func TestRenderHappyPath(t *testing.T) {
 	cfg := plugins.PluginConfig{
@@ -228,6 +280,65 @@ func TestRenderOmitDeviceIDForGateway(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("rendered gateway config missing %q\n--- full body ---\n%s", want, body)
 		}
+	}
+}
+
+func TestRenderStandaloneGatewayUsesBoundedRemoteWritePipelines(t *testing.T) {
+	cfg := plugins.PluginConfig{
+		Enabled:  true,
+		Endpoint: "https://manager.example.com/v1/traces",
+		AuthUser: "kt_access",
+		AuthPass: "ks_secret",
+		Spec: map[string]interface{}{
+			"omit_device_id":                    true,
+			"enable_k8sattributes":              true,
+			"enable_logs":                       true,
+			"enable_metrics":                    true,
+			"logs_endpoint":                     "https://manager.example.com/loki/api/v1/push",
+			"metrics_remote_write_endpoint":     "https://manager.example.com/prometheus/api/v1/write",
+			"metrics_remote_write_auth_user":    "kt_access",
+			"metrics_remote_write_auth_pass":    "ks_secret",
+			"metrics_remote_write_tls_insecure": true,
+			"bounded_pipelines":                 true,
+			"memory_limit_mib":                  384,
+			"memory_spike_limit_mib":            96,
+			"batch_send_size":                   2048,
+			"batch_max_size":                    4096,
+			"queue_size":                        512,
+			"collector_metrics_endpoint":        "0.0.0.0:8888",
+		},
+	}
+	out, err := render(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := string(out)
+	for _, want := range []string{
+		"memory_limiter:",
+		"limit_mib: 384",
+		"spike_limit_mib: 96",
+		"batch/traces:",
+		"batch/logs:",
+		"batch/metrics:",
+		"send_batch_max_size: 4096",
+		"timeout: 1s",
+		"queue_size: 512",
+		"prometheusremotewrite/manager:",
+		"endpoint: https://manager.example.com/prometheus/api/v1/write",
+		"remote_write_queue:",
+		"num_consumers: 1",
+		"exporters: [prometheusremotewrite/manager]",
+		"processors: [memory_limiter, k8sattributes, resource/device, batch/traces]",
+		"processors: [memory_limiter, k8sattributes, resource/device, resource/loki_labels, batch/logs]",
+		"processors: [memory_limiter, k8sattributes, resource/device, batch/metrics]",
+		"address: 0.0.0.0:8888",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered standalone gateway config missing %q\n--- full body ---\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "prometheus/gateway:") {
+		t.Fatalf("standalone gateway must not retain the in-memory scrape exporter:\n%s", body)
 	}
 }
 

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -228,6 +228,44 @@ func TestRenderBasicWhenUserSet(t *testing.T) {
 	}
 }
 
+func TestRenderUsesIndependentTraceAndLogAuthAndTLS(t *testing.T) {
+	out, err := render(plugins.PluginConfig{
+		Enabled:  true,
+		EdgeID:   1,
+		Endpoint: "https://tempo.example/v1/traces",
+		AuthUser: "tempo-user",
+		AuthPass: "tempo-pass",
+		Spec: map[string]interface{}{
+			"enable_logs":                   true,
+			"logs_endpoint":                 "https://loki.example/loki/api/v1/push",
+			"logs_auth_override":            true,
+			"logs_auth_user":                "loki-user",
+			"logs_auth_pass":                "loki-pass",
+			"tls_insecure_skip_verify":      true,
+			"logs_tls_insecure_skip_verify": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "Authorization: \"Basic dGVtcG8tdXNlcjp0ZW1wby1wYXNz\"") ||
+		!strings.Contains(body, "Authorization: \"Basic bG9raS11c2VyOmxva2ktcGFzcw==\"") {
+		t.Fatalf("independent auth headers missing:\n%s", body)
+	}
+	start := strings.Index(body, "loki/manager:")
+	if start < 0 {
+		t.Fatalf("Loki exporter missing:\n%s", body)
+	}
+	end := strings.Index(body[start:], "default_labels_enabled:")
+	if end < 0 {
+		t.Fatalf("Loki exporter missing:\n%s", body)
+	}
+	if strings.Contains(body[start:start+end], "tls:") {
+		t.Fatalf("Loki inherited trace TLS policy:\n%s", body[start:start+end])
+	}
+}
+
 func TestRenderOmitDeviceIDForGateway(t *testing.T) {
 	cfg := plugins.PluginConfig{
 		Enabled:  true,

--- a/internal/manager/biz/k8s/telemetry_auth.go
+++ b/internal/manager/biz/k8s/telemetry_auth.go
@@ -1,0 +1,108 @@
+package k8s
+
+import (
+	"context"
+	"crypto/sha256"
+	"sync"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/passwd"
+)
+
+const (
+	telemetryAuthCacheTTL        = 30 * time.Second
+	maxTelemetryAuthCacheEntries = 1024
+)
+
+// TelemetryAuthenticator validates the cluster-scoped write-only identity.
+// The tunnel authenticator does not use this type, which is the enforcement
+// boundary preventing data-plane credentials from becoming controller
+// credentials.
+type TelemetryAuthenticator struct {
+	repo  Repository
+	cache *telemetryAuthCache
+}
+
+func NewTelemetryAuthenticator(repo Repository) *TelemetryAuthenticator {
+	return &TelemetryAuthenticator{repo: repo, cache: newTelemetryAuthCache()}
+}
+
+func (a *TelemetryAuthenticator) Authenticate(ctx context.Context, accessKey, secretKey string) (uint64, error) {
+	if a == nil || a.repo == nil {
+		return 0, errs.ErrNotWiredYet
+	}
+	if clusterID, ok := a.cache.lookup(accessKey, secretKey, time.Now()); ok {
+		return clusterID, nil
+	}
+	credential, err := a.repo.GetTelemetryCredentialByAccessKey(ctx, accessKey)
+	if err != nil || credential == nil || !passwd.Verify(secretKey, credential.SecretKeyHash) {
+		return 0, errs.ErrUnauthorized
+	}
+	a.cache.store(accessKey, secretKey, credential.ClusterID, time.Now())
+	return credential.ClusterID, nil
+}
+
+type telemetryAuthCacheEntry struct {
+	clusterID uint64
+	expiresAt time.Time
+}
+
+type telemetryAuthCache struct {
+	mu      sync.Mutex
+	entries map[[32]byte]telemetryAuthCacheEntry
+}
+
+func newTelemetryAuthCache() *telemetryAuthCache {
+	return &telemetryAuthCache{entries: make(map[[32]byte]telemetryAuthCacheEntry)}
+}
+
+func (c *telemetryAuthCache) lookup(accessKey, secretKey string, now time.Time) (uint64, bool) {
+	if c == nil {
+		return 0, false
+	}
+	key := telemetryAuthCacheKey(accessKey, secretKey)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return 0, false
+	}
+	if !now.Before(entry.expiresAt) {
+		delete(c.entries, key)
+		return 0, false
+	}
+	return entry.clusterID, entry.clusterID != 0
+}
+
+func (c *telemetryAuthCache) store(accessKey, secretKey string, clusterID uint64, now time.Time) {
+	if c == nil || clusterID == 0 {
+		return
+	}
+	c.mu.Lock()
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+	if len(c.entries) >= maxTelemetryAuthCacheEntries {
+		var oldestKey [32]byte
+		var oldestExpiry time.Time
+		for key, entry := range c.entries {
+			if oldestExpiry.IsZero() || entry.expiresAt.Before(oldestExpiry) {
+				oldestKey = key
+				oldestExpiry = entry.expiresAt
+			}
+		}
+		delete(c.entries, oldestKey)
+	}
+	c.entries[telemetryAuthCacheKey(accessKey, secretKey)] = telemetryAuthCacheEntry{
+		clusterID: clusterID,
+		expiresAt: now.Add(telemetryAuthCacheTTL),
+	}
+	c.mu.Unlock()
+}
+
+func telemetryAuthCacheKey(accessKey, secretKey string) [32]byte {
+	return sha256.Sum256([]byte(accessKey + "\x00" + secretKey))
+}

--- a/internal/manager/biz/k8s/telemetry_auth_test.go
+++ b/internal/manager/biz/k8s/telemetry_auth_test.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/k8s"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/passwd"
+)
+
+func TestTelemetryAuthenticatorAcceptsOnlyTelemetryCredential(t *testing.T) {
+	repo := newFakeRepo()
+	hash, err := passwd.Hash("ks_secret")
+	if err != nil {
+		t.Fatalf("passwd.Hash() error = %v", err)
+	}
+	repo.telemetryCredential = &model.TelemetryCredential{
+		ClusterID:     7,
+		AccessKeyID:   "kt_access",
+		SecretKeyHash: hash,
+	}
+	auth := NewTelemetryAuthenticator(repo)
+	clusterID, err := auth.Authenticate(context.Background(), "kt_access", "ks_secret")
+	if err != nil || clusterID != 7 {
+		t.Fatalf("Authenticate(valid) = (%d, %v), want (7, nil)", clusterID, err)
+	}
+	if _, err := auth.Authenticate(context.Background(), "kt_access", "wrong"); !errors.Is(err, errs.ErrUnauthorized) {
+		t.Fatalf("Authenticate(wrong secret) error = %v, want unauthorized", err)
+	}
+	if _, err := auth.Authenticate(context.Background(), "edge_access", "edge_secret"); !errors.Is(err, errs.ErrUnauthorized) {
+		t.Fatalf("Authenticate(edge credential) error = %v, want unauthorized", err)
+	}
+}
+
+func TestTelemetryAuthCacheIsBounded(t *testing.T) {
+	cache := newTelemetryAuthCache()
+	now := time.Now()
+	for i := 0; i < maxTelemetryAuthCacheEntries+100; i++ {
+		cache.store(fmt.Sprintf("access-%d", i), fmt.Sprintf("secret-%d", i), uint64(i+1), now)
+	}
+	if got := len(cache.entries); got != maxTelemetryAuthCacheEntries {
+		t.Fatalf("cache entries = %d, want %d", got, maxTelemetryAuthCacheEntries)
+	}
+}

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -21,6 +21,7 @@ import (
 	model "github.com/ongridio/ongrid/internal/manager/model/k8s"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/k8sredact"
+	"github.com/ongridio/ongrid/internal/pkg/passwd"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
@@ -44,7 +45,9 @@ type Repository interface {
 	UpdateClusterTokens(ctx context.Context, id uint64, controllerTokenHash, nodeTokenHash string) error
 	UpdateClusterController(ctx context.Context, id uint64, in ClusterControllerRegistration) error
 	TouchClusterControllerHeartbeat(ctx context.Context, edgeID uint64, at time.Time) error
-	BindControllerEnrollment(ctx context.Context, id uint64, registration ClusterControllerRegistration, installation *model.Installation) error
+	BindControllerEnrollment(ctx context.Context, id uint64, registration ClusterControllerRegistration, installation *model.Installation, telemetryCredential *model.TelemetryCredential) error
+	UpsertTelemetryCredential(ctx context.Context, telemetryCredential *model.TelemetryCredential) error
+	GetTelemetryCredentialByAccessKey(ctx context.Context, accessKey string) (*model.TelemetryCredential, error)
 	UpdateClusterInventorySync(ctx context.Context, id uint64, in ClusterInventorySync) error
 	UpdateClusterTopologyNode(ctx context.Context, id, nodeID uint64) error
 	UpdateDeviceTopologyNode(ctx context.Context, id, nodeID uint64) error
@@ -163,11 +166,30 @@ type Config struct {
 	EventCleanupInterval time.Duration
 }
 
+// RemoteWriteTarget is the exact data-plane destination published to a
+// Kubernetes cluster. UseTelemetryCredential means the endpoint is the
+// manager's auth_request-gated proxy; otherwise the backend-specific auth is
+// copied into the cluster telemetry Secret.
+type RemoteWriteTarget struct {
+	Endpoint               string
+	BearerToken            string
+	BasicUser              string
+	BasicPassword          string
+	TLSInsecure            bool
+	TLSCAPEM               string
+	UseTelemetryCredential bool
+}
+
+type RemoteWriteResolver interface {
+	ResolveRemoteWrite(ctx context.Context) (RemoteWriteTarget, error)
+}
+
 type Usecase struct {
 	repo               Repository
 	edgeIssuer         EdgeIssuer
 	edgeRemover        EdgeRemover
 	topology           TopologyMirror
+	remoteWrite        RemoteWriteResolver
 	cfg                Config
 	enrollmentLocksMu  sync.Mutex
 	enrollmentLocks    map[string]*enrollmentLock
@@ -204,6 +226,10 @@ func NewUsecase(repo Repository, edgeIssuer EdgeIssuer, cfg Config) *Usecase {
 }
 
 func (u *Usecase) SetTopologyMirror(m TopologyMirror) { u.topology = m }
+
+// SetRemoteWriteResolver wires the active Prometheus-compatible write target.
+// It is called once during manager startup before the HTTP server is exposed.
+func (u *Usecase) SetRemoteWriteResolver(r RemoteWriteResolver) { u.remoteWrite = r }
 
 func (u *Usecase) EventCleanupInterval() time.Duration {
 	if u == nil || u.cfg.EventCleanupInterval <= 0 {
@@ -990,6 +1016,33 @@ type EnrollResult struct {
 	SecretKey        string
 	CloudAddr        string
 	ManagerPublicURL string
+	Telemetry        *TelemetryConfig
+}
+
+// TelemetryConfig is returned only to a controller enrollment and is written
+// by that controller into a Kubernetes Secret. Secrets are never persisted in
+// plaintext by manager.
+type TelemetryConfig struct {
+	ClusterID              uint64
+	AccessKey              string
+	SecretKey              string
+	TracesEndpoint         string
+	LogsEndpoint           string
+	RemoteWriteEndpoint    string
+	RemoteWriteBearer      string
+	RemoteWriteBasicUser   string
+	RemoteWriteBasicPass   string
+	RemoteWriteTLSInsecure bool
+	RemoteWriteTLSCAPEM    string
+}
+
+// TelemetryCredentialProof lets an authenticated controller prove that the
+// current data-plane credential is still available in its Kubernetes Secret.
+// Manager verifies the secret against the stored hash and can then republish
+// changed endpoints without rotating a live credential.
+type TelemetryCredentialProof struct {
+	AccessKey string
+	SecretKey string
 }
 
 func (u *Usecase) Enroll(ctx context.Context, in EnrollInput) (*EnrollResult, error) {
@@ -1024,6 +1077,49 @@ func (u *Usecase) Enroll(ctx context.Context, in EnrollInput) (*EnrollResult, er
 	default:
 		return nil, errors.Join(errs.ErrInvalid, fmt.Errorf("unsupported k8s enroll role %q", in.Role))
 	}
+}
+
+// RefreshTelemetryConfig republishes endpoints while preserving a valid
+// write-only credential. It rotates only when the controller has no usable
+// telemetry credential, which avoids a Secret-projection/reload 401 window on
+// every controller restart.
+func (u *Usecase) RefreshTelemetryConfig(ctx context.Context, controllerEdgeID uint64, proof TelemetryCredentialProof) (*TelemetryConfig, error) {
+	if u.repo == nil {
+		return nil, errs.ErrNotWiredYet
+	}
+	if controllerEdgeID == 0 {
+		return nil, errors.Join(errs.ErrInvalid, fmt.Errorf("controller edge id is required"))
+	}
+	cluster, err := u.repo.GetClusterByControllerEdge(ctx, controllerEdgeID)
+	if err != nil {
+		return nil, err
+	}
+	proof.AccessKey = strings.TrimSpace(proof.AccessKey)
+	proof.SecretKey = strings.TrimSpace(proof.SecretKey)
+	if (proof.AccessKey == "") != (proof.SecretKey == "") {
+		return nil, errors.Join(errs.ErrInvalid, fmt.Errorf("telemetry credential proof requires both access key and secret key"))
+	}
+	if proof.AccessKey != "" {
+		current, lookupErr := u.repo.GetTelemetryCredentialByAccessKey(ctx, proof.AccessKey)
+		if lookupErr == nil && current != nil && current.ClusterID == cluster.ID && passwd.Verify(proof.SecretKey, current.SecretKeyHash) {
+			return u.resolveTelemetryConfig(ctx, cluster.ID, proof.AccessKey, proof.SecretKey)
+		}
+		if lookupErr != nil && !errors.Is(lookupErr, errs.ErrNotFound) {
+			return nil, fmt.Errorf("look up kubernetes telemetry credential: %w", lookupErr)
+		}
+	}
+	credential, accessKey, secretKey, err := newTelemetryCredential(cluster.ID)
+	if err != nil {
+		return nil, err
+	}
+	config, err := u.resolveTelemetryConfig(ctx, cluster.ID, accessKey, secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("resolve kubernetes telemetry config: %w", err)
+	}
+	if err := u.repo.UpsertTelemetryCredential(ctx, credential); err != nil {
+		return nil, fmt.Errorf("rotate kubernetes telemetry credential: %w", err)
+	}
+	return config, nil
 }
 
 func (u *Usecase) lockEnrollment(clusterID uint64, role, nodeName string) func() {
@@ -1763,14 +1859,95 @@ func (u *Usecase) enrollController(ctx context.Context, c *model.Cluster, in Enr
 		CapabilitiesJSON: capabilitiesJSON,
 		LastSeenAt:       &ts,
 	}
-	if err := u.repo.BindControllerEnrollment(ctx, c.ID, registration, installation); err != nil {
+	telemetryCredential, telemetryAccessKey, telemetrySecretKey, err := newTelemetryCredential(c.ID)
+	if err != nil {
+		if created {
+			return nil, u.compensateCreatedEdge(ctx, cred.EdgeID, err)
+		}
+		return nil, err
+	}
+	telemetry, err := u.resolveTelemetryConfig(ctx, c.ID, telemetryAccessKey, telemetrySecretKey)
+	if err != nil {
+		if created {
+			return nil, u.compensateCreatedEdge(ctx, cred.EdgeID, fmt.Errorf("resolve kubernetes telemetry config: %w", err))
+		}
+		return nil, fmt.Errorf("resolve kubernetes telemetry config: %w", err)
+	}
+	if err := u.repo.BindControllerEnrollment(ctx, c.ID, registration, installation, telemetryCredential); err != nil {
 		bindErr := fmt.Errorf("bind k8s controller enrollment: %w", err)
 		if created {
 			return nil, u.compensateCreatedEdge(ctx, cred.EdgeID, bindErr)
 		}
 		return nil, bindErr
 	}
-	return u.enrollResult(c.ID, model.RoleController, mode, cred), nil
+	out := u.enrollResult(c.ID, model.RoleController, mode, cred)
+	out.Telemetry = telemetry
+	return out, nil
+}
+
+func newTelemetryCredential(clusterID uint64) (*model.TelemetryCredential, string, string, error) {
+	accessSuffix, err := randomURLSafe(18)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("generate telemetry access key: %w", err)
+	}
+	secretSuffix, err := randomURLSafe(32)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("generate telemetry secret key: %w", err)
+	}
+	accessKey := "kt_" + accessSuffix
+	secretKey := "ks_" + secretSuffix
+	hash, err := passwd.Hash(secretKey)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("hash telemetry secret key: %w", err)
+	}
+	return &model.TelemetryCredential{
+		ClusterID:     clusterID,
+		AccessKeyID:   accessKey,
+		SecretKeyHash: hash,
+	}, accessKey, secretKey, nil
+}
+
+func (u *Usecase) resolveTelemetryConfig(ctx context.Context, clusterID uint64, accessKey, secretKey string) (*TelemetryConfig, error) {
+	publicURL := strings.TrimRight(strings.TrimSpace(u.cfg.PublicURL), "/")
+	out := &TelemetryConfig{
+		ClusterID:      clusterID,
+		AccessKey:      accessKey,
+		SecretKey:      secretKey,
+		TracesEndpoint: endpointPath(publicURL, "/v1/traces"),
+		LogsEndpoint:   endpointPath(publicURL, "/loki/api/v1/push"),
+	}
+	target := RemoteWriteTarget{
+		Endpoint:               endpointPath(publicURL, "/prometheus/api/v1/write"),
+		UseTelemetryCredential: true,
+	}
+	if u.remoteWrite != nil {
+		resolved, err := u.remoteWrite.ResolveRemoteWrite(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(resolved.Endpoint) != "" {
+			target = resolved
+		}
+	}
+	out.RemoteWriteEndpoint = strings.TrimSpace(target.Endpoint)
+	out.RemoteWriteTLSInsecure = target.TLSInsecure
+	out.RemoteWriteTLSCAPEM = target.TLSCAPEM
+	if target.UseTelemetryCredential {
+		out.RemoteWriteBasicUser = accessKey
+		out.RemoteWriteBasicPass = secretKey
+	} else {
+		out.RemoteWriteBearer = target.BearerToken
+		out.RemoteWriteBasicUser = target.BasicUser
+		out.RemoteWriteBasicPass = target.BasicPassword
+	}
+	return out, nil
+}
+
+func endpointPath(base, suffix string) string {
+	if base == "" {
+		return ""
+	}
+	return base + suffix
 }
 
 func (u *Usecase) issueNodeCredential(ctx context.Context, c *model.Cluster, n *model.Node) (*EdgeCredential, bool, error) {

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -2111,7 +2111,7 @@ func (u *Usecase) UpgradeCommand(cluster *model.Cluster) string {
 	}
 	args = append(args,
 		"--namespace "+shellQuote(namespace),
-		"--reuse-values",
+		"--reset-then-reuse-values",
 		"--set-string manager.publicURL="+shellQuote(publicURL),
 		"--set-string manager.tunnelAddr="+shellQuote(tunnelAddr),
 		"--set-string manager.tlsInsecure=true",
@@ -2119,6 +2119,12 @@ func (u *Usecase) UpgradeCommand(cluster *model.Cluster) string {
 	if imageTag := strings.TrimSpace(u.cfg.ImageTag); imageTag != "" {
 		args = append(args, "--set-string image.tag="+shellQuote(imageTag))
 	}
+	args = append(args,
+		"--wait",
+		"--wait-for-jobs",
+		"--atomic",
+		"--timeout "+shellQuote("15m"),
+	)
 	return strings.Join(args, " ")
 }
 

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -32,6 +32,8 @@ const (
 	eventRetentionBatchLimit    = 1000
 	bootstrapTokenBytes         = 32
 	defaultK8sChartRef          = "oci://helm.cnb.cool/ongridio/ongrid-edge"
+	telemetryAuthModeTelemetry  = "telemetry"
+	telemetryAuthModeBackend    = "backend"
 )
 
 // Repository is the k8s bounded context persistence contract.
@@ -184,12 +186,34 @@ type RemoteWriteResolver interface {
 	ResolveRemoteWrite(ctx context.Context) (RemoteWriteTarget, error)
 }
 
+const (
+	TelemetrySignalTraces = "traces"
+	TelemetrySignalLogs   = "logs"
+)
+
+// TelemetryTarget is an exact trace or log destination published to a
+// Kubernetes telemetry gateway. Manager-proxied targets use the cluster's
+// telemetry credential; external targets carry only their backend-specific
+// basic auth and TLS policy.
+type TelemetryTarget struct {
+	Endpoint               string
+	BasicUser              string
+	BasicPassword          string
+	TLSInsecure            bool
+	UseTelemetryCredential bool
+}
+
+type TelemetryTargetResolver interface {
+	ResolveTelemetryTarget(ctx context.Context, signal string) (TelemetryTarget, error)
+}
+
 type Usecase struct {
 	repo               Repository
 	edgeIssuer         EdgeIssuer
 	edgeRemover        EdgeRemover
 	topology           TopologyMirror
 	remoteWrite        RemoteWriteResolver
+	telemetryTargets   TelemetryTargetResolver
 	cfg                Config
 	enrollmentLocksMu  sync.Mutex
 	enrollmentLocks    map[string]*enrollmentLock
@@ -230,6 +254,10 @@ func (u *Usecase) SetTopologyMirror(m TopologyMirror) { u.topology = m }
 // SetRemoteWriteResolver wires the active Prometheus-compatible write target.
 // It is called once during manager startup before the HTTP server is exposed.
 func (u *Usecase) SetRemoteWriteResolver(r RemoteWriteResolver) { u.remoteWrite = r }
+
+// SetTelemetryTargetResolver wires the active Loki and Tempo ingest targets.
+// It is called once during manager startup before the HTTP server is exposed.
+func (u *Usecase) SetTelemetryTargetResolver(r TelemetryTargetResolver) { u.telemetryTargets = r }
 
 func (u *Usecase) EventCleanupInterval() time.Duration {
 	if u == nil || u.cfg.EventCleanupInterval <= 0 {
@@ -1027,7 +1055,15 @@ type TelemetryConfig struct {
 	AccessKey              string
 	SecretKey              string
 	TracesEndpoint         string
+	TracesAuthMode         string
+	TracesBasicUser        string
+	TracesBasicPass        string
+	TracesTLSInsecure      bool
 	LogsEndpoint           string
+	LogsAuthMode           string
+	LogsBasicUser          string
+	LogsBasicPass          string
+	LogsTLSInsecure        bool
 	RemoteWriteEndpoint    string
 	RemoteWriteBearer      string
 	RemoteWriteBasicUser   string
@@ -1910,12 +1946,28 @@ func newTelemetryCredential(clusterID uint64) (*model.TelemetryCredential, strin
 func (u *Usecase) resolveTelemetryConfig(ctx context.Context, clusterID uint64, accessKey, secretKey string) (*TelemetryConfig, error) {
 	publicURL := strings.TrimRight(strings.TrimSpace(u.cfg.PublicURL), "/")
 	out := &TelemetryConfig{
-		ClusterID:      clusterID,
-		AccessKey:      accessKey,
-		SecretKey:      secretKey,
-		TracesEndpoint: endpointPath(publicURL, "/v1/traces"),
-		LogsEndpoint:   endpointPath(publicURL, "/loki/api/v1/push"),
+		ClusterID: clusterID,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
 	}
+	traces, err := u.resolveTelemetryTarget(ctx, TelemetrySignalTraces, endpointPath(publicURL, "/v1/traces"))
+	if err != nil {
+		return nil, err
+	}
+	logs, err := u.resolveTelemetryTarget(ctx, TelemetrySignalLogs, endpointPath(publicURL, "/loki/api/v1/push"))
+	if err != nil {
+		return nil, err
+	}
+	out.TracesEndpoint = traces.Endpoint
+	out.TracesAuthMode = traces.AuthMode
+	out.TracesBasicUser = traces.BasicUser
+	out.TracesBasicPass = traces.BasicPass
+	out.TracesTLSInsecure = traces.TLSInsecure
+	out.LogsEndpoint = logs.Endpoint
+	out.LogsAuthMode = logs.AuthMode
+	out.LogsBasicUser = logs.BasicUser
+	out.LogsBasicPass = logs.BasicPass
+	out.LogsTLSInsecure = logs.TLSInsecure
 	target := RemoteWriteTarget{
 		Endpoint:               endpointPath(publicURL, "/prometheus/api/v1/write"),
 		UseTelemetryCredential: true,
@@ -1939,6 +1991,45 @@ func (u *Usecase) resolveTelemetryConfig(ctx context.Context, clusterID uint64, 
 		out.RemoteWriteBearer = target.BearerToken
 		out.RemoteWriteBasicUser = target.BasicUser
 		out.RemoteWriteBasicPass = target.BasicPassword
+	}
+	return out, nil
+}
+
+type resolvedTelemetryTarget struct {
+	Endpoint    string
+	AuthMode    string
+	BasicUser   string
+	BasicPass   string
+	TLSInsecure bool
+}
+
+func (u *Usecase) resolveTelemetryTarget(ctx context.Context, signal, fallbackEndpoint string) (resolvedTelemetryTarget, error) {
+	target := TelemetryTarget{
+		Endpoint:               fallbackEndpoint,
+		UseTelemetryCredential: true,
+	}
+	if u.telemetryTargets != nil {
+		resolved, err := u.telemetryTargets.ResolveTelemetryTarget(ctx, signal)
+		if err != nil {
+			return resolvedTelemetryTarget{}, fmt.Errorf("resolve kubernetes %s target: %w", signal, err)
+		}
+		if strings.TrimSpace(resolved.Endpoint) != "" {
+			target = resolved
+		}
+	}
+	out := resolvedTelemetryTarget{
+		Endpoint:    strings.TrimSpace(target.Endpoint),
+		TLSInsecure: target.TLSInsecure,
+	}
+	if target.UseTelemetryCredential {
+		out.AuthMode = telemetryAuthModeTelemetry
+		return out, nil
+	}
+	out.AuthMode = telemetryAuthModeBackend
+	out.BasicUser = strings.TrimSpace(target.BasicUser)
+	out.BasicPass = strings.TrimSpace(target.BasicPassword)
+	if (out.BasicUser == "") != (out.BasicPass == "") {
+		return resolvedTelemetryTarget{}, fmt.Errorf("resolve kubernetes %s target: basic auth requires both username and password", signal)
 	}
 	return out, nil
 }

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -12,6 +12,7 @@ import (
 	model "github.com/ongridio/ongrid/internal/manager/model/k8s"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/k8sredact"
+	"github.com/ongridio/ongrid/internal/pkg/passwd"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
@@ -405,6 +406,156 @@ func TestUsecaseControllerEnrollmentRequiresExplicitRecoveryAfterRegister(t *tes
 	if third.EdgeID != first.EdgeID || issuer.rotate != 2 {
 		t.Fatalf("recovery edge=%d rotates=%d, want edge=%d rotates=2", third.EdgeID, issuer.rotate, first.EdgeID)
 	}
+}
+
+func TestUsecaseControllerEnrollmentIssuesSeparateTelemetryCredential(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, newFakeIssuer(), Config{
+		PublicURL:  "https://manager.example",
+		TunnelAddr: "manager.example:40012",
+	})
+	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	out, err := uc.Enroll(ctx, EnrollInput{
+		BootstrapToken: reg.BootstrapToken,
+		ClusterID:      reg.Cluster.ID,
+		ClusterUID:     testClusterUID,
+		Role:           model.RoleController,
+		Namespace:      "ongrid-system",
+	})
+	if err != nil {
+		t.Fatalf("Enroll() error = %v", err)
+	}
+	if out.Telemetry == nil {
+		t.Fatal("Enroll() telemetry config is nil")
+	}
+	if !strings.HasPrefix(out.Telemetry.AccessKey, "kt_") || !strings.HasPrefix(out.Telemetry.SecretKey, "ks_") {
+		t.Fatalf("telemetry credential has unexpected shape: %#v", out.Telemetry)
+	}
+	if out.Telemetry.AccessKey == out.AccessKey || out.Telemetry.SecretKey == out.SecretKey {
+		t.Fatal("telemetry credential must not reuse controller credential")
+	}
+	if out.Telemetry.TracesEndpoint != "https://manager.example/v1/traces" ||
+		out.Telemetry.LogsEndpoint != "https://manager.example/loki/api/v1/push" ||
+		out.Telemetry.RemoteWriteEndpoint != "https://manager.example/prometheus/api/v1/write" {
+		t.Fatalf("unexpected telemetry endpoints: %#v", out.Telemetry)
+	}
+	if out.Telemetry.RemoteWriteBasicUser != out.Telemetry.AccessKey || out.Telemetry.RemoteWriteBasicPass != out.Telemetry.SecretKey {
+		t.Fatal("manager proxy must use the telemetry credential")
+	}
+	if repo.telemetryCredential == nil || repo.telemetryCredential.SecretKeyHash == out.Telemetry.SecretKey ||
+		!passwd.Verify(out.Telemetry.SecretKey, repo.telemetryCredential.SecretKeyHash) {
+		t.Fatal("telemetry secret must be persisted only as a verifiable hash")
+	}
+}
+
+func TestUsecaseControllerEnrollmentPublishesResolvedExternalRemoteWrite(t *testing.T) {
+	ctx := context.Background()
+	uc := NewUsecase(newFakeRepo(), newFakeIssuer(), Config{PublicURL: "https://manager.example"})
+	uc.SetRemoteWriteResolver(staticRemoteWriteResolver{target: RemoteWriteTarget{
+		Endpoint:    "https://metrics.example/write",
+		BearerToken: "backend-token",
+		TLSInsecure: true,
+		TLSCAPEM:    "test-ca",
+	}})
+	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	out, err := uc.Enroll(ctx, EnrollInput{
+		BootstrapToken: reg.BootstrapToken,
+		ClusterID:      reg.Cluster.ID,
+		ClusterUID:     testClusterUID,
+		Role:           model.RoleController,
+	})
+	if err != nil {
+		t.Fatalf("Enroll() error = %v", err)
+	}
+	if out.Telemetry.RemoteWriteEndpoint != "https://metrics.example/write" ||
+		out.Telemetry.RemoteWriteBearer != "backend-token" ||
+		!out.Telemetry.RemoteWriteTLSInsecure || out.Telemetry.RemoteWriteTLSCAPEM != "test-ca" {
+		t.Fatalf("unexpected remote write config: %#v", out.Telemetry)
+	}
+}
+
+func TestUsecaseRefreshTelemetryConfigRotatesOnlyDataPlaneCredential(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, newFakeIssuer(), Config{PublicURL: "https://manager.example"})
+	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	bindFakeController(t, repo, reg.Cluster.ID, 41)
+	repo.telemetryCredential = &model.TelemetryCredential{
+		ClusterID:     reg.Cluster.ID,
+		AccessKeyID:   "kt_old",
+		SecretKeyHash: "old-hash",
+	}
+
+	out, err := uc.RefreshTelemetryConfig(ctx, 41, TelemetryCredentialProof{})
+	if err != nil {
+		t.Fatalf("RefreshTelemetryConfig() error = %v", err)
+	}
+	if out.ClusterID != reg.Cluster.ID || !strings.HasPrefix(out.AccessKey, "kt_") || !strings.HasPrefix(out.SecretKey, "ks_") {
+		t.Fatalf("refreshed config = %#v", out)
+	}
+	if out.AccessKey == "kt_old" || repo.telemetryCredential == nil || repo.telemetryCredential.AccessKeyID != out.AccessKey {
+		t.Fatalf("credential was not rotated: out=%#v stored=%#v", out, repo.telemetryCredential)
+	}
+	if !passwd.Verify(out.SecretKey, repo.telemetryCredential.SecretKeyHash) {
+		t.Fatal("rotated secret does not match persisted hash")
+	}
+	if _, err := uc.RefreshTelemetryConfig(ctx, 99, TelemetryCredentialProof{}); !errors.Is(err, errs.ErrNotFound) {
+		t.Fatalf("RefreshTelemetryConfig(non-controller) error = %v, want not found", err)
+	}
+}
+
+func TestUsecaseRefreshTelemetryConfigPreservesValidCredential(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, newFakeIssuer(), Config{PublicURL: "https://manager.example"})
+	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	bindFakeController(t, repo, reg.Cluster.ID, 41)
+	secret := "ks_existing"
+	hash, err := passwd.Hash(secret)
+	if err != nil {
+		t.Fatalf("hash telemetry secret: %v", err)
+	}
+	repo.telemetryCredential = &model.TelemetryCredential{
+		ClusterID:     reg.Cluster.ID,
+		AccessKeyID:   "kt_existing",
+		SecretKeyHash: hash,
+	}
+
+	out, err := uc.RefreshTelemetryConfig(ctx, 41, TelemetryCredentialProof{
+		AccessKey: "kt_existing",
+		SecretKey: secret,
+	})
+	if err != nil {
+		t.Fatalf("RefreshTelemetryConfig() error = %v", err)
+	}
+	if out.AccessKey != "kt_existing" || out.SecretKey != secret {
+		t.Fatalf("valid credential was rotated: %#v", out)
+	}
+	if repo.telemetryCredential.AccessKeyID != "kt_existing" || repo.telemetryCredential.SecretKeyHash != hash {
+		t.Fatalf("stored credential changed: %#v", repo.telemetryCredential)
+	}
+}
+
+type staticRemoteWriteResolver struct {
+	target RemoteWriteTarget
+	err    error
+}
+
+func (r staticRemoteWriteResolver) ResolveRemoteWrite(context.Context) (RemoteWriteTarget, error) {
+	return r.target, r.err
 }
 
 func TestUsecaseLookupControllerCluster(t *testing.T) {
@@ -1598,17 +1749,18 @@ func TestUsecaseListEventsIssueOnlyExcludesRecoveredWarnings(t *testing.T) {
 }
 
 type fakeRepo struct {
-	nextClusterID      uint64
-	nextNodeID         uint64
-	clusters           map[uint64]*model.Cluster
-	nodes              map[string]*model.Node
-	deviceNodeIDs      map[uint64]uint64
-	pods               map[string]*model.Pod
-	events             []*model.Event
-	pruned             []string
-	lastInstallation   *model.Installation
-	failUpdateNodeEdge bool
-	failBindController bool
+	nextClusterID       uint64
+	nextNodeID          uint64
+	clusters            map[uint64]*model.Cluster
+	nodes               map[string]*model.Node
+	deviceNodeIDs       map[uint64]uint64
+	pods                map[string]*model.Pod
+	events              []*model.Event
+	pruned              []string
+	lastInstallation    *model.Installation
+	telemetryCredential *model.TelemetryCredential
+	failUpdateNodeEdge  bool
+	failBindController  bool
 }
 
 func bindFakeController(t *testing.T, repo *fakeRepo, clusterID, edgeID uint64) {
@@ -1751,18 +1903,37 @@ func (r *fakeRepo) TouchClusterControllerHeartbeat(_ context.Context, edgeID uin
 	return nil
 }
 
-func (r *fakeRepo) BindControllerEnrollment(ctx context.Context, id uint64, registration ClusterControllerRegistration, installation *model.Installation) error {
+func (r *fakeRepo) BindControllerEnrollment(ctx context.Context, id uint64, registration ClusterControllerRegistration, installation *model.Installation, telemetryCredential *model.TelemetryCredential) error {
 	if r.failBindController {
 		return errors.New("bind controller failed")
 	}
 	if err := r.UpdateClusterController(ctx, id, registration); err != nil {
 		return err
 	}
-	if installation == nil {
+	if installation == nil || telemetryCredential == nil {
 		return errs.ErrInvalid
 	}
 	cp := *installation
 	r.lastInstallation = &cp
+	credentialCopy := *telemetryCredential
+	r.telemetryCredential = &credentialCopy
+	return nil
+}
+
+func (r *fakeRepo) GetTelemetryCredentialByAccessKey(_ context.Context, accessKey string) (*model.TelemetryCredential, error) {
+	if r.telemetryCredential == nil || r.telemetryCredential.AccessKeyID != accessKey {
+		return nil, errs.ErrNotFound
+	}
+	cp := *r.telemetryCredential
+	return &cp, nil
+}
+
+func (r *fakeRepo) UpsertTelemetryCredential(_ context.Context, credential *model.TelemetryCredential) error {
+	if credential == nil {
+		return errs.ErrInvalid
+	}
+	cp := *credential
+	r.telemetryCredential = &cp
 	return nil
 }
 

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -450,9 +450,43 @@ func TestUsecaseControllerEnrollmentIssuesSeparateTelemetryCredential(t *testing
 	if out.Telemetry.RemoteWriteBasicUser != out.Telemetry.AccessKey || out.Telemetry.RemoteWriteBasicPass != out.Telemetry.SecretKey {
 		t.Fatal("manager proxy must use the telemetry credential")
 	}
+	if out.Telemetry.TracesAuthMode != telemetryAuthModeTelemetry || out.Telemetry.LogsAuthMode != telemetryAuthModeTelemetry {
+		t.Fatalf("manager signal auth modes = traces:%q logs:%q", out.Telemetry.TracesAuthMode, out.Telemetry.LogsAuthMode)
+	}
 	if repo.telemetryCredential == nil || repo.telemetryCredential.SecretKeyHash == out.Telemetry.SecretKey ||
 		!passwd.Verify(out.Telemetry.SecretKey, repo.telemetryCredential.SecretKeyHash) {
 		t.Fatal("telemetry secret must be persisted only as a verifiable hash")
+	}
+}
+
+func TestResolveTelemetryConfigPublishesIndependentExternalTraceAndLogTargets(t *testing.T) {
+	uc := NewUsecase(nil, nil, Config{PublicURL: "https://manager.example"})
+	uc.SetTelemetryTargetResolver(staticTelemetryTargetResolver{targets: map[string]TelemetryTarget{
+		TelemetrySignalTraces: {
+			Endpoint:      "https://tempo.example/v1/traces",
+			BasicUser:     "tempo-user",
+			BasicPassword: "tempo-pass",
+			TLSInsecure:   true,
+		},
+		TelemetrySignalLogs: {
+			Endpoint: "https://loki.example/loki/api/v1/push",
+		},
+	}})
+
+	out, err := uc.resolveTelemetryConfig(context.Background(), 7, "kt_access", "ks_secret")
+	if err != nil {
+		t.Fatalf("resolveTelemetryConfig() error = %v", err)
+	}
+	if out.TracesEndpoint != "https://tempo.example/v1/traces" || out.TracesAuthMode != telemetryAuthModeBackend ||
+		out.TracesBasicUser != "tempo-user" || out.TracesBasicPass != "tempo-pass" || !out.TracesTLSInsecure {
+		t.Fatalf("trace target = %#v", out)
+	}
+	if out.LogsEndpoint != "https://loki.example/loki/api/v1/push" || out.LogsAuthMode != telemetryAuthModeBackend ||
+		out.LogsBasicUser != "" || out.LogsBasicPass != "" || out.LogsTLSInsecure {
+		t.Fatalf("log target = %#v", out)
+	}
+	if out.RemoteWriteBasicUser != "kt_access" || out.RemoteWriteBasicPass != "ks_secret" {
+		t.Fatalf("manager remote_write credential changed: %#v", out)
 	}
 }
 
@@ -556,6 +590,15 @@ func TestUsecaseRefreshTelemetryConfigPreservesValidCredential(t *testing.T) {
 type staticRemoteWriteResolver struct {
 	target RemoteWriteTarget
 	err    error
+}
+
+type staticTelemetryTargetResolver struct {
+	targets map[string]TelemetryTarget
+	err     error
+}
+
+func (r staticTelemetryTargetResolver) ResolveTelemetryTarget(_ context.Context, signal string) (TelemetryTarget, error) {
+	return r.targets[signal], r.err
 }
 
 func (r staticRemoteWriteResolver) ResolveRemoteWrite(context.Context) (RemoteWriteTarget, error) {

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -210,10 +210,14 @@ func TestUpgradeCommandUsesManagerConfig(t *testing.T) {
 		"'oci://helm.cnb.cool/ongridio/ongrid-edge'",
 		"--version '0.9.1'",
 		"--namespace 'ongrid-system'",
-		"--reuse-values",
+		"--reset-then-reuse-values",
 		"manager.publicURL='https://manager.example.com:8443'",
 		"manager.tunnelAddr='manager.example.com:40012'",
 		"image.tag='v0.9.1'",
+		"--wait",
+		"--wait-for-jobs",
+		"--atomic",
+		"--timeout '15m'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("UpgradeCommand() = %q, missing %q", command, want)

--- a/internal/manager/data/k8s/store/migrate.go
+++ b/internal/manager/data/k8s/store/migrate.go
@@ -21,6 +21,7 @@ func Migrate(db *gorm.DB) error {
 		&model.Pod{},
 		&model.Event{},
 		&model.Installation{},
+		&model.TelemetryCredential{},
 	); err != nil {
 		return err
 	}

--- a/internal/manager/data/k8s/store/repo.go
+++ b/internal/manager/data/k8s/store/repo.go
@@ -164,8 +164,8 @@ func (r *Repo) TouchClusterControllerHeartbeat(ctx context.Context, edgeID uint6
 		}).Error
 }
 
-func (r *Repo) BindControllerEnrollment(ctx context.Context, id uint64, registration biz.ClusterControllerRegistration, installation *model.Installation) error {
-	if installation == nil {
+func (r *Repo) BindControllerEnrollment(ctx context.Context, id uint64, registration biz.ClusterControllerRegistration, installation *model.Installation, telemetryCredential *model.TelemetryCredential) error {
+	if installation == nil || telemetryCredential == nil || installation.ClusterID != id || telemetryCredential.ClusterID != id {
 		return errs.ErrInvalid
 	}
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -183,7 +183,7 @@ func (r *Repo) BindControllerEnrollment(ctx context.Context, id uint64, registra
 		if res.RowsAffected == 0 {
 			return errs.ErrNotFound
 		}
-		return tx.Clauses(clause.OnConflict{
+		if err := tx.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
 				{Name: "cluster_id"},
 				{Name: "mode"},
@@ -199,8 +199,43 @@ func (r *Repo) BindControllerEnrollment(ctx context.Context, id uint64, registra
 				"last_seen_at":       installation.LastSeenAt,
 				"updated_at":         time.Now(),
 			}),
-		}).Create(installation).Error
+		}).Create(installation).Error; err != nil {
+			return err
+		}
+		return tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "cluster_id"}},
+			DoUpdates: clause.Assignments(map[string]any{
+				"access_key_id":   telemetryCredential.AccessKeyID,
+				"secret_key_hash": telemetryCredential.SecretKeyHash,
+				"updated_at":      time.Now(),
+			}),
+		}).Create(telemetryCredential).Error
 	})
+}
+
+func (r *Repo) GetTelemetryCredentialByAccessKey(ctx context.Context, accessKey string) (*model.TelemetryCredential, error) {
+	var credential model.TelemetryCredential
+	if err := r.db.WithContext(ctx).Where("access_key_id = ?", accessKey).First(&credential).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errs.ErrNotFound
+		}
+		return nil, err
+	}
+	return &credential, nil
+}
+
+func (r *Repo) UpsertTelemetryCredential(ctx context.Context, credential *model.TelemetryCredential) error {
+	if credential == nil || credential.ClusterID == 0 || credential.AccessKeyID == "" || credential.SecretKeyHash == "" {
+		return errs.ErrInvalid
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "cluster_id"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"access_key_id":   credential.AccessKeyID,
+			"secret_key_hash": credential.SecretKeyHash,
+			"updated_at":      time.Now(),
+		}),
+	}).Create(credential).Error
 }
 
 func (r *Repo) UpdateClusterInventorySync(ctx context.Context, id uint64, in biz.ClusterInventorySync) error {
@@ -329,6 +364,7 @@ func (r *Repo) DeleteCluster(ctx context.Context, id uint64) error {
 			&model.Pod{},
 			&model.Event{},
 			&model.Installation{},
+			&model.TelemetryCredential{},
 		} {
 			if err := tx.Where("cluster_id = ?", id).Delete(item).Error; err != nil {
 				return err

--- a/internal/manager/data/k8s/store/repo_test.go
+++ b/internal/manager/data/k8s/store/repo_test.go
@@ -99,6 +99,10 @@ func TestRepo_BindControllerEnrollmentUpsertsInstallationOnSQLite(t *testing.T) 
 		ControllerEdgeID: &firstEdgeID,
 		CapabilitiesJSON: `["inventory"]`,
 		LastSeenAt:       &firstSeen,
+	}, &model.TelemetryCredential{
+		ClusterID:     cluster.ID,
+		AccessKeyID:   "kt_first",
+		SecretKeyHash: "first-hash",
 	}); err != nil {
 		t.Fatalf("BindControllerEnrollment(first): %v", err)
 	}
@@ -119,6 +123,10 @@ func TestRepo_BindControllerEnrollmentUpsertsInstallationOnSQLite(t *testing.T) 
 		ControllerEdgeID: &secondEdgeID,
 		CapabilitiesJSON: `["inventory","events"]`,
 		LastSeenAt:       &secondSeen,
+	}, &model.TelemetryCredential{
+		ClusterID:     cluster.ID,
+		AccessKeyID:   "kt_second",
+		SecretKeyHash: "second-hash",
 	}); err != nil {
 		t.Fatalf("BindControllerEnrollment(second): %v", err)
 	}
@@ -136,6 +144,13 @@ func TestRepo_BindControllerEnrollmentUpsertsInstallationOnSQLite(t *testing.T) 
 	}
 	if installation.CapabilitiesJSON != `["inventory","events"]` {
 		t.Fatalf("installation capabilities = %s", installation.CapabilitiesJSON)
+	}
+	credential, err := repo.GetTelemetryCredentialByAccessKey(ctx, "kt_second")
+	if err != nil {
+		t.Fatalf("GetTelemetryCredentialByAccessKey: %v", err)
+	}
+	if credential.ClusterID != cluster.ID || credential.SecretKeyHash != "second-hash" {
+		t.Fatalf("telemetry credential = %+v", credential)
 	}
 
 	var updated model.Cluster
@@ -699,6 +714,13 @@ func TestRepo_DeleteClusterDeletesSnapshots(t *testing.T) {
 	}).Error; err != nil {
 		t.Fatalf("Create installation: %v", err)
 	}
+	if err := db.Create(&model.TelemetryCredential{
+		ClusterID:     cluster.ID,
+		AccessKeyID:   "kt_cluster",
+		SecretKeyHash: "secret-hash",
+	}).Error; err != nil {
+		t.Fatalf("Create telemetry credential: %v", err)
+	}
 
 	if err := repo.DeleteCluster(context.Background(), cluster.ID); err != nil {
 		t.Fatalf("DeleteCluster: %v", err)
@@ -709,6 +731,7 @@ func TestRepo_DeleteClusterDeletesSnapshots(t *testing.T) {
 	assertTableCount(t, db, &model.Pod{}, "cluster_id = ?", cluster.ID, 0)
 	assertTableCount(t, db, &model.Event{}, "cluster_id = ?", cluster.ID, 0)
 	assertTableCount(t, db, &model.Installation{}, "cluster_id = ?", cluster.ID, 0)
+	assertTableCount(t, db, &model.TelemetryCredential{}, "cluster_id = ?", cluster.ID, 0)
 }
 
 func assertTableCount(t *testing.T, db *gorm.DB, model any, query string, arg any, want int64) {

--- a/internal/manager/model/k8s/model.go
+++ b/internal/manager/model/k8s/model.go
@@ -169,3 +169,18 @@ type Installation struct {
 }
 
 func (Installation) TableName() string { return "k8s_installations" }
+
+// TelemetryCredential is the cluster-scoped, write-only identity used by
+// Kubernetes telemetry data-plane workloads. It is deliberately separate
+// from Edge credentials: the tunnel authenticator only reads the edges table,
+// so this credential cannot establish a controller tunnel or execute actions.
+type TelemetryCredential struct {
+	ClusterID     uint64 `gorm:"primaryKey;column:cluster_id"`
+	AccessKeyID   string `gorm:"size:128;not null;uniqueIndex:idx_k8s_telemetry_credentials_access_key;column:access_key_id"`
+	SecretKeyHash string `gorm:"size:512;not null;column:secret_key_hash"`
+
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func (TelemetryCredential) TableName() string { return "k8s_telemetry_credentials" }

--- a/internal/manager/server/edgeauth/http.go
+++ b/internal/manager/server/edgeauth/http.go
@@ -2,11 +2,10 @@
 // `auth_request` module calls before proxying telemetry data plane
 // requests to downstream backends (Loki, Tempo, ...).
 //
-// The endpoint validates the Authorization header (Basic auth, where
-// username = edge access key, password = edge secret key) by reusing
-// edge.AccessKeyAuthenticator — the same code that authenticates tunnel
-// handshakes. So data plane HTTPS and tunnel both gate on identical
-// credentials; revoking an edge revokes both paths simultaneously.
+// The endpoint validates the Authorization header (Basic auth) through a
+// wiring-provided authenticator. The manager exposes separate edge-only,
+// telemetry-only, and compatibility endpoints so nginx can enforce the
+// credential scope required by each exact data-plane route.
 //
 // This endpoint is mounted on the public mux (no JWT auth) because nginx
 // itself is the only legitimate caller, and it lives behind the local
@@ -27,11 +26,15 @@ import (
 )
 
 // Authenticator is the narrow contract this handler needs. The concrete
-// implementation lives in cmd/ongrid wiring, adapting
-// *edge.AccessKeyAuthenticator (which returns tunnel.Session) to this
-// signature so we don't drag the tunnel package into the HTTP handler.
+// implementation lives in cmd/ongrid wiring so this package does not depend
+// on either the edge identity or Kubernetes telemetry credential domain.
 type Authenticator interface {
-	AuthenticateEdge(ctx context.Context, accessKey, secretKey string) (edgeID uint64, err error)
+	AuthenticateDataPlane(ctx context.Context, accessKey, secretKey string) (Identity, error)
+}
+
+type Identity struct {
+	EdgeID    uint64
+	ClusterID uint64
 }
 
 // Handler exposes /internal/auth/dataplane-verify.
@@ -52,7 +55,13 @@ func NewHandler(authn Authenticator, log *slog.Logger) *Handler {
 // whether to gate by network policy (typically yes — only nginx should
 // reach this).
 func (h *Handler) Register(r chi.Router) {
-	r.Get("/internal/auth/dataplane-verify", h.verify)
+	h.RegisterAt(r, "/internal/auth/dataplane-verify")
+}
+
+// RegisterAt mounts the same verifier at a narrower internal path. Wiring
+// uses this for edge-only and telemetry-only nginx auth_request endpoints.
+func (h *Handler) RegisterAt(r chi.Router, path string) {
+	r.Get(path, h.verify)
 }
 
 func (h *Handler) verify(w http.ResponseWriter, r *http.Request) {
@@ -63,10 +72,10 @@ func (h *Handler) verify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	edgeID, err := h.authn.AuthenticateEdge(r.Context(), user, pass)
+	identity, err := h.authn.AuthenticateDataPlane(r.Context(), user, pass)
 	if err != nil {
 		if errors.Is(err, errs.ErrUnauthorized) {
-			h.log.Debug("dataplane auth rejected", slog.String("user", user))
+			h.log.Debug("dataplane auth rejected")
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -78,7 +87,12 @@ func (h *Handler) verify(w http.ResponseWriter, r *http.Request) {
 	// Surface edge_id back to nginx so it can pass through to downstream
 	// (e.g. inject as a forced label header into Loki). nginx reads via
 	// `auth_request_set $edge_id $upstream_http_x_edge_id;`.
-	w.Header().Set("X-Edge-Id", uintToA(edgeID))
+	if identity.EdgeID != 0 {
+		w.Header().Set("X-Edge-Id", uintToA(identity.EdgeID))
+	}
+	if identity.ClusterID != 0 {
+		w.Header().Set("X-Cluster-Id", uintToA(identity.ClusterID))
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/manager/server/edgeauth/http_test.go
+++ b/internal/manager/server/edgeauth/http_test.go
@@ -1,0 +1,87 @@
+package edgeauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+type stubAuthenticator struct {
+	identity Identity
+	err      error
+	user     string
+	pass     string
+}
+
+func (a *stubAuthenticator) AuthenticateDataPlane(_ context.Context, accessKey, secretKey string) (Identity, error) {
+	a.user = accessKey
+	a.pass = secretKey
+	return a.identity, a.err
+}
+
+func TestVerifyReturnsScopedIdentityHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		identity  Identity
+		wantEdge  string
+		wantK8sID string
+	}{
+		{name: "edge", identity: Identity{EdgeID: 42}, wantEdge: "42"},
+		{name: "telemetry", identity: Identity{ClusterID: 7}, wantK8sID: "7"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authn := &stubAuthenticator{identity: tt.identity}
+			h := NewHandler(authn, nil)
+			req := httptest.NewRequest(http.MethodGet, "/internal/auth/test", nil)
+			req.SetBasicAuth("access", "secret")
+			resp := httptest.NewRecorder()
+
+			h.verify(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.Code)
+			}
+			if authn.user != "access" || authn.pass != "secret" {
+				t.Fatalf("credentials = %q/%q", authn.user, authn.pass)
+			}
+			if got := resp.Header().Get("X-Edge-Id"); got != tt.wantEdge {
+				t.Fatalf("X-Edge-Id = %q, want %q", got, tt.wantEdge)
+			}
+			if got := resp.Header().Get("X-Cluster-Id"); got != tt.wantK8sID {
+				t.Fatalf("X-Cluster-Id = %q, want %q", got, tt.wantK8sID)
+			}
+		})
+	}
+}
+
+func TestVerifyFailsClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		authErr    error
+		wantStatus int
+	}{
+		{name: "missing header", wantStatus: http.StatusUnauthorized},
+		{name: "bad credentials", authHeader: "Basic YWNjZXNzOnNlY3JldA==", authErr: errs.ErrUnauthorized, wantStatus: http.StatusUnauthorized},
+		{name: "backend failure", authHeader: "Basic YWNjZXNzOnNlY3JldA==", authErr: errors.New("database unavailable"), wantStatus: http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandler(&stubAuthenticator{err: tt.authErr}, nil)
+			req := httptest.NewRequest(http.MethodGet, "/internal/auth/test", nil)
+			req.Header.Set("Authorization", tt.authHeader)
+			resp := httptest.NewRecorder()
+
+			h.verify(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/manager/server/k8s/http.go
+++ b/internal/manager/server/k8s/http.go
@@ -41,6 +41,7 @@ type Service interface {
 	RotateBootstrapToken(ctx context.Context, id uint64) (*biz.ClusterRegistration, error)
 	DeleteCluster(ctx context.Context, in biz.DeleteClusterInput) error
 	Enroll(ctx context.Context, in biz.EnrollInput) (*biz.EnrollResult, error)
+	RefreshTelemetryConfig(ctx context.Context, controllerEdgeID uint64, proof biz.TelemetryCredentialProof) (*biz.TelemetryConfig, error)
 }
 
 type Handler struct {
@@ -122,6 +123,7 @@ func (h *Handler) getClusterHealth(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) RegisterInternal(r chi.Router) {
 	r.Post("/internal/k8s/enroll", h.enroll)
+	r.Post("/internal/k8s/telemetry-config", h.refreshTelemetryConfig)
 }
 
 // @Summary Create Kubernetes cluster enrollment
@@ -481,7 +483,33 @@ func (h *Handler) enroll(w http.ResponseWriter, r *http.Request) {
 		SecretKey:        out.SecretKey,
 		CloudAddr:        out.CloudAddr,
 		ManagerPublicURL: out.ManagerPublicURL,
+		Telemetry:        telemetryConfigDTO(out.Telemetry),
 	})
+}
+
+// @Summary Refresh Kubernetes telemetry data-plane configuration
+// @Router /internal/k8s/telemetry-config [post]
+// @Success 200 {object} telemetryConfigResponse
+func (h *Handler) refreshTelemetryConfig(w http.ResponseWriter, r *http.Request) {
+	edgeID, err := strconv.ParseUint(strings.TrimSpace(r.Header.Get("X-Edge-Id")), 10, 64)
+	if err != nil || edgeID == 0 {
+		writeErr(w, errs.ErrUnauthorized)
+		return
+	}
+	var req telemetryRefreshRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeErr(w, err)
+		return
+	}
+	out, err := h.svc.RefreshTelemetryConfig(r.Context(), edgeID, biz.TelemetryCredentialProof{
+		AccessKey: req.AccessKey,
+		SecretKey: req.SecretKey,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, telemetryConfigDTO(out))
 }
 
 func (h *Handler) requireAdmin(next http.Handler) http.Handler {
@@ -511,6 +539,11 @@ type enrollRequest struct {
 	Namespace    string   `json:"namespace,omitempty"`
 	AgentVersion string   `json:"agent_version,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+type telemetryRefreshRequest struct {
+	AccessKey string `json:"access_key,omitempty"`
+	SecretKey string `json:"secret_key,omitempty"`
 }
 
 type clusterDTO struct {
@@ -657,14 +690,48 @@ type eventDTO struct {
 }
 
 type enrollResponse struct {
-	ClusterID        uint64 `json:"cluster_id"`
-	Role             string `json:"role"`
-	Mode             string `json:"mode"`
-	EdgeID           uint64 `json:"edge_id"`
-	AccessKey        string `json:"access_key"`
-	SecretKey        string `json:"secret_key"`
-	CloudAddr        string `json:"cloud_addr,omitempty"`
-	ManagerPublicURL string `json:"manager_public_url,omitempty"`
+	ClusterID        uint64                   `json:"cluster_id"`
+	Role             string                   `json:"role"`
+	Mode             string                   `json:"mode"`
+	EdgeID           uint64                   `json:"edge_id"`
+	AccessKey        string                   `json:"access_key"`
+	SecretKey        string                   `json:"secret_key"`
+	CloudAddr        string                   `json:"cloud_addr,omitempty"`
+	ManagerPublicURL string                   `json:"manager_public_url,omitempty"`
+	Telemetry        *telemetryConfigResponse `json:"telemetry,omitempty"`
+}
+
+type telemetryConfigResponse struct {
+	ClusterID              uint64 `json:"cluster_id"`
+	AccessKey              string `json:"access_key"`
+	SecretKey              string `json:"secret_key"`
+	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
+	LogsEndpoint           string `json:"logs_endpoint,omitempty"`
+	RemoteWriteEndpoint    string `json:"remote_write_endpoint,omitempty"`
+	RemoteWriteBearer      string `json:"remote_write_bearer,omitempty"`
+	RemoteWriteBasicUser   string `json:"remote_write_basic_user,omitempty"`
+	RemoteWriteBasicPass   string `json:"remote_write_basic_pass,omitempty"`
+	RemoteWriteTLSInsecure bool   `json:"remote_write_tls_insecure,omitempty"`
+	RemoteWriteTLSCAPEM    string `json:"remote_write_tls_ca_pem,omitempty"`
+}
+
+func telemetryConfigDTO(in *biz.TelemetryConfig) *telemetryConfigResponse {
+	if in == nil {
+		return nil
+	}
+	return &telemetryConfigResponse{
+		ClusterID:              in.ClusterID,
+		AccessKey:              in.AccessKey,
+		SecretKey:              in.SecretKey,
+		TracesEndpoint:         in.TracesEndpoint,
+		LogsEndpoint:           in.LogsEndpoint,
+		RemoteWriteEndpoint:    in.RemoteWriteEndpoint,
+		RemoteWriteBearer:      in.RemoteWriteBearer,
+		RemoteWriteBasicUser:   in.RemoteWriteBasicUser,
+		RemoteWriteBasicPass:   in.RemoteWriteBasicPass,
+		RemoteWriteTLSInsecure: in.RemoteWriteTLSInsecure,
+		RemoteWriteTLSCAPEM:    in.RemoteWriteTLSCAPEM,
+	}
 }
 
 func registrationDTO(in *biz.ClusterRegistration) clusterRegistrationDTO {

--- a/internal/manager/server/k8s/http.go
+++ b/internal/manager/server/k8s/http.go
@@ -706,7 +706,15 @@ type telemetryConfigResponse struct {
 	AccessKey              string `json:"access_key"`
 	SecretKey              string `json:"secret_key"`
 	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
+	TracesAuthMode         string `json:"traces_auth_mode,omitempty"`
+	TracesBasicUser        string `json:"traces_basic_user,omitempty"`
+	TracesBasicPass        string `json:"traces_basic_pass,omitempty"`
+	TracesTLSInsecure      bool   `json:"traces_tls_insecure,omitempty"`
 	LogsEndpoint           string `json:"logs_endpoint,omitempty"`
+	LogsAuthMode           string `json:"logs_auth_mode,omitempty"`
+	LogsBasicUser          string `json:"logs_basic_user,omitempty"`
+	LogsBasicPass          string `json:"logs_basic_pass,omitempty"`
+	LogsTLSInsecure        bool   `json:"logs_tls_insecure,omitempty"`
 	RemoteWriteEndpoint    string `json:"remote_write_endpoint,omitempty"`
 	RemoteWriteBearer      string `json:"remote_write_bearer,omitempty"`
 	RemoteWriteBasicUser   string `json:"remote_write_basic_user,omitempty"`
@@ -724,7 +732,15 @@ func telemetryConfigDTO(in *biz.TelemetryConfig) *telemetryConfigResponse {
 		AccessKey:              in.AccessKey,
 		SecretKey:              in.SecretKey,
 		TracesEndpoint:         in.TracesEndpoint,
+		TracesAuthMode:         in.TracesAuthMode,
+		TracesBasicUser:        in.TracesBasicUser,
+		TracesBasicPass:        in.TracesBasicPass,
+		TracesTLSInsecure:      in.TracesTLSInsecure,
 		LogsEndpoint:           in.LogsEndpoint,
+		LogsAuthMode:           in.LogsAuthMode,
+		LogsBasicUser:          in.LogsBasicUser,
+		LogsBasicPass:          in.LogsBasicPass,
+		LogsTLSInsecure:        in.LogsTLSInsecure,
 		RemoteWriteEndpoint:    in.RemoteWriteEndpoint,
 		RemoteWriteBearer:      in.RemoteWriteBearer,
 		RemoteWriteBasicUser:   in.RemoteWriteBasicUser,

--- a/internal/manager/server/k8s/http_test.go
+++ b/internal/manager/server/k8s/http_test.go
@@ -1,12 +1,73 @@
 package k8s
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	biz "github.com/ongridio/ongrid/internal/manager/biz/k8s"
 	model "github.com/ongridio/ongrid/internal/manager/model/k8s"
 )
+
+type telemetryRefreshService struct {
+	Service
+	controllerEdgeID uint64
+	proof            biz.TelemetryCredentialProof
+	out              *biz.TelemetryConfig
+	err              error
+}
+
+func (s *telemetryRefreshService) RefreshTelemetryConfig(_ context.Context, controllerEdgeID uint64, proof biz.TelemetryCredentialProof) (*biz.TelemetryConfig, error) {
+	s.controllerEdgeID = controllerEdgeID
+	s.proof = proof
+	return s.out, s.err
+}
+
+func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T) {
+	svc := &telemetryRefreshService{out: &biz.TelemetryConfig{
+		ClusterID:           7,
+		AccessKey:           "kt_access",
+		SecretKey:           "ks_secret",
+		RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write",
+	}}
+	h := NewHandler(svc)
+	req := httptest.NewRequest(http.MethodPost, "/internal/k8s/telemetry-config", bytes.NewBufferString(`{"access_key":"kt_current","secret_key":"ks_current"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Edge-Id", "41")
+	resp := httptest.NewRecorder()
+
+	h.refreshTelemetryConfig(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	if svc.controllerEdgeID != 41 {
+		t.Fatalf("controller edge id = %d, want 41", svc.controllerEdgeID)
+	}
+	if svc.proof.AccessKey != "kt_current" || svc.proof.SecretKey != "ks_current" {
+		t.Fatalf("credential proof = %#v", svc.proof)
+	}
+	var got telemetryConfigResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ClusterID != 7 || got.AccessKey != "kt_access" || got.SecretKey != "ks_secret" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestRefreshTelemetryConfigRejectsMissingAuthenticatedIdentity(t *testing.T) {
+	h := NewHandler(&telemetryRefreshService{})
+	resp := httptest.NewRecorder()
+	h.refreshTelemetryConfig(resp, httptest.NewRequest(http.MethodPost, "/internal/k8s/telemetry-config", nil))
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.Code)
+	}
+}
 
 func TestClusterCapabilitiesFromModel(t *testing.T) {
 	edgeID := uint64(42)

--- a/internal/manager/server/k8s/http_test.go
+++ b/internal/manager/server/k8s/http_test.go
@@ -32,6 +32,13 @@ func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T)
 		ClusterID:           7,
 		AccessKey:           "kt_access",
 		SecretKey:           "ks_secret",
+		TracesEndpoint:      "https://tempo.example/v1/traces",
+		TracesAuthMode:      "backend",
+		TracesBasicUser:     "tempo-user",
+		TracesBasicPass:     "tempo-pass",
+		TracesTLSInsecure:   true,
+		LogsEndpoint:        "https://loki.example/loki/api/v1/push",
+		LogsAuthMode:        "backend",
 		RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write",
 	}}
 	h := NewHandler(svc)
@@ -57,6 +64,11 @@ func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T)
 	}
 	if got.ClusterID != 7 || got.AccessKey != "kt_access" || got.SecretKey != "ks_secret" {
 		t.Fatalf("response = %#v", got)
+	}
+	if got.TracesEndpoint != "https://tempo.example/v1/traces" || got.TracesAuthMode != "backend" ||
+		got.TracesBasicUser != "tempo-user" || got.TracesBasicPass != "tempo-pass" || !got.TracesTLSInsecure ||
+		got.LogsEndpoint != "https://loki.example/loki/api/v1/push" || got.LogsAuthMode != "backend" {
+		t.Fatalf("signal target response = %#v", got)
 	}
 }
 

--- a/internal/manager/service/k8s/service.go
+++ b/internal/manager/service/k8s/service.go
@@ -114,6 +114,10 @@ func (s *Service) Enroll(ctx context.Context, in EnrollInput) (*EnrollResult, er
 	return s.uc.Enroll(ctx, in)
 }
 
+func (s *Service) RefreshTelemetryConfig(ctx context.Context, controllerEdgeID uint64, proof biz.TelemetryCredentialProof) (*biz.TelemetryConfig, error) {
+	return s.uc.RefreshTelemetryConfig(ctx, controllerEdgeID, proof)
+}
+
 func (s *Service) HandleRegister(ctx context.Context, edgeID uint64, deviceID *uint64, info tunnel.KubernetesInfo) error {
 	return s.uc.HandleRegister(ctx, edgeID, deviceID, info)
 }

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir=${1:-deploy/kubernetes/ongrid-edge}
+chart_package=${2:-bin/k8s/ongrid-edge.tgz}
+expected_image=${3:-}
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+common_args=(
+  --namespace ongrid-system
+  --set-string manager.publicURL=https://manager.example:8443
+  --set-string manager.tunnelAddr=manager.example:40012
+  --set-string enrollment.clusterID=1
+  --set-string enrollment.controllerBootstrapToken=controller-token
+  --set-string enrollment.nodeBootstrapToken=node-token
+)
+
+extract_source() {
+  local source=$1
+  local input=$2
+  local output=$3
+  awk -v marker="# Source: ${source}" '
+    $0 == marker { capture = 1; next }
+    capture && /^---$/ { exit }
+    capture { print }
+  ' "$input" >"$output"
+}
+
+expect_template_failure() {
+  local expected=$1
+  shift
+  if "$@" >"$tmp_dir/failure.log" 2>&1; then
+    echo "expected Helm template failure containing: $expected" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$tmp_dir/failure.log"
+}
+
+helm lint "$chart_dir" "${common_args[@]}"
+
+helm template ongrid-edge "$chart_package" "${common_args[@]}" >"$tmp_dir/default.yaml"
+extract_source 'ongrid-edge/templates/telemetry-credentials-secret.yaml' "$tmp_dir/default.yaml" "$tmp_dir/telemetry-secret.yaml"
+grep -q 'type: Recreate' "$tmp_dir/default.yaml"
+! grep -q 'kubernetes.io/arch:' "$tmp_dir/default.yaml"
+if [[ -n "$expected_image" ]]; then
+  test "$(grep -F -c "image: \"${expected_image}\"" "$tmp_dir/default.yaml")" -eq 3
+fi
+grep -q 'k8s-inventory-full-sync-interval: "10m"' "$tmp_dir/default.yaml"
+grep -q 'k8s-metrics-timeout: "15s"' "$tmp_dir/default.yaml"
+grep -q 'k8s-metrics-push-timeout: "30s"' "$tmp_dir/default.yaml"
+grep -q 'k8s-metrics-sample-limit: "250000"' "$tmp_dir/default.yaml"
+grep -q 'k8s-metrics-batch-sample-limit: "10000"' "$tmp_dir/default.yaml"
+grep -q 'k8s-metrics-batch-byte-limit: "4194304"' "$tmp_dir/default.yaml"
+grep -q 'name: ONGRID_K8S_METRICS_TIMEOUT' "$tmp_dir/default.yaml"
+grep -q 'name: ONGRID_K8S_METRICS_PUSH_TIMEOUT' "$tmp_dir/default.yaml"
+grep -q 'name: ONGRID_K8S_METRICS_SAMPLE_LIMIT' "$tmp_dir/default.yaml"
+grep -q 'name: ONGRID_K8S_METRICS_BATCH_SAMPLE_LIMIT' "$tmp_dir/default.yaml"
+grep -q 'name: ONGRID_K8S_METRICS_BATCH_BYTE_LIMIT' "$tmp_dir/default.yaml"
+grep -A1 'name: ONGRID_K8S_TELEMETRY_CONFIG_REFRESH_INTERVAL' "$tmp_dir/default.yaml" | grep -q 'value: "1m"'
+grep -q 'hostNetwork: true' "$tmp_dir/default.yaml"
+grep -q 'name: install-host-runtime' "$tmp_dir/default.yaml"
+grep -q -- '- install-k8s-host-runtime' "$tmp_dir/default.yaml"
+grep -A16 'name: install-host-runtime' "$tmp_dir/default.yaml" | grep -q 'memory: 128Mi'
+grep -q -- '- enter-k8s-host' "$tmp_dir/default.yaml"
+test "$(grep -F -c 'mountPath: /host/root' "$tmp_dir/default.yaml")" -eq 2
+grep -q 'mountPropagation: HostToContainer' "$tmp_dir/default.yaml"
+grep -A1 'name: ONGRID_EDGE_COLLECTOR_MODE' "$tmp_dir/default.yaml" | grep -q 'value: "off"'
+grep -q 'add: \["CHOWN", "DAC_OVERRIDE", "FOWNER"\]' "$tmp_dir/default.yaml"
+grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"\]' "$tmp_dir/default.yaml"
+! grep -q 'SYS_ADMIN\|SYS_PTRACE' "$tmp_dir/default.yaml"
+! grep -q 'privileged: true' "$tmp_dir/default.yaml"
+! grep -q 'supplementalGroups:' "$tmp_dir/default.yaml"
+! grep -q '^data:' "$tmp_dir/telemetry-secret.yaml"
+
+helm template split "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.mode=deployment \
+  --set kubernetesMetrics.mode=scraper \
+  >"$tmp_dir/split.yaml"
+extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/split.yaml" "$tmp_dir/split-controller.yaml"
+extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/split.yaml" "$tmp_dir/scraper.yaml"
+grep -q '# Source: ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/split.yaml"
+grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/split.yaml"
+! grep -q 'ONGRID_K8S_TELEMETRY_GATEWAY_ENABLED\|ONGRID_K8S_METRICS_ENDPOINT\|containerPort: 4317\|containerPort: 4318' "$tmp_dir/split-controller.yaml"
+grep -A1 'name: ONGRID_K8S_TELEMETRY_REQUIRED' "$tmp_dir/split-controller.yaml" | grep -q 'value: "true"'
+grep -q 'replicas: 1' "$tmp_dir/scraper.yaml"
+grep -q 'automountServiceAccountToken: false' "$tmp_dir/scraper.yaml"
+! grep -q 'telemetry-access-key\|telemetry-secret-key\|telemetry-traces-endpoint\|telemetry-logs-endpoint' "$tmp_dir/scraper.yaml"
+
+helm template paused "$chart_package" "${common_args[@]}" \
+  --set kubernetesMetrics.mode=controller \
+  --set kubernetesMetrics.enabled=false \
+  >"$tmp_dir/paused.yaml"
+extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/paused.yaml" "$tmp_dir/paused-controller.yaml"
+! grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/paused.yaml"
+! grep -q 'ONGRID_K8S_METRICS_ENDPOINT' "$tmp_dir/paused-controller.yaml"
+grep -A1 'name: ONGRID_K8S_TELEMETRY_REQUIRED' "$tmp_dir/paused-controller.yaml" | grep -q 'value: "false"'
+
+helm template hpa "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.mode=deployment \
+  --set telemetryGateway.autoscaling.enabled=true \
+  >"$tmp_dir/hpa.yaml"
+grep -q '# Source: ongrid-edge/templates/telemetry-gateway-policy.yaml' "$tmp_dir/hpa.yaml"
+grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/hpa.yaml"
+grep -q 'averageValue: 600Mi' "$tmp_dir/hpa.yaml"
+
+expect_template_failure 'kubernetesMetrics.mode must be controller or scraper' \
+  helm template invalid-mode "$chart_package" "${common_args[@]}" --set kubernetesMetrics.mode=invalid
+expect_template_failure 'kubernetesMetrics.replicas must be 1' \
+  helm template invalid-scraper "$chart_package" "${common_args[@]}" --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.replicas=2
+expect_template_failure 'telemetryGateway.replicas must be at least 2' \
+  helm template invalid-gateway "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.replicas=1
+expect_template_failure 'telemetryGateway.memoryLimiter.limitMiB must be at most 80%' \
+  helm template invalid-limiter "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.memoryLimiter.limitMiB=900
+expect_template_failure 'telemetryGateway.batch requires 0 < sendSize <= maxSize <= 4096' \
+  helm template invalid-batch "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.batch.maxSize=5000
+expect_template_failure 'targetMemoryAverageValue must be below the memory_limiter soft limit' \
+  helm template invalid-hpa "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.targetMemoryAverageValue=650Mi
+
+echo "Kubernetes Helm chart validation passed"

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -58,7 +58,12 @@ grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/default.yaml"
 grep -q 'minReplicas: 2' "$tmp_dir/default.yaml"
 grep -q 'maxReplicas: 10' "$tmp_dir/default.yaml"
 grep -q 'averageUtilization: 60' "$tmp_dir/default.yaml"
-grep -q 'averageValue: 600Mi' "$tmp_dir/default.yaml"
+grep -q 'averageValue: 512Mi' "$tmp_dir/default.yaml"
+grep -A12 '^    scaleUp:' "$tmp_dir/default.yaml" | grep -q 'value: 100'
+grep -A12 '^    scaleUp:' "$tmp_dir/default.yaml" | grep -q 'value: 4'
+grep -A8 '^    scaleDown:' "$tmp_dir/default.yaml" | grep -q 'stabilizationWindowSeconds: 300'
+grep -A8 '^    scaleDown:' "$tmp_dir/default.yaml" | grep -q 'value: 1'
+grep -A8 '^    scaleDown:' "$tmp_dir/default.yaml" | grep -q 'periodSeconds: 60'
 ! grep -q '^  replicas:' "$tmp_dir/default-gateway.yaml"
 ! grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/default.yaml"
 ! grep -q 'ONGRID_K8S_METRICS_ENDPOINT\|containerPort: 4317\|containerPort: 4318' "$tmp_dir/default-controller.yaml"
@@ -208,12 +213,18 @@ helm template hpa "$chart_package" "${common_args[@]}" \
   --set telemetryGateway.autoscaling.enabled=true \
   --set telemetryGateway.autoscaling.minReplicas=3 \
   --set telemetryGateway.autoscaling.maxReplicas=12 \
+  --set telemetryGateway.autoscaling.scaleDownStabilizationWindowSeconds=0 \
+  --set telemetryGateway.autoscaling.scaleDownMaxPods=2 \
+  --set telemetryGateway.autoscaling.scaleDownPeriodSeconds=120 \
   >"$tmp_dir/hpa.yaml"
 grep -q '# Source: ongrid-edge/templates/telemetry-gateway-policy.yaml' "$tmp_dir/hpa.yaml"
 grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/hpa.yaml"
 grep -q 'minReplicas: 3' "$tmp_dir/hpa.yaml"
 grep -q 'maxReplicas: 12' "$tmp_dir/hpa.yaml"
-grep -q 'averageValue: 600Mi' "$tmp_dir/hpa.yaml"
+grep -q 'averageValue: 512Mi' "$tmp_dir/hpa.yaml"
+grep -A8 '^    scaleDown:' "$tmp_dir/hpa.yaml" | grep -q 'stabilizationWindowSeconds: 0'
+grep -A8 '^    scaleDown:' "$tmp_dir/hpa.yaml" | grep -q 'value: 2'
+grep -A8 '^    scaleDown:' "$tmp_dir/hpa.yaml" | grep -q 'periodSeconds: 120'
 
 helm template fixed-gateway "$chart_package" "${common_args[@]}" \
   --set telemetryGateway.autoscaling.enabled=false \
@@ -232,8 +243,16 @@ expect_template_failure 'telemetryGateway.memoryLimiter.limitMiB must be at most
   helm template invalid-limiter "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.memoryLimiter.limitMiB=900
 expect_template_failure 'telemetryGateway.batch requires 0 < sendSize <= maxSize <= 4096' \
   helm template invalid-batch "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.batch.maxSize=5000
-expect_template_failure 'targetMemoryAverageValue must be below the memory_limiter soft limit' \
-  helm template invalid-hpa "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.targetMemoryAverageValue=650Mi
+expect_template_failure 'targetMemoryAverageValue must be positive and at most 80% of the memory_limiter soft limit' \
+  helm template invalid-hpa-memory "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.targetMemoryAverageValue=600Mi
+expect_template_failure 'targetCPUUtilizationPercentage must be between 1 and 100' \
+  helm template invalid-hpa-cpu "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.targetCPUUtilizationPercentage=0
+expect_template_failure 'scaleDownMaxPods must be at least 1' \
+  helm template invalid-hpa-scale-down-pods "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.scaleDownMaxPods=-1
+expect_template_failure 'scaleDownStabilizationWindowSeconds must be between 0 and 3600' \
+  helm template invalid-hpa-scale-down-window "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.scaleDownStabilizationWindowSeconds=3601
+expect_template_failure 'scaleDownPeriodSeconds must be between 1 and 1800' \
+  helm template invalid-hpa-scale-down-period "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.scaleDownPeriodSeconds=1801
 expect_template_failure 'upgrade.migrationHook.timeout must be a whole second, minute, or hour duration' \
   helm template invalid-upgrade-timeout "$chart_package" "${common_args[@]}" --is-upgrade --set upgrade.migrationHook.timeout=1m30s
 

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -42,11 +42,19 @@ helm lint "$chart_dir" "${common_args[@]}"
 
 helm template ongrid-edge "$chart_package" "${common_args[@]}" >"$tmp_dir/default.yaml"
 extract_source 'ongrid-edge/templates/telemetry-credentials-secret.yaml' "$tmp_dir/default.yaml" "$tmp_dir/telemetry-secret.yaml"
+extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-controller.yaml"
+extract_source 'ongrid-edge/templates/telemetry-gateway-service.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway-service.yaml"
 grep -q 'type: Recreate' "$tmp_dir/default.yaml"
 ! grep -q 'kubernetes.io/arch:' "$tmp_dir/default.yaml"
 if [[ -n "$expected_image" ]]; then
-  test "$(grep -F -c "image: \"${expected_image}\"" "$tmp_dir/default.yaml")" -eq 3
+  test "$(grep -F -c "image: \"${expected_image}\"" "$tmp_dir/default.yaml")" -eq 5
 fi
+grep -q '# Source: ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/default.yaml"
+grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml"
+! grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/default.yaml"
+! grep -q 'ONGRID_K8S_METRICS_ENDPOINT\|containerPort: 4317\|containerPort: 4318' "$tmp_dir/default-controller.yaml"
+grep -q 'ongrid.io/telemetry-backend: "false"' "$tmp_dir/default-controller.yaml"
+grep -q 'ongrid.io/telemetry-backend: "true"' "$tmp_dir/default-gateway-service.yaml"
 grep -q 'k8s-inventory-full-sync-interval: "10m"' "$tmp_dir/default.yaml"
 grep -q 'k8s-metrics-timeout: "15s"' "$tmp_dir/default.yaml"
 grep -q 'k8s-metrics-push-timeout: "30s"' "$tmp_dir/default.yaml"
@@ -74,6 +82,17 @@ grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "
 ! grep -q 'supplementalGroups:' "$tmp_dir/default.yaml"
 ! grep -q '^data:' "$tmp_dir/telemetry-secret.yaml"
 
+helm template compatibility "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.mode=embedded \
+  --set kubernetesMetrics.mode=controller \
+  >"$tmp_dir/compatibility.yaml"
+extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/compatibility.yaml" "$tmp_dir/compatibility-controller.yaml"
+! grep -q '# Source: ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/compatibility.yaml"
+! grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/compatibility.yaml"
+grep -q 'ONGRID_K8S_METRICS_ENDPOINT' "$tmp_dir/compatibility-controller.yaml"
+grep -q 'containerPort: 4317' "$tmp_dir/compatibility-controller.yaml"
+grep -q 'ongrid.io/telemetry-backend: "true"' "$tmp_dir/compatibility-controller.yaml"
+
 helm template split "$chart_package" "${common_args[@]}" \
   --set telemetryGateway.mode=deployment \
   --set kubernetesMetrics.mode=scraper \
@@ -88,7 +107,21 @@ grep -q 'replicas: 1' "$tmp_dir/scraper.yaml"
 grep -q 'automountServiceAccountToken: false' "$tmp_dir/scraper.yaml"
 ! grep -q 'telemetry-access-key\|telemetry-secret-key\|telemetry-traces-endpoint\|telemetry-logs-endpoint' "$tmp_dir/scraper.yaml"
 
+helm template upgrade "$chart_package" "${common_args[@]}" --is-upgrade >"$tmp_dir/upgrade.yaml"
+grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/upgrade.yaml"
+test "$(grep -F -c 'helm.sh/hook: pre-upgrade' "$tmp_dir/upgrade.yaml")" -eq 4
+grep -q 'activeDeadlineSeconds: 480' "$tmp_dir/upgrade.yaml"
+grep -q -- '- prepare-k8s-upgrade' "$tmp_dir/upgrade.yaml"
+grep -q -- '- --gateway-mode=deployment' "$tmp_dir/upgrade.yaml"
+grep -q -- '- --metrics-mode=scraper' "$tmp_dir/upgrade.yaml"
+
+helm template upgrade-hook-disabled "$chart_package" "${common_args[@]}" --is-upgrade \
+  --set upgrade.migrationHook.enabled=false \
+  >"$tmp_dir/upgrade-hook-disabled.yaml"
+! grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/upgrade-hook-disabled.yaml"
+
 helm template paused "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.mode=embedded \
   --set kubernetesMetrics.mode=controller \
   --set kubernetesMetrics.enabled=false \
   >"$tmp_dir/paused.yaml"
@@ -117,5 +150,7 @@ expect_template_failure 'telemetryGateway.batch requires 0 < sendSize <= maxSize
   helm template invalid-batch "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.batch.maxSize=5000
 expect_template_failure 'targetMemoryAverageValue must be below the memory_limiter soft limit' \
   helm template invalid-hpa "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=true --set telemetryGateway.autoscaling.targetMemoryAverageValue=650Mi
+expect_template_failure 'upgrade.migrationHook.timeout must be a whole second, minute, or hour duration' \
+  helm template invalid-upgrade-timeout "$chart_package" "${common_args[@]}" --is-upgrade --set upgrade.migrationHook.timeout=1m30s
 
 echo "Kubernetes Helm chart validation passed"

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -45,6 +45,7 @@ extract_source 'ongrid-edge/templates/telemetry-credentials-secret.yaml' "$tmp_d
 extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-controller.yaml"
 extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-node.yaml"
 extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-scraper.yaml"
+extract_source 'ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-service.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway-service.yaml"
 grep -q 'type: Recreate' "$tmp_dir/default.yaml"
 ! grep -q 'kubernetes.io/arch:' "$tmp_dir/default.yaml"
@@ -53,6 +54,12 @@ if [[ -n "$expected_image" ]]; then
 fi
 grep -q '# Source: ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/default.yaml"
 grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml"
+grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/default.yaml"
+grep -q 'minReplicas: 2' "$tmp_dir/default.yaml"
+grep -q 'maxReplicas: 10' "$tmp_dir/default.yaml"
+grep -q 'averageUtilization: 60' "$tmp_dir/default.yaml"
+grep -q 'averageValue: 600Mi' "$tmp_dir/default.yaml"
+! grep -q '^  replicas:' "$tmp_dir/default-gateway.yaml"
 ! grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/default.yaml"
 ! grep -q 'ONGRID_K8S_METRICS_ENDPOINT\|containerPort: 4317\|containerPort: 4318' "$tmp_dir/default-controller.yaml"
 grep -q 'ongrid.io/telemetry-backend: "false"' "$tmp_dir/default-controller.yaml"
@@ -199,17 +206,28 @@ grep -A1 'name: ONGRID_K8S_TELEMETRY_REQUIRED' "$tmp_dir/paused-controller.yaml"
 helm template hpa "$chart_package" "${common_args[@]}" \
   --set telemetryGateway.mode=deployment \
   --set telemetryGateway.autoscaling.enabled=true \
+  --set telemetryGateway.autoscaling.minReplicas=3 \
+  --set telemetryGateway.autoscaling.maxReplicas=12 \
   >"$tmp_dir/hpa.yaml"
 grep -q '# Source: ongrid-edge/templates/telemetry-gateway-policy.yaml' "$tmp_dir/hpa.yaml"
 grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/hpa.yaml"
+grep -q 'minReplicas: 3' "$tmp_dir/hpa.yaml"
+grep -q 'maxReplicas: 12' "$tmp_dir/hpa.yaml"
 grep -q 'averageValue: 600Mi' "$tmp_dir/hpa.yaml"
+
+helm template fixed-gateway "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.autoscaling.enabled=false \
+  >"$tmp_dir/fixed-gateway.yaml"
+extract_source 'ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/fixed-gateway.yaml" "$tmp_dir/fixed-gateway-deployment.yaml"
+! grep -q 'kind: HorizontalPodAutoscaler' "$tmp_dir/fixed-gateway.yaml"
+grep -q '^  replicas: 2' "$tmp_dir/fixed-gateway-deployment.yaml"
 
 expect_template_failure 'kubernetesMetrics.mode must be controller or scraper' \
   helm template invalid-mode "$chart_package" "${common_args[@]}" --set kubernetesMetrics.mode=invalid
 expect_template_failure 'kubernetesMetrics.replicas must be 1' \
   helm template invalid-scraper "$chart_package" "${common_args[@]}" --set kubernetesMetrics.mode=scraper --set kubernetesMetrics.replicas=2
 expect_template_failure 'telemetryGateway.replicas must be at least 2' \
-  helm template invalid-gateway "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.replicas=1
+  helm template invalid-gateway "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.autoscaling.enabled=false --set telemetryGateway.replicas=1
 expect_template_failure 'telemetryGateway.memoryLimiter.limitMiB must be at most 80%' \
   helm template invalid-limiter "$chart_package" "${common_args[@]}" --set telemetryGateway.mode=deployment --set telemetryGateway.memoryLimiter.limitMiB=900
 expect_template_failure 'telemetryGateway.batch requires 0 < sendSize <= maxSize <= 4096' \

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -43,6 +43,8 @@ helm lint "$chart_dir" "${common_args[@]}"
 helm template ongrid-edge "$chart_package" "${common_args[@]}" >"$tmp_dir/default.yaml"
 extract_source 'ongrid-edge/templates/telemetry-credentials-secret.yaml' "$tmp_dir/default.yaml" "$tmp_dir/telemetry-secret.yaml"
 extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-controller.yaml"
+extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-node.yaml"
+extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-scraper.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-service.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway-service.yaml"
 grep -q 'type: Recreate' "$tmp_dir/default.yaml"
 ! grep -q 'kubernetes.io/arch:' "$tmp_dir/default.yaml"
@@ -55,6 +57,13 @@ grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_
 ! grep -q 'ONGRID_K8S_METRICS_ENDPOINT\|containerPort: 4317\|containerPort: 4318' "$tmp_dir/default-controller.yaml"
 grep -q 'ongrid.io/telemetry-backend: "false"' "$tmp_dir/default-controller.yaml"
 grep -q 'ongrid.io/telemetry-backend: "true"' "$tmp_dir/default-gateway-service.yaml"
+test "$(grep -F -c 'checksum/config:' "$tmp_dir/default.yaml")" -eq 3
+grep -q 'checksum/controller-bootstrap:' "$tmp_dir/default-controller.yaml"
+grep -q 'checksum/node-bootstrap:' "$tmp_dir/default.yaml"
+# kube-state-metrics, the telemetry gateway k8sattributes processor, and the
+# controller each need the same read-only workload ownership resources.
+test "$(grep -F -c 'resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]' "$tmp_dir/default.yaml")" -ge 3
+test "$(grep -F -c 'resources: ["jobs", "cronjobs"]' "$tmp_dir/default.yaml")" -ge 3
 grep -q 'k8s-inventory-full-sync-interval: "10m"' "$tmp_dir/default.yaml"
 grep -q 'k8s-metrics-timeout: "15s"' "$tmp_dir/default.yaml"
 grep -q 'k8s-metrics-push-timeout: "30s"' "$tmp_dir/default.yaml"
@@ -105,7 +114,64 @@ grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_
 grep -A1 'name: ONGRID_K8S_TELEMETRY_REQUIRED' "$tmp_dir/split-controller.yaml" | grep -q 'value: "true"'
 grep -q 'replicas: 1' "$tmp_dir/scraper.yaml"
 grep -q 'automountServiceAccountToken: false' "$tmp_dir/scraper.yaml"
+grep -q 'name: ONGRID_K8S_APP_METRICS_DISCOVERY' "$tmp_dir/scraper.yaml"
 ! grep -q 'telemetry-access-key\|telemetry-secret-key\|telemetry-traces-endpoint\|telemetry-logs-endpoint' "$tmp_dir/scraper.yaml"
+
+# Values persisted by Charts before kubernetesMetrics existed must continue to
+# drive the standalone Scraper after --reset-then-reuse-values.
+helm template legacy-external "$chart_package" "${common_args[@]}" \
+  --set kubeStateMetrics.enabled=false \
+  --set controller.metrics.enabled=true \
+  --set-string controller.metrics.endpoint=http://metrics.monitoring.svc:9090/metrics \
+  --set-string controller.metrics.interval=2m \
+  --set-string controller.metrics.timeout=45s \
+  --set-string controller.metrics.pushTimeout=1m \
+  --set controller.metrics.sampleLimit=123456 \
+  --set controller.metrics.batchSampleLimit=4321 \
+  --set controller.metrics.batchByteLimit=2097152 \
+  >"$tmp_dir/legacy-external.yaml"
+grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-endpoint: "http://metrics.monitoring.svc:9090/metrics"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-interval: "2m"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-timeout: "45s"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-push-timeout: "1m"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-sample-limit: "123456"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-batch-sample-limit: "4321"' "$tmp_dir/legacy-external.yaml"
+grep -q 'k8s-metrics-batch-byte-limit: "2097152"' "$tmp_dir/legacy-external.yaml"
+
+helm template explicit-new-metrics "$chart_package" "${common_args[@]}" \
+  --set-string controller.metrics.interval=2m \
+  --set-string kubernetesMetrics.interval=45s \
+  >"$tmp_dir/explicit-new-metrics.yaml"
+grep -q 'k8s-metrics-interval: "45s"' "$tmp_dir/explicit-new-metrics.yaml"
+
+helm template legacy-disabled "$chart_package" "${common_args[@]}" \
+  --set kubeStateMetrics.enabled=false \
+  --set controller.metrics.enabled=false \
+  >"$tmp_dir/legacy-disabled.yaml"
+! grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/legacy-disabled.yaml"
+
+helm template legacy-app-discovery "$chart_package" "${common_args[@]}" \
+  --set kubeStateMetrics.enabled=false \
+  --set controller.metrics.appDiscovery.enabled=true \
+  >"$tmp_dir/legacy-app-discovery.yaml"
+extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/legacy-app-discovery.yaml" "$tmp_dir/legacy-app-scraper.yaml"
+grep -q 'k8s-metrics-endpoint: ""' "$tmp_dir/legacy-app-discovery.yaml"
+grep -q 'k8s-app-metrics-discovery: "true"' "$tmp_dir/legacy-app-discovery.yaml"
+grep -q 'automountServiceAccountToken: true' "$tmp_dir/legacy-app-scraper.yaml"
+grep -q 'ongrid-edge-metrics-scraper-discovery' "$tmp_dir/legacy-app-discovery.yaml"
+
+# A Scraper-only tuning change must restart the Scraper without needlessly
+# recycling the cluster-wide Controller or every node Agent.
+helm template metrics-config-change "$chart_package" "${common_args[@]}" \
+  --set-string kubernetesMetrics.endpoint=http://metrics.monitoring.svc:9090/metrics \
+  >"$tmp_dir/metrics-config-change.yaml"
+extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/metrics-config-change.yaml" "$tmp_dir/metrics-config-controller.yaml"
+extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/metrics-config-change.yaml" "$tmp_dir/metrics-config-node.yaml"
+extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/metrics-config-change.yaml" "$tmp_dir/metrics-config-scraper.yaml"
+test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-controller.yaml")" = "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-controller.yaml")"
+test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-node.yaml")" = "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-node.yaml")"
+test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-scraper.yaml")" != "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-scraper.yaml")"
 
 helm template upgrade "$chart_package" "${common_args[@]}" --is-upgrade >"$tmp_dir/upgrade.yaml"
 grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/upgrade.yaml"

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -28,7 +28,7 @@ const cluster = {
   inventory_sync_duration_ms: 51,
   created_at: '2026-06-29T09:00:00Z',
   updated_at: '2026-06-29T10:00:00Z',
-  upgrade_command: "helm upgrade ongrid-edge 'oci://helm.cnb.cool/ongridio/ongrid-edge' --version '0.10.0' --namespace 'ongrid-system' --reuse-values --set-string manager.publicURL='https://manager.example' --set-string manager.tunnelAddr='manager.example:40012' --set-string manager.tlsInsecure=true",
+  upgrade_command: "helm upgrade ongrid-edge 'oci://helm.cnb.cool/ongridio/ongrid-edge' --version '0.10.0' --namespace 'ongrid-system' --reset-then-reuse-values --set-string manager.publicURL='https://manager.example' --set-string manager.tunnelAddr='manager.example:40012' --set-string manager.tlsInsecure=true --wait --wait-for-jobs --atomic --timeout '15m'",
 };
 
 function ChatStateProbe() {
@@ -460,13 +460,15 @@ describe('KubernetesPage', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: '升级命令' }));
 
-    expect(screen.getByText('Helm 升级命令')).toBeInTheDocument();
+    expect(screen.getByText('一键 Helm 升级')).toBeInTheDocument();
     const command = screen.getByText(/helm upgrade ongrid-edge/);
     expect(command).toHaveTextContent("'oci://helm.cnb.cool/ongridio/ongrid-edge'");
     expect(command).toHaveTextContent("--version '0.10.0'");
     expect(command).toHaveTextContent("--namespace 'ongrid-system'");
-    expect(command).toHaveTextContent('--reuse-values');
+    expect(command).toHaveTextContent('--reset-then-reuse-values');
     expect(command).toHaveTextContent("manager.tunnelAddr='manager.example:40012'");
+    expect(command).toHaveTextContent('--wait-for-jobs');
+    expect(command).toHaveTextContent('--atomic');
   });
 
   it('已恢复的 Warning Event 不进入健康结论和异常线索', async () => {

--- a/web/src/pages/kubernetes/KubernetesLifecycleModals.tsx
+++ b/web/src/pages/kubernetes/KubernetesLifecycleModals.tsx
@@ -98,13 +98,13 @@ export function UpgradeCommandModal({
   const { tr } = useI18n();
   if (!cluster) return null;
   return (
-    <Modal open onClose={onClose} title={tr('Helm 升级命令', 'Helm upgrade command')} size="lg">
+    <Modal open onClose={onClose} title={tr('一键 Helm 升级', 'One-command Helm upgrade')} size="lg">
       <div className="space-y-3 text-xs">
         <ClusterIdentity cluster={cluster} />
         <div className="rounded-md border border-sky-500/20 bg-sky-500/10 px-2 py-1.5 text-sky-200">
           {tr(
-            '在目标 Kubernetes 集群执行该命令，会复用现有 Helm values，并从 CNB 公共镜像仓库拉取新版多架构镜像后滚动升级 Controller 与 Node Edge。',
-            'Run this in the target Kubernetes cluster. It reuses existing Helm values, pulls the new multi-arch image from the public CNB registry, and rolls both Controller and Node Edge agents.',
+            '在目标 Kubernetes 集群执行这一条命令即可（需要 Helm 3.14+）。Chart 会先采用新版默认值、再合并现有自定义 values，自动完成必要的数据面迁移和健康检查；失败时自动回滚。仅更新镜像的版本不会重复执行迁移。',
+            'Run this single command in the target Kubernetes cluster (Helm 3.14+ required). The chart starts from the new defaults, reapplies existing custom values, performs any required data-plane migration and health checks, and rolls back automatically on failure. Image-only upgrades do not repeat completed migrations.',
           )}
         </div>
         <CommandBlock label={tr('升级命令', 'Upgrade command')} command={kubernetesUpgradeCommand(cluster)} />


### PR DESCRIPTION
## Summary

- separate Kubernetes telemetry ingestion from the single Controller by moving OTLP traffic to a horizontally scalable Telemetry Gateway
- move kube-state-metrics scraping to a single-active Metrics Scraper that writes directly through Prometheus remote_write instead of the Controller tunnel
- keep the Controller focused on enrollment, heartbeat, Kubernetes inventory watch/query, and approved cluster actions
- add bounded data-plane resources, scoped credentials, health checks, rollout modes, and an idempotent Helm pre-upgrade migration hook
- generate one atomic Helm 3.14+ upgrade command that applies new chart defaults, preserves existing custom values, waits for jobs and workloads, and rolls back on failure

## Root cause

The Kubernetes Controller previously hosted both the control plane and telemetry data plane in one Pod and cgroup. OTLP throughput, Collector queues and Kubernetes metadata caches therefore competed directly with inventory watches and control-plane RPCs, causing the repeated OOM kills reported in #235.

Kubernetes state metrics also traveled as JSON `push_prom_samples` calls over the same tunnel used by heartbeat. Large writes could monopolize the connection and delay heartbeat and re-registration until the Controller restarted, as reported in #239. Batching reduced individual payload size but did not remove this head-of-line contention.

## Impact

- normal installs and upgrades use `telemetryGateway.mode=deployment` and `kubernetesMetrics.mode=scraper`
- OTLP traces, logs and metrics no longer consume Controller memory or CPU
- kube-state-metrics samples no longer use the Controller tunnel; direct protobuf + Snappy remote_write failures are isolated to the Metrics Scraper
- the existing OTLP Service DNS remains stable across the hand-off
- explicit `embedded` and `controller` compatibility modes remain available for emergency rollback
- already migrated, image-only upgrades run state checks without patching or restarting the Controller unnecessarily

Fixes #235
Fixes #239

## Validation

- `go test -race ./internal/edgeagent/k8s ./cmd/ongrid-edge ./internal/manager/biz/k8s`
- `go vet ./internal/edgeagent/k8s ./cmd/ongrid-edge ./internal/manager/biz/k8s`
- `make test-k8s-chart`
- `npm test -- --run src/pages/Kubernetes.test.tsx` (28 tests)
- `npm run typecheck`
- `npx eslint src/pages/Kubernetes.test.tsx src/pages/kubernetes/KubernetesLifecycleModals.tsx --report-unused-disable-directives --max-warnings 0`
- `git diff --check`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
