### PR TITLE
fix(llm): support fixed-temperature Kimi models

### DIFF
--- a/internal/pkg/llm/client.go
+++ b/internal/pkg/llm/client.go
@@ -590,6 +590,7 @@ func fromOpenAIMessage(m openai.ChatCompletionMessage) (Message, error) {
 // Covered families:
 //   - OpenAI o-series: o1, o1-mini, o3, o3-mini, o4-mini, …
 //   - GPT-5 family: gpt-5, gpt-5.5, gpt-5-mini, gpt-5.6-sol, … (all reasoning)
+//   - Kimi K2/K3 families: kimi-k2.5, kimi-k2.6, kimi-k3, …
 //   - Any name tagged "reasoner"/"reasoning" (e.g. deepseek-reasoner)
 func isReasoningModel(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
@@ -602,6 +603,8 @@ func isReasoningModel(model string) bool {
 	case strings.HasPrefix(m, "o1-") || strings.HasPrefix(m, "o3-") || strings.HasPrefix(m, "o4-"):
 		return true
 	case strings.HasPrefix(m, "gpt-5"):
+		return true
+	case strings.HasPrefix(m, "kimi-k2") || strings.HasPrefix(m, "kimi-k3"):
 		return true
 	case strings.Contains(m, "reasoner") || strings.Contains(m, "reasoning"):
 		return true
@@ -649,6 +652,7 @@ func isSamplingParamError(err error) bool {
 		return false
 	}
 	return strings.Contains(msg, "fixed at 1") ||
+		strings.Contains(msg, "only 1 is allowed") ||
 		strings.Contains(msg, "beta-limitations") ||
 		strings.Contains(msg, "only the default") ||
 		strings.Contains(msg, "does not support") ||

--- a/internal/pkg/llm/client_test.go
+++ b/internal/pkg/llm/client_test.go
@@ -314,30 +314,42 @@ func TestTemperatureDefault(t *testing.T) {
 	}
 }
 
-// TestReasoningModelOmitsTemperature — a reasoning model (gpt-5.x) must NOT
-// carry a temperature: the SDK's omitempty drops the zero value so the
+// TestReasoningModelOmitsTemperature — fixed-sampling reasoning models must
+// NOT carry a temperature: the SDK's omitempty drops the zero value so the
 // provider applies its fixed default (1) instead of 400-ing on 0.1.
 func TestReasoningModelOmitsTemperature(t *testing.T) {
-	var present bool
-	_, cfg := fakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		// Probe the raw body: a present key means we sent it, even if 0.
-		var probe map[string]json.RawMessage
-		_ = json.Unmarshal(raw, &probe)
-		_, present = probe["temperature"]
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(sampleChatResponse("ok", nil))
-	})
-	client := newTestClient(t, cfg, nil)
-	_, err := client.Chat(context.Background(), ChatReq{
-		Model:    "gpt-5.5",
-		Messages: []Message{{Role: "user", Content: "hi"}},
-	})
-	if err != nil {
-		t.Fatalf("Chat: %v", err)
-	}
-	if present {
-		t.Errorf("temperature was sent for a reasoning model, want omitted")
+	for _, model := range []string{"gpt-5.5", "kimi-k2.5", "kimi-k2.6", "kimi-k3"} {
+		t.Run(model, func(t *testing.T) {
+			var present bool
+			_, cfg := fakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+				raw, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+					return
+				}
+				// Probe the raw body: a present key means we sent it, even if 0.
+				var probe map[string]json.RawMessage
+				if err := json.Unmarshal(raw, &probe); err != nil {
+					t.Errorf("decode request body: %v", err)
+					return
+				}
+				_, present = probe["temperature"]
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(sampleChatResponse("ok", nil))
+			})
+			client := newTestClient(t, cfg, nil)
+			_, err := client.Chat(context.Background(), ChatReq{
+				Model:       model,
+				Messages:    []Message{{Role: "user", Content: "hi"}},
+				Temperature: 0.1,
+			})
+			if err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+			if present {
+				t.Errorf("temperature was sent for model %q, want omitted", model)
+			}
+		})
 	}
 }
 
@@ -397,9 +409,16 @@ func TestSamplingErrorTriggersRetry(t *testing.T) {
 	}
 }
 
+func TestIsSamplingParamError_KimiOnlyOneAllowed(t *testing.T) {
+	err := errors.New("error, status code: 400, status: 400 Bad Request, message: invalid temperature: only 1 is allowed for this model")
+	if !isSamplingParamError(err) {
+		t.Fatal("isSamplingParamError returned false for Kimi fixed-temperature error")
+	}
+}
+
 // TestIsReasoningModel spot-checks the name heuristic.
 func TestIsReasoningModel(t *testing.T) {
-	reasoning := []string{"gpt-5", "gpt-5.5", "gpt-5.6-sol", "GPT-5-mini", "o1", "o1-mini", "o3-mini", "o4-mini", "deepseek-reasoner"}
+	reasoning := []string{"gpt-5", "gpt-5.5", "gpt-5.6-sol", "GPT-5-mini", "o1", "o1-mini", "o3-mini", "o4-mini", "deepseek-reasoner", "kimi-k2.5", "KIMI-K2.6", "kimi-k3"}
 	for _, m := range reasoning {
 		if !isReasoningModel(m) {
 			t.Errorf("isReasoningModel(%q) = false, want true", m)


### PR DESCRIPTION
## Summary

- omit fixed sampling parameters for Kimi K2 and K3 model families so chat requests do not fail with HTTP 400
- recognize Kimi's `only 1 is allowed` response and retry unknown future aliases without sampling overrides
- cover Kimi K2.5, K2.6, K3, and the provider-specific fallback error in unit tests

Closes #219

## Validation

- `go test -race ./internal/pkg/llm`
- `go vet ./internal/pkg/llm`
- `go test ./cmd/... ./internal/... ./tests/...`
- `make build-ongrid`
- local end-to-end chat with Kimi K2.5
- live provider check confirming Kimi K3 rejects `temperature: 0.1` and accepts an omitted temperature

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
