### PR TITLE
fix(install): validate detected public URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
+        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh deploy/install/public-url.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-public-url.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
 
       - name: Verify Compose image routing
         run: make verify-compose-images

--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,8 @@ package-all: ## [release] 打 amd64 + arm64 两个生产安装包到 dist/out/
 		[ -f "$$f" ] && cat "$$f"; \
 	done
 
-test-release-package: ## [test] 校验发布包仅支持 Compose 且不含 Manager systemd 文件
+test-release-package: ## [test] 校验安装 URL 与 Compose 发布包内容
+	bash scripts/test-public-url.sh
 	bash scripts/test-compose-release-package.sh
 
 .PHONY: dist-clean

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -23,6 +23,14 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+PUBLIC_URL_LIB="$SCRIPT_DIR/public-url.sh"
+if [[ ! -r "$PUBLIC_URL_LIB" ]]; then
+    log_error "install package is missing public-url.sh"
+    exit 1
+fi
+# shellcheck source=public-url.sh
+source "$PUBLIC_URL_LIB"
+
 generate_self_signed_tls_cert() {
     local cert_dir="$1"
     local cert_file="$cert_dir/tls.crt"
@@ -623,33 +631,21 @@ fi
 # (10.0.4.17 et al), which remote edges cannot route to. We try each big
 # cloud's metadata service in turn (they NAT the public/EIP onto the host),
 # then a couple of public probes, then fall back to the internal-IP guess.
-detect_public_ip() {
-    local ip=""
-    # Tencent Cloud
-    ip=$(curl -sS --max-time 2 http://metadata.tencentyun.com/latest/meta-data/public-ipv4 2>/dev/null || true)
-    if [[ -n "$ip" && "$ip" != "null" ]]; then echo "$ip"; return; fi
-    # Aliyun (EIP)
-    ip=$(curl -sS --max-time 2 http://100.100.100.200/latest/meta-data/eipv4 2>/dev/null || true)
-    if [[ -n "$ip" ]]; then echo "$ip"; return; fi
-    # AWS / GCP / Azure (IMDSv1; AWS v2 needs a token but most VMs still allow v1)
-    ip=$(curl -sS --max-time 2 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)
-    if [[ -n "$ip" ]]; then echo "$ip"; return; fi
-    # Public probe (last network-resort)
-    ip=$(curl -sS --max-time 3 https://api.ipify.org 2>/dev/null || true)
-    if [[ -n "$ip" ]]; then echo "$ip"; return; fi
-    ip=$(curl -sS --max-time 3 https://ifconfig.me 2>/dev/null || true)
-    if [[ -n "$ip" ]]; then echo "$ip"; return; fi
-    # Internal-IP fallback (preserves old behaviour)
-    ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' || true)
-    echo "$ip"
-}
-
 if is_blank ONGRID_PUBLIC_URL; then
     # ---- best-guess default host: cloud metadata → public probe → internal NIC ----
-    HOST_FOR_URL="$(detect_public_ip | tr -d '[:space:]')"
+    HOST_FOR_URL="$(ongrid_detect_public_ipv4 || true)"
+    if [[ -z "$HOST_FOR_URL" ]]; then
+        route_ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' || true)
+        route_ip=$(printf '%s' "$route_ip" | tr -d '[:space:]')
+        if ongrid_is_valid_ipv4 "$route_ip"; then
+            HOST_FOR_URL="$route_ip"
+        fi
+    fi
     if [[ -z "$HOST_FOR_URL" ]]; then
         if h=$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -v '^127\.' | grep -v '^$' | head -1); then
-            HOST_FOR_URL="$h"
+            if ongrid_is_valid_ipv4 "$h"; then
+                HOST_FOR_URL="$h"
+            fi
         fi
     fi
     if [[ -z "$HOST_FOR_URL" ]]; then
@@ -685,8 +681,20 @@ the detected default, or type the correct address." \
         log_warn "no interactive terminal and ONGRID_PUBLIC_URL unset; auto-set to ${RESOLVED_PUBLIC_URL}"
         log_warn "if that is an INTERNAL address your remote edges can't reach, edit ${ENV_FILE} and restart"
     fi
+    if ! ongrid_is_valid_public_url "$RESOLVED_PUBLIC_URL"; then
+        log_error "invalid ONGRID_PUBLIC_URL; expected http(s)://host[:port]"
+        log_error "set a URL reachable from edge nodes and re-run sudo ./install.sh"
+        exit 1
+    fi
     fill_blank ONGRID_PUBLIC_URL "$RESOLVED_PUBLIC_URL"
     log_info "ONGRID_PUBLIC_URL=${RESOLVED_PUBLIC_URL} (edit .env to change)"
+fi
+
+CONFIGURED_PUBLIC_URL=$(grep -E '^ONGRID_PUBLIC_URL=' "$ENV_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)
+if ! ongrid_is_valid_public_url "$CONFIGURED_PUBLIC_URL"; then
+    log_error "invalid ONGRID_PUBLIC_URL in ${ENV_FILE}; expected http(s)://host[:port]"
+    log_error "set a URL reachable from edge nodes and re-run sudo ./install.sh"
+    exit 1
 fi
 ensure_tunnel_addr_env
 

--- a/deploy/install/public-url.sh
+++ b/deploy/install/public-url.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Shared ONGRID_PUBLIC_URL validation and public IPv4 detection helpers.
+# Keep this file compatible with Bash 4.2 (the default on CentOS 7).
+
+ongrid_is_valid_ipv4() {
+    local value="${1:-}" octet
+    local -a octets
+
+    [[ "$value" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+    IFS=. read -r -a octets <<<"$value"
+    [[ ${#octets[@]} -eq 4 ]] || return 1
+
+    for octet in "${octets[@]}"; do
+        (( 10#$octet <= 255 )) || return 1
+    done
+    return 0
+}
+
+ongrid_fetch_public_ipv4() {
+    local url="$1" timeout_seconds="${2:-3}" candidate
+
+    # -f rejects HTTP 4xx/5xx bodies. The format check below also rejects
+    # proxies or metadata services that return an HTML error with status 200.
+    candidate=$(curl -fsS --max-time "$timeout_seconds" "$url" 2>/dev/null || true)
+    candidate=$(printf '%s' "$candidate" | tr -d '[:space:]')
+    ongrid_is_valid_ipv4 "$candidate" || return 1
+    printf '%s' "$candidate"
+}
+
+ongrid_detect_public_ipv4() {
+    local timeout_seconds url candidate
+
+    while IFS='|' read -r timeout_seconds url; do
+        candidate=$(ongrid_fetch_public_ipv4 "$url" "$timeout_seconds" || true)
+        if [[ -n "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done <<'EOF'
+2|http://metadata.tencentyun.com/latest/meta-data/public-ipv4
+2|http://100.100.100.200/latest/meta-data/eipv4
+2|http://169.254.169.254/latest/meta-data/public-ipv4
+3|https://api.ipify.org
+3|https://ifconfig.me
+EOF
+
+    return 1
+}
+
+ongrid_is_valid_public_url() {
+    local value="${1:-}" rest authority host port="" label
+    local -a labels
+
+    case "$value" in
+        http://*)  rest=${value#http://} ;;
+        https://*) rest=${value#https://} ;;
+        *) return 1 ;;
+    esac
+
+    # PublicURL is later concatenated with fixed data-plane paths. Reject
+    # whitespace, HTML, fragments, queries and credentials up front.
+    [[ -n "$rest" ]] || return 1
+    [[ "$value" != *[[:space:]]* ]] || return 1
+    [[ "$value" != *'<'* && "$value" != *'>'* ]] || return 1
+    [[ "$value" != *'"'* && "$value" != *"'"* && "$value" != *'`'* ]] || return 1
+    [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
+
+    authority=${rest%%/*}
+    [[ -n "$authority" && "$authority" != *'@'* ]] || return 1
+
+    if [[ "$authority" == \[* ]]; then
+        [[ "$authority" =~ ^\[([0-9A-Fa-f:.]+)\](:([0-9]{1,5}))?$ ]] || return 1
+        host=${BASH_REMATCH[1]}
+        port=${BASH_REMATCH[3]:-}
+        [[ "$host" == *:* ]] || return 1
+    else
+        [[ "$authority" != *:*:* ]] || return 1
+        if [[ "$authority" == *:* ]]; then
+            host=${authority%%:*}
+            port=${authority##*:}
+            [[ -n "$port" ]] || return 1
+        else
+            host=$authority
+        fi
+
+        [[ -n "$host" ]] || return 1
+        if [[ "$host" =~ ^[0-9.]+$ ]]; then
+            ongrid_is_valid_ipv4 "$host" || return 1
+        else
+            [[ "$host" != .* && "$host" != *. && "$host" != *..* ]] || return 1
+            IFS=. read -r -a labels <<<"$host"
+            for label in "${labels[@]}"; do
+                [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$ ]] || return 1
+            done
+        fi
+    fi
+
+    if [[ -n "$port" ]]; then
+        [[ "$port" =~ ^[0-9]{1,5}$ ]] || return 1
+        (( 10#$port >= 1 && 10#$port <= 65535 )) || return 1
+    fi
+    return 0
+}

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -18,6 +18,14 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+PUBLIC_URL_LIB="$SCRIPT_DIR/public-url.sh"
+if [[ ! -r "$PUBLIC_URL_LIB" ]]; then
+    log_error "upgrade package is missing public-url.sh"
+    exit 1
+fi
+# shellcheck source=public-url.sh
+source "$PUBLIC_URL_LIB"
+
 generate_self_signed_tls_cert() {
     local cert_dir="$1"
     local cert_file="$cert_dir/tls.crt"
@@ -213,6 +221,16 @@ MIGRATION_HELPER_IMAGE="docker.cnb.cool/ongridio/ongrid:${NEW_VERSION}"
 
 OLD_VERSION=$(grep -E '^ONGRID_VERSION=' "$ENV_FILE" | cut -d= -f2- | tr -d '[:space:]' || true)
 log_info "old version: ${OLD_VERSION:-unknown}"
+
+# Reject malformed values before pulling images or stopping the current stack.
+# Empty remains supported for legacy installs that intentionally disable the
+# data plane; install.sh always writes a non-empty value for new installs.
+CONFIGURED_PUBLIC_URL=$(grep -E '^ONGRID_PUBLIC_URL=' "$ENV_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)
+if [[ -n "$CONFIGURED_PUBLIC_URL" ]] && ! ongrid_is_valid_public_url "$CONFIGURED_PUBLIC_URL"; then
+    log_error "invalid ONGRID_PUBLIC_URL in ${ENV_FILE}; expected http(s)://host[:port]"
+    log_error "correct it before retrying; the existing stack was not stopped"
+    exit 1
+fi
 
 # Validate the new Compose model and pull every exact image before stopping the
 # existing stack. Registry or manifest failures therefore leave the old version

--- a/dist/package.sh
+++ b/dist/package.sh
@@ -106,6 +106,7 @@ copy_opt "${REPO_ROOT}/deploy/install/README.md"           "${STAGE_DIR}/README.
 copy_opt "${REPO_ROOT}/deploy/install/install.sh"          "${STAGE_DIR}/install.sh"          755
 copy_opt "${REPO_ROOT}/deploy/install/uninstall.sh"        "${STAGE_DIR}/uninstall.sh"        755
 copy_opt "${REPO_ROOT}/deploy/install/upgrade.sh"          "${STAGE_DIR}/upgrade.sh"          755
+copy_opt "${REPO_ROOT}/deploy/install/public-url.sh"       "${STAGE_DIR}/public-url.sh"       644
 copy_opt "${REPO_ROOT}/deploy/install/docker-compose.yml"  "${STAGE_DIR}/docker-compose.yml"
 copy_opt "${REPO_ROOT}/deploy/install/.env.example"        "${STAGE_DIR}/.env.example"
 copy_opt "${REPO_ROOT}/deploy/install/frontier.yaml"       "${STAGE_DIR}/frontier.yaml"

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -48,10 +48,16 @@ tar -tf "$archive" >"$tmp_dir/archive.list"
 for required in \
   ongrid-vtest-linux-amd64/install.sh \
   ongrid-vtest-linux-amd64/uninstall.sh \
+  ongrid-vtest-linux-amd64/upgrade.sh \
+  ongrid-vtest-linux-amd64/public-url.sh \
   ongrid-vtest-linux-amd64/docker-compose.yml \
   ongrid-vtest-linux-amd64/prometheus.yml; do
   grep -Fxq "$required" "$tmp_dir/archive.list"
 done
+
+mkdir -p "$tmp_dir/extracted"
+tar -xf "$archive" -C "$tmp_dir/extracted"
+bash "$tmp_dir/extracted/ongrid-vtest-linux-amd64/install.sh" --help >/dev/null
 
 for forbidden in \
   ongrid-vtest-linux-amd64/bin/ \

--- a/scripts/test-public-url.sh
+++ b/scripts/test-public-url.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=../deploy/install/public-url.sh
+source "$repo_root/deploy/install/public-url.sh"
+
+fail() {
+    printf 'public URL test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+for value in 0.0.0.0 10.11.1.110 203.0.113.9 255.255.255.255; do
+    ongrid_is_valid_ipv4 "$value" || fail "expected valid IPv4: $value"
+done
+
+for value in '' null 1.2.3 1.2.3.256 999.1.1.1 manager.example.com \
+    '<?xml version="1.0"?><html><title>404-Not Found</title></html>'; do
+    if ongrid_is_valid_ipv4 "$value"; then
+        fail "expected invalid IPv4: $value"
+    fi
+done
+
+for value in \
+    https://10.11.1.110 \
+    https://manager.example.com \
+    http://manager.internal:8443 \
+    https://localhost \
+    'https://[2001:db8::1]:8443' \
+    https://manager.example.com/ongrid; do
+    ongrid_is_valid_public_url "$value" || fail "expected valid public URL: $value"
+done
+
+for value in \
+    '' \
+    10.11.1.110 \
+    ftp://manager.example.com \
+    https:// \
+    https://https://manager.example.com \
+    https://999.1.1.1 \
+    https://manager.example.com: \
+    https://manager.example.com:70000 \
+    https://manager.example.com:18446744073709551617 \
+    'https://manager.example.com/path?token=secret' \
+    'https://user:password@manager.example.com' \
+    'https://<?xml version="1.0"?><html><title>404-Not Found</title></html>'; do
+    if ongrid_is_valid_public_url "$value"; then
+        fail "expected invalid public URL: $value"
+    fi
+done
+
+# Reproduce the original failure deterministically: Tencent metadata returns
+# a 404 HTML body. The detector must reject it and continue to the next valid
+# endpoint instead of placing the body into ONGRID_PUBLIC_URL.
+curl() {
+    local url=${!#}
+    case "$url" in
+        *metadata.tencentyun.com*)
+            printf '%s' '<?xml version="1.0"?><html><title>404-Not Found</title></html>'
+            ;;
+        *100.100.100.200*)
+            printf '%s' '198.51.100.42'
+            ;;
+        *)
+            return 22
+            ;;
+    esac
+}
+
+detected=$(ongrid_detect_public_ipv4)
+[[ "$detected" == 198.51.100.42 ]] || fail "expected detector to skip HTML, got: $detected"
+
+curl() {
+    printf '%s' '<html><title>404-Not Found</title></html>'
+}
+if ongrid_detect_public_ipv4 >/dev/null; then
+    fail "detector accepted an HTML response as an IPv4 address"
+fi
+unset -f curl
+
+grep -Fq 'ongrid_is_valid_public_url "$CONFIGURED_PUBLIC_URL"' \
+    "$repo_root/deploy/install/install.sh" || fail "install.sh does not validate ONGRID_PUBLIC_URL"
+grep -Fq 'ongrid_is_valid_public_url "$CONFIGURED_PUBLIC_URL"' \
+    "$repo_root/deploy/install/upgrade.sh" || fail "upgrade.sh does not validate ONGRID_PUBLIC_URL"
+
+printf 'public URL validation tests passed\n'


### PR DESCRIPTION
## Summary

- reject HTTP error pages and non-IPv4 responses from public IP discovery
- validate configured `ONGRID_PUBLIC_URL` during install and before an upgrade stops the existing stack
- preserve the existing fallback to the validated outbound interface IP when public probes fail
- bundle the shared validator and cover package extraction plus CentOS 7 compatibility

## Root cause

The installer accepted any non-empty cloud metadata response. A metadata endpoint returning a 404 HTML body was therefore written into `ONGRID_PUBLIC_URL`, and Promtail later tried to resolve the HTML prefix as a hostname.

## Validation

- `make test-release-package`
- `bash -n deploy/install/public-url.sh deploy/install/install.sh deploy/install/upgrade.sh scripts/test-public-url.sh scripts/test-compose-release-package.sh dist/package.sh`
- `docker run --platform linux/amd64 --rm -v "$PWD:/workspace:ro" -w /workspace centos:7 bash scripts/test-public-url.sh`
- `go list ./... | rg -v "/output/" | xargs go test`
- `git diff --check`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md