### PR TITLE
fix(edgeagent/k8s): CronJob status.active is []ObjectReference, not int

### DIFF
--- a/internal/edgeagent/k8s/inventory.go
+++ b/internal/edgeagent/k8s/inventory.go
@@ -1074,7 +1074,6 @@ type workloadItem struct {
 		DesiredNumberScheduled int            `json:"desiredNumberScheduled"`
 		NumberReady            int            `json:"numberReady"`
 		Succeeded              int            `json:"succeeded"`
-		Active                 int            `json:"active"`
 		Conditions             []k8sCondition `json:"conditions"`
 	} `json:"status"`
 }


### PR DESCRIPTION
## Summary

  ## Problem

  `internal/edgeagent/k8s/inventory.go` uses one shared `workloadItem` struct
  for all six workload kinds. Its `Status.Active int` field matches Job
  semantics, but **CronJob's `status.active` is `[]ObjectReference`**
  ([k8s.io/api/batch/v1](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobStatus)).

  Any cluster with an active CronJob fails to decode the batch workload list:

      json: cannot unmarshal array into Go struct field .items.status.active of type int

  One bad entry discards the **entire** inventory snapshot (nodes, pods,
  workloads) — manager shows `inventory: degraded / waiting for the first
  inventory snapshot` and the Kubernetes inventory page stays empty.

  ## Fix

  Remove the unused `Active` field. It is not referenced anywhere in the
  codebase, and unknown JSON fields are ignored during decode — so Job (int)
  and CronJob ([]ObjectReference) both parse fine afterwards.

  Verified on a live cluster (3 nodes, 7 CronJobs, 2 active): after the fix,
  controller logs `k8s inventory pushed` (nodes=3, workloads=237, pods=167)
  and manager reports `inventory: ready`.

  ## Test

  - `go build ./internal/edgeagent/k8s/`
  - `go test ./internal/edgeagent/k8s/`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
