### PR TITLE
fix(web): improve high-cardinality metric charts

### DIFF
--- a/web/src/pages/EdgeDetail.test.tsx
+++ b/web/src/pages/EdgeDetail.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import EdgeDetailPage, {
+  calculateTooltipYDomain,
+  findNearestTooltipEntry,
+} from './EdgeDetail';
+import { server } from '@/test/msw-server';
+
+const CPU_SERIES = Array.from({ length: 496 }, (_, cpu) => ({
+  metric: { device_id: '586', cpu: String(cpu) },
+  values: [
+    [1_785_217_600, '20'],
+    [1_785_217_660, '21'],
+  ] as [number, string][],
+}));
+
+function useMetricsSeries(series = CPU_SERIES) {
+  server.use(
+    http.get('/api/v1/metrics/query_range', ({ request }) => {
+      const expr = new URL(request.url).searchParams.get('expr') ?? '';
+      return HttpResponse.json({
+        resolution: '1m',
+        from: '2026-07-28T00:00:00Z',
+        to: '2026-07-28T06:00:00Z',
+        matrix: expr.includes('node_cpu_seconds_total') ? series : [],
+      });
+    }),
+  );
+}
+
+function renderDeviceMetrics() {
+  render(
+    <MemoryRouter initialEntries={['/devices/586']}>
+      <Routes>
+        <Route path="/devices/:edgeId" element={<EdgeDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+describe('EdgeDetailPage high-cardinality metrics', () => {
+  beforeEach(() => {
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    server.use(
+      http.get('/api/v1/devices/586', () =>
+        HttpResponse.json({
+          id: 586,
+          name: 'Issue #238 - 496-core chart repro',
+          hostname: 'issue-238-496core',
+          cpu_count: 496,
+          online: true,
+        }),
+      ),
+      http.get('/api/v1/devices/586/edges', () => HttpResponse.json({ items: [] })),
+    );
+    useMetricsSeries();
+  });
+
+  it('在图表外完整展示 496 条 CPU 图例并保持自然数字顺序', async () => {
+    renderDeviceMetrics();
+
+    const heading = await screen.findByRole('heading', { name: 'CPU 利用率（按核）' });
+    const panel = heading.closest('section');
+    expect(panel).not.toBeNull();
+
+    const numericLegendButtons = () =>
+      within(panel as HTMLElement)
+        .queryAllByRole('button')
+        .filter((button) => /^\d+$/.test(button.textContent?.trim() ?? ''));
+
+    await waitFor(() => expect(numericLegendButtons()).toHaveLength(496));
+    expect(numericLegendButtons().map((button) => button.textContent)).toEqual(
+      Array.from({ length: 496 }, (_, cpu) => String(cpu)),
+    );
+    expect(
+      within(panel as HTMLElement).queryByRole('button', { name: '下一组序列' }),
+    ).not.toBeInTheDocument();
+
+    const legend = within(panel as HTMLElement).getByRole('group', { name: '序列图例' });
+    const chart = legend.previousElementSibling;
+    expect(chart).not.toBeNull();
+    expect(chart).toHaveClass('h-60');
+  });
+
+  it('按只看、切换、恢复循环切换序列状态', async () => {
+    useMetricsSeries(CPU_SERIES.slice(0, 3));
+    renderDeviceMetrics();
+
+    const heading = await screen.findByRole('heading', { name: 'CPU 利用率（按核）' });
+    const panel = heading.closest('section');
+    expect(panel).not.toBeNull();
+
+    await waitFor(() =>
+      expect(
+        within(panel as HTMLElement).getByRole('button', { name: '0 · 正常' }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(within(panel as HTMLElement).getByRole('button', { name: '0 · 正常' }));
+    await waitFor(() =>
+      expect(
+        within(panel as HTMLElement).getByRole('button', { name: '0 · 已选中' }),
+      ).toHaveAttribute('aria-pressed', 'true'),
+    );
+
+    fireEvent.click(within(panel as HTMLElement).getByRole('button', { name: '1 · 正常' }));
+    await waitFor(() =>
+      expect(
+        within(panel as HTMLElement).getByRole('button', { name: '1 · 已选中' }),
+      ).toHaveAttribute('aria-pressed', 'true'),
+    );
+    expect(
+      within(panel as HTMLElement).getByRole('button', { name: '0 · 正常' }),
+    ).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(within(panel as HTMLElement).getByRole('button', { name: '1 · 已选中' }));
+    await waitFor(() =>
+      expect(
+        within(panel as HTMLElement).getByRole('button', { name: '1 · 正常' }),
+      ).toHaveAttribute('aria-pressed', 'false'),
+    );
+  });
+});
+
+describe('findNearestTooltipEntry', () => {
+  it('自动纵轴使用实际数据范围而不是强制从零开始', () => {
+    const rows = [
+      { ts: 1, tsLabel: '00:01', netRx_eth0: 80, netRx_eth1: 90 },
+      { ts: 2, tsLabel: '00:02', netRx_eth0: 85, netRx_eth1: 95 },
+    ];
+    const series = [
+      { key: 'netRx_eth0', label: 'eth0', color: '#000' },
+      { key: 'netRx_eth1', label: 'eth1', color: '#fff' },
+    ];
+
+    expect(calculateTooltipYDomain(rows, series)).toEqual([80, 95]);
+  });
+
+  it('只返回鼠标纵向位置最近的序列', () => {
+    const payload = [
+      { dataKey: 'cpu_20', value: 20 },
+      { dataKey: 'cpu_80', value: 80 },
+    ];
+
+    expect(findNearestTooltipEntry(payload, 22, { y: 0, height: 100 }, [0, 100])).toEqual(
+      payload[1],
+    );
+    expect(findNearestTooltipEntry(payload, 79, { y: 0, height: 100 }, [0, 100])).toEqual(
+      payload[0],
+    );
+  });
+});

--- a/web/src/pages/EdgeDetail.tsx
+++ b/web/src/pages/EdgeDetail.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-  Legend,
+  type TooltipProps,
 } from 'recharts';
 import {
   ChevronLeft,
@@ -109,6 +109,12 @@ type PanelData = {
   series: SeriesDescriptor[];
 };
 
+type TooltipEntry = {
+  color?: string;
+  dataKey?: string | number;
+  value?: unknown;
+};
+
 type PanelKey = 'cpu' | 'disk' | 'netRx' | 'netTx';
 
 const EMPTY_PANEL: PanelData = { rows: [], series: [] };
@@ -132,11 +138,11 @@ export default function EdgeDetailPage() {
   });
   const [metricsErr, setMetricsErr] = useState<string | null>(null);
   const [promErr, setPromErr] = useState<string | null>(null);
-  const [hidden, setHidden] = useState<Record<PanelKey, Set<string>>>({
-    cpu: new Set(),
-    disk: new Set(),
-    netRx: new Set(),
-    netTx: new Set(),
+  const [selectedSeriesKeys, setSelectedSeriesKeys] = useState<Record<PanelKey, string | null>>({
+    cpu: null,
+    disk: null,
+    netRx: null,
+    netTx: null,
   });
 
   const [tab, setTab] = useState<Tab>('metrics');
@@ -305,12 +311,10 @@ export default function EdgeDetailPage() {
   );
 
   const toggleSeries = (panel: PanelKey, key: string) => {
-    setHidden((prev) => {
-      const nextSet = new Set(prev[panel]);
-      if (nextSet.has(key)) nextSet.delete(key);
-      else nextSet.add(key);
-      return { ...prev, [panel]: nextSet };
-    });
+    setSelectedSeriesKeys((prev) => ({
+      ...prev,
+      [panel]: prev[panel] === key ? null : key,
+    }));
   };
 
   const displayName = device?.name || device?.hostname || edge?.name || edgeId;
@@ -383,7 +387,7 @@ export default function EdgeDetailPage() {
                 subtitle={tr('最近 6 小时 · 1m 粒度 · 每条线 = 一个 cpu', 'Last 6h · 1m step · one line per CPU')}
                 icon={Cpu}
                 panel={panels.cpu}
-                hidden={hidden.cpu}
+                selectedSeriesKey={selectedSeriesKeys.cpu}
                 onToggle={(k) => toggleSeries('cpu', k)}
                 formatValue={(v) => `${v.toFixed(1)}%`}
                 yDomain={[0, 100]}
@@ -397,7 +401,7 @@ export default function EdgeDetailPage() {
                 subtitle={tr('最近 6 小时 · 1m 粒度 · 每条线 = 一个物理设备', 'Last 6h · 1m step · one line per physical device')}
                 icon={HardDrive}
                 panel={panels.disk}
-                hidden={hidden.disk}
+                selectedSeriesKey={selectedSeriesKeys.disk}
                 onToggle={(k) => toggleSeries('disk', k)}
                 formatValue={(v) => `${v.toFixed(1)}%`}
                 yDomain={[0, 100]}
@@ -413,7 +417,7 @@ export default function EdgeDetailPage() {
                 subtitle={tr('最近 6 小时 · 1m 粒度 · 每条线 = 一个 device · bytes/s', 'Last 6h · 1m step · one line per device · bytes/s')}
                 icon={ArrowDownRight}
                 panel={panels.netRx}
-                hidden={hidden.netRx}
+                selectedSeriesKey={selectedSeriesKeys.netRx}
                 onToggle={(k) => toggleSeries('netRx', k)}
                 formatValue={formatBytesPerSec}
                 onOpenDrilldown={
@@ -428,7 +432,7 @@ export default function EdgeDetailPage() {
                 subtitle={tr('最近 6 小时 · 1m 粒度 · 每条线 = 一个 device · bytes/s', 'Last 6h · 1m step · one line per device · bytes/s')}
                 icon={ArrowUpRight}
                 panel={panels.netTx}
-                hidden={hidden.netTx}
+                selectedSeriesKey={selectedSeriesKeys.netTx}
                 onToggle={(k) => toggleSeries('netTx', k)}
                 formatValue={formatBytesPerSec}
                 onOpenDrilldown={
@@ -511,7 +515,12 @@ function matrixToPanel(
       const key = `${panelKey}_${labelVal}`;
       return { labelVal, key, raw: s };
     })
-    .sort((a, b) => a.labelVal.localeCompare(b.labelVal))
+    .sort((a, b) =>
+      a.labelVal.localeCompare(b.labelVal, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      }),
+    )
     .map((entry, idx) => ({
       key: entry.key,
       label: entry.labelVal,
@@ -583,7 +592,7 @@ function MultiLinePanel({
   subtitle,
   icon: Icon,
   panel,
-  hidden,
+  selectedSeriesKey,
   onToggle,
   formatValue,
   yDomain,
@@ -593,14 +602,22 @@ function MultiLinePanel({
   subtitle: string;
   icon: typeof Cpu;
   panel: PanelData;
-  hidden: Set<string>;
+  selectedSeriesKey: string | null;
   onToggle(key: string): void;
   formatValue(v: number): string;
   yDomain?: [number, number];
   onOpenDrilldown?(): void;
 }) {
   const { tr } = useI18n();
-  const visibleSeries = panel.series.filter((s) => !hidden.has(s.key));
+  const visibleSeries = useMemo(() => {
+    if (!selectedSeriesKey) return panel.series;
+    const selectedSeries = panel.series.find((series) => series.key === selectedSeriesKey);
+    return selectedSeries ? [selectedSeries] : panel.series;
+  }, [panel.series, selectedSeriesKey]);
+  const tooltipYDomain = useMemo(
+    () => calculateTooltipYDomain(panel.rows, visibleSeries, yDomain),
+    [panel.rows, visibleSeries, yDomain],
+  );
 
   return (
     <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
@@ -626,35 +643,6 @@ function MultiLinePanel({
         )}
       </div>
 
-      {panel.series.length > 0 && (
-        <div className="mb-3 flex flex-wrap gap-x-3 gap-y-1.5">
-          {panel.series.map((s) => {
-            const isHidden = hidden.has(s.key);
-            return (
-              <button
-                key={s.key}
-                type="button"
-                onClick={() => onToggle(s.key)}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] transition-colors',
-                  isHidden
-                    ? 'text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
-                    : 'text-zinc-300 hover:bg-zinc-800/60',
-                )}
-              >
-                <span
-                  className="h-2 w-3 rounded-sm"
-                  style={{ backgroundColor: isHidden ? '#3f3f46' : s.color }}
-                />
-                <span className={cn('font-mono', isHidden && 'line-through decoration-zinc-600')}>
-                  {s.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-
       <div className="h-60 w-full">
         {panel.rows.length === 0 || panel.series.length === 0 ? (
           <div className="flex h-full items-center justify-center text-xs text-zinc-500">
@@ -679,28 +667,13 @@ function MultiLinePanel({
                 tickFormatter={(v) => formatValue(v as number)}
               />
               <Tooltip
-                contentStyle={{
-                  background: '#0a0a0aee',
-                  border: '1px solid #27272a',
-                  borderRadius: 8,
-                  fontSize: 12,
-                  color: '#e4e4e7',
-                  padding: '8px 10px',
-                }}
-                labelStyle={{ color: '#a1a1aa', marginBottom: 4 }}
-                itemStyle={{ padding: '1px 0' }}
-                formatter={(value, name) => {
-                  const desc = panel.series.find((s) => s.key === String(name));
-                  return [formatValue(value as number), desc?.label ?? String(name)];
-                }}
-              />
-              <Legend
-                wrapperStyle={{ fontSize: 10, color: '#a1a1aa', paddingTop: 8 }}
-                iconType="plainline"
-                formatter={(value) => {
-                  const desc = panel.series.find((s) => s.key === String(value));
-                  return desc?.label ?? String(value);
-                }}
+                content={
+                  <SingleSeriesTooltip
+                    series={visibleSeries}
+                    yDomain={tooltipYDomain}
+                    formatValue={formatValue}
+                  />
+                }
               />
               {visibleSeries.map((s) => (
                 <Line
@@ -712,8 +685,9 @@ function MultiLinePanel({
                   type="linear"
                   dataKey={s.key}
                   stroke={s.color}
-                  strokeWidth={1.4}
+                  strokeWidth={s.key === selectedSeriesKey ? 2.6 : 1.4}
                   dot={false}
+                  activeDot={false}
                   // false on purpose: gaps in the underlying Prom data
                   // (manager outages / scrape failures) MUST render as
                   // breaks, not silently get connected. Matches the
@@ -726,7 +700,145 @@ function MultiLinePanel({
           </ResponsiveContainer>
         )}
       </div>
+
+      {panel.series.length > 0 && (
+        <div
+          role="group"
+          aria-label={tr('序列图例', 'Series legend')}
+          className="mt-3 flex flex-wrap gap-x-3 gap-y-1.5"
+        >
+          {panel.series.map((s) => {
+            const isSelected = s.key === selectedSeriesKey;
+            const stateLabel = isSelected ? tr('已选中', 'Selected') : tr('正常', 'Normal');
+            return (
+              <button
+                key={s.key}
+                type="button"
+                aria-label={`${s.label} · ${stateLabel}`}
+                aria-pressed={isSelected}
+                title={tr(
+                  '点击只看此序列；再次点击恢复全部',
+                  'Click to show only this series; click again to restore all',
+                )}
+                onClick={() => onToggle(s.key)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-[11px] transition-colors',
+                  isSelected
+                    ? 'border-indigo-400/50 bg-indigo-500/15 text-indigo-700 dark:text-indigo-200'
+                    : 'border-transparent text-zinc-300 hover:bg-zinc-800/60',
+                )}
+              >
+                <span
+                  className={cn('h-2 w-3 rounded-sm', isSelected && 'ring-1 ring-indigo-300')}
+                  style={{ backgroundColor: s.color }}
+                />
+                <span className="font-mono">{s.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </section>
+  );
+}
+
+export function calculateTooltipYDomain(
+  rows: ChartRow[],
+  series: SeriesDescriptor[],
+  fixedDomain?: [number, number],
+): [number, number] {
+  if (fixedDomain) return fixedDomain;
+
+  // The network panels use Recharts' automatic numeric domain. Derive the
+  // same data span here instead of assuming a zero baseline, otherwise a
+  // tightly clustered positive range can select the wrong hovered line.
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const row of rows) {
+    for (const descriptor of series) {
+      const value = row[descriptor.key];
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [0, 1];
+  if (min === max) {
+    const padding = Math.abs(min) * 0.01 || 1;
+    return [min - padding, max + padding];
+  }
+  return [min, max];
+}
+
+export function findNearestTooltipEntry(
+  payload: ReadonlyArray<TooltipEntry>,
+  cursorY: number | undefined,
+  viewBox: { y?: number; height?: number } | undefined,
+  yDomain: [number, number],
+): TooltipEntry | null {
+  const entries = payload.filter((entry) => Number.isFinite(Number(entry.value)));
+  if (entries.length === 0) return null;
+
+  const top = viewBox?.y;
+  const height = viewBox?.height;
+  if (cursorY === undefined || top === undefined || !height) return entries[0];
+
+  const [domainMin, domainMax] = yDomain;
+  const domainRange = domainMax - domainMin || 1;
+  let nearest = entries[0];
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const entry of entries) {
+    const value = Number(entry.value);
+    const lineY = top + ((domainMax - value) / domainRange) * height;
+    const distance = Math.abs(lineY - cursorY);
+    if (distance < nearestDistance) {
+      nearest = entry;
+      nearestDistance = distance;
+    }
+  }
+  return nearest;
+}
+
+function SingleSeriesTooltip({
+  active,
+  payload,
+  label,
+  coordinate,
+  viewBox,
+  series,
+  yDomain,
+  formatValue,
+}: TooltipProps<number, string> & {
+  series: SeriesDescriptor[];
+  yDomain: [number, number];
+  formatValue(value: number): string;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const entry = findNearestTooltipEntry(payload, coordinate?.y, viewBox, yDomain);
+  if (!entry) return null;
+  const value = Number(entry.value);
+  const descriptor = series.find((item) => item.key === String(entry.dataKey));
+
+  return (
+    <div
+      role="tooltip"
+      className="pointer-events-none min-w-32 rounded-lg border border-zinc-700 bg-zinc-950/95 px-2.5 py-2 text-xs text-white shadow-xl"
+    >
+      <div className="mb-1.5 text-[11px] text-zinc-400">{String(label ?? '')}</div>
+      <div className="flex items-center gap-2">
+        <span
+          className="h-2 w-2 shrink-0 rounded-sm"
+          style={{ backgroundColor: entry.color ?? descriptor?.color ?? '#a1a1aa' }}
+        />
+        <span className="min-w-0 flex-1 truncate font-mono">
+          {descriptor?.label ?? String(entry.dataKey ?? '')}
+        </span>
+        <span className="shrink-0 font-mono tabular-nums text-white">
+          {formatValue(value)}
+        </span>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- keep high-cardinality metric charts at a stable height and render the complete, naturally sorted series legend below the chart
- use Grafana-style legend interaction: click to isolate one series, click another to switch, and click the active series again to restore all
- show only the series nearest to the pointer in the tooltip and keep automatic tooltip scaling accurate for network metrics
- add regression coverage for a 496-core device, legend interaction, and tooltip selection

## Root cause

The built-in Recharts legend and shared tooltip competed with the plotting area as series cardinality grew, causing the chart to be squeezed and hover details to become unusable.

## Validation

- `npm test -- --run` (96 tests passed)
- `npm run typecheck`
- `npm run build`
- `npx eslint src/pages/EdgeDetail.tsx src/pages/EdgeDetail.test.tsx`
- browser verification with 496 CPU series in light and dark themes; observed line counts `496 -> 1 -> 1 -> 496` and no console errors

Closes #238

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
