### PR TITLE
fix: normalize Kubernetes inventory and observability probes

### DIFF
--- a/api/manager/k8s/v1/k8s.proto
+++ b/api/manager/k8s/v1/k8s.proto
@@ -195,6 +195,14 @@ message KubernetesWorkload {
     string annotations_json = 10 [json_name = "annotations_json"];
     string conditions_json = 11 [json_name = "conditions_json"];
     google.protobuf.Timestamp last_seen_at = 12 [json_name = "last_seen_at"];
+    int32 active_replicas = 13 [json_name = "active_replicas"];
+    int32 failed_replicas = 14 [json_name = "failed_replicas"];
+    string owner_kind = 15 [json_name = "owner_kind"];
+    string owner_name = 16 [json_name = "owner_name"];
+    string owner_uid = 17 [json_name = "owner_uid"];
+    int64 revision = 18 [json_name = "revision"];
+    google.protobuf.Timestamp creation_timestamp = 19 [json_name = "creation_timestamp"];
+    repeated KubernetesWorkload replica_sets = 20 [json_name = "replica_sets"];
 }
 
 message KubernetesPod {
@@ -260,6 +268,7 @@ message ListWorkloadsRequest {
     int32 offset = 5 [json_name = "offset"];
     string q = 6 [json_name = "q"];
     bool issue_only = 7 [json_name = "issue_only"];
+    bool group_replica_sets = 8 [json_name = "group_replica_sets"];
 }
 
 message ListWorkloadsResponse {

--- a/api/manager/k8s/v1/k8s.proto
+++ b/api/manager/k8s/v1/k8s.proto
@@ -126,6 +126,16 @@ message GetClusterHealthResponse {
     int64 oom_killed_pods = 4 [json_name = "oom_killed_pods"];
     int64 image_pull_back_off_pods = 5 [json_name = "image_pull_back_off_pods"];
     int64 not_ready_nodes = 6 [json_name = "not_ready_nodes"];
+    repeated KubernetesNamespaceSummary namespaces = 7 [json_name = "namespaces"];
+}
+
+message KubernetesNamespaceSummary {
+    string namespace = 1 [json_name = "namespace"];
+    int64 workloads = 2 [json_name = "workloads"];
+    int64 pods = 3 [json_name = "pods"];
+    int64 events = 4 [json_name = "events"];
+    int64 warnings = 5 [json_name = "warnings"];
+    google.protobuf.Timestamp last_seen_at = 6 [json_name = "last_seen_at"];
 }
 
 message ListEdgeAttachmentsRequest {

--- a/api/tunnel/v1/tunnel.proto
+++ b/api/tunnel/v1/tunnel.proto
@@ -214,6 +214,13 @@ message KubernetesWorkloadSnapshot {
     map<string, string> labels = 7 [json_name = "labels"];
     map<string, string> annotations = 8 [json_name = "annotations"];
     google.protobuf.ListValue conditions = 9 [json_name = "conditions"];
+    int32 active_replicas = 10 [json_name = "active_replicas"];
+    int32 failed_replicas = 11 [json_name = "failed_replicas"];
+    string owner_kind = 12 [json_name = "owner_kind"];
+    string owner_name = 13 [json_name = "owner_name"];
+    string owner_uid = 14 [json_name = "owner_uid"];
+    int64 revision = 15 [json_name = "revision"];
+    google.protobuf.Timestamp creation_timestamp = 16 [json_name = "creation_timestamp"];
 }
 
 message KubernetesPodSnapshot {

--- a/cmd/ongrid-edge/k8s_credentials.go
+++ b/cmd/ongrid-edge/k8s_credentials.go
@@ -82,6 +82,7 @@ func loadStoredK8sCredential(ctx context.Context, cfg *config.Config, info *tunn
 	}
 	cfg.Edge.AccessKey = stored.AccessKey
 	cfg.Edge.SecretKey = stored.SecretKey
+	cfg.Edge.ManagerPublicURL = strings.TrimRight(strings.TrimSpace(stored.ManagerPublicURL), "/")
 	if cfg.Edge.CloudAddr == "" && stored.CloudAddr != "" {
 		cfg.Edge.CloudAddr = stored.CloudAddr
 	}
@@ -133,7 +134,7 @@ func storeK8sCredential(ctx context.Context, info *tunnel.KubernetesInfo, out k8
 			return fmt.Errorf("kubernetes telemetry credential does not match controller cluster")
 		}
 		telemetry := *out.Telemetry
-		applyManagerTelemetryTLS(&telemetry, out.ManagerPublicURL)
+		applyManagerTelemetryTLS(&telemetry, out.ManagerPublicURL, telemetry.ManagerPublicURL)
 		telemetryClient := *client
 		if secretName := strings.TrimSpace(os.Getenv("ONGRID_K8S_TELEMETRY_SECRET")); secretName != "" {
 			telemetryClient.secretName = secretName
@@ -217,6 +218,7 @@ func loadStoredK8sCredentialFile(cfg *config.Config, info *tunnel.KubernetesInfo
 	}
 	cfg.Edge.AccessKey = stored.AccessKey
 	cfg.Edge.SecretKey = stored.SecretKey
+	cfg.Edge.ManagerPublicURL = strings.TrimRight(strings.TrimSpace(stored.ManagerPublicURL), "/")
 	if cfg.Edge.CloudAddr == "" && stored.CloudAddr != "" {
 		cfg.Edge.CloudAddr = stored.CloudAddr
 	}
@@ -479,17 +481,31 @@ func dataContainsValues(current, desired map[string][]byte) bool {
 // applyManagerTelemetryTLS carries the controller's explicit trust choice to
 // Manager-origin signals only. External backends keep the TLS policy resolved
 // by Manager from their integration settings.
-func applyManagerTelemetryTLS(in *k8sTelemetryConfig, managerURL string) {
+func applyManagerTelemetryTLS(in *k8sTelemetryConfig, managerURLs ...string) {
 	if in == nil || !parseBoolEnv("ONGRID_K8S_ENROLL_TLS_INSECURE", false) {
 		return
 	}
-	manager, managerErr := url.Parse(strings.TrimSpace(managerURL))
-	if managerErr != nil || manager.Scheme == "" || manager.Host == "" {
+	managerOrigins := make([]*url.URL, 0, len(managerURLs))
+	for _, raw := range managerURLs {
+		manager, err := url.Parse(strings.TrimSpace(raw))
+		if err == nil && manager.Scheme != "" && manager.Host != "" {
+			managerOrigins = append(managerOrigins, manager)
+		}
+	}
+	if len(managerOrigins) == 0 {
 		return
 	}
 	sameOrigin := func(raw string) bool {
 		target, err := url.Parse(strings.TrimSpace(raw))
-		return err == nil && strings.EqualFold(manager.Scheme, target.Scheme) && strings.EqualFold(manager.Host, target.Host)
+		if err != nil {
+			return false
+		}
+		for _, manager := range managerOrigins {
+			if strings.EqualFold(manager.Scheme, target.Scheme) && strings.EqualFold(manager.Host, target.Host) {
+				return true
+			}
+		}
+		return false
 	}
 	if sameOrigin(in.TracesEndpoint) {
 		in.TracesTLSInsecure = true

--- a/cmd/ongrid-edge/k8s_credentials_test.go
+++ b/cmd/ongrid-edge/k8s_credentials_test.go
@@ -42,7 +42,12 @@ func TestK8sCredentialFileRoundTrip(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "node-credential.json")
 	info := &tunnel.KubernetesInfo{ClusterID: 7, Role: "node", NodeName: "worker-a"}
 	cfg := &config.Config{Edge: config.EdgeConfig{CloudAddr: "manager:40012"}}
-	out := k8sEnrollResponse{EdgeID: 9, AccessKey: "access", SecretKey: "secret"}
+	out := k8sEnrollResponse{
+		EdgeID:           9,
+		AccessKey:        "access",
+		SecretKey:        "secret",
+		ManagerPublicURL: "https://manager.example",
+	}
 
 	if err := storeK8sCredentialFile(info, out, cfg, filePath); err != nil {
 		t.Fatalf("storeK8sCredentialFile: %v", err)
@@ -60,7 +65,8 @@ func TestK8sCredentialFileRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadStoredK8sCredentialFile: %v", err)
 	}
-	if !loaded || loadedCfg.Edge.AccessKey != "access" || loadedCfg.Edge.SecretKey != "secret" || loadedCfg.Edge.CloudAddr != "manager:40012" {
+	if !loaded || loadedCfg.Edge.AccessKey != "access" || loadedCfg.Edge.SecretKey != "secret" ||
+		loadedCfg.Edge.CloudAddr != "manager:40012" || loadedCfg.Edge.ManagerPublicURL != "https://manager.example" {
 		t.Fatalf("loaded=%v cfg=%+v", loaded, loadedCfg.Edge)
 	}
 }
@@ -169,6 +175,18 @@ func TestApplyManagerTelemetryTLSIsOriginScoped(t *testing.T) {
 	if externalTarget.TracesTLSInsecure || externalTarget.LogsTLSInsecure || externalTarget.RemoteWriteTLSInsecure {
 		t.Fatalf("external signals inherited the manager TLS setting: %#v", externalTarget)
 	}
+
+	managerAliasTarget := k8sTelemetryConfig{
+		RemoteWriteEndpoint: "https://192.168.200.1:8443/prometheus/api/v1/write",
+	}
+	applyManagerTelemetryTLS(
+		&managerAliasTarget,
+		"https://host.orb.internal:8443",
+		"https://192.168.200.1:8443",
+	)
+	if !managerAliasTarget.RemoteWriteTLSInsecure {
+		t.Fatalf("canonical manager origin did not inherit the explicit TLS setting: %#v", managerAliasTarget)
+	}
 }
 
 func TestDataContainsValuesRequiresProjectedEmptyKeys(t *testing.T) {
@@ -244,6 +262,7 @@ func TestK8sSecretClientDataKeyRoundTrip(t *testing.T) {
 }
 
 func TestRefreshK8sTelemetryConfigPreservesCurrentCredentialProof(t *testing.T) {
+	t.Setenv("ONGRID_K8S_ENROLL_TLS_INSECURE", "true")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/internal/k8s/telemetry-config" {
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
@@ -263,6 +282,7 @@ func TestRefreshK8sTelemetryConfigPreservesCurrentCredentialProof(t *testing.T) 
 			ClusterID:           7,
 			AccessKey:           proof["access_key"],
 			SecretKey:           proof["secret_key"],
+			ManagerPublicURL:    "https://manager.example",
 			TracesEndpoint:      "https://manager.example/v1/traces",
 			LogsEndpoint:        "https://manager.example/loki/api/v1/push",
 			RemoteWriteEndpoint: "https://manager.example/prometheus/api/v1/write",
@@ -272,14 +292,22 @@ func TestRefreshK8sTelemetryConfigPreservesCurrentCredentialProof(t *testing.T) 
 	}))
 	defer server.Close()
 
-	out, err := refreshK8sTelemetryConfig(context.Background(), &config.Config{Edge: config.EdgeConfig{
-		AccessKey: "controller-access",
-		SecretKey: "controller-secret",
-	}}, server.URL, "kt_current", "ks_current")
+	cfg := &config.Config{Edge: config.EdgeConfig{
+		AccessKey:        "controller-access",
+		SecretKey:        "controller-secret",
+		ManagerPublicURL: "https://stale-manager-alias.example",
+	}}
+	out, err := refreshK8sTelemetryConfig(context.Background(), cfg, server.URL, "kt_current", "ks_current")
 	if err != nil {
 		t.Fatalf("refreshK8sTelemetryConfig: %v", err)
 	}
 	if out.AccessKey != "kt_current" || out.SecretKey != "ks_current" {
 		t.Fatalf("refreshed credential = %#v", out)
+	}
+	if !out.TracesTLSInsecure || !out.LogsTLSInsecure || !out.RemoteWriteTLSInsecure {
+		t.Fatalf("refreshed manager-origin endpoints lost the explicit TLS policy: %#v", out)
+	}
+	if cfg.Edge.ManagerPublicURL != "https://manager.example" {
+		t.Fatalf("manager public URL = %q, want refreshed canonical URL", cfg.Edge.ManagerPublicURL)
 	}
 }

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -494,6 +494,7 @@ type k8sTelemetryConfig struct {
 	ClusterID              uint64 `json:"cluster_id"`
 	AccessKey              string `json:"access_key"`
 	SecretKey              string `json:"secret_key"`
+	ManagerPublicURL       string `json:"manager_public_url,omitempty"`
 	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
 	TracesAuthMode         string `json:"traces_auth_mode,omitempty"`
 	TracesBasicUser        string `json:"traces_basic_user,omitempty"`
@@ -624,6 +625,7 @@ func ensureK8sEnrollment(ctx context.Context, cfg *config.Config, log *slog.Logg
 	}
 	cfg.Edge.AccessKey = out.AccessKey
 	cfg.Edge.SecretKey = out.SecretKey
+	cfg.Edge.ManagerPublicURL = strings.TrimRight(strings.TrimSpace(out.ManagerPublicURL), "/")
 	if cfg.Edge.CloudAddr == "" && out.CloudAddr != "" {
 		cfg.Edge.CloudAddr = out.CloudAddr
 	}
@@ -689,7 +691,11 @@ func refreshK8sTelemetryConfig(ctx context.Context, cfg *config.Config, managerU
 	if out.ClusterID == 0 || out.AccessKey == "" || out.SecretKey == "" {
 		return nil, fmt.Errorf("k8s telemetry config response is incomplete")
 	}
-	applyManagerTelemetryTLS(&out, managerURL)
+	canonicalManagerURL := strings.TrimRight(strings.TrimSpace(out.ManagerPublicURL), "/")
+	applyManagerTelemetryTLS(&out, managerURL, cfg.Edge.ManagerPublicURL, canonicalManagerURL)
+	if canonicalManagerURL != "" {
+		cfg.Edge.ManagerPublicURL = canonicalManagerURL
+	}
 	return &out, nil
 }
 

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -983,13 +983,16 @@ func main() {
 		})
 	}
 	// Loki / Tempo URL probes — back the Integrations "测试连接" buttons.
-	// They both hit GET <url>/ready with optional basic auth + TLS-skip.
+	// Loki checks /ready; Tempo checks either a query URL or an explicit
+	// edge-facing OTLP/HTTP endpoint. Tempo's manager-side query readiness is
+	// wired separately below because standard deployments use another port.
 	lokiProbe := managerbizsetting.NewLokiURLProbe(lokiResolver)
-	tempoProbe := managerbizsetting.NewTempoURLProbe(tempoResolver)
+	tempoIngestProbe := managerbizsetting.NewTempoURLProbe(tempoResolver)
+	tempoReadinessProbe := managerbizsetting.NewTempoReadinessProbe(cfg.Traces.URL)
 	// Web search probe — same WebSearchResolver the skill uses, so a
 	// passing probe means the skill itself will work.
 	webSearchProbe := managerbizsetting.NewWebSearchProbe(managerbizsetting.NewWebSearchResolver(settingSvc))
-	integrationHandler = managerserverintegration.NewHandler(grafanaSvc, promTester, lokiProbe, tempoProbe, webSearchProbe)
+	integrationHandler = managerserverintegration.NewHandler(grafanaSvc, promTester, lokiProbe, tempoIngestProbe, webSearchProbe)
 	integrationHandler.SetLLMRouter(llmRouter)
 	integrationHandler.SetLLMProbe(managerbizsetting.NewLLMConfigurationService(llmEnvDefaults, settingSvc))
 
@@ -1729,7 +1732,7 @@ func main() {
 		Prom:      promTester,
 		Grafana:   grafanaSvc,
 		Loki:      lokiProbe,
-		Tempo:     tempoProbe,
+		Tempo:     tempoReadinessProbe,
 		Rules:     alertSvc,
 		Incidents: alertSvc,
 		Edges:     edgeSvc,

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,14 @@
+# Database migrations
+
+Production MySQL schema changes are versioned under `db/migrations` and use
+`golang-migrate` naming. Apply the expand migration before rolling out a binary
+that reads the new columns:
+
+```bash
+DB_DSN='user:password@tcp(mysql:3306)/ongrid?parseTime=true&charset=utf8mb4' make migrate-up
+```
+
+Rollback is a two-step operation: first roll the application back to a version
+that does not read the added columns, then run `make migrate-down`. Local and
+fresh single-node installs still use GORM AutoMigrate to initialize an empty
+database.

--- a/db/migrations/20260729070000_add_k8s_workload_rollout_metadata.down.sql
+++ b/db/migrations/20260729070000_add_k8s_workload_rollout_metadata.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE k8s_workloads
+    DROP INDEX idx_k8s_workloads_owner,
+    DROP COLUMN resource_created_at,
+    DROP COLUMN revision,
+    DROP COLUMN owner_uid,
+    DROP COLUMN owner_name,
+    DROP COLUMN owner_kind,
+    DROP COLUMN is_terminal_failure,
+    DROP COLUMN failed_replicas,
+    DROP COLUMN active_replicas;

--- a/db/migrations/20260729070000_add_k8s_workload_rollout_metadata.up.sql
+++ b/db/migrations/20260729070000_add_k8s_workload_rollout_metadata.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE k8s_workloads
+    ADD COLUMN active_replicas BIGINT NOT NULL DEFAULT 0 AFTER ready_replicas,
+    ADD COLUMN failed_replicas BIGINT NOT NULL DEFAULT 0 AFTER active_replicas,
+    ADD COLUMN is_terminal_failure BOOLEAN NOT NULL DEFAULT FALSE AFTER failed_replicas,
+    ADD COLUMN owner_kind VARCHAR(64) NOT NULL DEFAULT '' AFTER is_terminal_failure,
+    ADD COLUMN owner_name VARCHAR(255) NOT NULL DEFAULT '' AFTER owner_kind,
+    ADD COLUMN owner_uid VARCHAR(128) NOT NULL DEFAULT '' AFTER owner_name,
+    ADD COLUMN revision BIGINT NOT NULL DEFAULT 0 AFTER owner_uid,
+    ADD COLUMN resource_created_at DATETIME(3) NULL AFTER revision,
+    ADD INDEX idx_k8s_workloads_owner (cluster_id, owner_kind, owner_uid);

--- a/internal/edgeagent/k8s/inventory.go
+++ b/internal/edgeagent/k8s/inventory.go
@@ -604,27 +604,9 @@ func (c *apiClient) listEvents(ctx context.Context, namespace string) ([]tunnel.
 	}
 	out := make([]tunnel.KubernetesEventSnapshot, 0, len(items))
 	for _, item := range items {
-		out = append(out, tunnel.KubernetesEventSnapshot{
-			Namespace:           item.Metadata.Namespace,
-			Name:                item.Metadata.Name,
-			UID:                 item.Metadata.UID,
-			Type:                item.Type,
-			Reason:              item.Reason,
-			Message:             k8sredact.Text(item.Message),
-			InvolvedKind:        item.InvolvedObject.Kind,
-			InvolvedNamespace:   item.InvolvedObject.Namespace,
-			InvolvedName:        item.InvolvedObject.Name,
-			InvolvedUID:         item.InvolvedObject.UID,
-			SourceComponent:     item.Source.Component,
-			SourceHost:          item.Source.Host,
-			ReportingController: item.ReportingComponent,
-			ReportingInstance:   item.ReportingInstance,
-			Action:              item.Action,
-			Count:               item.Count,
-			FirstTimestamp:      item.FirstTimestamp,
-			LastTimestamp:       item.LastTimestamp,
-			EventTime:           item.EventTime,
-		})
+		snapshot := eventSnapshotFromItem(item)
+		snapshot.Message = k8sredact.Text(snapshot.Message)
+		out = append(out, snapshot)
 	}
 	return out, rv, nil
 }
@@ -1177,13 +1159,19 @@ type eventItem struct {
 		Component string `json:"component"`
 		Host      string `json:"host"`
 	} `json:"source"`
-	ReportingComponent string `json:"reportingComponent"`
-	ReportingInstance  string `json:"reportingInstance"`
-	Action             string `json:"action"`
-	Count              int    `json:"count"`
-	FirstTimestamp     string `json:"firstTimestamp"`
-	LastTimestamp      string `json:"lastTimestamp"`
-	EventTime          string `json:"eventTime"`
+	ReportingComponent string       `json:"reportingComponent"`
+	ReportingInstance  string       `json:"reportingInstance"`
+	Action             string       `json:"action"`
+	Count              int          `json:"count"`
+	FirstTimestamp     string       `json:"firstTimestamp"`
+	LastTimestamp      string       `json:"lastTimestamp"`
+	EventTime          string       `json:"eventTime"`
+	Series             *eventSeries `json:"series"`
+}
+
+type eventSeries struct {
+	Count            int    `json:"count"`
+	LastObservedTime string `json:"lastObservedTime"`
 }
 
 type containerStatus struct {

--- a/internal/edgeagent/k8s/inventory.go
+++ b/internal/edgeagent/k8s/inventory.go
@@ -819,22 +819,34 @@ func (c *apiClient) listWorkloads(ctx context.Context, group, resource, kind, na
 	if namespace != "" {
 		apiPath = "/apis/" + group + "/v1/namespaces/" + url.PathEscape(namespace) + "/" + resource
 	}
-	items, rv, err := listAllK8sItems[workloadItem](ctx, c, apiPath)
+	apiItems, rv, err := listAllK8sItems[workloadAPIItem](ctx, c, apiPath)
 	if err != nil {
 		return nil, "", err
 	}
-	out := make([]tunnel.KubernetesWorkloadSnapshot, 0, len(items))
-	for _, item := range items {
+	out := make([]tunnel.KubernetesWorkloadSnapshot, 0, len(apiItems))
+	for index, apiItem := range apiItems {
+		item, err := decodeWorkloadItem(kind, apiItem)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode %s item %d: %w", resource, index, err)
+		}
+		ownerKind, ownerName, ownerUID := controllerOwnerDetails(item.Metadata.OwnerReferences)
 		out = append(out, tunnel.KubernetesWorkloadSnapshot{
-			Kind:            kind,
-			Namespace:       item.Metadata.Namespace,
-			Name:            item.Metadata.Name,
-			UID:             item.Metadata.UID,
-			DesiredReplicas: desiredReplicas(kind, item),
-			ReadyReplicas:   readyReplicas(kind, item),
-			Labels:          k8sredact.StringMap(item.Metadata.Labels),
-			Annotations:     k8sredact.StringMap(item.Metadata.Annotations),
-			Conditions:      conditionMaps(item.Status.Conditions),
+			Kind:              kind,
+			Namespace:         item.Metadata.Namespace,
+			Name:              item.Metadata.Name,
+			UID:               item.Metadata.UID,
+			DesiredReplicas:   item.DesiredReplicas,
+			ReadyReplicas:     item.ReadyReplicas,
+			ActiveReplicas:    item.ActiveReplicas,
+			FailedReplicas:    item.FailedReplicas,
+			OwnerKind:         ownerKind,
+			OwnerName:         ownerName,
+			OwnerUID:          ownerUID,
+			Revision:          workloadRevision(item.Metadata.Annotations),
+			CreationTimestamp: item.Metadata.CreationTimestamp,
+			Labels:            k8sredact.StringMap(item.Metadata.Labels),
+			Annotations:       k8sredact.StringMap(item.Metadata.Annotations),
+			Conditions:        conditionMaps(item.Conditions),
 		})
 	}
 	return out, rv, nil
@@ -1008,13 +1020,14 @@ func watchEventError(event k8sWatchEvent) error {
 }
 
 type objectMeta struct {
-	Name            string            `json:"name"`
-	Namespace       string            `json:"namespace"`
-	UID             string            `json:"uid"`
-	ResourceVersion string            `json:"resourceVersion"`
-	Labels          map[string]string `json:"labels"`
-	Annotations     map[string]string `json:"annotations"`
-	OwnerReferences []ownerRef        `json:"ownerReferences"`
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	UID               string            `json:"uid"`
+	ResourceVersion   string            `json:"resourceVersion"`
+	CreationTimestamp *time.Time        `json:"creationTimestamp"`
+	Labels            map[string]string `json:"labels"`
+	Annotations       map[string]string `json:"annotations"`
+	OwnerReferences   []ownerRef        `json:"ownerReferences"`
 }
 
 type listMeta struct {
@@ -1025,6 +1038,7 @@ type listMeta struct {
 type ownerRef struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
+	UID        string `json:"uid"`
 	Controller *bool  `json:"controller"`
 }
 
@@ -1056,27 +1070,60 @@ type nodeItem struct {
 	} `json:"status"`
 }
 
-type workloadList struct {
-	Metadata listMeta       `json:"metadata"`
-	Items    []workloadItem `json:"items"`
+type workloadItem struct {
+	Metadata        objectMeta
+	DesiredReplicas int
+	ReadyReplicas   int
+	ActiveReplicas  int
+	FailedReplicas  int
+	Conditions      []k8sCondition
 }
 
-type workloadItem struct {
-	Metadata objectMeta `json:"metadata"`
-	Spec     struct {
-		Replicas    *int `json:"replicas"`
-		Completions *int `json:"completions"`
-	} `json:"spec"`
-	Status struct {
-		Replicas               int            `json:"replicas"`
-		ReadyReplicas          int            `json:"readyReplicas"`
-		AvailableReplicas      int            `json:"availableReplicas"`
-		DesiredNumberScheduled int            `json:"desiredNumberScheduled"`
-		NumberReady            int            `json:"numberReady"`
-		Succeeded              int            `json:"succeeded"`
-		Active                 int            `json:"active"`
-		Conditions             []k8sCondition `json:"conditions"`
-	} `json:"status"`
+type workloadAPIItem struct {
+	Metadata objectMeta      `json:"metadata"`
+	Spec     json.RawMessage `json:"spec"`
+	Status   json.RawMessage `json:"status"`
+}
+
+type replicatedWorkloadSpec struct {
+	Replicas *int `json:"replicas"`
+}
+
+type replicatedWorkloadStatus struct {
+	Replicas      int            `json:"replicas"`
+	ReadyReplicas int            `json:"readyReplicas"`
+	Conditions    []k8sCondition `json:"conditions"`
+}
+
+type daemonSetStatus struct {
+	DesiredNumberScheduled int            `json:"desiredNumberScheduled"`
+	NumberReady            int            `json:"numberReady"`
+	Conditions             []k8sCondition `json:"conditions"`
+}
+
+type jobSpec struct {
+	Completions *int `json:"completions"`
+}
+
+type jobStatus struct {
+	Active     int            `json:"active"`
+	Succeeded  int            `json:"succeeded"`
+	Failed     int            `json:"failed"`
+	Conditions []k8sCondition `json:"conditions"`
+}
+
+type objectReference struct {
+	APIVersion      string `json:"apiVersion"`
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	UID             string `json:"uid"`
+	ResourceVersion string `json:"resourceVersion"`
+	FieldPath       string `json:"fieldPath"`
+}
+
+type cronJobStatus struct {
+	Active []objectReference `json:"active"`
 }
 
 type podList struct {
@@ -1165,15 +1212,28 @@ func conditionMaps(in []k8sCondition) []map[string]string {
 }
 
 func controllerOwner(refs []ownerRef) (string, string) {
+	kind, name, _ := controllerOwnerDetails(refs)
+	return kind, name
+}
+
+func controllerOwnerDetails(refs []ownerRef) (string, string, string) {
 	if len(refs) == 0 {
-		return "", ""
+		return "", "", ""
 	}
 	for _, ref := range refs {
 		if ref.Controller != nil && *ref.Controller {
-			return ref.Kind, ref.Name
+			return ref.Kind, ref.Name, ref.UID
 		}
 	}
-	return refs[0].Kind, refs[0].Name
+	return refs[0].Kind, refs[0].Name, refs[0].UID
+}
+
+func workloadRevision(annotations map[string]string) int64 {
+	revision, err := strconv.ParseInt(strings.TrimSpace(annotations["deployment.kubernetes.io/revision"]), 10, 64)
+	if err != nil || revision < 1 {
+		return 0
+	}
+	return revision
 }
 
 func podRestartCount(items []containerStatus) int {
@@ -1199,25 +1259,79 @@ func podReason(status podStatus) string {
 	return ""
 }
 
-func desiredReplicas(kind string, item workloadItem) int {
-	if item.Spec.Replicas != nil {
-		return *item.Spec.Replicas
+func decodeWorkloadItem(kind string, apiItem workloadAPIItem) (workloadItem, error) {
+	decode := func(section string, raw json.RawMessage, dst any) error {
+		if len(raw) == 0 {
+			return nil
+		}
+		if err := json.Unmarshal(raw, dst); err != nil {
+			return fmt.Errorf("decode kubernetes %s workload %s: %w", kind, section, err)
+		}
+		return nil
 	}
-	if kind == "DaemonSet" {
-		return item.Status.DesiredNumberScheduled
-	}
-	if item.Spec.Completions != nil {
-		return *item.Spec.Completions
-	}
-	return item.Status.Replicas
-}
 
-func readyReplicas(kind string, item workloadItem) int {
-	if kind == "DaemonSet" {
-		return item.Status.NumberReady
+	switch kind {
+	case "Deployment", "StatefulSet", "ReplicaSet":
+		var spec replicatedWorkloadSpec
+		if err := decode("spec", apiItem.Spec, &spec); err != nil {
+			return workloadItem{}, err
+		}
+		var status replicatedWorkloadStatus
+		if err := decode("status", apiItem.Status, &status); err != nil {
+			return workloadItem{}, err
+		}
+		desired := status.Replicas
+		if spec.Replicas != nil {
+			desired = *spec.Replicas
+		}
+		return workloadItem{
+			Metadata:        apiItem.Metadata,
+			DesiredReplicas: desired,
+			ReadyReplicas:   status.ReadyReplicas,
+			Conditions:      status.Conditions,
+		}, nil
+	case "DaemonSet":
+		var status daemonSetStatus
+		if err := decode("status", apiItem.Status, &status); err != nil {
+			return workloadItem{}, err
+		}
+		return workloadItem{
+			Metadata:        apiItem.Metadata,
+			DesiredReplicas: status.DesiredNumberScheduled,
+			ReadyReplicas:   status.NumberReady,
+			Conditions:      status.Conditions,
+		}, nil
+	case "Job":
+		var spec jobSpec
+		if err := decode("spec", apiItem.Spec, &spec); err != nil {
+			return workloadItem{}, err
+		}
+		var status jobStatus
+		if err := decode("status", apiItem.Status, &status); err != nil {
+			return workloadItem{}, err
+		}
+		desired := 0
+		if spec.Completions != nil {
+			desired = *spec.Completions
+		}
+		return workloadItem{
+			Metadata:        apiItem.Metadata,
+			DesiredReplicas: desired,
+			ReadyReplicas:   status.Succeeded,
+			ActiveReplicas:  status.Active,
+			FailedReplicas:  status.Failed,
+			Conditions:      status.Conditions,
+		}, nil
+	case "CronJob":
+		var status cronJobStatus
+		if err := decode("status", apiItem.Status, &status); err != nil {
+			return workloadItem{}, err
+		}
+		return workloadItem{
+			Metadata:       apiItem.Metadata,
+			ActiveReplicas: len(status.Active),
+		}, nil
+	default:
+		return workloadItem{}, fmt.Errorf("unsupported kubernetes workload kind %q", kind)
 	}
-	if kind == "Job" {
-		return item.Status.Succeeded
-	}
-	return item.Status.ReadyReplicas
 }

--- a/internal/edgeagent/k8s/inventory_delta.go
+++ b/internal/edgeagent/k8s/inventory_delta.go
@@ -135,8 +135,12 @@ func (c *inventoryCache) applyWatchUpsert(spec inventoryWatchSpec, event k8sWatc
 		c.mu.Unlock()
 		trigger.events = []tunnel.KubernetesEventSnapshot{snap}
 	case watchResourceWorkloads:
-		var item workloadItem
-		if err := unmarshalWatchObject(event, &item); err != nil {
+		var apiItem workloadAPIItem
+		if err := unmarshalWatchObject(event, &apiItem); err != nil {
+			return inventoryWatchTrigger{}, err
+		}
+		item, err := decodeWorkloadItem(spec.workloadKind, apiItem)
+		if err != nil {
 			return inventoryWatchTrigger{}, err
 		}
 		snap := workloadSnapshotFromItem(spec.workloadKind, item)
@@ -246,16 +250,24 @@ func nodeSnapshotFromItem(item nodeItem) tunnel.KubernetesNodeSnapshot {
 }
 
 func workloadSnapshotFromItem(kind string, item workloadItem) tunnel.KubernetesWorkloadSnapshot {
+	ownerKind, ownerName, ownerUID := controllerOwnerDetails(item.Metadata.OwnerReferences)
 	return tunnel.KubernetesWorkloadSnapshot{
-		Kind:            kind,
-		Namespace:       item.Metadata.Namespace,
-		Name:            item.Metadata.Name,
-		UID:             item.Metadata.UID,
-		DesiredReplicas: desiredReplicas(kind, item),
-		ReadyReplicas:   readyReplicas(kind, item),
-		Labels:          item.Metadata.Labels,
-		Annotations:     item.Metadata.Annotations,
-		Conditions:      conditionMaps(item.Status.Conditions),
+		Kind:              kind,
+		Namespace:         item.Metadata.Namespace,
+		Name:              item.Metadata.Name,
+		UID:               item.Metadata.UID,
+		DesiredReplicas:   item.DesiredReplicas,
+		ReadyReplicas:     item.ReadyReplicas,
+		ActiveReplicas:    item.ActiveReplicas,
+		FailedReplicas:    item.FailedReplicas,
+		OwnerKind:         ownerKind,
+		OwnerName:         ownerName,
+		OwnerUID:          ownerUID,
+		Revision:          workloadRevision(item.Metadata.Annotations),
+		CreationTimestamp: item.Metadata.CreationTimestamp,
+		Labels:            item.Metadata.Labels,
+		Annotations:       item.Metadata.Annotations,
+		Conditions:        conditionMaps(item.Conditions),
 	}
 }
 

--- a/internal/edgeagent/k8s/inventory_delta.go
+++ b/internal/edgeagent/k8s/inventory_delta.go
@@ -303,11 +303,38 @@ func eventSnapshotFromItem(item eventItem) tunnel.KubernetesEventSnapshot {
 		ReportingController: item.ReportingComponent,
 		ReportingInstance:   item.ReportingInstance,
 		Action:              item.Action,
-		Count:               item.Count,
+		Count:               eventOccurrenceCount(item),
 		FirstTimestamp:      item.FirstTimestamp,
-		LastTimestamp:       item.LastTimestamp,
+		LastTimestamp:       eventLastObservedTimestamp(item),
 		EventTime:           item.EventTime,
 	}
+}
+
+func eventOccurrenceCount(item eventItem) int {
+	if item.Series != nil && item.Series.Count > item.Count {
+		return item.Series.Count
+	}
+	return item.Count
+}
+
+func eventLastObservedTimestamp(item eventItem) string {
+	current := strings.TrimSpace(item.LastTimestamp)
+	if item.Series == nil {
+		return current
+	}
+	candidate := strings.TrimSpace(item.Series.LastObservedTime)
+	if candidate == "" {
+		return current
+	}
+	candidateTime, err := time.Parse(time.RFC3339Nano, candidate)
+	if err != nil {
+		return current
+	}
+	currentTime, err := time.Parse(time.RFC3339Nano, current)
+	if err != nil || candidateTime.After(currentTime) {
+		return candidate
+	}
+	return current
 }
 
 func nodeSnapshotKey(item tunnel.KubernetesNodeSnapshot) string {

--- a/internal/edgeagent/k8s/inventory_resource_test.go
+++ b/internal/edgeagent/k8s/inventory_resource_test.go
@@ -164,7 +164,8 @@ func TestAPIClientListCoreResourcesDecodesResourceSchemas(t *testing.T) {
 				"type":"Warning","reason":"Failed","message":"container failed",
 				"source":{"component":"kubelet","host":"node-a"},
 				"reportingComponent":"kubelet","reportingInstance":"node-a","action":"BackOff","count":3,
-				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:01:00.123456Z"
+				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:00:00.123456Z",
+				"series":{"count":7,"lastObservedTime":"2026-07-29T00:03:00.123456Z"}
 			}]
 		}`)
 
@@ -177,10 +178,10 @@ func TestAPIClientListCoreResourcesDecodesResourceSchemas(t *testing.T) {
 			t.Fatalf("resourceVersion = %q events = %d, want 53 and 1", rv, len(items))
 		}
 		got := items[0]
-		if got.Name != "api.123" || got.InvolvedKind != "Pod" || got.InvolvedName != "api-0" || got.Count != 3 {
+		if got.Name != "api.123" || got.InvolvedKind != "Pod" || got.InvolvedName != "api-0" || got.Count != 7 {
 			t.Fatalf("event snapshot = %+v", got)
 		}
-		if got.SourceComponent != "kubelet" || got.ReportingController != "kubelet" || got.EventTime != "2026-07-29T00:01:00.123456Z" {
+		if got.SourceComponent != "kubelet" || got.ReportingController != "kubelet" || got.EventTime != "2026-07-29T00:00:00.123456Z" || got.LastTimestamp != "2026-07-29T00:03:00.123456Z" {
 			t.Fatalf("event source/time = %+v", got)
 		}
 	})
@@ -253,7 +254,8 @@ func TestInventoryCacheApplyWatchUpsertDecodesCoreResourceSchemas(t *testing.T) 
 				"involvedObject":{"kind":"Pod","namespace":"apps","name":"api-0","uid":"pod-uid"},
 				"type":"Warning","reason":"Failed","message":"container failed","source":{"component":"kubelet","host":"node-a"},
 				"reportingComponent":"kubelet","reportingInstance":"node-a","action":"BackOff","count":3,
-				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:01:00.123456Z"
+				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:00:00.123456Z",
+				"series":{"count":7,"lastObservedTime":"2026-07-29T00:03:00.123456Z"}
 			}`),
 		}, time.Unix(100, 0))
 		if err != nil {
@@ -263,7 +265,7 @@ func TestInventoryCacheApplyWatchUpsertDecodesCoreResourceSchemas(t *testing.T) 
 			t.Fatalf("trigger events len = %d, want 1", len(trigger.events))
 		}
 		got := trigger.events[0]
-		if got.Name != "api.123" || got.InvolvedName != "api-0" || got.Count != 3 || got.EventTime != "2026-07-29T00:01:00.123456Z" {
+		if got.Name != "api.123" || got.InvolvedName != "api-0" || got.Count != 7 || got.EventTime != "2026-07-29T00:00:00.123456Z" || got.LastTimestamp != "2026-07-29T00:03:00.123456Z" {
 			t.Fatalf("event snapshot = %+v", got)
 		}
 	})

--- a/internal/edgeagent/k8s/inventory_resource_test.go
+++ b/internal/edgeagent/k8s/inventory_resource_test.go
@@ -1,0 +1,410 @@
+package k8s
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+type workloadResourceSchemaCase struct {
+	name              string
+	group             string
+	resource          string
+	kind              string
+	object            string
+	wantDesired       int
+	wantReady         int
+	wantActive        int
+	wantFailed        int
+	wantOwnerKind     string
+	wantOwnerName     string
+	wantOwnerUID      string
+	wantRevision      int64
+	wantCreatedAt     string
+	wantConditionType string
+}
+
+func TestAPIClientListWorkloadsDecodesResourceSchemas(t *testing.T) {
+	for _, tt := range workloadResourceSchemaCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wantPath := "/apis/" + tt.group + "/v1/" + tt.resource
+				if r.URL.Path != wantPath {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, wantPath)
+				}
+				writeTestResponse(t, w, `{"metadata":{"resourceVersion":"42"},"items":[`+tt.object+`]}`)
+			}))
+			t.Cleanup(srv.Close)
+
+			api := &apiClient{baseURL: srv.URL, token: "token", http: srv.Client()}
+			items, rv, err := api.listWorkloads(context.Background(), tt.group, tt.resource, tt.kind, "")
+			if err != nil {
+				t.Fatalf("listWorkloads() error = %v", err)
+			}
+			if rv != "42" {
+				t.Fatalf("resourceVersion = %q, want 42", rv)
+			}
+			if len(items) != 1 {
+				t.Fatalf("workloads len = %d, want 1", len(items))
+			}
+			assertWorkloadResourceSnapshot(t, items[0], tt)
+		})
+	}
+}
+
+func TestInventoryCacheApplyWatchUpsertDecodesWorkloadResourceSchemas(t *testing.T) {
+	for _, tt := range workloadResourceSchemaCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newInventoryCache(nil)
+			trigger, err := cache.applyWatchEvent(inventoryWatchSpec{
+				name:         tt.resource,
+				resource:     watchResourceWorkloads,
+				workloadKind: tt.kind,
+			}, k8sWatchEvent{
+				Type:   "ADDED",
+				Object: []byte(tt.object),
+			}, time.Unix(100, 0))
+			if err != nil {
+				t.Fatalf("applyWatchEvent() error = %v", err)
+			}
+			if len(trigger.workloads) != 1 {
+				t.Fatalf("trigger workloads len = %d, want 1", len(trigger.workloads))
+			}
+			assertWorkloadResourceSnapshot(t, trigger.workloads[0], tt)
+		})
+	}
+}
+
+func TestAPIClientListCoreResourcesDecodesResourceSchemas(t *testing.T) {
+	t.Run("node", func(t *testing.T) {
+		srv := newInventoryResourceServer(t, `{
+			"metadata":{"resourceVersion":"51"},
+			"items":[{
+				"metadata":{"name":"node-a","uid":"node-uid","labels":{"zone":"east"}},
+				"spec":{"providerID":"provider://node-a","taints":[{"key":"dedicated","value":"edge","effect":"NoSchedule","timeAdded":"2026-07-29T00:00:00Z"}]},
+				"status":{
+					"capacity":{"cpu":"4","memory":"8Gi"},
+					"allocatable":{"cpu":"3800m","memory":"7Gi"},
+					"conditions":[{"type":"Ready","status":"True","reason":"KubeletReady","message":"ready"}],
+					"nodeInfo":{"kubeletVersion":"v1.34.9"}
+				}
+			}]
+		}`)
+
+		api := &apiClient{baseURL: srv.URL, token: "token", http: srv.Client()}
+		items, rv, err := api.listNodes(context.Background())
+		if err != nil {
+			t.Fatalf("listNodes() error = %v", err)
+		}
+		if rv != "51" || len(items) != 1 {
+			t.Fatalf("resourceVersion = %q nodes = %d, want 51 and 1", rv, len(items))
+		}
+		got := items[0]
+		if got.Name != "node-a" || got.ProviderID != "provider://node-a" || got.KubeletVersion != "v1.34.9" {
+			t.Fatalf("node snapshot = %+v", got)
+		}
+		if got.Capacity["memory"] != "8Gi" || got.Allocatable["cpu"] != "3800m" || len(got.Taints) != 1 {
+			t.Fatalf("node resources = capacity:%v allocatable:%v taints:%v", got.Capacity, got.Allocatable, got.Taints)
+		}
+		if len(got.Conditions) != 1 || got.Conditions[0]["type"] != "Ready" {
+			t.Fatalf("node conditions = %v", got.Conditions)
+		}
+	})
+
+	t.Run("pod", func(t *testing.T) {
+		srv := newInventoryResourceServer(t, `{
+			"metadata":{"resourceVersion":"52"},
+			"items":[{
+				"metadata":{
+					"namespace":"apps","name":"api-0","uid":"pod-uid",
+					"ownerReferences":[{"kind":"ReplicaSet","name":"api-rs","uid":"rs-uid","controller":true}]
+				},
+				"spec":{
+					"nodeName":"node-a",
+					"containers":[{"name":"api","ports":[{"name":"http","containerPort":8080,"protocol":"TCP"}]}],
+					"volumes":[{"name":"cache","emptyDir":{"medium":"Memory","sizeLimit":"64Mi"}}]
+				},
+				"status":{
+					"phase":"Pending",
+					"containerStatuses":[
+						{"name":"api","restartCount":2,"state":{"waiting":{"reason":"CrashLoopBackOff"}}},
+						{"name":"sidecar","restartCount":1,"state":{"running":{"startedAt":"2026-07-29T00:00:00Z"}}}
+					]
+				}
+			}]
+		}`)
+
+		api := &apiClient{baseURL: srv.URL, token: "token", http: srv.Client()}
+		items, rv, err := api.listPods(context.Background(), "apps")
+		if err != nil {
+			t.Fatalf("listPods() error = %v", err)
+		}
+		if rv != "52" || len(items) != 1 {
+			t.Fatalf("resourceVersion = %q pods = %d, want 52 and 1", rv, len(items))
+		}
+		got := items[0]
+		if got.Namespace != "apps" || got.Name != "api-0" || got.NodeName != "node-a" || got.Phase != "Pending" {
+			t.Fatalf("pod snapshot = %+v", got)
+		}
+		if got.OwnerKind != "ReplicaSet" || got.OwnerName != "api-rs" || got.RestartCount != 3 || got.Reason != "CrashLoopBackOff" {
+			t.Fatalf("pod ownership/status = %+v", got)
+		}
+	})
+
+	t.Run("event", func(t *testing.T) {
+		srv := newInventoryResourceServer(t, `{
+			"metadata":{"resourceVersion":"53"},
+			"items":[{
+				"metadata":{"namespace":"apps","name":"api.123","uid":"event-uid"},
+				"involvedObject":{"kind":"Pod","namespace":"apps","name":"api-0","uid":"pod-uid"},
+				"type":"Warning","reason":"Failed","message":"container failed",
+				"source":{"component":"kubelet","host":"node-a"},
+				"reportingComponent":"kubelet","reportingInstance":"node-a","action":"BackOff","count":3,
+				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:01:00.123456Z"
+			}]
+		}`)
+
+		api := &apiClient{baseURL: srv.URL, token: "token", http: srv.Client()}
+		items, rv, err := api.listEvents(context.Background(), "apps")
+		if err != nil {
+			t.Fatalf("listEvents() error = %v", err)
+		}
+		if rv != "53" || len(items) != 1 {
+			t.Fatalf("resourceVersion = %q events = %d, want 53 and 1", rv, len(items))
+		}
+		got := items[0]
+		if got.Name != "api.123" || got.InvolvedKind != "Pod" || got.InvolvedName != "api-0" || got.Count != 3 {
+			t.Fatalf("event snapshot = %+v", got)
+		}
+		if got.SourceComponent != "kubelet" || got.ReportingController != "kubelet" || got.EventTime != "2026-07-29T00:01:00.123456Z" {
+			t.Fatalf("event source/time = %+v", got)
+		}
+	})
+}
+
+func TestInventoryCacheApplyWatchUpsertDecodesCoreResourceSchemas(t *testing.T) {
+	t.Run("node", func(t *testing.T) {
+		cache := newInventoryCache(nil)
+		trigger, err := cache.applyWatchEvent(inventoryWatchSpec{
+			name:     "nodes",
+			resource: watchResourceNodes,
+		}, k8sWatchEvent{
+			Type: "ADDED",
+			Object: []byte(`{
+				"metadata":{"name":"node-a","uid":"node-uid","resourceVersion":"61"},
+				"spec":{"providerID":"provider://node-a","taints":[{"key":"dedicated","value":"edge","effect":"NoSchedule"}]},
+				"status":{
+					"capacity":{"cpu":"4"},"allocatable":{"cpu":"3800m"},
+					"conditions":[{"type":"Ready","status":"True","reason":"KubeletReady","message":"ready"}],
+					"nodeInfo":{"kubeletVersion":"v1.34.9"}
+				}
+			}`),
+		}, time.Unix(100, 0))
+		if err != nil {
+			t.Fatalf("applyWatchEvent() error = %v", err)
+		}
+		if len(trigger.nodes) != 1 {
+			t.Fatalf("trigger nodes len = %d, want 1", len(trigger.nodes))
+		}
+		got := trigger.nodes[0]
+		if got.Name != "node-a" || got.ProviderID != "provider://node-a" || got.KubeletVersion != "v1.34.9" || got.Capacity["cpu"] != "4" {
+			t.Fatalf("node snapshot = %+v", got)
+		}
+	})
+
+	t.Run("pod", func(t *testing.T) {
+		cache := newInventoryCache(nil)
+		trigger, err := cache.applyWatchEvent(inventoryWatchSpec{
+			name:     "pods",
+			resource: watchResourcePods,
+		}, k8sWatchEvent{
+			Type: "ADDED",
+			Object: []byte(`{
+				"metadata":{"namespace":"apps","name":"api-0","uid":"pod-uid","resourceVersion":"62","ownerReferences":[{"kind":"ReplicaSet","name":"api-rs","controller":true}]},
+				"spec":{"nodeName":"node-a","containers":[{"name":"api","ports":[{"containerPort":8080,"protocol":"TCP"}]}],"volumes":[{"emptyDir":{"medium":"Memory"}}]},
+				"status":{"phase":"Pending","containerStatuses":[{"name":"api","restartCount":2,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}]}
+			}`),
+		}, time.Unix(100, 0))
+		if err != nil {
+			t.Fatalf("applyWatchEvent() error = %v", err)
+		}
+		if len(trigger.pods) != 1 {
+			t.Fatalf("trigger pods len = %d, want 1", len(trigger.pods))
+		}
+		got := trigger.pods[0]
+		if got.Name != "api-0" || got.OwnerName != "api-rs" || got.RestartCount != 2 || got.Reason != "CrashLoopBackOff" {
+			t.Fatalf("pod snapshot = %+v", got)
+		}
+	})
+
+	t.Run("event", func(t *testing.T) {
+		cache := newInventoryCache(nil)
+		trigger, err := cache.applyWatchEvent(inventoryWatchSpec{
+			name:     "events",
+			resource: watchResourceEvents,
+		}, k8sWatchEvent{
+			Type: "ADDED",
+			Object: []byte(`{
+				"metadata":{"namespace":"apps","name":"api.123","uid":"event-uid","resourceVersion":"63"},
+				"involvedObject":{"kind":"Pod","namespace":"apps","name":"api-0","uid":"pod-uid"},
+				"type":"Warning","reason":"Failed","message":"container failed","source":{"component":"kubelet","host":"node-a"},
+				"reportingComponent":"kubelet","reportingInstance":"node-a","action":"BackOff","count":3,
+				"firstTimestamp":"2026-07-29T00:00:00Z","lastTimestamp":"2026-07-29T00:01:00Z","eventTime":"2026-07-29T00:01:00.123456Z"
+			}`),
+		}, time.Unix(100, 0))
+		if err != nil {
+			t.Fatalf("applyWatchEvent() error = %v", err)
+		}
+		if len(trigger.events) != 1 {
+			t.Fatalf("trigger events len = %d, want 1", len(trigger.events))
+		}
+		got := trigger.events[0]
+		if got.Name != "api.123" || got.InvolvedName != "api-0" || got.Count != 3 || got.EventTime != "2026-07-29T00:01:00.123456Z" {
+			t.Fatalf("event snapshot = %+v", got)
+		}
+	})
+}
+
+func newInventoryResourceServer(t *testing.T, response string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTestResponse(t, w, response)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func assertWorkloadResourceSnapshot(t *testing.T, got tunnel.KubernetesWorkloadSnapshot, want workloadResourceSchemaCase) {
+	t.Helper()
+	if got.Kind != want.kind || got.Namespace != "apps" || got.Name != want.name || got.UID != want.name+"-uid" {
+		t.Fatalf("workload identity = %+v", got)
+	}
+	if got.DesiredReplicas != want.wantDesired || got.ReadyReplicas != want.wantReady {
+		t.Fatalf("workload replicas = desired:%d ready:%d, want desired:%d ready:%d", got.DesiredReplicas, got.ReadyReplicas, want.wantDesired, want.wantReady)
+	}
+	if got.ActiveReplicas != want.wantActive || got.FailedReplicas != want.wantFailed {
+		t.Fatalf("workload execution = active:%d failed:%d, want active:%d failed:%d", got.ActiveReplicas, got.FailedReplicas, want.wantActive, want.wantFailed)
+	}
+	if got.OwnerKind != want.wantOwnerKind || got.OwnerName != want.wantOwnerName || got.OwnerUID != want.wantOwnerUID || got.Revision != want.wantRevision {
+		t.Fatalf("workload rollout metadata = owner:%s/%s/%s revision:%d, want owner:%s/%s/%s revision:%d", got.OwnerKind, got.OwnerName, got.OwnerUID, got.Revision, want.wantOwnerKind, want.wantOwnerName, want.wantOwnerUID, want.wantRevision)
+	}
+	if want.wantCreatedAt == "" {
+		if got.CreationTimestamp != nil {
+			t.Fatalf("workload creation timestamp = %v, want nil", got.CreationTimestamp)
+		}
+	} else if got.CreationTimestamp == nil || got.CreationTimestamp.UTC().Format(time.RFC3339) != want.wantCreatedAt {
+		t.Fatalf("workload creation timestamp = %v, want %s", got.CreationTimestamp, want.wantCreatedAt)
+	}
+	if got.Labels["app"] != want.name || got.Annotations["example.com/note"] != "safe" {
+		t.Fatalf("workload metadata = labels:%v annotations:%v", got.Labels, got.Annotations)
+	}
+	if want.wantConditionType == "" {
+		if len(got.Conditions) != 0 {
+			t.Fatalf("workload conditions = %v, want none", got.Conditions)
+		}
+		return
+	}
+	if len(got.Conditions) != 1 || got.Conditions[0]["type"] != want.wantConditionType {
+		t.Fatalf("workload conditions = %v, want type %q", got.Conditions, want.wantConditionType)
+	}
+}
+
+func workloadResourceSchemaCases() []workloadResourceSchemaCase {
+	return []workloadResourceSchemaCase{
+		{
+			name:              "deployment",
+			group:             "apps",
+			resource:          "deployments",
+			kind:              "Deployment",
+			wantDesired:       3,
+			wantReady:         2,
+			wantConditionType: "Available",
+			object: `{
+				"metadata":{"namespace":"apps","name":"deployment","uid":"deployment-uid","labels":{"app":"deployment"},"annotations":{"example.com/note":"safe"}},
+				"spec":{"replicas":3},
+				"status":{"replicas":3,"readyReplicas":2,"availableReplicas":2,"conditions":[{"type":"Available","status":"True","reason":"MinimumReplicasAvailable","message":"ready"}]}
+			}`,
+		},
+		{
+			name:              "statefulset",
+			group:             "apps",
+			resource:          "statefulsets",
+			kind:              "StatefulSet",
+			wantDesired:       2,
+			wantReady:         1,
+			wantConditionType: "Available",
+			object: `{
+				"metadata":{"namespace":"apps","name":"statefulset","uid":"statefulset-uid","labels":{"app":"statefulset"},"annotations":{"example.com/note":"safe"}},
+				"spec":{"replicas":2},
+				"status":{"replicas":2,"readyReplicas":1,"currentReplicas":1,"updatedReplicas":1,"conditions":[{"type":"Available","status":"False","reason":"ReplicasNotReady","message":"waiting"}]}
+			}`,
+		},
+		{
+			name:              "daemonset",
+			group:             "apps",
+			resource:          "daemonsets",
+			kind:              "DaemonSet",
+			wantDesired:       4,
+			wantReady:         3,
+			wantConditionType: "Progressing",
+			object: `{
+				"metadata":{"namespace":"apps","name":"daemonset","uid":"daemonset-uid","labels":{"app":"daemonset"},"annotations":{"example.com/note":"safe"}},
+				"spec":{"selector":{"matchLabels":{"app":"daemonset"}}},
+				"status":{"desiredNumberScheduled":4,"numberReady":3,"numberAvailable":3,"conditions":[{"type":"Progressing","status":"True","reason":"RollingUpdate","message":"updating"}]}
+			}`,
+		},
+		{
+			name:              "replicaset",
+			group:             "apps",
+			resource:          "replicasets",
+			kind:              "ReplicaSet",
+			wantDesired:       5,
+			wantReady:         4,
+			wantOwnerKind:     "Deployment",
+			wantOwnerName:     "api",
+			wantOwnerUID:      "deployment-uid",
+			wantRevision:      12,
+			wantCreatedAt:     "2026-07-28T08:09:10Z",
+			wantConditionType: "ReplicaFailure",
+			object: `{
+				"metadata":{"namespace":"apps","name":"replicaset","uid":"replicaset-uid","creationTimestamp":"2026-07-28T08:09:10Z","labels":{"app":"replicaset"},"annotations":{"example.com/note":"safe","deployment.kubernetes.io/revision":"12"},"ownerReferences":[{"kind":"Deployment","name":"api","uid":"deployment-uid","controller":true}]},
+				"spec":{"replicas":5},
+				"status":{"replicas":5,"readyReplicas":4,"availableReplicas":4,"conditions":[{"type":"ReplicaFailure","status":"True","reason":"FailedCreate","message":"waiting"}]}
+			}`,
+		},
+		{
+			name:              "job",
+			group:             "batch",
+			resource:          "jobs",
+			kind:              "Job",
+			wantDesired:       2,
+			wantReady:         1,
+			wantActive:        1,
+			wantFailed:        1,
+			wantConditionType: "Complete",
+			object: `{
+				"metadata":{"namespace":"apps","name":"job","uid":"job-uid","labels":{"app":"job"},"annotations":{"example.com/note":"safe"}},
+				"spec":{"completions":2,"parallelism":1},
+				"status":{"active":1,"succeeded":1,"failed":1,"conditions":[{"type":"Complete","status":"False","reason":"Running","message":"one completion remains"}]}
+			}`,
+		},
+		{
+			name:        "cronjob",
+			group:       "batch",
+			resource:    "cronjobs",
+			kind:        "CronJob",
+			wantDesired: 0,
+			wantReady:   0,
+			wantActive:  1,
+			object: `{
+				"metadata":{"namespace":"apps","name":"cronjob","uid":"cronjob-uid","labels":{"app":"cronjob"},"annotations":{"example.com/note":"safe"}},
+				"spec":{"schedule":"*/5 * * * *","jobTemplate":{"spec":{"template":{"spec":{"restartPolicy":"Never","containers":[{"name":"task","image":"busybox"}]}}}}},
+				"status":{"active":[{"apiVersion":"batch/v1","kind":"Job","namespace":"apps","name":"cronjob-123","uid":"job-uid","resourceVersion":"99"}],"lastScheduleTime":"2026-07-29T00:00:00Z"}
+			}`,
+		},
+	}
+}

--- a/internal/manager/biz/aiops/tools/query_k8s_snapshot.go
+++ b/internal/manager/biz/aiops/tools/query_k8s_snapshot.go
@@ -213,6 +213,8 @@ type k8sWorkloadSnapshotRow struct {
 	UID             string     `json:"uid,omitempty"`
 	DesiredReplicas int        `json:"desired_replicas"`
 	ReadyReplicas   int        `json:"ready_replicas"`
+	ActiveReplicas  int        `json:"active_replicas"`
+	FailedReplicas  int        `json:"failed_replicas"`
 	LastSeenAt      *time.Time `json:"last_seen_at,omitempty"`
 }
 
@@ -707,6 +709,8 @@ func workloadSnapshotRow(w *k8smodel.Workload) k8sWorkloadSnapshotRow {
 		UID:             w.UID,
 		DesiredReplicas: w.DesiredReplicas,
 		ReadyReplicas:   w.ReadyReplicas,
+		ActiveReplicas:  w.ActiveReplicas,
+		FailedReplicas:  w.FailedReplicas,
 		LastSeenAt:      w.LastSeenAt,
 	}
 }

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -955,13 +955,21 @@ func actionableWarningEvent(
 	case "node":
 		_, ok := nodeIssues[event.InvolvedName]
 		return ok
-	case "deployment", "statefulset", "daemonset", "replicaset", "job", "cronjob":
+	case "deployment", "statefulset", "daemonset", "replicaset", "job":
 		_, ok := workloadKeys[workloadResourceKey(kind, eventResourceNamespace(event), event.InvolvedName)]
 		return ok
+	case "cronjob":
+		// CronJobs do not expose desired/ready replicas, so they are absent from
+		// the issue-only workload set even when a recent controller warning exists.
+		return warningEventIsRecent(event, now)
 	default:
-		occurredAt, ok := warningEventOccurredAt(event)
-		return ok && !occurredAt.Before(now.Add(-warningActionableWindow(event)))
+		return warningEventIsRecent(event, now)
 	}
+}
+
+func warningEventIsRecent(event *model.Event, now time.Time) bool {
+	occurredAt, ok := warningEventOccurredAt(event)
+	return ok && !occurredAt.Before(now.Add(-warningActionableWindow(event)))
 }
 
 // HPA metric warnings are emitted continuously while the metrics pipeline is

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,8 @@ const (
 	defaultEventRetention       = 24 * time.Hour
 	defaultEventMaxPerCluster   = 5000
 	defaultEventCleanupInterval = time.Hour
+	actionableWarningWindow     = 15 * time.Minute
+	hpaMetricWarningWindow      = 5 * time.Minute
 	eventRetentionBatchLimit    = 1000
 	bootstrapTokenBytes         = 32
 	defaultK8sChartRef          = "oci://helm.cnb.cool/ongridio/ongrid-edge"
@@ -376,14 +379,25 @@ type ListNodesFilter struct {
 	Offset    int
 }
 
-type ListWorkloadsFilter struct {
-	ClusterID uint64
+// WorkloadOwnerRef identifies a workload controller whose retained children
+// should be loaded. UID is authoritative; name is the compatibility fallback.
+type WorkloadOwnerRef struct {
 	Namespace string
 	Kind      string
-	Query     string
-	IssueOnly bool
-	Limit     int
-	Offset    int
+	Name      string
+	UID       string
+}
+
+type ListWorkloadsFilter struct {
+	ClusterID        uint64
+	Namespace        string
+	Kind             string
+	Query            string
+	IssueOnly        bool
+	GroupReplicaSets bool
+	OwnerRefs        []WorkloadOwnerRef
+	Limit            int
+	Offset           int
 }
 
 type ListPodsFilter struct {
@@ -673,7 +687,93 @@ func (u *Usecase) ListWorkloads(ctx context.Context, f ListWorkloadsFilter) ([]*
 	if _, err := u.repo.GetCluster(ctx, f.ClusterID); err != nil {
 		return nil, err
 	}
-	return u.repo.ListWorkloads(ctx, f)
+	items, err := u.repo.ListWorkloads(ctx, f)
+	if err != nil || !f.GroupReplicaSets || len(items) == 0 {
+		return items, err
+	}
+	ownerRefs := make([]WorkloadOwnerRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || !strings.EqualFold(strings.TrimSpace(item.Kind), "Deployment") {
+			continue
+		}
+		ownerRefs = append(ownerRefs, WorkloadOwnerRef{
+			Namespace: item.Namespace,
+			Kind:      "Deployment",
+			Name:      item.Name,
+			UID:       item.UID,
+		})
+	}
+	if len(ownerRefs) == 0 {
+		return items, nil
+	}
+	replicaSets, err := u.repo.ListWorkloads(ctx, ListWorkloadsFilter{
+		ClusterID: f.ClusterID,
+		OwnerRefs: ownerRefs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list deployment ReplicaSets: %w", err)
+	}
+	sortWorkloadRevisions(replicaSets)
+	groupedByUID := make(map[string][]*model.Workload, len(ownerRefs))
+	legacyByName := make(map[string][]*model.Workload, len(ownerRefs))
+	allByName := make(map[string][]*model.Workload, len(ownerRefs))
+	for _, item := range replicaSets {
+		if item == nil {
+			continue
+		}
+		nameKey := workloadOwnerKey(item.Namespace, item.OwnerKind, item.OwnerName)
+		allByName[nameKey] = append(allByName[nameKey], item)
+		if strings.TrimSpace(item.OwnerUID) == "" {
+			legacyByName[nameKey] = append(legacyByName[nameKey], item)
+			continue
+		}
+		uidKey := workloadOwnerKey(item.Namespace, item.OwnerKind, item.OwnerUID)
+		groupedByUID[uidKey] = append(groupedByUID[uidKey], item)
+	}
+	for _, item := range items {
+		if item == nil || !strings.EqualFold(strings.TrimSpace(item.Kind), "Deployment") {
+			continue
+		}
+		nameKey := workloadOwnerKey(item.Namespace, item.Kind, item.Name)
+		if strings.TrimSpace(item.UID) == "" {
+			item.ReplicaSets = allByName[nameKey]
+			sortWorkloadRevisions(item.ReplicaSets)
+			continue
+		}
+		uidKey := workloadOwnerKey(item.Namespace, item.Kind, item.UID)
+		item.ReplicaSets = append(groupedByUID[uidKey], legacyByName[nameKey]...)
+		sortWorkloadRevisions(item.ReplicaSets)
+	}
+	return items, nil
+}
+
+func workloadOwnerKey(namespace, kind, identity string) string {
+	return strings.TrimSpace(namespace) + "\x00" + strings.ToLower(strings.TrimSpace(kind)) + "\x00" + strings.TrimSpace(identity)
+}
+
+func sortWorkloadRevisions(items []*model.Workload) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := items[i], items[j]
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		if left.Revision != right.Revision {
+			return left.Revision > right.Revision
+		}
+		if left.ResourceCreatedAt != nil && right.ResourceCreatedAt != nil && !left.ResourceCreatedAt.Equal(*right.ResourceCreatedAt) {
+			return left.ResourceCreatedAt.After(*right.ResourceCreatedAt)
+		}
+		if left.ResourceCreatedAt != nil && right.ResourceCreatedAt == nil {
+			return true
+		}
+		if left.ResourceCreatedAt == nil && right.ResourceCreatedAt != nil {
+			return false
+		}
+		return left.Name > right.Name
+	})
 }
 
 func (u *Usecase) CountWorkloads(ctx context.Context, f ListWorkloadsFilter) (int64, error) {
@@ -810,8 +910,9 @@ func (u *Usecase) listActionableWarningEvents(ctx context.Context, f ListEventsF
 	}
 
 	actionable := make([]*model.Event, 0, len(events))
+	now := time.Now()
 	for _, event := range events {
-		if event != nil && actionableWarningEvent(event, podsByUID, podsByName, workloadKeys, nodeIssues) {
+		if event != nil && actionableWarningEvent(event, podsByUID, podsByName, workloadKeys, nodeIssues, now) {
 			actionable = append(actionable, event)
 		}
 	}
@@ -828,6 +929,7 @@ func (u *Usecase) listActionableWarningEvents(ctx context.Context, f ListEventsF
 func actionableWarningEvent(
 	event *model.Event,
 	podsByUID, podsByName, workloadKeys, nodeIssues map[string]struct{},
+	now time.Time,
 ) bool {
 	kind := strings.ToLower(strings.TrimSpace(event.InvolvedKind))
 	switch kind {
@@ -842,12 +944,47 @@ func actionableWarningEvent(
 	case "node":
 		_, ok := nodeIssues[event.InvolvedName]
 		return ok
-	case "deployment", "statefulset", "daemonset", "job", "cronjob":
+	case "deployment", "statefulset", "daemonset", "replicaset", "job", "cronjob":
 		_, ok := workloadKeys[workloadResourceKey(kind, eventResourceNamespace(event), event.InvolvedName)]
 		return ok
 	default:
-		return true
+		occurredAt, ok := warningEventOccurredAt(event)
+		return ok && !occurredAt.Before(now.Add(-warningActionableWindow(event)))
 	}
+}
+
+// HPA metric warnings are emitted continuously while the metrics pipeline is
+// unavailable. Once reconciliation succeeds Kubernetes stops refreshing the
+// Event, so a shorter quiet period is a reliable recovery signal without
+// requiring HPA objects in the workload inventory.
+func warningActionableWindow(event *model.Event) time.Duration {
+	if event == nil || !strings.EqualFold(strings.TrimSpace(event.InvolvedKind), "HorizontalPodAutoscaler") {
+		return actionableWarningWindow
+	}
+	switch strings.ToLower(strings.TrimSpace(event.Reason)) {
+	case "failedgetresourcemetric", "failedcomputemetricsreplicas":
+		return hpaMetricWarningWindow
+	default:
+		return actionableWarningWindow
+	}
+}
+
+// warningEventOccurredAt intentionally excludes LastSeenAt and UpdatedAt.
+// Inventory refreshes can advance those ingestion timestamps while Kubernetes
+// keeps an old Event object, which must not turn recovered warnings current.
+func warningEventOccurredAt(event *model.Event) (time.Time, bool) {
+	if event == nil {
+		return time.Time{}, false
+	}
+	for _, timestamp := range []*time.Time{event.LastTimestamp, event.EventTime, event.FirstTimestamp} {
+		if timestamp != nil && !timestamp.IsZero() {
+			return *timestamp, true
+		}
+	}
+	if !event.CreatedAt.IsZero() {
+		return event.CreatedAt, true
+	}
+	return time.Time{}, false
 }
 
 func eventResourceNamespace(event *model.Event) string {
@@ -1054,6 +1191,7 @@ type TelemetryConfig struct {
 	ClusterID              uint64
 	AccessKey              string
 	SecretKey              string
+	ManagerPublicURL       string
 	TracesEndpoint         string
 	TracesAuthMode         string
 	TracesBasicUser        string
@@ -1536,18 +1674,30 @@ func (u *Usecase) IngestInventory(ctx context.Context, edgeID uint64, in tunnel.
 			continue
 		}
 		ts := now
+		var resourceCreatedAt *time.Time
+		if item.CreationTimestamp != nil {
+			createdAt := item.CreationTimestamp.UTC()
+			resourceCreatedAt = &createdAt
+		}
 		workloads = append(workloads, &model.Workload{
-			ClusterID:       in.ClusterID,
-			Namespace:       strings.TrimSpace(item.Namespace),
-			Kind:            kind,
-			Name:            name,
-			UID:             strings.TrimSpace(item.UID),
-			DesiredReplicas: item.DesiredReplicas,
-			ReadyReplicas:   item.ReadyReplicas,
-			LabelsJSON:      jsonText(k8sredact.StringMap(item.Labels), "{}"),
-			AnnotationsJSON: jsonText(k8sredact.StringMap(item.Annotations), "{}"),
-			ConditionsJSON:  jsonText(item.Conditions, "[]"),
-			LastSeenAt:      &ts,
+			ClusterID:         in.ClusterID,
+			Namespace:         strings.TrimSpace(item.Namespace),
+			Kind:              kind,
+			Name:              name,
+			UID:               strings.TrimSpace(item.UID),
+			DesiredReplicas:   item.DesiredReplicas,
+			ReadyReplicas:     item.ReadyReplicas,
+			ActiveReplicas:    item.ActiveReplicas,
+			FailedReplicas:    item.FailedReplicas,
+			OwnerKind:         strings.TrimSpace(item.OwnerKind),
+			OwnerName:         strings.TrimSpace(item.OwnerName),
+			OwnerUID:          strings.TrimSpace(item.OwnerUID),
+			Revision:          item.Revision,
+			ResourceCreatedAt: resourceCreatedAt,
+			LabelsJSON:        jsonText(k8sredact.StringMap(item.Labels), "{}"),
+			AnnotationsJSON:   jsonText(k8sredact.StringMap(item.Annotations), "{}"),
+			ConditionsJSON:    jsonText(item.Conditions, "[]"),
+			LastSeenAt:        &ts,
 		})
 	}
 	if err := u.repo.UpsertWorkloads(ctx, workloads); err != nil {
@@ -1946,9 +2096,10 @@ func newTelemetryCredential(clusterID uint64) (*model.TelemetryCredential, strin
 func (u *Usecase) resolveTelemetryConfig(ctx context.Context, clusterID uint64, accessKey, secretKey string) (*TelemetryConfig, error) {
 	publicURL := strings.TrimRight(strings.TrimSpace(u.cfg.PublicURL), "/")
 	out := &TelemetryConfig{
-		ClusterID: clusterID,
-		AccessKey: accessKey,
-		SecretKey: secretKey,
+		ClusterID:        clusterID,
+		AccessKey:        accessKey,
+		SecretKey:        secretKey,
+		ManagerPublicURL: publicURL,
 	}
 	traces, err := u.resolveTelemetryTarget(ctx, TelemetrySignalTraces, endpointPath(publicURL, "/v1/traces"))
 	if err != nil {

--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -91,6 +91,7 @@ type Repository interface {
 	ListEdgeAttachments(ctx context.Context, limit, offset int) ([]EdgeAttachment, int64, error)
 	ListWorkloads(ctx context.Context, f ListWorkloadsFilter) ([]*model.Workload, error)
 	CountWorkloads(ctx context.Context, f ListWorkloadsFilter) (int64, error)
+	ListNamespaceSummaries(ctx context.Context, clusterID uint64) ([]NamespaceSummary, error)
 	ListPods(ctx context.Context, f ListPodsFilter) ([]*model.Pod, error)
 	CountPods(ctx context.Context, f ListPodsFilter) (int64, error)
 	ListEvents(ctx context.Context, f ListEventsFilter) ([]*model.Event, error)
@@ -160,6 +161,16 @@ type ClusterHealthSummary struct {
 	OOMKilledPods        int64
 	ImagePullBackOffPods int64
 	NotReadyNodes        int64
+	Namespaces           []NamespaceSummary
+}
+
+type NamespaceSummary struct {
+	Namespace  string
+	Workloads  int64
+	Pods       int64
+	Events     int64
+	Warnings   int64
+	LastSeenAt *time.Time
 }
 
 type Config struct {
@@ -1011,7 +1022,7 @@ func (u *Usecase) GetClusterHealth(ctx context.Context, clusterID uint64) (Clust
 		return out, err
 	}
 	var err error
-	if out.DegradedWorkloads, err = u.repo.CountWorkloads(ctx, ListWorkloadsFilter{ClusterID: clusterID, IssueOnly: true}); err != nil {
+	if out.DegradedWorkloads, err = u.repo.CountWorkloads(ctx, ListWorkloadsFilter{ClusterID: clusterID, IssueOnly: true, GroupReplicaSets: true}); err != nil {
 		return out, err
 	}
 	if out.PendingPods, err = u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Phase: "Pending"}); err != nil {
@@ -1041,7 +1052,57 @@ func (u *Usecase) GetClusterHealth(ctx context.Context, clusterID uint64) (Clust
 			out.NotReadyNodes++
 		}
 	}
+	out.Namespaces, err = u.namespaceSummaries(ctx, clusterID)
+	if err != nil {
+		return out, err
+	}
 	return out, nil
+}
+
+func (u *Usecase) namespaceSummaries(ctx context.Context, clusterID uint64) ([]NamespaceSummary, error) {
+	summaries, err := u.repo.ListNamespaceSummaries(ctx, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	byNamespace := make(map[string]*NamespaceSummary, len(summaries))
+	for _, current := range summaries {
+		namespace := strings.TrimSpace(current.Namespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		current.Namespace = namespace
+		summary := current
+		byNamespace[namespace] = &summary
+	}
+	warnings, err := u.listActionableWarningEvents(ctx, ListEventsFilter{ClusterID: clusterID})
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range warnings {
+		if event == nil {
+			continue
+		}
+		namespace := strings.TrimSpace(eventResourceNamespace(event))
+		if namespace == "" {
+			namespace = "default"
+		}
+		summary := byNamespace[namespace]
+		if summary == nil {
+			summary = &NamespaceSummary{Namespace: namespace}
+			byNamespace[namespace] = summary
+		}
+		summary.Warnings++
+		if occurredAt, ok := warningEventOccurredAt(event); ok && (summary.LastSeenAt == nil || occurredAt.After(*summary.LastSeenAt)) {
+			ts := occurredAt
+			summary.LastSeenAt = &ts
+		}
+	}
+	summaries = summaries[:0]
+	for _, summary := range byNamespace {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].Namespace < summaries[j].Namespace })
+	return summaries, nil
 }
 
 func nodeIsNotReady(raw string) bool {
@@ -1689,6 +1750,7 @@ func (u *Usecase) IngestInventory(ctx context.Context, edgeID uint64, in tunnel.
 			ReadyReplicas:     item.ReadyReplicas,
 			ActiveReplicas:    item.ActiveReplicas,
 			FailedReplicas:    item.FailedReplicas,
+			IsTerminalFailure: workloadHasTerminalFailure(item.Conditions),
 			OwnerKind:         strings.TrimSpace(item.OwnerKind),
 			OwnerName:         strings.TrimSpace(item.OwnerName),
 			OwnerUID:          strings.TrimSpace(item.OwnerUID),
@@ -1823,6 +1885,17 @@ func (u *Usecase) IngestInventory(ctx context.Context, edgeID uint64, in tunnel.
 		return nil, err
 	}
 	return result, nil
+}
+
+func workloadHasTerminalFailure(conditions []map[string]string) bool {
+	for _, condition := range conditions {
+		typeName := strings.ToLower(strings.TrimSpace(condition["type"]))
+		status := strings.ToLower(strings.TrimSpace(condition["status"]))
+		if status == "true" && (typeName == "failed" || typeName == "failuretarget") {
+			return true
+		}
+	}
+	return false
 }
 
 const (

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -436,6 +436,9 @@ func TestUsecaseControllerEnrollmentIssuesSeparateTelemetryCredential(t *testing
 	if out.Telemetry == nil {
 		t.Fatal("Enroll() telemetry config is nil")
 	}
+	if out.Telemetry.ManagerPublicURL != "https://manager.example" {
+		t.Fatalf("telemetry manager public URL = %q", out.Telemetry.ManagerPublicURL)
+	}
 	if !strings.HasPrefix(out.Telemetry.AccessKey, "kt_") || !strings.HasPrefix(out.Telemetry.SecretKey, "ks_") {
 		t.Fatalf("telemetry credential has unexpected shape: %#v", out.Telemetry)
 	}
@@ -914,6 +917,127 @@ func TestUsecaseInventoryMergesNodeUIDWithExistingNodeEdge(t *testing.T) {
 	}
 	if _, err := repo.GetNodeByClusterUID(ctx, reg.Cluster.ID, "name:node-a"); !errors.Is(err, errs.ErrNotFound) {
 		t.Fatalf("fallback node err = %v, want not found", err)
+	}
+}
+
+func TestUsecaseInventoryPersistsWorkloadExecutionCountsAndRolloutMetadata(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, newFakeIssuer(), Config{})
+	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	bindFakeController(t, repo, reg.Cluster.ID, 99)
+	createdAt := time.Date(2026, time.July, 28, 8, 9, 10, 0, time.UTC)
+
+	_, err = uc.IngestInventory(ctx, 99, tunnel.KubernetesInventoryRequest{
+		ClusterID: reg.Cluster.ID,
+		Role:      model.RoleController,
+		Workloads: []tunnel.KubernetesWorkloadSnapshot{
+			{
+				Kind:            "Job",
+				Namespace:       "jobs",
+				Name:            "batch",
+				UID:             "job-uid",
+				DesiredReplicas: 3,
+				ReadyReplicas:   1,
+				ActiveReplicas:  1,
+				FailedReplicas:  1,
+			},
+			{
+				Kind:              "ReplicaSet",
+				Namespace:         "apps",
+				Name:              "api-7d8f9",
+				UID:               "rs-uid",
+				OwnerKind:         "Deployment",
+				OwnerName:         "api",
+				OwnerUID:          "deployment-uid",
+				Revision:          12,
+				CreationTimestamp: &createdAt,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("IngestInventory() error = %v", err)
+	}
+	if len(repo.lastWorkloads) != 2 {
+		t.Fatalf("persisted workloads = %d, want 2", len(repo.lastWorkloads))
+	}
+	got := repo.lastWorkloads[0]
+	if got.ActiveReplicas != 1 || got.FailedReplicas != 1 {
+		t.Fatalf("workload execution = active:%d failed:%d, want 1/1", got.ActiveReplicas, got.FailedReplicas)
+	}
+	rs := repo.lastWorkloads[1]
+	if rs.OwnerKind != "Deployment" || rs.OwnerName != "api" || rs.OwnerUID != "deployment-uid" || rs.Revision != 12 {
+		t.Fatalf("workload rollout metadata = owner:%s/%s/%s revision:%d", rs.OwnerKind, rs.OwnerName, rs.OwnerUID, rs.Revision)
+	}
+	if rs.ResourceCreatedAt == nil || !rs.ResourceCreatedAt.Equal(createdAt) {
+		t.Fatalf("workload resource created at = %v, want %v", rs.ResourceCreatedAt, createdAt)
+	}
+}
+
+type groupingWorkloadRepo struct {
+	*fakeRepo
+	listFilters []ListWorkloadsFilter
+	topLevel    []*model.Workload
+	replicaSets []*model.Workload
+}
+
+func (r *groupingWorkloadRepo) ListWorkloads(_ context.Context, f ListWorkloadsFilter) ([]*model.Workload, error) {
+	r.listFilters = append(r.listFilters, f)
+	if len(f.OwnerRefs) > 0 {
+		return r.replicaSets, nil
+	}
+	return r.topLevel, nil
+}
+
+func TestUsecaseListWorkloadsAttachesDeploymentReplicaSetVersions(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeRepo()
+	reg, err := NewUsecase(base, newFakeIssuer(), Config{}).CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	createdAt := time.Date(2026, time.July, 28, 8, 9, 10, 0, time.UTC)
+	repo := &groupingWorkloadRepo{
+		fakeRepo: base,
+		topLevel: []*model.Workload{{
+			ID:        1,
+			ClusterID: reg.Cluster.ID,
+			Namespace: "apps",
+			Kind:      "Deployment",
+			Name:      "api",
+			UID:       "deployment-uid",
+			Revision:  12,
+		}},
+		replicaSets: []*model.Workload{
+			{ID: 3, ClusterID: reg.Cluster.ID, Namespace: "apps", Kind: "ReplicaSet", Name: "api-old", OwnerKind: "Deployment", OwnerName: "api", OwnerUID: "deployment-uid", Revision: 11, ResourceCreatedAt: &createdAt},
+			{ID: 2, ClusterID: reg.Cluster.ID, Namespace: "apps", Kind: "ReplicaSet", Name: "api-current", OwnerKind: "Deployment", OwnerName: "api", OwnerUID: "deployment-uid", Revision: 12, ResourceCreatedAt: &createdAt},
+		},
+	}
+	uc := NewUsecase(repo, newFakeIssuer(), Config{})
+
+	items, err := uc.ListWorkloads(ctx, ListWorkloadsFilter{
+		ClusterID:        reg.Cluster.ID,
+		GroupReplicaSets: true,
+		Limit:            100,
+	})
+	if err != nil {
+		t.Fatalf("ListWorkloads() error = %v", err)
+	}
+	if len(repo.listFilters) != 2 {
+		t.Fatalf("ListWorkloads() repo calls = %d, want 2", len(repo.listFilters))
+	}
+	refs := repo.listFilters[1].OwnerRefs
+	if len(refs) != 1 || refs[0].Namespace != "apps" || refs[0].Kind != "Deployment" || refs[0].Name != "api" || refs[0].UID != "deployment-uid" {
+		t.Fatalf("ReplicaSet owner refs = %+v", refs)
+	}
+	if len(items) != 1 || len(items[0].ReplicaSets) != 2 {
+		t.Fatalf("grouped workloads = %+v", items)
+	}
+	if items[0].ReplicaSets[0].Revision != 12 || items[0].ReplicaSets[1].Revision != 11 {
+		t.Fatalf("ReplicaSet revision order = %+v", items[0].ReplicaSets)
 	}
 }
 
@@ -1753,6 +1877,9 @@ func TestUsecaseCleanupEventsAppliesRetentionAndClusterCap(t *testing.T) {
 
 func TestUsecaseListEventsIssueOnlyExcludesRecoveredWarnings(t *testing.T) {
 	ctx := context.Background()
+	now := time.Now()
+	recent := now.Add(-time.Minute)
+	stale := now.Add(-time.Hour)
 	repo := newFakeRepo()
 	uc := NewUsecase(repo, newFakeIssuer(), Config{})
 	reg, err := uc.CreateCluster(ctx, CreateClusterInput{Name: "prod"})
@@ -1776,7 +1903,8 @@ func TestUsecaseListEventsIssueOnlyExcludesRecoveredWarnings(t *testing.T) {
 		{ClusterID: reg.Cluster.ID, UID: "active-pod", Type: "Warning", InvolvedKind: "Pod", InvolvedNamespace: "default", InvolvedName: "broken", InvolvedUID: "pod-broken"},
 		{ClusterID: reg.Cluster.ID, UID: "recovered-pod", Type: "Warning", InvolvedKind: "Pod", InvolvedNamespace: "default", InvolvedName: "recovered", InvolvedUID: "pod-recovered"},
 		{ClusterID: reg.Cluster.ID, UID: "active-node", Type: "Warning", InvolvedKind: "Node", InvolvedName: "node-bad"},
-		{ClusterID: reg.Cluster.ID, UID: "unknown", Type: "Warning", InvolvedKind: "PersistentVolumeClaim", InvolvedNamespace: "default", InvolvedName: "data"},
+		{ClusterID: reg.Cluster.ID, UID: "recent-unknown", Type: "Warning", InvolvedKind: "PersistentVolumeClaim", InvolvedNamespace: "default", InvolvedName: "data", LastTimestamp: &recent},
+		{ClusterID: reg.Cluster.ID, UID: "recovered-hpa", Type: "Warning", InvolvedKind: "HorizontalPodAutoscaler", InvolvedNamespace: "default", InvolvedName: "api", LastTimestamp: &stale, LastSeenAt: &now},
 	}
 
 	items, err := uc.ListEvents(ctx, ListEventsFilter{ClusterID: reg.Cluster.ID, IssueOnly: true, Limit: 100})
@@ -1786,12 +1914,76 @@ func TestUsecaseListEventsIssueOnlyExcludesRecoveredWarnings(t *testing.T) {
 	if len(items) != 3 {
 		t.Fatalf("ListEvents(issue) count = %d, want 3", len(items))
 	}
+	for _, item := range items {
+		if item.UID == "recovered-hpa" {
+			t.Fatalf("stale HPA warning remained actionable: %#v", item)
+		}
+	}
 	total, err := uc.CountEvents(ctx, ListEventsFilter{ClusterID: reg.Cluster.ID, IssueOnly: true})
 	if err != nil {
 		t.Fatalf("CountEvents(issue) error = %v", err)
 	}
 	if total != 3 {
 		t.Fatalf("CountEvents(issue) = %d, want 3", total)
+	}
+}
+
+func TestActionableWarningEventUntrackedResourceUsesOccurrenceTime(t *testing.T) {
+	now := time.Date(2026, 7, 29, 6, 0, 0, 0, time.UTC)
+	recent := now.Add(-actionableWarningWindow)
+	stale := recent.Add(-time.Nanosecond)
+	recentHPAMetric := now.Add(-hpaMetricWarningWindow)
+	recoveredHPAMetric := recentHPAMetric.Add(-time.Nanosecond)
+	lastSeen := now
+
+	tests := []struct {
+		name  string
+		event *model.Event
+		want  bool
+	}{
+		{
+			name:  "recent boundary",
+			event: &model.Event{InvolvedKind: "HorizontalPodAutoscaler", LastTimestamp: &recent},
+			want:  true,
+		},
+		{
+			name:  "stale occurrence with fresh ingestion",
+			event: &model.Event{InvolvedKind: "HorizontalPodAutoscaler", LastTimestamp: &stale, LastSeenAt: &lastSeen},
+			want:  false,
+		},
+		{
+			name:  "ingestion timestamp only",
+			event: &model.Event{InvolvedKind: "HorizontalPodAutoscaler", LastSeenAt: &lastSeen},
+			want:  false,
+		},
+		{
+			name: "repeating HPA metric warning at recent boundary",
+			event: &model.Event{
+				InvolvedKind:  "HorizontalPodAutoscaler",
+				Reason:        "FailedGetResourceMetric",
+				LastTimestamp: &recentHPAMetric,
+			},
+			want: true,
+		},
+		{
+			name: "quiet HPA metric warning is recovered before generic warning window",
+			event: &model.Event{
+				InvolvedKind:  "HorizontalPodAutoscaler",
+				Reason:        "FailedComputeMetricsReplicas",
+				LastTimestamp: &recoveredHPAMetric,
+				LastSeenAt:    &lastSeen,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := actionableWarningEvent(tt.event, nil, nil, nil, nil, now)
+			if got != tt.want {
+				t.Fatalf("actionableWarningEvent() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1803,6 +1995,7 @@ type fakeRepo struct {
 	deviceNodeIDs       map[uint64]uint64
 	pods                map[string]*model.Pod
 	events              []*model.Event
+	lastWorkloads       []*model.Workload
 	pruned              []string
 	lastInstallation    *model.Installation
 	telemetryCredential *model.TelemetryCredential
@@ -2176,7 +2369,12 @@ func (r *fakeRepo) UpdateNodeEdge(_ context.Context, nodeID, edgeID uint64, devi
 	return errs.ErrNotFound
 }
 
-func (r *fakeRepo) UpsertWorkloads(_ context.Context, _ []*model.Workload) error {
+func (r *fakeRepo) UpsertWorkloads(_ context.Context, items []*model.Workload) error {
+	r.lastWorkloads = make([]*model.Workload, 0, len(items))
+	for _, item := range items {
+		cp := *item
+		r.lastWorkloads = append(r.lastWorkloads, &cp)
+	}
 	return nil
 }
 

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -956,17 +956,32 @@ func TestUsecaseInventoryPersistsWorkloadExecutionCountsAndRolloutMetadata(t *te
 				Revision:          12,
 				CreationTimestamp: &createdAt,
 			},
+			{
+				Kind:            "Job",
+				Namespace:       "jobs",
+				Name:            "terminal-failure",
+				UID:             "terminal-failure-uid",
+				DesiredReplicas: 1,
+				FailedReplicas:  1,
+				Conditions: []map[string]string{{
+					"type":   "FailureTarget",
+					"status": "True",
+				}},
+			},
 		},
 	})
 	if err != nil {
 		t.Fatalf("IngestInventory() error = %v", err)
 	}
-	if len(repo.lastWorkloads) != 2 {
-		t.Fatalf("persisted workloads = %d, want 2", len(repo.lastWorkloads))
+	if len(repo.lastWorkloads) != 3 {
+		t.Fatalf("persisted workloads = %d, want 3", len(repo.lastWorkloads))
 	}
 	got := repo.lastWorkloads[0]
 	if got.ActiveReplicas != 1 || got.FailedReplicas != 1 {
 		t.Fatalf("workload execution = active:%d failed:%d, want 1/1", got.ActiveReplicas, got.FailedReplicas)
+	}
+	if got.IsTerminalFailure {
+		t.Fatalf("retrying job with failed pods must not be terminal: %+v", got)
 	}
 	rs := repo.lastWorkloads[1]
 	if rs.OwnerKind != "Deployment" || rs.OwnerName != "api" || rs.OwnerUID != "deployment-uid" || rs.Revision != 12 {
@@ -974,6 +989,9 @@ func TestUsecaseInventoryPersistsWorkloadExecutionCountsAndRolloutMetadata(t *te
 	}
 	if rs.ResourceCreatedAt == nil || !rs.ResourceCreatedAt.Equal(createdAt) {
 		t.Fatalf("workload resource created at = %v, want %v", rs.ResourceCreatedAt, createdAt)
+	}
+	if !repo.lastWorkloads[2].IsTerminalFailure {
+		t.Fatalf("FailureTarget=True job was not persisted as a terminal failure: %+v", repo.lastWorkloads[2])
 	}
 }
 
@@ -1746,6 +1764,21 @@ func TestUsecaseClusterHealthUsesExactRepositoryCounts(t *testing.T) {
 	repo.pods[podKey(clusterID, "default", "crash", "crash-uid")] = &model.Pod{ClusterID: clusterID, Namespace: "default", Name: "crash", UID: "crash-uid", Phase: "Running", Reason: "CrashLoopBackOff"}
 	repo.pods[podKey(clusterID, "default", "pull", "pull-uid")] = &model.Pod{ClusterID: clusterID, Namespace: "default", Name: "pull", UID: "pull-uid", Phase: "Pending", Reason: "ErrImagePull"}
 	repo.nodes[nodeKey(clusterID, "node-uid")] = &model.Node{ClusterID: clusterID, NodeName: "node-a", NodeUID: "node-uid", ConditionsJSON: `[{"type":"Ready","status":"False"}]`}
+	repo.lastWorkloads = []*model.Workload{
+		{ClusterID: clusterID, Namespace: "default", Kind: "Deployment", Name: "api"},
+		{ClusterID: clusterID, Namespace: "default", Kind: "ReplicaSet", Name: "api-7d8f9", OwnerKind: "Deployment", OwnerName: "api"},
+	}
+	repo.events = []*model.Event{{
+		ClusterID:         clusterID,
+		Namespace:         "default",
+		UID:               "warning-uid",
+		Type:              "Warning",
+		Reason:            "FailedScheduling",
+		InvolvedKind:      "Pod",
+		InvolvedNamespace: "default",
+		InvolvedName:      "pending",
+		InvolvedUID:       "pending-uid",
+	}}
 
 	health, err := uc.GetClusterHealth(ctx, clusterID)
 	if err != nil {
@@ -1753,6 +1786,12 @@ func TestUsecaseClusterHealthUsesExactRepositoryCounts(t *testing.T) {
 	}
 	if health.PendingPods != 2 || health.CrashLoopBackOffPods != 1 || health.ImagePullBackOffPods != 1 || health.NotReadyNodes != 1 {
 		t.Fatalf("health = %+v", health)
+	}
+	if len(repo.countWorkloadFilters) != 1 || !repo.countWorkloadFilters[0].GroupReplicaSets {
+		t.Fatalf("workload health filters = %+v, want grouped ReplicaSets", repo.countWorkloadFilters)
+	}
+	if len(health.Namespaces) != 1 || health.Namespaces[0].Namespace != "default" || health.Namespaces[0].Workloads != 1 || health.Namespaces[0].Pods != 3 || health.Namespaces[0].Events != 1 || health.Namespaces[0].Warnings != 1 {
+		t.Fatalf("namespace health = %+v", health.Namespaces)
 	}
 }
 
@@ -1988,19 +2027,20 @@ func TestActionableWarningEventUntrackedResourceUsesOccurrenceTime(t *testing.T)
 }
 
 type fakeRepo struct {
-	nextClusterID       uint64
-	nextNodeID          uint64
-	clusters            map[uint64]*model.Cluster
-	nodes               map[string]*model.Node
-	deviceNodeIDs       map[uint64]uint64
-	pods                map[string]*model.Pod
-	events              []*model.Event
-	lastWorkloads       []*model.Workload
-	pruned              []string
-	lastInstallation    *model.Installation
-	telemetryCredential *model.TelemetryCredential
-	failUpdateNodeEdge  bool
-	failBindController  bool
+	nextClusterID        uint64
+	nextNodeID           uint64
+	clusters             map[uint64]*model.Cluster
+	nodes                map[string]*model.Node
+	deviceNodeIDs        map[uint64]uint64
+	pods                 map[string]*model.Pod
+	events               []*model.Event
+	lastWorkloads        []*model.Workload
+	countWorkloadFilters []ListWorkloadsFilter
+	pruned               []string
+	lastInstallation     *model.Installation
+	telemetryCredential  *model.TelemetryCredential
+	failUpdateNodeEdge   bool
+	failBindController   bool
 }
 
 func bindFakeController(t *testing.T, repo *fakeRepo, clusterID, edgeID uint64) {
@@ -2681,8 +2721,52 @@ func (r *fakeRepo) ListWorkloads(_ context.Context, _ ListWorkloadsFilter) ([]*m
 }
 
 func (r *fakeRepo) CountWorkloads(ctx context.Context, f ListWorkloadsFilter) (int64, error) {
+	r.countWorkloadFilters = append(r.countWorkloadFilters, f)
 	items, err := r.ListWorkloads(ctx, f)
 	return int64(len(items)), err
+}
+
+func (r *fakeRepo) ListNamespaceSummaries(_ context.Context, clusterID uint64) ([]NamespaceSummary, error) {
+	byNamespace := map[string]*NamespaceSummary{}
+	ensure := func(namespace string) *NamespaceSummary {
+		namespace = strings.TrimSpace(namespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		if summary := byNamespace[namespace]; summary != nil {
+			return summary
+		}
+		summary := &NamespaceSummary{Namespace: namespace}
+		byNamespace[namespace] = summary
+		return summary
+	}
+	for _, item := range r.lastWorkloads {
+		if item == nil || item.ClusterID != clusterID || (item.Kind == "ReplicaSet" && item.OwnerKind == "Deployment" && (item.OwnerUID != "" || item.OwnerName != "")) {
+			continue
+		}
+		ensure(item.Namespace).Workloads++
+	}
+	for _, item := range r.pods {
+		if item != nil && item.ClusterID == clusterID {
+			ensure(item.Namespace).Pods++
+		}
+	}
+	for _, item := range r.events {
+		if item == nil || item.ClusterID != clusterID {
+			continue
+		}
+		namespace := item.Namespace
+		if strings.TrimSpace(namespace) == "" {
+			namespace = item.InvolvedNamespace
+		}
+		ensure(namespace).Events++
+	}
+	out := make([]NamespaceSummary, 0, len(byNamespace))
+	for _, summary := range byNamespace {
+		out = append(out, *summary)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Namespace < out[j].Namespace })
+	return out, nil
 }
 
 func (r *fakeRepo) ListPods(_ context.Context, f ListPodsFilter) ([]*model.Pod, error) {

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -1967,7 +1967,7 @@ func TestUsecaseListEventsIssueOnlyExcludesRecoveredWarnings(t *testing.T) {
 	}
 }
 
-func TestActionableWarningEventUntrackedResourceUsesOccurrenceTime(t *testing.T) {
+func TestActionableWarningEventUnmodeledHealthUsesOccurrenceTime(t *testing.T) {
 	now := time.Date(2026, 7, 29, 6, 0, 0, 0, time.UTC)
 	recent := now.Add(-actionableWarningWindow)
 	stale := recent.Add(-time.Nanosecond)
@@ -1994,6 +1994,24 @@ func TestActionableWarningEventUntrackedResourceUsesOccurrenceTime(t *testing.T)
 			name:  "ingestion timestamp only",
 			event: &model.Event{InvolvedKind: "HorizontalPodAutoscaler", LastSeenAt: &lastSeen},
 			want:  false,
+		},
+		{
+			name: "recent CronJob warning",
+			event: &model.Event{
+				InvolvedKind:  "CronJob",
+				Reason:        "FailedCreate",
+				LastTimestamp: &recent,
+			},
+			want: true,
+		},
+		{
+			name: "stale CronJob warning",
+			event: &model.Event{
+				InvolvedKind:  "CronJob",
+				Reason:        "FailedCreate",
+				LastTimestamp: &stale,
+			},
+			want: false,
 		},
 		{
 			name: "repeating HPA metric warning at recent boundary",

--- a/internal/manager/biz/setting/probe.go
+++ b/internal/manager/biz/setting/probe.go
@@ -48,8 +48,9 @@ func (p *LokiURLProbe) Probe(ctx context.Context) error {
 	return probeReadyEndpoint(ctx, u+"/ready", user, pass, tlsInsecure, p.timeout)
 }
 
-// TempoURLProbe is the trace-side counterpart. Tempo also exposes
-// /ready returning 200 once compactors and ingesters have replayed.
+// TempoURLProbe verifies the configured Tempo integration URL. Explicit
+// OTLP/HTTP endpoints ending in /v1/traces receive an empty export request;
+// the built-in/legacy query URL shape is checked through GET /ready.
 type TempoURLProbe struct {
 	resolver *TempoResolver
 	timeout  time.Duration
@@ -60,9 +61,9 @@ func NewTempoURLProbe(r *TempoResolver) *TempoURLProbe {
 	return &TempoURLProbe{resolver: r, timeout: 5 * time.Second}
 }
 
-// Probe runs a GET <base>/ready against the configured Tempo. The
-// admin-supplied URL may be the OTLP push URL ending in /v1/traces; we
-// strip a /v1/traces suffix so /ready lands on the API root.
+// Probe checks the configured Tempo URL without conflating its two listeners:
+// /v1/traces is the OTLP/HTTP receiver, while a URL without that path denotes
+// the Tempo query API and exposes /ready.
 func (p *TempoURLProbe) Probe(ctx context.Context) error {
 	if p == nil || p.resolver == nil {
 		return fmt.Errorf("tempo probe not wired")
@@ -71,12 +72,37 @@ func (p *TempoURLProbe) Probe(ctx context.Context) error {
 	if u == "" {
 		return fmt.Errorf("tempo url is empty")
 	}
-	// Tempo's /ready lives at the API root; the OTLP push URL on
-	// otelcol-style endpoints is /v1/traces. Strip if present.
-	base := strings.TrimSuffix(u, "/v1/traces")
 	user, pass := p.resolver.Auth(ctx)
 	tlsInsecure := p.resolver.TLSInsecure(ctx)
-	return probeReadyEndpoint(ctx, base+"/ready", user, pass, tlsInsecure, p.timeout)
+	if strings.HasSuffix(u, "/v1/traces") {
+		return probeOTLPHTTPTraceEndpoint(ctx, u, user, pass, tlsInsecure, p.timeout)
+	}
+	return probeReadyEndpoint(ctx, u+"/ready", user, pass, tlsInsecure, p.timeout)
+}
+
+// TempoReadinessProbe checks the manager-side Tempo query API. This URL is
+// intentionally independent from TempoURLProbe's edge-facing OTLP endpoint:
+// a standard Tempo deployment serves /ready on port 3200 and OTLP/HTTP on
+// port 4318.
+type TempoReadinessProbe struct {
+	baseURL string
+	timeout time.Duration
+}
+
+// NewTempoReadinessProbe builds a readiness probe for the Tempo query API.
+func NewTempoReadinessProbe(baseURL string) *TempoReadinessProbe {
+	return &TempoReadinessProbe{
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		timeout: 5 * time.Second,
+	}
+}
+
+// Probe runs GET <query-api-url>/ready.
+func (p *TempoReadinessProbe) Probe(ctx context.Context) error {
+	if p == nil || p.baseURL == "" {
+		return fmt.Errorf("tempo query url is empty")
+	}
+	return probeReadyEndpoint(ctx, p.baseURL+"/ready", "", "", false, p.timeout)
 }
 
 // WebSearchProbe is the integration-handler-side probe for the
@@ -284,6 +310,32 @@ func probeReadyEndpoint(ctx context.Context, fullURL, user, pass string, insecur
 		},
 	}
 	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", fullURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
+	return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+// probeOTLPHTTPTraceEndpoint verifies both transport reachability and the
+// configured OTLP path. An empty ExportTraceServiceRequest is a valid protobuf
+// message and Tempo accepts it without storing a trace.
+func probeOTLPHTTPTraceEndpoint(ctx context.Context, fullURL, user, pass string, insecure bool, timeout time.Duration) error {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, fullURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if user != "" {
+		req.SetBasicAuth(user, pass)
+	}
+	resp, err := newHTTPClient(timeout, insecure).Do(req)
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", fullURL, err)
 	}

--- a/internal/manager/biz/setting/probe_test.go
+++ b/internal/manager/biz/setting/probe_test.go
@@ -1,0 +1,70 @@
+package setting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTempoURLProbeUsesOTLPHTTPExportEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/traces" {
+			t.Errorf("path = %q, want /v1/traces", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-protobuf" {
+			t.Errorf("Content-Type = %q, want application/x-protobuf", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	resolver := NewTempoResolver(New(newFakeRepo(), nil), server.URL+"/v1/traces")
+	if err := NewTempoURLProbe(resolver).Probe(context.Background()); err != nil {
+		t.Fatalf("Probe returned error: %v", err)
+	}
+}
+
+func TestTempoURLProbeUsesReadyForQueryAPIURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/ready" {
+			t.Errorf("path = %q, want /ready", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	resolver := NewTempoResolver(New(newFakeRepo(), nil), server.URL)
+	if err := NewTempoURLProbe(resolver).Probe(context.Background()); err != nil {
+		t.Fatalf("Probe returned error: %v", err)
+	}
+}
+
+func TestTempoReadinessProbeUsesQueryAPIURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/ready" {
+			t.Errorf("path = %q, want /ready", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := NewTempoReadinessProbe(server.URL).Probe(context.Background()); err != nil {
+		t.Fatalf("Probe returned error: %v", err)
+	}
+}

--- a/internal/manager/data/k8s/store/repo.go
+++ b/internal/manager/data/k8s/store/repo.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -534,6 +536,7 @@ func (r *Repo) UpsertWorkloads(ctx context.Context, items []*model.Workload) err
 			"ready_replicas",
 			"active_replicas",
 			"failed_replicas",
+			"is_terminal_failure",
 			"owner_kind",
 			"owner_name",
 			"owner_uid",
@@ -920,6 +923,112 @@ func (r *Repo) CountWorkloads(ctx context.Context, f biz.ListWorkloadsFilter) (i
 	return total, nil
 }
 
+func (r *Repo) ListNamespaceSummaries(ctx context.Context, clusterID uint64) ([]biz.NamespaceSummary, error) {
+	type resourceCountRow struct {
+		Namespace  string
+		Total      int64
+		LastSeenAt sql.NullString
+	}
+	type eventCountRow struct {
+		Namespace         string
+		InvolvedNamespace string
+		Total             int64
+		LastSeenAt        sql.NullString
+	}
+
+	byNamespace := make(map[string]*biz.NamespaceSummary)
+	ensure := func(namespace string) *biz.NamespaceSummary {
+		namespace = strings.TrimSpace(namespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		if summary := byNamespace[namespace]; summary != nil {
+			return summary
+		}
+		summary := &biz.NamespaceSummary{Namespace: namespace}
+		byNamespace[namespace] = summary
+		return summary
+	}
+	touch := func(summary *biz.NamespaceSummary, rawLastSeenAt sql.NullString) {
+		if !rawLastSeenAt.Valid {
+			return
+		}
+		lastSeenAt := parseAggregateTime(rawLastSeenAt.String)
+		if lastSeenAt == nil || (summary.LastSeenAt != nil && !lastSeenAt.After(*summary.LastSeenAt)) {
+			return
+		}
+		ts := *lastSeenAt
+		summary.LastSeenAt = &ts
+	}
+
+	var workloads []resourceCountRow
+	if err := applyWorkloadFilter(
+		r.db.WithContext(ctx).Model(&model.Workload{}),
+		biz.ListWorkloadsFilter{ClusterID: clusterID, GroupReplicaSets: true},
+	).Select("namespace, COUNT(*) AS total, CAST(MAX(last_seen_at) AS CHAR) AS last_seen_at").
+		Group("namespace").Scan(&workloads).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range workloads {
+		summary := ensure(row.Namespace)
+		summary.Workloads += row.Total
+		touch(summary, row.LastSeenAt)
+	}
+
+	var pods []resourceCountRow
+	if err := r.db.WithContext(ctx).Model(&model.Pod{}).
+		Where("cluster_id = ?", clusterID).
+		Select("namespace, COUNT(*) AS total, CAST(MAX(last_seen_at) AS CHAR) AS last_seen_at").
+		Group("namespace").Scan(&pods).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range pods {
+		summary := ensure(row.Namespace)
+		summary.Pods += row.Total
+		touch(summary, row.LastSeenAt)
+	}
+
+	var events []eventCountRow
+	if err := r.db.WithContext(ctx).Model(&model.Event{}).
+		Where("cluster_id = ?", clusterID).
+		Select("namespace, involved_namespace, COUNT(*) AS total, CAST(MAX(last_seen_at) AS CHAR) AS last_seen_at").
+		Group("namespace, involved_namespace").Scan(&events).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range events {
+		namespace := row.Namespace
+		if strings.TrimSpace(namespace) == "" {
+			namespace = row.InvolvedNamespace
+		}
+		summary := ensure(namespace)
+		summary.Events += row.Total
+		touch(summary, row.LastSeenAt)
+	}
+
+	out := make([]biz.NamespaceSummary, 0, len(byNamespace))
+	for _, summary := range byNamespace {
+		out = append(out, *summary)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Namespace < out[j].Namespace })
+	return out, nil
+}
+
+func parseAggregateTime(value string) *time.Time {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return &parsed
+		}
+	}
+	return nil
+}
+
 func (r *Repo) ListPods(ctx context.Context, f biz.ListPodsFilter) ([]*model.Pod, error) {
 	tx := applyPodFilter(r.db.WithContext(ctx).Model(&model.Pod{}), f)
 	if f.Limit > 0 {
@@ -998,8 +1107,8 @@ func applyWorkloadFilter(tx *gorm.DB, f biz.ListWorkloadsFilter) *gorm.DB {
 		tx = tx.Where(`
 			(LOWER(kind) <> ? AND ready_replicas < desired_replicas)
 			OR
-			(LOWER(kind) = ? AND ready_replicas < desired_replicas AND active_replicas = 0 AND failed_replicas > 0)
-		`, "job", "job")
+			(LOWER(kind) = ? AND is_terminal_failure = ?)
+		`, "job", "job", true)
 	}
 	if f.GroupReplicaSets {
 		tx = tx.Where("NOT (kind = ? AND owner_kind = ? AND (owner_uid <> ? OR owner_name <> ?))", "ReplicaSet", "Deployment", "", "")

--- a/internal/manager/data/k8s/store/repo.go
+++ b/internal/manager/data/k8s/store/repo.go
@@ -532,6 +532,13 @@ func (r *Repo) UpsertWorkloads(ctx context.Context, items []*model.Workload) err
 			"uid",
 			"desired_replicas",
 			"ready_replicas",
+			"active_replicas",
+			"failed_replicas",
+			"owner_kind",
+			"owner_name",
+			"owner_uid",
+			"revision",
+			"resource_created_at",
 			"labels_json",
 			"annotations_json",
 			"conditions_json",
@@ -895,7 +902,11 @@ func (r *Repo) ListWorkloads(ctx context.Context, f biz.ListWorkloadsFilter) ([]
 		tx = tx.Offset(f.Offset)
 	}
 	var out []*model.Workload
-	if err := tx.Order("namespace ASC, kind ASC, name ASC").Find(&out).Error; err != nil {
+	order := "namespace ASC, kind ASC, name ASC"
+	if len(f.OwnerRefs) > 0 {
+		order = "namespace ASC, owner_name ASC, revision DESC, resource_created_at DESC, name DESC"
+	}
+	if err := tx.Order(order).Find(&out).Error; err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -984,10 +995,76 @@ func applyWorkloadFilter(tx *gorm.DB, f biz.ListWorkloadsFilter) *gorm.DB {
 		tx = tx.Where("kind = ?", f.Kind)
 	}
 	if f.IssueOnly {
-		tx = tx.Where("ready_replicas < desired_replicas")
+		tx = tx.Where(`
+			(LOWER(kind) <> ? AND ready_replicas < desired_replicas)
+			OR
+			(LOWER(kind) = ? AND ready_replicas < desired_replicas AND active_replicas = 0 AND failed_replicas > 0)
+		`, "job", "job")
 	}
-	tx = applyLikeAny(tx, f.Query, []string{"namespace", "kind", "name", "uid"})
+	if f.GroupReplicaSets {
+		tx = tx.Where("NOT (kind = ? AND owner_kind = ? AND (owner_uid <> ? OR owner_name <> ?))", "ReplicaSet", "Deployment", "", "")
+	}
+	if len(f.OwnerRefs) > 0 {
+		clauses := make([]string, 0, len(f.OwnerRefs))
+		args := make([]any, 0, len(f.OwnerRefs)*6)
+		for _, ref := range f.OwnerRefs {
+			namespace := strings.TrimSpace(ref.Namespace)
+			kind := strings.TrimSpace(ref.Kind)
+			name := strings.TrimSpace(ref.Name)
+			uid := strings.TrimSpace(ref.UID)
+			if kind == "" || (name == "" && uid == "") {
+				continue
+			}
+			if uid != "" {
+				clauses = append(clauses, "(namespace = ? AND owner_kind = ? AND (owner_uid = ? OR (owner_uid = ? AND owner_name = ?)))")
+				args = append(args, namespace, kind, uid, "", name)
+				continue
+			}
+			clauses = append(clauses, "(namespace = ? AND owner_kind = ? AND owner_name = ?)")
+			args = append(args, namespace, kind, name)
+		}
+		if len(clauses) == 0 {
+			tx = tx.Where("1 = 0")
+		} else {
+			tx = tx.Where("kind = ?", "ReplicaSet").Where("("+strings.Join(clauses, " OR ")+")", args...)
+		}
+	}
+	if f.GroupReplicaSets {
+		tx = applyGroupedWorkloadQuery(tx, f.Query)
+	} else {
+		tx = applyLikeAny(tx, f.Query, []string{"namespace", "kind", "name", "uid"})
+	}
 	return tx
+}
+
+func applyGroupedWorkloadQuery(tx *gorm.DB, query string) *gorm.DB {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return tx
+	}
+	pattern := "%" + query + "%"
+	return tx.Where(`
+		k8s_workloads.namespace LIKE ?
+		OR k8s_workloads.kind LIKE ?
+		OR k8s_workloads.name LIKE ?
+		OR k8s_workloads.uid LIKE ?
+		OR (
+			k8s_workloads.kind = ?
+			AND EXISTS (
+				SELECT 1
+				FROM k8s_workloads AS child
+				WHERE child.cluster_id = k8s_workloads.cluster_id
+					AND child.namespace = k8s_workloads.namespace
+					AND child.kind = ?
+					AND child.owner_kind = ?
+					AND (
+						(child.owner_uid <> '' AND k8s_workloads.uid <> '' AND child.owner_uid = k8s_workloads.uid)
+						OR ((child.owner_uid = '' OR k8s_workloads.uid = '') AND child.owner_name = k8s_workloads.name)
+					)
+					AND (child.namespace LIKE ? OR child.kind LIKE ? OR child.name LIKE ? OR child.uid LIKE ?)
+			)
+		)
+	`, pattern, pattern, pattern, pattern, "Deployment", "ReplicaSet", "Deployment", pattern, pattern, pattern, pattern)
 }
 
 func applyNodeFilter(tx *gorm.DB, f biz.ListNodesFilter) *gorm.DB {

--- a/internal/manager/data/k8s/store/repo_test.go
+++ b/internal/manager/data/k8s/store/repo_test.go
@@ -251,12 +251,13 @@ func TestRepo_SnapshotUpsertsWorkOnSQLite(t *testing.T) {
 	workload.ReadyReplicas = 1
 	workload.ActiveReplicas = 0
 	workload.FailedReplicas = 1
+	workload.IsTerminalFailure = true
 	workload.LastSeenAt = &secondSeen
 	if err := repo.UpsertWorkloads(ctx, []*model.Workload{workload}); err != nil {
 		t.Fatalf("UpsertWorkloads(second): %v", err)
 	}
 	workloads, err := repo.ListWorkloads(ctx, biz.ListWorkloadsFilter{ClusterID: 1})
-	if err != nil || len(workloads) != 1 || workloads[0].UID != "workload-v2" || workloads[0].ReadyReplicas != 1 || workloads[0].ActiveReplicas != 0 || workloads[0].FailedReplicas != 1 {
+	if err != nil || len(workloads) != 1 || workloads[0].UID != "workload-v2" || workloads[0].ReadyReplicas != 1 || workloads[0].ActiveReplicas != 0 || workloads[0].FailedReplicas != 1 || !workloads[0].IsTerminalFailure {
 		t.Fatalf("workload upsert result=%+v err=%v", workloads, err)
 	}
 
@@ -325,17 +326,32 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 			LastSeenAt:      &now,
 		},
 		{
+			ClusterID:         1,
+			Namespace:         "jobs",
+			Kind:              "Job",
+			Name:              "failed-job",
+			UID:               "job-failed",
+			DesiredReplicas:   1,
+			ReadyReplicas:     0,
+			FailedReplicas:    1,
+			IsTerminalFailure: true,
+			LabelsJSON:        "{}",
+			AnnotationsJSON:   "{}",
+			ConditionsJSON:    `[{"type":"Failed","status":"True"}]`,
+			LastSeenAt:        &now,
+		},
+		{
 			ClusterID:       1,
 			Namespace:       "jobs",
 			Kind:            "Job",
-			Name:            "failed-job",
-			UID:             "job-failed",
+			Name:            "retrying-job",
+			UID:             "job-retrying",
 			DesiredReplicas: 1,
 			ReadyReplicas:   0,
 			FailedReplicas:  1,
 			LabelsJSON:      "{}",
 			AnnotationsJSON: "{}",
-			ConditionsJSON:  `[{"type":"Failed","status":"True"}]`,
+			ConditionsJSON:  "[]",
 			LastSeenAt:      &now,
 		},
 		{
@@ -471,8 +487,8 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListWorkloads(group replica sets): %v", err)
 	}
-	if len(visible) != 6 {
-		t.Fatalf("visible workloads=%d want 6", len(visible))
+	if len(visible) != 7 {
+		t.Fatalf("visible workloads=%d want 7", len(visible))
 	}
 	for _, item := range visible {
 		if item.Name == "checkout-api-history" || item.Name == "checkout-api-current" {
@@ -486,8 +502,8 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CountWorkloads(group replica sets): %v", err)
 	}
-	if visibleTotal != 6 {
-		t.Fatalf("visible total=%d want 6", visibleTotal)
+	if visibleTotal != 7 {
+		t.Fatalf("visible total=%d want 7", visibleTotal)
 	}
 
 	ownerFilter := biz.ListWorkloadsFilter{
@@ -525,6 +541,54 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 	parentTotal, err := repo.CountWorkloads(context.Background(), childQueryFilter)
 	if err != nil || parentTotal != 1 {
 		t.Fatalf("grouped child query total=%d err=%v, want 1", parentTotal, err)
+	}
+}
+
+func TestRepo_ListNamespaceSummariesAggregatesAllGroupedResources(t *testing.T) {
+	db, repo := newTestRepo(t)
+	now := time.Now().UTC()
+	workloads := []*model.Workload{
+		{ClusterID: 1, Namespace: "apps", Kind: "Deployment", Name: "api", UID: "deployment-uid", LabelsJSON: "{}", AnnotationsJSON: "{}", ConditionsJSON: "[]", LastSeenAt: &now},
+		{ClusterID: 1, Namespace: "apps", Kind: "ReplicaSet", Name: "api-7d8f9", UID: "rs-uid", OwnerKind: "Deployment", OwnerName: "api", OwnerUID: "deployment-uid", LabelsJSON: "{}", AnnotationsJSON: "{}", ConditionsJSON: "[]", LastSeenAt: &now},
+		{ClusterID: 1, Namespace: "jobs", Kind: "CronJob", Name: "cleanup", UID: "cronjob-uid", LabelsJSON: "{}", AnnotationsJSON: "{}", ConditionsJSON: "[]", LastSeenAt: &now},
+	}
+	pods := []*model.Pod{
+		{ClusterID: 1, Namespace: "apps", Name: "api-1", UID: "pod-apps", LastSeenAt: &now},
+		{ClusterID: 1, Namespace: "late-page", Name: "worker-1500", UID: "pod-late", LastSeenAt: &now},
+	}
+	events := []*model.Event{
+		{ClusterID: 1, Namespace: "apps", Name: "scheduled", UID: "event-apps", LastSeenAt: &now},
+		{ClusterID: 1, Namespace: "", Name: "late-warning", UID: "event-late", InvolvedNamespace: "late-page", LastSeenAt: &now},
+	}
+	if err := db.Create(&workloads).Error; err != nil {
+		t.Fatalf("Create workloads: %v", err)
+	}
+	if err := db.Create(&pods).Error; err != nil {
+		t.Fatalf("Create pods: %v", err)
+	}
+	if err := db.Create(&events).Error; err != nil {
+		t.Fatalf("Create events: %v", err)
+	}
+
+	summaries, err := repo.ListNamespaceSummaries(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListNamespaceSummaries: %v", err)
+	}
+	if len(summaries) != 3 {
+		t.Fatalf("namespace summaries = %+v, want 3 namespaces", summaries)
+	}
+	byNamespace := make(map[string]biz.NamespaceSummary, len(summaries))
+	for _, summary := range summaries {
+		byNamespace[summary.Namespace] = summary
+	}
+	if got := byNamespace["apps"]; got.Workloads != 1 || got.Pods != 1 || got.Events != 1 || got.LastSeenAt == nil {
+		t.Fatalf("apps summary = %+v", got)
+	}
+	if got := byNamespace["jobs"]; got.Workloads != 1 || got.Pods != 0 || got.Events != 0 {
+		t.Fatalf("jobs summary = %+v", got)
+	}
+	if got := byNamespace["late-page"]; got.Workloads != 0 || got.Pods != 1 || got.Events != 1 {
+		t.Fatalf("late-page summary = %+v", got)
 	}
 }
 

--- a/internal/manager/data/k8s/store/repo_test.go
+++ b/internal/manager/data/k8s/store/repo_test.go
@@ -237,6 +237,8 @@ func TestRepo_SnapshotUpsertsWorkOnSQLite(t *testing.T) {
 		UID:             "workload-v1",
 		DesiredReplicas: 1,
 		ReadyReplicas:   0,
+		ActiveReplicas:  1,
+		FailedReplicas:  0,
 		LabelsJSON:      "{}",
 		AnnotationsJSON: "{}",
 		ConditionsJSON:  "[]",
@@ -247,12 +249,14 @@ func TestRepo_SnapshotUpsertsWorkOnSQLite(t *testing.T) {
 	}
 	workload.UID = "workload-v2"
 	workload.ReadyReplicas = 1
+	workload.ActiveReplicas = 0
+	workload.FailedReplicas = 1
 	workload.LastSeenAt = &secondSeen
 	if err := repo.UpsertWorkloads(ctx, []*model.Workload{workload}); err != nil {
 		t.Fatalf("UpsertWorkloads(second): %v", err)
 	}
 	workloads, err := repo.ListWorkloads(ctx, biz.ListWorkloadsFilter{ClusterID: 1})
-	if err != nil || len(workloads) != 1 || workloads[0].UID != "workload-v2" || workloads[0].ReadyReplicas != 1 {
+	if err != nil || len(workloads) != 1 || workloads[0].UID != "workload-v2" || workloads[0].ReadyReplicas != 1 || workloads[0].ActiveReplicas != 0 || workloads[0].FailedReplicas != 1 {
 		t.Fatalf("workload upsert result=%+v err=%v", workloads, err)
 	}
 
@@ -289,6 +293,8 @@ func TestRepo_SnapshotUpsertsWorkOnSQLite(t *testing.T) {
 func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 	db, repo := newTestRepo(t)
 	now := time.Now()
+	previousRelease := now.Add(-24 * time.Hour)
+	currentRelease := now.Add(-time.Hour)
 	workloads := []*model.Workload{
 		{
 			ClusterID:       1,
@@ -298,9 +304,38 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 			UID:             "workload-checkout",
 			DesiredReplicas: 3,
 			ReadyReplicas:   2,
+			Revision:        3,
 			LabelsJSON:      "{}",
 			AnnotationsJSON: "{}",
 			ConditionsJSON:  "[]",
+			LastSeenAt:      &now,
+		},
+		{
+			ClusterID:       1,
+			Namespace:       "jobs",
+			Kind:            "Job",
+			Name:            "active-job",
+			UID:             "job-active",
+			DesiredReplicas: 1,
+			ReadyReplicas:   0,
+			ActiveReplicas:  1,
+			LabelsJSON:      "{}",
+			AnnotationsJSON: "{}",
+			ConditionsJSON:  "[]",
+			LastSeenAt:      &now,
+		},
+		{
+			ClusterID:       1,
+			Namespace:       "jobs",
+			Kind:            "Job",
+			Name:            "failed-job",
+			UID:             "job-failed",
+			DesiredReplicas: 1,
+			ReadyReplicas:   0,
+			FailedReplicas:  1,
+			LabelsJSON:      "{}",
+			AnnotationsJSON: "{}",
+			ConditionsJSON:  `[{"type":"Failed","status":"True"}]`,
 			LastSeenAt:      &now,
 		},
 		{
@@ -316,12 +351,90 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 			ConditionsJSON:  "[]",
 			LastSeenAt:      &now,
 		},
+		{
+			ClusterID:       1,
+			Namespace:       "default",
+			Kind:            "Deployment",
+			Name:            "paused-api",
+			UID:             "workload-paused",
+			DesiredReplicas: 0,
+			ReadyReplicas:   0,
+			LabelsJSON:      "{}",
+			AnnotationsJSON: "{}",
+			ConditionsJSON:  "[]",
+			LastSeenAt:      &now,
+		},
+		{
+			ClusterID:         1,
+			Namespace:         "default",
+			Kind:              "ReplicaSet",
+			Name:              "checkout-api-history",
+			UID:               "workload-history",
+			DesiredReplicas:   0,
+			ReadyReplicas:     0,
+			OwnerKind:         "Deployment",
+			OwnerName:         "checkout-api",
+			OwnerUID:          "workload-checkout",
+			Revision:          2,
+			ResourceCreatedAt: &previousRelease,
+			LabelsJSON:        "{}",
+			AnnotationsJSON:   "{}",
+			ConditionsJSON:    "[]",
+			LastSeenAt:        &now,
+		},
+		{
+			ClusterID:         1,
+			Namespace:         "default",
+			Kind:              "ReplicaSet",
+			Name:              "checkout-api-current",
+			UID:               "workload-current",
+			DesiredReplicas:   3,
+			ReadyReplicas:     2,
+			OwnerKind:         "Deployment",
+			OwnerName:         "checkout-api",
+			OwnerUID:          "workload-checkout",
+			Revision:          3,
+			ResourceCreatedAt: &currentRelease,
+			LabelsJSON:        "{}",
+			AnnotationsJSON:   "{}",
+			ConditionsJSON:    "[]",
+			LastSeenAt:        &now,
+		},
+		{
+			ClusterID:       1,
+			Namespace:       "default",
+			Kind:            "ReplicaSet",
+			Name:            "standalone-zero",
+			UID:             "standalone-zero",
+			DesiredReplicas: 0,
+			ReadyReplicas:   0,
+			LabelsJSON:      "{}",
+			AnnotationsJSON: "{}",
+			ConditionsJSON:  "[]",
+			LastSeenAt:      &now,
+		},
+		{
+			ClusterID:       1,
+			Namespace:       "default",
+			Kind:            "ReplicaSet",
+			Name:            "checkout-api-stale-owner",
+			UID:             "stale-owner-rs",
+			DesiredReplicas: 0,
+			ReadyReplicas:   0,
+			OwnerKind:       "Deployment",
+			OwnerName:       "checkout-api",
+			OwnerUID:        "deleted-deployment-uid",
+			LabelsJSON:      "{}",
+			AnnotationsJSON: "{}",
+			ConditionsJSON:  "[]",
+			LastSeenAt:      &now,
+		},
 	}
 	if err := db.Create(&workloads).Error; err != nil {
 		t.Fatalf("Create workloads: %v", err)
 	}
 
-	filter := biz.ListWorkloadsFilter{ClusterID: 1, Query: "checkout", IssueOnly: true}
+	filter := biz.ListWorkloadsFilter{ClusterID: 1, Query: "checkout", IssueOnly: true, GroupReplicaSets: true}
 	items, err := repo.ListWorkloads(context.Background(), filter)
 	if err != nil {
 		t.Fatalf("ListWorkloads: %v", err)
@@ -335,6 +448,83 @@ func TestRepo_ListWorkloadsSupportsQueryAndIssueOnly(t *testing.T) {
 	}
 	if total != 1 {
 		t.Fatalf("total=%d want 1", total)
+	}
+
+	issueFilter := biz.ListWorkloadsFilter{ClusterID: 1, IssueOnly: true, GroupReplicaSets: true}
+	issues, err := repo.ListWorkloads(context.Background(), issueFilter)
+	if err != nil {
+		t.Fatalf("ListWorkloads(issue only): %v", err)
+	}
+	if len(issues) != 2 || issues[0].Name != "checkout-api" || issues[1].Name != "failed-job" {
+		t.Fatalf("issue workloads: %+v", issues)
+	}
+	issueTotal, err := repo.CountWorkloads(context.Background(), issueFilter)
+	if err != nil {
+		t.Fatalf("CountWorkloads(issue only): %v", err)
+	}
+	if issueTotal != 2 {
+		t.Fatalf("issue total=%d want 2", issueTotal)
+	}
+
+	visibleFilter := biz.ListWorkloadsFilter{ClusterID: 1, GroupReplicaSets: true}
+	visible, err := repo.ListWorkloads(context.Background(), visibleFilter)
+	if err != nil {
+		t.Fatalf("ListWorkloads(group replica sets): %v", err)
+	}
+	if len(visible) != 6 {
+		t.Fatalf("visible workloads=%d want 6", len(visible))
+	}
+	for _, item := range visible {
+		if item.Name == "checkout-api-history" || item.Name == "checkout-api-current" {
+			t.Fatalf("deployment-owned ReplicaSet was not grouped: %+v", item)
+		}
+	}
+	if visible[3].Name != "standalone-zero" {
+		t.Fatalf("standalone ReplicaSet should remain top-level: %+v", visible)
+	}
+	visibleTotal, err := repo.CountWorkloads(context.Background(), visibleFilter)
+	if err != nil {
+		t.Fatalf("CountWorkloads(group replica sets): %v", err)
+	}
+	if visibleTotal != 6 {
+		t.Fatalf("visible total=%d want 6", visibleTotal)
+	}
+
+	ownerFilter := biz.ListWorkloadsFilter{
+		ClusterID: 1,
+		OwnerRefs: []biz.WorkloadOwnerRef{{
+			Namespace: "default",
+			Kind:      "Deployment",
+			Name:      "checkout-api",
+			UID:       "workload-checkout",
+		}},
+	}
+	history, err := repo.ListWorkloads(context.Background(), ownerFilter)
+	if err != nil {
+		t.Fatalf("ListWorkloads(owner refs): %v", err)
+	}
+	if len(history) != 2 || history[0].Name != "checkout-api-current" || history[1].Name != "checkout-api-history" {
+		t.Fatalf("deployment ReplicaSet versions: %+v", history)
+	}
+	historyTotal, err := repo.CountWorkloads(context.Background(), ownerFilter)
+	if err != nil {
+		t.Fatalf("CountWorkloads(owner refs): %v", err)
+	}
+	if historyTotal != 2 {
+		t.Fatalf("deployment ReplicaSet total=%d want 2", historyTotal)
+	}
+
+	childQueryFilter := biz.ListWorkloadsFilter{ClusterID: 1, GroupReplicaSets: true, Query: "checkout-api-history"}
+	parents, err := repo.ListWorkloads(context.Background(), childQueryFilter)
+	if err != nil {
+		t.Fatalf("ListWorkloads(grouped child query): %v", err)
+	}
+	if len(parents) != 1 || parents[0].Name != "checkout-api" {
+		t.Fatalf("grouped child query parents: %+v", parents)
+	}
+	parentTotal, err := repo.CountWorkloads(context.Background(), childQueryFilter)
+	if err != nil || parentTotal != 1 {
+		t.Fatalf("grouped child query total=%d err=%v, want 1", parentTotal, err)
 	}
 }
 

--- a/internal/manager/model/k8s/model.go
+++ b/internal/manager/model/k8s/model.go
@@ -79,18 +79,28 @@ func (Node) TableName() string { return "k8s_nodes" }
 // Workload is the current snapshot of a Kubernetes workload object.
 type Workload struct {
 	ID        uint64 `gorm:"primaryKey;autoIncrement"`
-	ClusterID uint64 `gorm:"not null;column:cluster_id;uniqueIndex:idx_k8s_workloads_key,priority:1;index:idx_k8s_workloads_cluster_seen,priority:1"`
+	ClusterID uint64 `gorm:"not null;column:cluster_id;uniqueIndex:idx_k8s_workloads_key,priority:1;index:idx_k8s_workloads_cluster_seen,priority:1;index:idx_k8s_workloads_owner,priority:1"`
 	Namespace string `gorm:"size:255;not null;default:'';column:namespace;uniqueIndex:idx_k8s_workloads_key,priority:3"`
 	Kind      string `gorm:"size:64;not null;column:kind;uniqueIndex:idx_k8s_workloads_key,priority:2"`
 	Name      string `gorm:"size:255;not null;column:name;uniqueIndex:idx_k8s_workloads_key,priority:4"`
 	UID       string `gorm:"size:128;not null;default:'';column:uid"`
 
-	DesiredReplicas int        `gorm:"not null;default:0;column:desired_replicas"`
-	ReadyReplicas   int        `gorm:"not null;default:0;column:ready_replicas"`
-	LabelsJSON      string     `gorm:"type:text;not null;column:labels_json"`
-	AnnotationsJSON string     `gorm:"type:text;not null;column:annotations_json"`
-	ConditionsJSON  string     `gorm:"type:text;not null;column:conditions_json"`
-	LastSeenAt      *time.Time `gorm:"column:last_seen_at;index:idx_k8s_workloads_cluster_seen,priority:2"`
+	DesiredReplicas   int        `gorm:"not null;default:0;column:desired_replicas"`
+	ReadyReplicas     int        `gorm:"not null;default:0;column:ready_replicas"`
+	ActiveReplicas    int        `gorm:"not null;default:0;column:active_replicas"`
+	FailedReplicas    int        `gorm:"not null;default:0;column:failed_replicas"`
+	OwnerKind         string     `gorm:"size:64;not null;default:'';column:owner_kind;index:idx_k8s_workloads_owner,priority:2"`
+	OwnerName         string     `gorm:"size:255;not null;default:'';column:owner_name"`
+	OwnerUID          string     `gorm:"size:128;not null;default:'';column:owner_uid;index:idx_k8s_workloads_owner,priority:3"`
+	Revision          int64      `gorm:"not null;default:0;column:revision"`
+	ResourceCreatedAt *time.Time `gorm:"column:resource_created_at"`
+	LabelsJSON        string     `gorm:"type:text;not null;column:labels_json"`
+	AnnotationsJSON   string     `gorm:"type:text;not null;column:annotations_json"`
+	ConditionsJSON    string     `gorm:"type:text;not null;column:conditions_json"`
+	LastSeenAt        *time.Time `gorm:"column:last_seen_at;index:idx_k8s_workloads_cluster_seen,priority:2"`
+
+	// ReplicaSets is populated only for grouped API reads and is never persisted.
+	ReplicaSets []*Workload `gorm:"-"`
 
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`

--- a/internal/manager/model/k8s/model.go
+++ b/internal/manager/model/k8s/model.go
@@ -89,6 +89,7 @@ type Workload struct {
 	ReadyReplicas     int        `gorm:"not null;default:0;column:ready_replicas"`
 	ActiveReplicas    int        `gorm:"not null;default:0;column:active_replicas"`
 	FailedReplicas    int        `gorm:"not null;default:0;column:failed_replicas"`
+	IsTerminalFailure bool       `gorm:"not null;default:false;column:is_terminal_failure"`
 	OwnerKind         string     `gorm:"size:64;not null;default:'';column:owner_kind;index:idx_k8s_workloads_owner,priority:2"`
 	OwnerName         string     `gorm:"size:255;not null;default:'';column:owner_name"`
 	OwnerUID          string     `gorm:"size:128;not null;default:'';column:owner_uid;index:idx_k8s_workloads_owner,priority:3"`

--- a/internal/manager/server/integration/http.go
+++ b/internal/manager/server/integration/http.go
@@ -41,7 +41,8 @@ type PromQuerier interface {
 // URLProbe is the narrow surface for the Loki / Tempo test endpoints.
 // The Probe(ctx) method does whatever lightweight check the resolver
 // owner thinks proves the URL is reachable + auth-accepted (Loki:
-// /ready; Tempo: /ready or /api/echo). Returning nil = ok.
+// GET /ready; Tempo: GET /ready or empty OTLP/HTTP export, depending on
+// the configured URL shape). Returning nil = ok.
 type URLProbe interface {
 	Probe(ctx context.Context) error
 }

--- a/internal/manager/server/k8s/http.go
+++ b/internal/manager/server/k8s/http.go
@@ -272,13 +272,14 @@ func (h *Handler) listWorkloads(w http.ResponseWriter, r *http.Request) {
 	limit := parseListLimit(r.URL.Query().Get("limit"), 100)
 	offset := parseListOffset(r.URL.Query().Get("offset"))
 	filter := biz.ListWorkloadsFilter{
-		ClusterID: id,
-		Namespace: strings.TrimSpace(r.URL.Query().Get("namespace")),
-		Kind:      strings.TrimSpace(r.URL.Query().Get("kind")),
-		Query:     strings.TrimSpace(r.URL.Query().Get("q")),
-		IssueOnly: parseBoolDefault(r.URL.Query().Get("issue_only"), false),
-		Limit:     limit,
-		Offset:    offset,
+		ClusterID:        id,
+		Namespace:        strings.TrimSpace(r.URL.Query().Get("namespace")),
+		Kind:             strings.TrimSpace(r.URL.Query().Get("kind")),
+		Query:            strings.TrimSpace(r.URL.Query().Get("q")),
+		IssueOnly:        parseBoolDefault(r.URL.Query().Get("issue_only"), false),
+		GroupReplicaSets: parseBoolDefault(r.URL.Query().Get("group_replica_sets"), false),
+		Limit:            limit,
+		Offset:           offset,
 	}
 	items, err := h.svc.ListWorkloads(r.Context(), filter)
 	if err != nil {
@@ -635,18 +636,26 @@ type nodeDTO struct {
 }
 
 type workloadDTO struct {
-	ID              uint64          `json:"id"`
-	ClusterID       uint64          `json:"cluster_id"`
-	Namespace       string          `json:"namespace"`
-	Kind            string          `json:"kind"`
-	Name            string          `json:"name"`
-	UID             string          `json:"uid,omitempty"`
-	DesiredReplicas int             `json:"desired_replicas"`
-	ReadyReplicas   int             `json:"ready_replicas"`
-	Labels          json.RawMessage `json:"labels,omitempty"`
-	Annotations     json.RawMessage `json:"annotations,omitempty"`
-	Conditions      json.RawMessage `json:"conditions,omitempty"`
-	LastSeenAt      *time.Time      `json:"last_seen_at,omitempty"`
+	ID                uint64          `json:"id"`
+	ClusterID         uint64          `json:"cluster_id"`
+	Namespace         string          `json:"namespace"`
+	Kind              string          `json:"kind"`
+	Name              string          `json:"name"`
+	UID               string          `json:"uid,omitempty"`
+	DesiredReplicas   int             `json:"desired_replicas"`
+	ReadyReplicas     int             `json:"ready_replicas"`
+	ActiveReplicas    int             `json:"active_replicas"`
+	FailedReplicas    int             `json:"failed_replicas"`
+	OwnerKind         string          `json:"owner_kind,omitempty"`
+	OwnerName         string          `json:"owner_name,omitempty"`
+	OwnerUID          string          `json:"owner_uid,omitempty"`
+	Revision          int64           `json:"revision,omitempty"`
+	CreationTimestamp *time.Time      `json:"creation_timestamp,omitempty"`
+	Labels            json.RawMessage `json:"labels,omitempty"`
+	Annotations       json.RawMessage `json:"annotations,omitempty"`
+	Conditions        json.RawMessage `json:"conditions,omitempty"`
+	LastSeenAt        *time.Time      `json:"last_seen_at,omitempty"`
+	ReplicaSets       []workloadDTO   `json:"replica_sets,omitempty"`
 }
 
 type podDTO struct {
@@ -705,6 +714,7 @@ type telemetryConfigResponse struct {
 	ClusterID              uint64 `json:"cluster_id"`
 	AccessKey              string `json:"access_key"`
 	SecretKey              string `json:"secret_key"`
+	ManagerPublicURL       string `json:"manager_public_url,omitempty"`
 	TracesEndpoint         string `json:"traces_endpoint,omitempty"`
 	TracesAuthMode         string `json:"traces_auth_mode,omitempty"`
 	TracesBasicUser        string `json:"traces_basic_user,omitempty"`
@@ -731,6 +741,7 @@ func telemetryConfigDTO(in *biz.TelemetryConfig) *telemetryConfigResponse {
 		ClusterID:              in.ClusterID,
 		AccessKey:              in.AccessKey,
 		SecretKey:              in.SecretKey,
+		ManagerPublicURL:       in.ManagerPublicURL,
 		TracesEndpoint:         in.TracesEndpoint,
 		TracesAuthMode:         in.TracesAuthMode,
 		TracesBasicUser:        in.TracesBasicUser,
@@ -936,20 +947,34 @@ func workloadDTOFromModel(item *model.Workload) workloadDTO {
 	if item == nil {
 		return workloadDTO{}
 	}
-	return workloadDTO{
-		ID:              item.ID,
-		ClusterID:       item.ClusterID,
-		Namespace:       item.Namespace,
-		Kind:            item.Kind,
-		Name:            item.Name,
-		UID:             item.UID,
-		DesiredReplicas: item.DesiredReplicas,
-		ReadyReplicas:   item.ReadyReplicas,
-		Labels:          rawJSON(item.LabelsJSON, "{}"),
-		Annotations:     rawJSON(item.AnnotationsJSON, "{}"),
-		Conditions:      rawJSON(item.ConditionsJSON, "[]"),
-		LastSeenAt:      item.LastSeenAt,
+	dto := workloadDTO{
+		ID:                item.ID,
+		ClusterID:         item.ClusterID,
+		Namespace:         item.Namespace,
+		Kind:              item.Kind,
+		Name:              item.Name,
+		UID:               item.UID,
+		DesiredReplicas:   item.DesiredReplicas,
+		ReadyReplicas:     item.ReadyReplicas,
+		ActiveReplicas:    item.ActiveReplicas,
+		FailedReplicas:    item.FailedReplicas,
+		OwnerKind:         item.OwnerKind,
+		OwnerName:         item.OwnerName,
+		OwnerUID:          item.OwnerUID,
+		Revision:          item.Revision,
+		CreationTimestamp: item.ResourceCreatedAt,
+		Labels:            rawJSON(item.LabelsJSON, "{}"),
+		Annotations:       rawJSON(item.AnnotationsJSON, "{}"),
+		Conditions:        rawJSON(item.ConditionsJSON, "[]"),
+		LastSeenAt:        item.LastSeenAt,
 	}
+	if len(item.ReplicaSets) > 0 {
+		dto.ReplicaSets = make([]workloadDTO, 0, len(item.ReplicaSets))
+		for _, replicaSet := range item.ReplicaSets {
+			dto.ReplicaSets = append(dto.ReplicaSets, workloadDTOFromModel(replicaSet))
+		}
+	}
+	return dto
 }
 
 func podDTOFromModel(item *model.Pod) podDTO {

--- a/internal/manager/server/k8s/http.go
+++ b/internal/manager/server/k8s/http.go
@@ -118,6 +118,7 @@ func (h *Handler) getClusterHealth(w http.ResponseWriter, r *http.Request) {
 		OOMKilledPods:        out.OOMKilledPods,
 		ImagePullBackOffPods: out.ImagePullBackOffPods,
 		NotReadyNodes:        out.NotReadyNodes,
+		Namespaces:           namespaceSummaryDTOs(out.Namespaces),
 	})
 }
 
@@ -596,12 +597,37 @@ type clusterRegistrationDTO struct {
 }
 
 type clusterHealthDTO struct {
-	DegradedWorkloads    int64 `json:"degraded_workloads"`
-	PendingPods          int64 `json:"pending_pods"`
-	CrashLoopBackOffPods int64 `json:"crash_loop_back_off_pods"`
-	OOMKilledPods        int64 `json:"oom_killed_pods"`
-	ImagePullBackOffPods int64 `json:"image_pull_back_off_pods"`
-	NotReadyNodes        int64 `json:"not_ready_nodes"`
+	DegradedWorkloads    int64                 `json:"degraded_workloads"`
+	PendingPods          int64                 `json:"pending_pods"`
+	CrashLoopBackOffPods int64                 `json:"crash_loop_back_off_pods"`
+	OOMKilledPods        int64                 `json:"oom_killed_pods"`
+	ImagePullBackOffPods int64                 `json:"image_pull_back_off_pods"`
+	NotReadyNodes        int64                 `json:"not_ready_nodes"`
+	Namespaces           []namespaceSummaryDTO `json:"namespaces"`
+}
+
+type namespaceSummaryDTO struct {
+	Namespace  string     `json:"namespace"`
+	Workloads  int64      `json:"workloads"`
+	Pods       int64      `json:"pods"`
+	Events     int64      `json:"events"`
+	Warnings   int64      `json:"warnings"`
+	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
+}
+
+func namespaceSummaryDTOs(items []biz.NamespaceSummary) []namespaceSummaryDTO {
+	out := make([]namespaceSummaryDTO, 0, len(items))
+	for _, item := range items {
+		out = append(out, namespaceSummaryDTO{
+			Namespace:  item.Namespace,
+			Workloads:  item.Workloads,
+			Pods:       item.Pods,
+			Events:     item.Events,
+			Warnings:   item.Warnings,
+			LastSeenAt: item.LastSeenAt,
+		})
+	}
+	return out
 }
 
 type edgeAttachmentDTO struct {

--- a/internal/manager/server/k8s/http_test.go
+++ b/internal/manager/server/k8s/http_test.go
@@ -145,6 +145,22 @@ func TestWorkloadDTOFromModelIncludesExecutionCounts(t *testing.T) {
 	}
 }
 
+func TestNamespaceSummaryDTOsPreservesClusterWideCounts(t *testing.T) {
+	now := time.Now().UTC()
+	items := namespaceSummaryDTOs([]biz.NamespaceSummary{{
+		Namespace:  "late-page",
+		Workloads:  1,
+		Pods:       1400,
+		Events:     12,
+		Warnings:   2,
+		LastSeenAt: &now,
+	}})
+
+	if len(items) != 1 || items[0].Namespace != "late-page" || items[0].Workloads != 1 || items[0].Pods != 1400 || items[0].Events != 12 || items[0].Warnings != 2 || items[0].LastSeenAt == nil {
+		t.Fatalf("namespace summary DTOs = %+v", items)
+	}
+}
+
 func TestListWorkloadsUsesOffsetAndReturnsGroupedReplicaSetVersions(t *testing.T) {
 	svc := &workloadPageService{}
 	h := NewHandler(svc)

--- a/internal/manager/server/k8s/http_test.go
+++ b/internal/manager/server/k8s/http_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	biz "github.com/ongridio/ongrid/internal/manager/biz/k8s"
 	model "github.com/ongridio/ongrid/internal/manager/model/k8s"
 )
@@ -19,6 +21,46 @@ type telemetryRefreshService struct {
 	proof            biz.TelemetryCredentialProof
 	out              *biz.TelemetryConfig
 	err              error
+}
+
+type workloadPageService struct {
+	Service
+	listFilter   biz.ListWorkloadsFilter
+	countFilters []biz.ListWorkloadsFilter
+}
+
+func (s *workloadPageService) ListWorkloads(_ context.Context, f biz.ListWorkloadsFilter) ([]*model.Workload, error) {
+	s.listFilter = f
+	createdAt := time.Date(2026, time.July, 28, 8, 9, 10, 0, time.UTC)
+	return []*model.Workload{{
+		ID:              1401,
+		ClusterID:       f.ClusterID,
+		Namespace:       "default",
+		Kind:            "Deployment",
+		Name:            "api-1401",
+		DesiredReplicas: 1,
+		ReadyReplicas:   1,
+		Revision:        12,
+		ReplicaSets: []*model.Workload{{
+			ID:                1501,
+			ClusterID:         f.ClusterID,
+			Namespace:         "default",
+			Kind:              "ReplicaSet",
+			Name:              "api-1401-7d8f9",
+			OwnerKind:         "Deployment",
+			OwnerName:         "api-1401",
+			OwnerUID:          "deployment-uid",
+			Revision:          12,
+			DesiredReplicas:   1,
+			ReadyReplicas:     1,
+			ResourceCreatedAt: &createdAt,
+		}},
+	}}, nil
+}
+
+func (s *workloadPageService) CountWorkloads(_ context.Context, f biz.ListWorkloadsFilter) (int64, error) {
+	s.countFilters = append(s.countFilters, f)
+	return 1500, nil
 }
 
 func (s *telemetryRefreshService) RefreshTelemetryConfig(_ context.Context, controllerEdgeID uint64, proof biz.TelemetryCredentialProof) (*biz.TelemetryConfig, error) {
@@ -32,6 +74,7 @@ func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T)
 		ClusterID:           7,
 		AccessKey:           "kt_access",
 		SecretKey:           "ks_secret",
+		ManagerPublicURL:    "https://manager.example",
 		TracesEndpoint:      "https://tempo.example/v1/traces",
 		TracesAuthMode:      "backend",
 		TracesBasicUser:     "tempo-user",
@@ -62,7 +105,8 @@ func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T)
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if got.ClusterID != 7 || got.AccessKey != "kt_access" || got.SecretKey != "ks_secret" {
+	if got.ClusterID != 7 || got.AccessKey != "kt_access" || got.SecretKey != "ks_secret" ||
+		got.ManagerPublicURL != "https://manager.example" {
 		t.Fatalf("response = %#v", got)
 	}
 	if got.TracesEndpoint != "https://tempo.example/v1/traces" || got.TracesAuthMode != "backend" ||
@@ -78,6 +122,77 @@ func TestRefreshTelemetryConfigRejectsMissingAuthenticatedIdentity(t *testing.T)
 	h.refreshTelemetryConfig(resp, httptest.NewRequest(http.MethodPost, "/internal/k8s/telemetry-config", nil))
 	if resp.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", resp.Code)
+	}
+}
+
+func TestWorkloadDTOFromModelIncludesExecutionCounts(t *testing.T) {
+	dto := workloadDTOFromModel(&model.Workload{
+		ClusterID:       48,
+		Namespace:       "jobs",
+		Kind:            "Job",
+		Name:            "batch",
+		DesiredReplicas: 3,
+		ReadyReplicas:   1,
+		ActiveReplicas:  1,
+		FailedReplicas:  1,
+		LabelsJSON:      "{}",
+		AnnotationsJSON: "{}",
+		ConditionsJSON:  "[]",
+	})
+
+	if dto.ActiveReplicas != 1 || dto.FailedReplicas != 1 {
+		t.Fatalf("workload execution = active:%d failed:%d, want 1/1", dto.ActiveReplicas, dto.FailedReplicas)
+	}
+}
+
+func TestListWorkloadsUsesOffsetAndReturnsGroupedReplicaSetVersions(t *testing.T) {
+	svc := &workloadPageService{}
+	h := NewHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/k8s/clusters/48/workloads?limit=100&offset=1400&group_replica_sets=true", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("cluster_id", "48")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	resp := httptest.NewRecorder()
+
+	h.listWorkloads(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	if svc.listFilter.Limit != 100 || svc.listFilter.Offset != 1400 || !svc.listFilter.GroupReplicaSets {
+		t.Fatalf("list filter = %+v", svc.listFilter)
+	}
+	if len(svc.countFilters) != 1 || !svc.countFilters[0].GroupReplicaSets {
+		t.Fatalf("count filters = %+v", svc.countFilters)
+	}
+	var got struct {
+		Items []struct {
+			Revision    int64 `json:"revision"`
+			ReplicaSets []struct {
+				Name              string     `json:"name"`
+				OwnerKind         string     `json:"owner_kind"`
+				OwnerName         string     `json:"owner_name"`
+				OwnerUID          string     `json:"owner_uid"`
+				Revision          int64      `json:"revision"`
+				CreationTimestamp *time.Time `json:"creation_timestamp"`
+			} `json:"replica_sets"`
+		} `json:"items"`
+		Total  int64 `json:"total"`
+		Limit  int   `json:"limit"`
+		Offset int   `json:"offset"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Total != 1500 || got.Limit != 100 || got.Offset != 1400 {
+		t.Fatalf("response = %+v", got)
+	}
+	if len(got.Items) != 1 || got.Items[0].Revision != 12 || len(got.Items[0].ReplicaSets) != 1 {
+		t.Fatalf("grouped response = %+v", got.Items)
+	}
+	rs := got.Items[0].ReplicaSets[0]
+	if rs.Name != "api-1401-7d8f9" || rs.OwnerKind != "Deployment" || rs.OwnerName != "api-1401" || rs.OwnerUID != "deployment-uid" || rs.Revision != 12 || rs.CreationTimestamp == nil {
+		t.Fatalf("ReplicaSet response = %+v", rs)
 	}
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -334,9 +334,10 @@ type AdminConfig struct {
 
 // EdgeConfig is consumed only by ongrid-edge to dial the cloud tunnel.
 type EdgeConfig struct {
-	CloudAddr string
-	AccessKey string
-	SecretKey string
+	CloudAddr        string
+	AccessKey        string
+	SecretKey        string
+	ManagerPublicURL string
 
 	// CollectorMode selects how the edge's periodic metric-push path
 	// behaves. Defaults to "off" because the hostmetrics + procmetrics

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -1,6 +1,9 @@
 package tunnel
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // This file hand-mirrors api/tunnel/v1/tunnel.proto message shapes as Go
 // structs with JSON tags. the tunnel body wire format is JSON
@@ -437,15 +440,22 @@ type KubernetesNodeSnapshot struct {
 }
 
 type KubernetesWorkloadSnapshot struct {
-	Kind            string              `json:"kind"`
-	Namespace       string              `json:"namespace,omitempty"`
-	Name            string              `json:"name"`
-	UID             string              `json:"uid,omitempty"`
-	DesiredReplicas int                 `json:"desired_replicas,omitempty"`
-	ReadyReplicas   int                 `json:"ready_replicas,omitempty"`
-	Labels          map[string]string   `json:"labels,omitempty"`
-	Annotations     map[string]string   `json:"annotations,omitempty"`
-	Conditions      []map[string]string `json:"conditions,omitempty"`
+	Kind              string              `json:"kind"`
+	Namespace         string              `json:"namespace,omitempty"`
+	Name              string              `json:"name"`
+	UID               string              `json:"uid,omitempty"`
+	DesiredReplicas   int                 `json:"desired_replicas,omitempty"`
+	ReadyReplicas     int                 `json:"ready_replicas,omitempty"`
+	ActiveReplicas    int                 `json:"active_replicas,omitempty"`
+	FailedReplicas    int                 `json:"failed_replicas,omitempty"`
+	OwnerKind         string              `json:"owner_kind,omitempty"`
+	OwnerName         string              `json:"owner_name,omitempty"`
+	OwnerUID          string              `json:"owner_uid,omitempty"`
+	Revision          int64               `json:"revision,omitempty"`
+	CreationTimestamp *time.Time          `json:"creation_timestamp,omitempty"`
+	Labels            map[string]string   `json:"labels,omitempty"`
+	Annotations       map[string]string   `json:"annotations,omitempty"`
+	Conditions        []map[string]string `json:"conditions,omitempty"`
 }
 
 type KubernetesPodSnapshot struct {

--- a/web/src/api/kubernetes.ts
+++ b/web/src/api/kubernetes.ts
@@ -135,6 +135,16 @@ export type KubernetesClusterHealth = {
   oom_killed_pods: number;
   image_pull_back_off_pods: number;
   not_ready_nodes: number;
+  namespaces?: KubernetesNamespaceSummary[];
+};
+
+export type KubernetesNamespaceSummary = {
+  namespace: string;
+  workloads: number;
+  pods: number;
+  events: number;
+  warnings: number;
+  last_seen_at?: string | null;
 };
 
 export type KubernetesEdgeAttachment = {

--- a/web/src/api/kubernetes.ts
+++ b/web/src/api/kubernetes.ts
@@ -67,6 +67,14 @@ export type KubernetesWorkload = {
   uid?: string;
   desired_replicas: number;
   ready_replicas: number;
+  active_replicas?: number;
+  failed_replicas?: number;
+  owner_kind?: string;
+  owner_name?: string;
+  owner_uid?: string;
+  revision?: number;
+  creation_timestamp?: string | null;
+  replica_sets?: KubernetesWorkload[];
   labels?: Record<string, unknown>;
   annotations?: Record<string, unknown>;
   conditions?: unknown[];
@@ -195,7 +203,15 @@ export function listKubernetesNodes(
 
 export function listKubernetesWorkloads(
   clusterID: string | number,
-  params?: { namespace?: string; kind?: string; q?: string; issue_only?: boolean; limit?: number; offset?: number },
+  params?: {
+    namespace?: string;
+    kind?: string;
+    q?: string;
+    issue_only?: boolean;
+    group_replica_sets?: boolean;
+    limit?: number;
+    offset?: number;
+  },
 ) {
   const qs = buildQuery(params);
   return request<ListResponse<KubernetesWorkload>>(

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -77,10 +77,10 @@ export function testPromConnection(): Promise<{ status: string }> {
   return request<{ status: string }>('POST', '/integrations/prom/test');
 }
 
-// testLokiConnection / testTempoConnection: GET /ready probes that
-// proxy through the manager so the auth + TLS-skip + URL come from
-// system_settings (loki / tempo categories) rather than from the
-// browser. The handler validates URL is set before dialing.
+// testLokiConnection / testTempoConnection proxy through the manager so
+// auth + TLS-skip + URL come from system_settings rather than the browser.
+// Loki checks GET /ready; Tempo checks /ready for a query URL or sends an
+// empty OTLP/HTTP export when the configured URL ends in /v1/traces.
 export function testLokiConnection(): Promise<{ status: string }> {
   return request<{ status: string }>('POST', '/integrations/loki/test');
 }

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -430,6 +430,13 @@ describe('KubernetesPage', () => {
       conditions: [{ type: 'Failed', status: 'True', reason: 'BackoffLimitExceeded' }],
       last_seen_at: new Date().toISOString(),
     };
+    const retryingJob = {
+      ...failedJob,
+      id: 54,
+      name: 'schema-job-retrying',
+      failed_replicas: 1,
+      conditions: [],
+    };
     const failedJobPod = {
       id: 53,
       cluster_id: 1,
@@ -460,7 +467,7 @@ describe('KubernetesPage', () => {
         if (issueOnly) issueOnlyRequests += 1;
         const items = issueOnly
           ? includeFailedJob ? [failedJob] : []
-          : includeFailedJob ? [activeJob, failedJob] : [activeJob];
+          : includeFailedJob ? [activeJob, retryingJob, failedJob] : [activeJob, retryingJob];
         return HttpResponse.json({ items, total: items.length, limit: 100, offset: 0 });
       }),
       http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
@@ -481,11 +488,18 @@ describe('KubernetesPage', () => {
     expect(within(activeRow as HTMLElement).getByText('运行中')).toBeInTheDocument();
     expect(within(activeRow as HTMLElement).getByText('0/1 完成 · 1 运行')).toBeInTheDocument();
 
+    const retryingCell = screen.getByText('schema-job-retrying');
+    const retryingRow = retryingCell.closest('tr');
+    expect(retryingRow).not.toBeNull();
+    expect(within(retryingRow as HTMLElement).getByText('等待中')).toBeInTheDocument();
+    expect(within(retryingRow as HTMLElement).getByText('0/1 完成 · 1 失败')).toBeInTheDocument();
+
     const failedCell = screen.getByText('schema-job-failed');
     const failedRow = failedCell.closest('tr');
     expect(failedRow).not.toBeNull();
     expect(within(failedRow as HTMLElement).getByText('失败')).toBeInTheDocument();
     expect(screen.queryByText('Job/schema-job-active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Job/schema-job-retrying')).not.toBeInTheDocument();
     expect(screen.getByText('Job/schema-job-failed')).toBeInTheDocument();
     expect(screen.getByText('1 个待确认问题')).toBeInTheDocument();
 
@@ -503,6 +517,63 @@ describe('KubernetesPage', () => {
       expect(issueOnlyRequests).toBeGreaterThan(issueOnlyRequestsBeforeRefresh);
       expect(screen.queryByText('schema-job-failed')).not.toBeInTheDocument();
     });
+  });
+
+  it('集群级异常和 Namespace 汇总不受首屏 100 条限制', async () => {
+    const lateWorkload = {
+      id: 1501,
+      cluster_id: 1,
+      namespace: 'late-page',
+      kind: 'Deployment',
+      name: 'late-api',
+      uid: 'late-api-uid',
+      desired_replicas: 3,
+      ready_replicas: 1,
+      conditions: [],
+      last_seen_at: new Date().toISOString(),
+    };
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
+        degraded_workloads: 1,
+        pending_pods: 0,
+        crash_loop_back_off_pods: 0,
+        oom_killed_pods: 0,
+        image_pull_back_off_pods: 0,
+        not_ready_nodes: 0,
+        namespaces: [
+          { namespace: 'first-page', workloads: 100, pods: 100, events: 100, warnings: 0 },
+          { namespace: 'late-page', workloads: 1, pods: 1400, events: 12, warnings: 0 },
+        ],
+      })),
+      http.get('/api/v1/k8s/clusters/:id/workloads', ({ request }) => {
+        const issueOnly = new URL(request.url).searchParams.get('issue_only') === 'true';
+        if (issueOnly) return HttpResponse.json({ items: [lateWorkload], total: 1, limit: 100, offset: 0 });
+        return HttpResponse.json({
+          items: [{ ...lateWorkload, id: 1, namespace: 'first-page', name: 'healthy-api', ready_replicas: 3 }],
+          total: 1501,
+          limit: 100,
+          offset: 0,
+        });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get('reason') === 'CrashLoopBackOff' || url.searchParams.get('issue_only') === 'true') {
+          return HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 });
+        }
+        return HttpResponse.json({ items: [], total: 1500, limit: 100, offset: 0 });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+    );
+
+    renderKubernetesDetail('/kubernetes/1?tab=namespaces');
+
+    expect(await screen.findByText('Deployment/late-api')).toBeInTheDocument();
+    const namespaceCell = (await screen.findAllByText('late-page')).find((item) => item.closest('td'));
+    const row = namespaceCell?.closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText('1400')).toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText('12')).toBeInTheDocument();
+    expect(screen.getAllByRole('option', { name: 'late-page' }).length).toBeGreaterThan(0);
   });
 
   it('异常 Pod 通过 ReplicaSet 合并到 Deployment 根因', async () => {

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -403,6 +403,307 @@ describe('KubernetesPage', () => {
     expect(screen.getAllByText('查询详情').length).toBeGreaterThanOrEqual(3);
   });
 
+  it('运行中的 Job 不计入异常而终止失败的 Job 保留异常', async () => {
+    const activeJob = {
+      id: 51,
+      cluster_id: 1,
+      namespace: 'jobs',
+      kind: 'Job',
+      name: 'schema-job-active',
+      desired_replicas: 1,
+      ready_replicas: 0,
+      active_replicas: 1,
+      failed_replicas: 0,
+      conditions: [],
+      last_seen_at: new Date().toISOString(),
+    };
+    const failedJob = {
+      id: 52,
+      cluster_id: 1,
+      namespace: 'jobs',
+      kind: 'Job',
+      name: 'schema-job-failed',
+      desired_replicas: 1,
+      ready_replicas: 0,
+      active_replicas: 0,
+      failed_replicas: 1,
+      conditions: [{ type: 'Failed', status: 'True', reason: 'BackoffLimitExceeded' }],
+      last_seen_at: new Date().toISOString(),
+    };
+    const failedJobPod = {
+      id: 53,
+      cluster_id: 1,
+      namespace: 'jobs',
+      name: 'schema-job-failed-pod',
+      uid: 'schema-job-failed-pod',
+      node_name: 'worker-a',
+      phase: 'Failed',
+      owner_kind: 'Job',
+      owner_name: 'schema-job-failed',
+      restart_count: 0,
+      reason: 'Unknown',
+      last_seen_at: new Date().toISOString(),
+    };
+    let issueOnlyRequests = 0;
+    let includeFailedJob = true;
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
+        degraded_workloads: 1,
+        pending_pods: 0,
+        crash_loop_back_off_pods: 0,
+        oom_killed_pods: 0,
+        image_pull_back_off_pods: 0,
+        not_ready_nodes: 0,
+      })),
+      http.get('/api/v1/k8s/clusters/:id/workloads', ({ request }) => {
+        const issueOnly = new URL(request.url).searchParams.get('issue_only') === 'true';
+        if (issueOnly) issueOnlyRequests += 1;
+        const items = issueOnly
+          ? includeFailedJob ? [failedJob] : []
+          : includeFailedJob ? [activeJob, failedJob] : [activeJob];
+        return HttpResponse.json({ items, total: items.length, limit: 100, offset: 0 });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
+        const reason = new URL(request.url).searchParams.get('reason');
+        if (reason === 'CrashLoopBackOff') {
+          return HttpResponse.json({ items: [], total: 0, limit: 20, offset: 0 });
+        }
+        return HttpResponse.json({ items: [failedJobPod], total: 1, limit: 20, offset: 0 });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+    );
+
+    renderKubernetesDetail('/kubernetes/1?tab=workloads');
+
+    const activeCell = await screen.findByText('schema-job-active');
+    const activeRow = activeCell.closest('tr');
+    expect(activeRow).not.toBeNull();
+    expect(within(activeRow as HTMLElement).getByText('运行中')).toBeInTheDocument();
+    expect(within(activeRow as HTMLElement).getByText('0/1 完成 · 1 运行')).toBeInTheDocument();
+
+    const failedCell = screen.getByText('schema-job-failed');
+    const failedRow = failedCell.closest('tr');
+    expect(failedRow).not.toBeNull();
+    expect(within(failedRow as HTMLElement).getByText('失败')).toBeInTheDocument();
+    expect(screen.queryByText('Job/schema-job-active')).not.toBeInTheDocument();
+    expect(screen.getByText('Job/schema-job-failed')).toBeInTheDocument();
+    expect(screen.getByText('1 个待确认问题')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '只看异常' }));
+    await waitFor(() => {
+      expect(issueOnlyRequests).toBeGreaterThan(0);
+      expect(screen.queryByText('schema-job-active')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('schema-job-failed')).toBeInTheDocument();
+
+    const issueOnlyRequestsBeforeRefresh = issueOnlyRequests;
+    includeFailedJob = false;
+    fireEvent.click(screen.getByRole('button', { name: '刷新' }));
+    await waitFor(() => {
+      expect(issueOnlyRequests).toBeGreaterThan(issueOnlyRequestsBeforeRefresh);
+      expect(screen.queryByText('schema-job-failed')).not.toBeInTheDocument();
+    });
+  });
+
+  it('异常 Pod 通过 ReplicaSet 合并到 Deployment 根因', async () => {
+    const deployment = {
+      id: 54,
+      cluster_id: 1,
+      namespace: 'apps',
+      kind: 'Deployment',
+      name: 'api',
+      uid: 'deployment-api',
+      desired_replicas: 1,
+      ready_replicas: 0,
+      conditions: [],
+      replica_sets: [{
+        id: 55,
+        cluster_id: 1,
+        namespace: 'apps',
+        kind: 'ReplicaSet',
+        name: 'api-7d8f9',
+        owner_kind: 'Deployment',
+        owner_name: 'api',
+        desired_replicas: 1,
+        ready_replicas: 0,
+        conditions: [],
+        last_seen_at: new Date().toISOString(),
+      }],
+      last_seen_at: new Date().toISOString(),
+    };
+    const pod = {
+      id: 56,
+      cluster_id: 1,
+      namespace: 'apps',
+      name: 'api-7d8f9-broken',
+      uid: 'api-pod-broken',
+      node_name: 'worker-a',
+      phase: 'Running',
+      owner_kind: 'ReplicaSet',
+      owner_name: 'api-7d8f9',
+      restart_count: 6,
+      reason: 'CrashLoopBackOff',
+      last_seen_at: new Date().toISOString(),
+    };
+
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
+        degraded_workloads: 1,
+        pending_pods: 0,
+        crash_loop_back_off_pods: 1,
+        oom_killed_pods: 0,
+        image_pull_back_off_pods: 0,
+        not_ready_nodes: 0,
+      })),
+      http.get('/api/v1/k8s/clusters/:id/workloads', () => HttpResponse.json({
+        items: [deployment], total: 1, limit: 20, offset: 0,
+      })),
+      http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
+        const reason = new URL(request.url).searchParams.get('reason');
+        if (reason === 'CrashLoopBackOff' || reason == null) {
+          return HttpResponse.json({ items: [pod], total: 1, limit: 20, offset: 0 });
+        }
+        return HttpResponse.json({ items: [], total: 0, limit: 20, offset: 0 });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+    );
+
+    renderKubernetesDetail('/kubernetes/1?tab=workloads');
+
+    expect(await screen.findByText('Deployment/api')).toBeInTheDocument();
+    expect(screen.getByText('1 个待确认问题')).toBeInTheDocument();
+    expect(screen.getAllByText('CrashLoopBackOff').length).toBeGreaterThan(0);
+  });
+
+  it('在 Deployment 行内展开关联的 ReplicaSet 发布版本', async () => {
+    const groupedWorkloads = [
+      {
+        id: 61,
+        cluster_id: 1,
+        namespace: 'apps',
+        kind: 'Deployment',
+        name: 'api',
+        desired_replicas: 1,
+        ready_replicas: 1,
+        revision: 3,
+        replica_sets: [
+          {
+            id: 62,
+            cluster_id: 1,
+            namespace: 'apps',
+            kind: 'ReplicaSet',
+            name: 'api-current-7d8f9',
+            desired_replicas: 1,
+            ready_replicas: 1,
+            owner_kind: 'Deployment',
+            owner_name: 'api',
+            revision: 3,
+            creation_timestamp: '2026-07-28T08:09:10Z',
+            last_seen_at: new Date().toISOString(),
+          },
+          {
+            id: 63,
+            cluster_id: 1,
+            namespace: 'apps',
+            kind: 'ReplicaSet',
+            name: 'api-history-6c7e8',
+            desired_replicas: 0,
+            ready_replicas: 0,
+            owner_kind: 'Deployment',
+            owner_name: 'api',
+            revision: 2,
+            creation_timestamp: '2026-07-27T08:09:10Z',
+            last_seen_at: new Date().toISOString(),
+          },
+        ],
+        last_seen_at: new Date().toISOString(),
+      },
+      {
+        id: 64,
+        cluster_id: 1,
+        namespace: 'staging',
+        kind: 'Deployment',
+        name: 'worker',
+        desired_replicas: 1,
+        ready_replicas: 1,
+        revision: 7,
+        replica_sets: [{
+          id: 65,
+          cluster_id: 1,
+          namespace: 'staging',
+          kind: 'ReplicaSet',
+          name: 'worker-current-5b6d7',
+          desired_replicas: 1,
+          ready_replicas: 1,
+          owner_kind: 'Deployment',
+          owner_name: 'worker',
+          revision: 7,
+          creation_timestamp: '2026-07-26T08:09:10Z',
+          last_seen_at: new Date().toISOString(),
+        }],
+        last_seen_at: new Date().toISOString(),
+      },
+      {
+        id: 66,
+        cluster_id: 1,
+        namespace: 'apps',
+        kind: 'ReplicaSet',
+        name: 'standalone-zero',
+        desired_replicas: 0,
+        ready_replicas: 0,
+        last_seen_at: new Date().toISOString(),
+      },
+    ];
+    const groupReplicaSetParams: string[] = [];
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/workloads', ({ request }) => {
+        const url = new URL(request.url);
+        const namespace = url.searchParams.get('namespace');
+        groupReplicaSetParams.push(url.searchParams.get('group_replica_sets') || 'unset');
+        const matchedItems = namespace
+          ? groupedWorkloads.filter((item) => item.namespace === namespace)
+          : groupedWorkloads;
+        return HttpResponse.json({
+          items: matchedItems,
+          total: matchedItems.length,
+          limit: 100,
+          offset: Number(url.searchParams.get('offset') || 0),
+        });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/pods', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+      http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+    );
+
+    renderKubernetesDetail('/kubernetes/1?tab=workloads');
+
+    expect(await screen.findByText('api')).toBeInTheDocument();
+    expect(screen.getByText('standalone-zero')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /显示发布历史/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('api-current-7d8f9')).not.toBeInTheDocument();
+    expect(screen.queryByText('api-history-6c7e8')).not.toBeInTheDocument();
+    expect(groupReplicaSetParams).toContain('true');
+
+    const expand = screen.getByRole('button', { name: '展开 api 的发布版本' });
+    expect(expand).toHaveAttribute('aria-expanded', 'false');
+    expect(expand).toHaveTextContent('2 个版本');
+    fireEvent.click(expand);
+
+    expect(await screen.findByText('api-history-6c7e8')).toBeInTheDocument();
+    expect(screen.getByText('api-current-7d8f9')).toBeInTheDocument();
+    expect(screen.getByText('Revision 3')).toBeInTheDocument();
+    expect(screen.getByText('Revision 2')).toBeInTheDocument();
+    expect(screen.getByText('当前版本')).toBeInTheDocument();
+    expect(screen.getByText('历史版本')).toBeInTheDocument();
+    expect(expand).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByText('worker-current-5b6d7')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: '命名空间过滤' }), { target: { value: 'apps' } });
+    await waitFor(() => {
+      expect(screen.queryByText('worker')).not.toBeInTheDocument();
+      expect(screen.getByText('api')).toBeInTheDocument();
+    });
+  });
+
   it('K8s 指标使用 Grafana 11 Explore 深链打开 Prometheus 查询', async () => {
     let launchPayload: { expr?: string } | null = null;
     const replace = vi.fn();
@@ -524,6 +825,91 @@ describe('KubernetesPage', () => {
     expect(screen.queryByText('Readiness probe failed: HTTP probe failed with statuscode: 500')).not.toBeInTheDocument();
   });
 
+  it('同一 HPA 的多条 Warning Event 合并为一个异常线索', async () => {
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
+        degraded_workloads: 0,
+        pending_pods: 0,
+        crash_loop_back_off_pods: 0,
+        oom_killed_pods: 0,
+        image_pull_back_off_pods: 0,
+        not_ready_nodes: 0,
+      })),
+      http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get('reason') === 'CrashLoopBackOff') {
+          return HttpResponse.json({ items: [], total: 0, limit: 20, offset: 0 });
+        }
+        return HttpResponse.json({
+          items: [{
+            id: 31,
+            cluster_id: 1,
+            namespace: 'ongrid-system',
+            name: 'ongrid-edge-controller-abc',
+            uid: 'pod-healthy',
+            node_name: 'ongrid-k8s-control-plane',
+            phase: 'Running',
+            owner_kind: 'Deployment',
+            owner_name: 'ongrid-edge-controller',
+            restart_count: 0,
+            reason: '',
+            last_seen_at: '2026-06-29T10:00:00Z',
+          }],
+          total: 1,
+          limit: 100,
+          offset: 0,
+        });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/events', ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get('issue_only') !== 'true') {
+          return HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 });
+        }
+        return HttpResponse.json({
+          items: [
+            {
+              id: 71,
+              cluster_id: 1,
+              namespace: 'ongrid-system',
+              name: 'hpa-failed-compute',
+              type: 'Warning',
+              reason: 'FailedComputeMetricsReplicas',
+              message: 'invalid metrics',
+              involved_kind: 'HorizontalPodAutoscaler',
+              involved_namespace: 'ongrid-system',
+              involved_name: 'ongrid-edge-telemetry-gateway',
+              count: 4,
+            },
+            {
+              id: 72,
+              cluster_id: 1,
+              namespace: 'ongrid-system',
+              name: 'hpa-failed-resource',
+              type: 'Warning',
+              reason: 'FailedGetResourceMetric',
+              message: 'did not receive metrics for targeted pods',
+              involved_kind: 'HorizontalPodAutoscaler',
+              involved_namespace: 'ongrid-system',
+              involved_name: 'ongrid-edge-telemetry-gateway',
+              count: 4,
+            },
+          ],
+          total: 2,
+          limit: 100,
+          offset: 0,
+        });
+      }),
+    );
+
+    renderKubernetesDetail('/kubernetes/1');
+
+    expect(await screen.findByText('1 个待确认问题')).toBeInTheDocument();
+    expect(screen.getByText('Warning Event 2')).toBeInTheDocument();
+    expect(screen.queryByText('2 个待确认问题')).not.toBeInTheDocument();
+    expect(screen.getByText('FailedComputeMetricsReplicas')).toBeInTheDocument();
+    expect(screen.getByText('FailedGetResourceMetric')).toBeInTheDocument();
+  });
+
   it('Agent 版本只统计节点 Edge，不把 Controller 纳入覆盖率', async () => {
     server.use(
       http.get('/api/v1/edges', () =>
@@ -563,8 +949,8 @@ describe('KubernetesPage', () => {
     expect(screen.queryByText('已上报 1/2')).not.toBeInTheDocument();
   });
 
-  it('Pod 资源表支持加载更多快照结果', async () => {
-    const podLimits: number[] = [];
+  it('Pod 资源表使用 offset 分页访问 1500 条结果', async () => {
+    const podPages: Array<{ limit: number; offset: number }> = [];
     server.use(
       http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
         const url = new URL(request.url);
@@ -572,11 +958,12 @@ describe('KubernetesPage', () => {
           return HttpResponse.json({ items: [], total: 0, limit: 20, offset: 0 });
         }
         const limit = Number(url.searchParams.get('limit') || 100);
-        podLimits.push(limit);
-        const count = Math.min(limit, 150);
+        const offset = Number(url.searchParams.get('offset') || 0);
+        podPages.push({ limit, offset });
+        const count = Math.max(0, Math.min(limit, 1500 - offset));
         return HttpResponse.json({
           items: Array.from({ length: count }, (_, index) => {
-            const n = index + 1;
+            const n = offset + index + 1;
             return {
               id: n,
               cluster_id: 1,
@@ -590,9 +977,9 @@ describe('KubernetesPage', () => {
               last_seen_at: '2026-06-29T10:00:00Z',
             };
           }),
-          total: 150,
+          total: 1500,
           limit,
-          offset: 0,
+          offset,
         });
       }),
     );
@@ -600,18 +987,30 @@ describe('KubernetesPage', () => {
     renderKubernetesDetail('/kubernetes/1?tab=pods');
 
     expect(await screen.findByText('pod-001')).toBeInTheDocument();
-    expect(screen.getByText('显示前 100 条，共 150 条')).toBeInTheDocument();
+    expect(screen.getByText('第 1 / 15 页')).toBeInTheDocument();
+    expect(screen.getByText('1–100 / 共 1,500 条')).toBeInTheDocument();
+    expect(screen.queryByText('pod-101')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: '加载更多' }));
+    fireEvent.click(screen.getByRole('button', { name: '下一页' }));
 
     await waitFor(() => {
-      expect(podLimits).toContain(200);
+      expect(podPages).toContainEqual({ limit: 100, offset: 100 });
     });
-    expect(await screen.findByText('pod-150')).toBeInTheDocument();
+    expect(await screen.findByText('pod-101')).toBeInTheDocument();
+    expect(screen.getByText('pod-200')).toBeInTheDocument();
+    expect(screen.queryByText('pod-001')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('combobox', { name: '页码' }), { target: { value: '15' } });
+    await waitFor(() => {
+      expect(podPages).toContainEqual({ limit: 100, offset: 1400 });
+    });
+    expect(await screen.findByText('pod-1500')).toBeInTheDocument();
+    expect(screen.getByText('第 15 / 15 页')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '下一页' })).toBeDisabled();
   });
 
-  it('Pod 资源表筛选分页明确展示匹配结果', async () => {
-    const podLimits: number[] = [];
+  it('Pod 资源表筛选后从第一页开始按 offset 分页', async () => {
+    const podPages: Array<{ limit: number; offset: number }> = [];
     server.use(
       http.get('/api/v1/k8s/clusters/:id/pods', ({ request }) => {
         const url = new URL(request.url);
@@ -620,12 +1019,13 @@ describe('KubernetesPage', () => {
         }
         const query = url.searchParams.get('q') || '';
         const limit = Number(url.searchParams.get('limit') || 100);
+        const offset = Number(url.searchParams.get('offset') || 0);
         if (query === 'api') {
-          podLimits.push(limit);
-          const count = Math.min(limit, 150);
+          podPages.push({ limit, offset });
+          const count = Math.max(0, Math.min(limit, 150 - offset));
           return HttpResponse.json({
             items: Array.from({ length: count }, (_, index) => {
-              const n = index + 1;
+              const n = offset + index + 1;
               return {
                 id: n,
                 cluster_id: 1,
@@ -641,7 +1041,7 @@ describe('KubernetesPage', () => {
             }),
             total: 150,
             limit,
-            offset: 0,
+            offset,
           });
         }
         return HttpResponse.json({
@@ -670,13 +1070,16 @@ describe('KubernetesPage', () => {
     fireEvent.change(screen.getByRole('textbox', { name: '搜索资源' }), { target: { value: 'api' } });
 
     expect(await screen.findByText('api-pod-001')).toBeInTheDocument();
-    expect(screen.getByText('显示前 100 条匹配，共 150 条匹配')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: '加载更多匹配' }));
+    expect(screen.getByText('第 1 / 2 页')).toBeInTheDocument();
+    expect(screen.getByText('1–100 / 共 150 条匹配')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '下一页' }));
 
     await waitFor(() => {
-      expect(podLimits).toContain(200);
+      expect(podPages).toContainEqual({ limit: 100, offset: 100 });
     });
+    expect(await screen.findByText('api-pod-101')).toBeInTheDocument();
     expect(await screen.findByText('api-pod-150')).toBeInTheDocument();
+    expect(screen.queryByText('api-pod-001')).not.toBeInTheDocument();
   });
 
   it('Pod 资源搜索防抖后再请求服务端', async () => {

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -576,6 +576,58 @@ describe('KubernetesPage', () => {
     expect(screen.getAllByRole('option', { name: 'late-page' }).length).toBeGreaterThan(0);
   });
 
+  it('关键异常先按严重程度排序再截断展示', async () => {
+    const degradedDeployments = Array.from({ length: 8 }, (_, index) => ({
+      id: 1600 + index,
+      cluster_id: 1,
+      namespace: 'apps',
+      kind: 'Deployment',
+      name: `degraded-${index + 1}`,
+      uid: `degraded-${index + 1}-uid`,
+      desired_replicas: 2,
+      ready_replicas: 1,
+      conditions: [],
+      last_seen_at: new Date().toISOString(),
+    }));
+    const failedJob = {
+      id: 1700,
+      cluster_id: 1,
+      namespace: 'apps',
+      kind: 'Job',
+      name: 'critical-failed',
+      uid: 'critical-failed-uid',
+      desired_replicas: 1,
+      ready_replicas: 0,
+      active_replicas: 0,
+      failed_replicas: 1,
+      conditions: [{ type: 'Failed', status: 'True', reason: 'BackoffLimitExceeded' }],
+      last_seen_at: new Date().toISOString(),
+    };
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
+        degraded_workloads: 9,
+        pending_pods: 0,
+        crash_loop_back_off_pods: 0,
+        oom_killed_pods: 0,
+        image_pull_back_off_pods: 0,
+        not_ready_nodes: 0,
+      })),
+      http.get('/api/v1/k8s/clusters/:id/workloads', ({ request }) => {
+        const issueOnly = new URL(request.url).searchParams.get('issue_only') === 'true';
+        const items = issueOnly ? [...degradedDeployments, failedJob] : [];
+        return HttpResponse.json({ items, total: items.length, limit: 100, offset: 0 });
+      }),
+      http.get('/api/v1/k8s/clusters/:id/pods', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+      http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
+    );
+
+    renderKubernetesDetail('/kubernetes/1?tab=workloads');
+
+    expect(await screen.findByText('Job/critical-failed')).toBeInTheDocument();
+    expect(screen.getByText('9 个待确认问题')).toBeInTheDocument();
+    expect(screen.queryByText('Deployment/degraded-8')).not.toBeInTheDocument();
+  });
+
   it('异常 Pod 通过 ReplicaSet 合并到 Deployment 根因', async () => {
     const deployment = {
       id: 54,

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   Activity,
@@ -6,6 +6,9 @@ import {
   ArrowLeft,
   BarChart3,
   Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Clipboard,
   ExternalLink,
   FileText,
@@ -58,7 +61,7 @@ import {
 import { useI18n } from '@/i18n/locale';
 import { cn } from '@/lib/cn';
 import { buildExploreUrl, fetchGrafanaRootURL, openObservabilityUrl } from '@/lib/drilldown';
-import { formatNumber, relativeTime } from '@/lib/format';
+import { formatNumber, fullDateTime, relativeTime } from '@/lib/format';
 import { usePoll } from '@/lib/usePoll';
 import { useObservability } from '@/store/observability';
 import { usePermissions } from '@/store/me';
@@ -353,11 +356,13 @@ export function KubernetesClusterDetailPage() {
   const [resourceIssueOnly, setResourceIssueOnly] = useState(false);
   const [resourceActionDecision, setResourceActionDecision] = useState<ActionDecisionFilter>('all');
   const [resourceActionType, setResourceActionType] = useState('all');
-  const [resourceLimit, setResourceLimit] = useState(RESOURCE_PAGE_SIZE);
+  const [resourcePage, setResourcePage] = useState(1);
+  const [workloadVisibleTotal, setWorkloadVisibleTotal] = useState(0);
   const [serverFilteredResources, setServerFilteredResources] = useState<ServerFilteredResources | null>(null);
   const [resourceFilterLoading, setResourceFilterLoading] = useState(false);
   const [resourceFilterError, setResourceFilterError] = useState<string | null>(null);
   const [resourceFilterRetryNonce, setResourceFilterRetryNonce] = useState(0);
+  const [resourceFilterRefreshNonce, setResourceFilterRefreshNonce] = useState(0);
 
   const refresh = useCallback(async (opts?: { silent?: boolean }) => {
     if (!clusterId) return;
@@ -380,7 +385,7 @@ export function KubernetesClusterDetailPage() {
         getKubernetesCluster(clusterId),
         getKubernetesClusterHealth(clusterId),
         listKubernetesNodes(clusterId, { limit: RESOURCE_PAGE_SIZE }),
-        listKubernetesWorkloads(clusterId, { limit: RESOURCE_PAGE_SIZE }),
+        listKubernetesWorkloads(clusterId, { group_replica_sets: true, limit: RESOURCE_PAGE_SIZE }),
         listKubernetesPods(clusterId, { limit: RESOURCE_PAGE_SIZE }),
         listKubernetesPods(clusterId, { reason: 'CrashLoopBackOff', limit: 20 }),
         listKubernetesEvents(clusterId, { limit: RESOURCE_PAGE_SIZE }),
@@ -395,17 +400,20 @@ export function KubernetesClusterDetailPage() {
       setPods(podsOut.items ?? []);
       setCrashLoopPods(crashLoopPodsOut.items ?? []);
       setEvents(eventsOut.items ?? []);
+      const visibleWorkloadsTotal = workloadsOut.total ?? (workloadsOut.items?.length ?? 0);
+      setWorkloadVisibleTotal(visibleWorkloadsTotal);
       const warningItems = (warningEventsOut.items ?? []).filter(isWarningK8sEvent);
       setWarningEvents(warningItems);
       setWarningEventTotal(warningEventsOut.total ?? warningItems.length);
       if (edgeVersionMap) setEdgeVersionsByID(edgeVersionMap);
       setTotals({
         nodes: nodesOut.total ?? (nodesOut.items?.length ?? 0),
-        workloads: workloadsOut.total ?? (workloadsOut.items?.length ?? 0),
+        workloads: visibleWorkloadsTotal,
         pods: podsOut.total ?? (podsOut.items?.length ?? 0),
         events: eventsOut.total ?? (eventsOut.items?.length ?? 0),
       });
       setCrashLoopTotal(crashLoopPodsOut.total ?? (crashLoopPodsOut.items?.length ?? 0));
+      setResourceFilterRefreshNonce((value) => value + 1);
       if (auditOut) {
         const clusterIDNum = Number(clusterId);
         const clusterItems = (auditOut.items ?? []).filter((item) => proposalClusterID(item) === clusterIDNum);
@@ -472,14 +480,33 @@ export function KubernetesClusterDetailPage() {
   useEffect(() => {
     if (resourceQuery === appliedResourceQuery) return;
     const timer = window.setTimeout(() => {
-      setResourceLimit(RESOURCE_PAGE_SIZE);
+      setResourcePage(1);
       setAppliedResourceQuery(resourceQuery);
     }, RESOURCE_SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
   }, [appliedResourceQuery, resourceQuery]);
 
+  const resourceOffset = (resourcePage - 1) * RESOURCE_PAGE_SIZE;
+  const needsServerResourceFetch = activeTabSupportsServerFilter
+    && (filterActive || resourcePage > 1);
+  const serverResourceRequestKey = useMemo(
+    () => JSON.stringify({
+      tab: activeTab,
+      query: resourceFilters.query,
+      namespace: resourceFilters.namespace,
+      issueOnly: resourceFilters.issueOnly,
+      page: resourcePage,
+    }),
+    [
+      activeTab,
+      resourceFilters.issueOnly,
+      resourceFilters.namespace,
+      resourceFilters.query,
+      resourcePage,
+    ],
+  );
+
   useEffect(() => {
-    const needsServerResourceFetch = activeTabSupportsServerFilter && (filterActive || resourceLimit > RESOURCE_PAGE_SIZE);
     if (!clusterId || !needsServerResourceFetch) {
       setServerFilteredResources(null);
       setResourceFilterLoading(false);
@@ -487,27 +514,36 @@ export function KubernetesClusterDetailPage() {
       return;
     }
     let cancelled = false;
-    const params = resourceAPIParams(resourceFilters, resourceLimit);
+    const params = resourceAPIParams(resourceFilters, RESOURCE_PAGE_SIZE, resourceOffset);
+    setServerFilteredResources(null);
+    setResourceFilterError(null);
     setResourceFilterLoading(true);
     const request = activeTab === 'nodes'
       ? listKubernetesNodes(clusterId, params).then((out): ServerFilteredResources => ({
+          requestKey: serverResourceRequestKey,
           tab: 'nodes',
           nodes: out.items ?? [],
           nodesTotal: out.total ?? (out.items?.length ?? 0),
         }))
       : activeTab === 'workloads'
-        ? listKubernetesWorkloads(clusterId, params).then((out): ServerFilteredResources => ({
+        ? listKubernetesWorkloads(clusterId, {
+            ...params,
+            group_replica_sets: true,
+          }).then((out): ServerFilteredResources => ({
+            requestKey: serverResourceRequestKey,
             tab: 'workloads',
             workloads: out.items ?? [],
             workloadsTotal: out.total ?? (out.items?.length ?? 0),
           }))
         : activeTab === 'pods'
           ? listKubernetesPods(clusterId, params).then((out): ServerFilteredResources => ({
+              requestKey: serverResourceRequestKey,
               tab: 'pods',
               pods: out.items ?? [],
               podsTotal: out.total ?? (out.items?.length ?? 0),
             }))
           : listKubernetesEvents(clusterId, params).then((out): ServerFilteredResources => ({
+              requestKey: serverResourceRequestKey,
               tab: 'events',
               events: out.items ?? [],
               eventsTotal: out.total ?? (out.items?.length ?? 0),
@@ -522,6 +558,7 @@ export function KubernetesClusterDetailPage() {
         if (cancelled) return;
         setServerFilteredResources(null);
         setResourceFilterError(e instanceof ApiError ? e.message : (e as Error).message);
+        if (resourcePage > 1) setResourcePage(1);
       })
       .finally(() => {
         if (!cancelled) setResourceFilterLoading(false);
@@ -529,31 +566,91 @@ export function KubernetesClusterDetailPage() {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, activeTabSupportsServerFilter, clusterId, filterActive, resourceFilters, resourceFilterRetryNonce, resourceLimit]);
+  }, [
+    activeTab,
+    clusterId,
+    needsServerResourceFetch,
+    resourceFilters,
+    resourceFilterRefreshNonce,
+    resourceFilterRetryNonce,
+    resourceOffset,
+    resourcePage,
+    serverResourceRequestKey,
+  ]);
 
   const visibleNodes = nodes;
   const locallyFilteredNodes = useMemo(() => filterNodes(visibleNodes, localResourceFilters), [localResourceFilters, visibleNodes]);
   const locallyFilteredWorkloads = useMemo(() => filterWorkloads(workloads, localResourceFilters), [localResourceFilters, workloads]);
   const locallyFilteredPods = useMemo(() => filterPods(pods, localResourceFilters), [pods, localResourceFilters]);
   const locallyFilteredEvents = useMemo(() => filterEvents(events, localResourceFilters), [events, localResourceFilters]);
-  const serverResourceActive = Boolean(activeTabSupportsServerFilter && serverFilteredResources?.tab === activeTab && (filterActive || resourceLimit > RESOURCE_PAGE_SIZE));
-  const filteredNodes = serverResourceActive && activeTab === 'nodes' && serverFilteredResources?.nodes ? serverFilteredResources.nodes : locallyFilteredNodes;
-  const filteredWorkloads = serverResourceActive && activeTab === 'workloads' && serverFilteredResources?.workloads ? serverFilteredResources.workloads : locallyFilteredWorkloads;
-  const filteredPods = serverResourceActive && activeTab === 'pods' && serverFilteredResources?.pods ? serverFilteredResources.pods : locallyFilteredPods;
-  const filteredEvents = serverResourceActive && activeTab === 'events' && serverFilteredResources?.events ? serverFilteredResources.events : locallyFilteredEvents;
-  const filteredResourceTotals = serverResourceActive
-    ? {
-        nodes: activeTab === 'nodes' ? (serverFilteredResources?.nodesTotal ?? filteredNodes.length) : locallyFilteredNodes.length,
-        workloads: activeTab === 'workloads' ? (serverFilteredResources?.workloadsTotal ?? filteredWorkloads.length) : locallyFilteredWorkloads.length,
-        pods: activeTab === 'pods' ? (serverFilteredResources?.podsTotal ?? filteredPods.length) : locallyFilteredPods.length,
-        events: activeTab === 'events' ? (serverFilteredResources?.eventsTotal ?? filteredEvents.length) : locallyFilteredEvents.length,
-      }
-    : {
-        nodes: locallyFilteredNodes.length,
-        workloads: locallyFilteredWorkloads.length,
-        pods: locallyFilteredPods.length,
-        events: locallyFilteredEvents.length,
-      };
+  const serverResourceActive = Boolean(
+    needsServerResourceFetch
+      && serverFilteredResources?.tab === activeTab
+      && serverFilteredResources.requestKey === serverResourceRequestKey,
+  );
+  const serverResourcePending = needsServerResourceFetch && !serverResourceActive && !resourceFilterError;
+  const paginatedResourceLoading = resourceFilterLoading || resourceQueryPending || serverResourcePending;
+  const filteredNodes = serverResourcePending && activeTab === 'nodes'
+    ? []
+    : serverResourceActive && activeTab === 'nodes' && serverFilteredResources?.nodes
+      ? serverFilteredResources.nodes
+      : locallyFilteredNodes;
+  const filterMatchedWorkloads = serverResourcePending && activeTab === 'workloads'
+    ? []
+    : serverResourceActive && activeTab === 'workloads' && serverFilteredResources?.workloads
+      ? serverFilteredResources.workloads
+      : locallyFilteredWorkloads;
+  const filteredWorkloads = filterMatchedWorkloads;
+  const filteredPods = serverResourcePending && activeTab === 'pods'
+    ? []
+    : serverResourceActive && activeTab === 'pods' && serverFilteredResources?.pods
+      ? serverFilteredResources.pods
+      : locallyFilteredPods;
+  const filteredEvents = serverResourcePending && activeTab === 'events'
+    ? []
+    : serverResourceActive && activeTab === 'events' && serverFilteredResources?.events
+      ? serverFilteredResources.events
+      : locallyFilteredEvents;
+  const visibleNodeTotal = serverResourceActive && activeTab === 'nodes'
+    ? (serverFilteredResources?.nodesTotal ?? filteredNodes.length)
+    : activeTabFilterActive
+      ? locallyFilteredNodes.length
+      : totals.nodes;
+  const visibleWorkloadTotal = serverResourceActive && activeTab === 'workloads'
+    ? (serverFilteredResources?.workloadsTotal ?? filteredWorkloads.length)
+    : activeTabFilterActive
+      ? filteredWorkloads.length
+      : workloadVisibleTotal;
+  const visiblePodTotal = serverResourceActive && activeTab === 'pods'
+    ? (serverFilteredResources?.podsTotal ?? filteredPods.length)
+    : activeTabFilterActive
+      ? locallyFilteredPods.length
+      : totals.pods;
+  const visibleEventTotal = serverResourceActive && activeTab === 'events'
+    ? (serverFilteredResources?.eventsTotal ?? filteredEvents.length)
+    : activeTabFilterActive
+      ? locallyFilteredEvents.length
+      : totals.events;
+  const filteredResourceTotals = {
+    nodes: visibleNodeTotal,
+    workloads: visibleWorkloadTotal,
+    pods: visiblePodTotal,
+    events: visibleEventTotal,
+  };
+  const activePaginatedTotal = activeTab === 'nodes'
+    ? visibleNodeTotal
+    : activeTab === 'workloads'
+      ? visibleWorkloadTotal
+      : activeTab === 'pods'
+        ? visiblePodTotal
+        : activeTab === 'events'
+          ? visibleEventTotal
+          : 0;
+  useEffect(() => {
+    if (!activeTabSupportsServerFilter || (needsServerResourceFetch && !serverResourceActive)) return;
+    const lastPage = Math.max(1, Math.ceil(activePaginatedTotal / RESOURCE_PAGE_SIZE));
+    setResourcePage((current) => Math.min(current, lastPage));
+  }, [activePaginatedTotal, activeTabSupportsServerFilter, needsServerResourceFetch, serverResourceActive]);
   const namespaceRows = useMemo(() => buildNamespaceRows(workloads, pods, events, warningEvents), [events, pods, warningEvents, workloads]);
   const filteredNamespaceRows = useMemo(() => filterNamespaceRows(namespaceRows, localResourceFilters), [localResourceFilters, namespaceRows]);
   const filteredActionProposals = useMemo(() => filterActionProposals(actionProposals, localResourceFilters), [actionProposals, localResourceFilters]);
@@ -577,8 +674,8 @@ export function KubernetesClusterDetailPage() {
   );
 
   const openResourceTab = useCallback((tab: DetailTab, opts?: { scroll?: boolean; resetFilters?: boolean }) => {
+    setResourcePage(1);
     if (opts?.resetFilters) {
-      setResourceLimit(RESOURCE_PAGE_SIZE);
       setResourceQuery('');
       setAppliedResourceQuery('');
       setResourceNamespace('all');
@@ -595,7 +692,7 @@ export function KubernetesClusterDetailPage() {
   }, [setSearchParams]);
   const focusResourceIssue = useCallback((issue: K8sTriageIssue) => {
     const focus = resourceFocusForIssue(issue);
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceQuery(focus.query);
     setAppliedResourceQuery(focus.query);
     setResourceNamespace(focus.namespace);
@@ -603,7 +700,7 @@ export function KubernetesClusterDetailPage() {
     openResourceTab(focus.tab, { scroll: true });
   }, [openResourceTab]);
   const openNamespaceResource = useCallback((namespace: string, tab: 'workloads' | 'pods' | 'events') => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceQuery('');
     setAppliedResourceQuery('');
     setResourceNamespace(namespace || 'default');
@@ -653,34 +750,34 @@ export function KubernetesClusterDetailPage() {
     navigate(`/chat/${session.id}`, { state: { initialPrompt: prompt } });
   }, [cluster, navigate, tr]);
 
-  const loadMoreResources = useCallback(() => {
-    setResourceLimit((current) => current + RESOURCE_PAGE_SIZE);
+  const updateResourcePage = useCallback((page: number) => {
+    setResourcePage(Math.max(1, page));
   }, []);
   const updateResourceQuery = useCallback((value: string) => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceQuery(value);
     if (value.trim() === '') {
       setAppliedResourceQuery('');
     }
   }, []);
   const updateResourceNamespace = useCallback((value: string) => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceNamespace(value);
   }, []);
   const updateResourceIssueOnly = useCallback((value: boolean) => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceIssueOnly(value);
   }, []);
   const updateResourceActionDecision = useCallback((value: ActionDecisionFilter) => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceActionDecision(value);
   }, []);
   const updateResourceActionType = useCallback((value: string) => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceActionType(value);
   }, []);
   const clearResourceFilters = useCallback(() => {
-    setResourceLimit(RESOURCE_PAGE_SIZE);
+    setResourcePage(1);
     setResourceQuery('');
     setAppliedResourceQuery('');
     setResourceNamespace('all');
@@ -849,9 +946,20 @@ export function KubernetesClusterDetailPage() {
                   actionType={resourceActionType}
                   actionTypes={actionTypeOptions}
                   filteredCount={detailTabLoadedCount(activeTab, filteredNodes, filteredWorkloads, filteredPods, filteredEvents, filteredNamespaceRows, filteredActionProposals)}
-                  loadedCount={serverResourceActive ? detailTabLoadedCount(activeTab, filteredNodes, filteredWorkloads, filteredPods, filteredEvents, filteredNamespaceRows, filteredActionProposals) : detailTabLoadedCount(activeTab, visibleNodes, workloads, pods, events, namespaceRows, actionProposals)}
-                  totalCount={serverResourceActive || activeTabFilterActive ? detailTabFilteredTotal(activeTab, filteredResourceTotals.nodes, filteredResourceTotals, filteredNamespaceRows.length, filteredActionProposals.length) : detailTabCount(activeTab, totals, namespaces.length, actionProposalTotal)}
-                  loading={resourceSupportsServerFilter(activeTab) && (resourceFilterLoading || resourceQueryPending)}
+                  loadedCount={activeTab === 'workloads'
+                    ? filteredWorkloads.length
+                    : serverResourceActive
+                      ? detailTabLoadedCount(activeTab, filteredNodes, filteredWorkloads, filteredPods, filteredEvents, filteredNamespaceRows, filteredActionProposals)
+                      : detailTabLoadedCount(activeTab, visibleNodes, workloads, pods, events, namespaceRows, actionProposals)}
+                  totalCount={activeTab === 'workloads'
+                    ? visibleWorkloadTotal
+                    : resourceSupportsServerFilter(activeTab)
+                      ? activePaginatedTotal
+                      : serverResourceActive || activeTabFilterActive
+                      ? detailTabFilteredTotal(activeTab, filteredResourceTotals.nodes, filteredResourceTotals, filteredNamespaceRows.length, filteredActionProposals.length)
+                      : detailTabCount(activeTab, totals, namespaces.length, actionProposalTotal)}
+                  paginated={resourceSupportsServerFilter(activeTab)}
+                  loading={resourceSupportsServerFilter(activeTab) && paginatedResourceLoading}
                   onQueryChange={updateResourceQuery}
                   onNamespaceChange={updateResourceNamespace}
                   onIssueOnlyChange={updateResourceIssueOnly}
@@ -875,13 +983,15 @@ export function KubernetesClusterDetailPage() {
                   {activeTab === 'nodes' && (
                     <NodesTable
                       items={filteredNodes}
-                      loading={loading || resourceFilterLoading || resourceQueryPending}
-                      total={activeTabFilterActive ? filteredResourceTotals.nodes : totals.nodes}
+                      loading={loading || paginatedResourceLoading}
+                      total={visibleNodeTotal}
+                      page={resourcePage}
+                      pageSize={RESOURCE_PAGE_SIZE}
                       filtered={activeTabFilterActive}
                       emptyHint={resourceFilterHint}
                       edgeVersionsByID={edgeVersionsByID}
                       onClearFilters={clearResourceFilters}
-                      onLoadMore={loadMoreResources}
+                      onPageChange={updateResourcePage}
                       actions={{
                         onOpenLogs: openResourceLogs,
                         onDescribe: (issue) => void startResourceChat(issue, 'describe'),
@@ -893,12 +1003,14 @@ export function KubernetesClusterDetailPage() {
                   {activeTab === 'workloads' && (
                     <WorkloadsTable
                       items={filteredWorkloads}
-                      loading={loading || resourceFilterLoading || resourceQueryPending}
-                      total={activeTabFilterActive ? filteredResourceTotals.workloads : totals.workloads}
+                      loading={loading || paginatedResourceLoading}
+                      total={visibleWorkloadTotal}
+                      page={resourcePage}
+                      pageSize={RESOURCE_PAGE_SIZE}
                       filtered={activeTabFilterActive}
                       emptyHint={resourceFilterHint}
                       onClearFilters={clearResourceFilters}
-                      onLoadMore={loadMoreResources}
+                      onPageChange={updateResourcePage}
                       actions={{
                         onOpenLogs: openResourceLogs,
                         onDescribe: (issue) => void startResourceChat(issue, 'describe'),
@@ -910,12 +1022,14 @@ export function KubernetesClusterDetailPage() {
                   {activeTab === 'pods' && (
                     <PodsTable
                       items={filteredPods}
-                      loading={loading || resourceFilterLoading || resourceQueryPending}
-                      total={activeTabFilterActive ? filteredResourceTotals.pods : totals.pods}
+                      loading={loading || paginatedResourceLoading}
+                      total={visiblePodTotal}
+                      page={resourcePage}
+                      pageSize={RESOURCE_PAGE_SIZE}
                       filtered={activeTabFilterActive}
                       emptyHint={resourceFilterHint}
                       onClearFilters={clearResourceFilters}
-                      onLoadMore={loadMoreResources}
+                      onPageChange={updateResourcePage}
                       actions={{
                         onOpenLogs: openResourceLogs,
                         onDescribe: (issue) => void startResourceChat(issue, 'describe'),
@@ -927,12 +1041,14 @@ export function KubernetesClusterDetailPage() {
                   {activeTab === 'events' && (
                     <EventsTable
                       items={filteredEvents}
-                      loading={loading || resourceFilterLoading || resourceQueryPending}
-                      total={activeTabFilterActive ? filteredResourceTotals.events : totals.events}
+                      loading={loading || paginatedResourceLoading}
+                      total={visibleEventTotal}
+                      page={resourcePage}
+                      pageSize={RESOURCE_PAGE_SIZE}
                       filtered={activeTabFilterActive}
                       emptyHint={resourceFilterHint}
                       onClearFilters={clearResourceFilters}
-                      onLoadMore={loadMoreResources}
+                      onPageChange={updateResourcePage}
                       actions={{
                         onOpenLogs: openResourceLogs,
                         onDescribe: (issue) => void startResourceChat(issue, 'describe'),
@@ -1474,6 +1590,8 @@ type K8sTriageIssue = {
   name?: string;
   nodeName?: string;
   reason?: string;
+  relatedWorkloadKind?: string;
+  relatedWorkloadName?: string;
   labels: string[];
   tab: DetailTab;
 };
@@ -2471,6 +2589,7 @@ type ActionDecisionFilter = 'all' | 'pending' | 'approved' | 'executed' | 'rejec
 const ACTION_DECISION_FILTERS: ActionDecisionFilter[] = ['all', 'pending', 'approved', 'executed', 'rejected'];
 
 type ServerFilteredResources = {
+  requestKey: string;
   tab: DetailTab;
   nodes?: KubernetesNode[];
   nodesTotal?: number;
@@ -2516,7 +2635,7 @@ function ResourceViewHeader({
   onOpenTab(tab: DetailTab): void;
 }) {
   const { tr } = useI18n();
-  const degradedWorkloads = workloads.filter((item) => item.desired_replicas > item.ready_replicas).length;
+  const degradedWorkloads = workloads.filter(isDegradedWorkload).length;
   const abnormalPods = buildAbnormalPods(pods, crashLoopPods).length;
   const nodeIssues = buildNodeIssues(nodes).length;
   const missingEdgeNodes = edgeAccess ? edgeAccess.total - edgeAccess.linked : 0;
@@ -2581,6 +2700,7 @@ function ResourceFilterBar({
   filteredCount,
   loadedCount,
   totalCount,
+  paginated,
   loading,
   onQueryChange,
   onNamespaceChange,
@@ -2600,6 +2720,7 @@ function ResourceFilterBar({
   filteredCount: number;
   loadedCount: number;
   totalCount: number;
+  paginated?: boolean;
   loading?: boolean;
   onQueryChange(value: string): void;
   onNamespaceChange(value: string): void;
@@ -2693,6 +2814,10 @@ function ResourceFilterBar({
         <Chip tone={filterActive ? 'info' : 'default'} className="ml-auto">
           {loading
             ? tr('加载中…', 'Loading…')
+            : paginated
+              ? filterActive
+                ? tr(`${formatNumber(totalCount)} 条匹配`, `${formatNumber(totalCount)} matched`)
+                : tr(`${formatNumber(totalCount)} 条`, `${formatNumber(totalCount)} row(s)`)
             : filterActive
               ? totalCount > filteredCount
                 ? tr(`已返回 ${formatNumber(filteredCount)} / ${formatNumber(totalCount)} 条匹配`, `${formatNumber(filteredCount)} / ${formatNumber(totalCount)} matched`)
@@ -2808,21 +2933,25 @@ function NodesTable({
   items,
   loading,
   total,
+  page,
+  pageSize,
   filtered,
   emptyHint,
   edgeVersionsByID,
   onClearFilters,
-  onLoadMore,
+  onPageChange,
   actions,
 }: {
   items: KubernetesNode[];
   loading: boolean;
   total: number;
+  page: number;
+  pageSize: number;
   filtered?: boolean;
   emptyHint?: string;
   edgeVersionsByID: Record<number, string>;
   onClearFilters?: () => void;
-  onLoadMore?: () => void;
+  onPageChange(page: number): void;
   actions?: ResourceRowActionHandlers;
 }) {
   const { tr } = useI18n();
@@ -2840,7 +2969,7 @@ function NodesTable({
   }
   return (
     <>
-      <TableLimitNotice shown={items.length} total={total} loading={loading} filtered={filtered} onLoadMore={onLoadMore} />
+      <ResourcePagination shown={items.length} total={total} page={page} pageSize={pageSize} loading={loading} filtered={filtered} onPageChange={onPageChange} />
       <table className="min-w-[1120px] w-full text-sm">
       <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
         <tr>
@@ -2899,22 +3028,35 @@ function WorkloadsTable({
   items,
   loading,
   total,
+  page,
+  pageSize,
   filtered,
   emptyHint,
   onClearFilters,
-  onLoadMore,
+  onPageChange,
   actions,
 }: {
   items: KubernetesWorkload[];
   loading: boolean;
   total: number;
+  page: number;
+  pageSize: number;
   filtered?: boolean;
   emptyHint?: string;
   onClearFilters?: () => void;
-  onLoadMore?: () => void;
+  onPageChange(page: number): void;
   actions?: ResourceRowActionHandlers;
 }) {
   const { tr } = useI18n();
+  const [expandedDeployments, setExpandedDeployments] = useState<Set<string>>(() => new Set());
+  const toggleDeployment = useCallback((key: string) => {
+    setExpandedDeployments((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
   if (loading && items.length === 0) return <LoadingRows colSpan={actions ? 7 : 6} />;
   if (items.length === 0) {
     return (
@@ -2929,14 +3071,14 @@ function WorkloadsTable({
   }
   return (
     <>
-      <TableLimitNotice shown={items.length} total={total} loading={loading} filtered={filtered} onLoadMore={onLoadMore} />
+      <ResourcePagination shown={items.length} total={total} page={page} pageSize={pageSize} loading={loading} filtered={filtered} onPageChange={onPageChange} />
       <table className="min-w-[1120px] w-full text-sm">
         <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
           <tr>
             <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('命名空间', 'Namespace')}</th>
             <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('类型', 'Kind')}</th>
             <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('名称', 'Name')}</th>
-            <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('副本', 'Replicas')}</th>
+            <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('进度', 'Progress')}</th>
             <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('状态', 'Status')}</th>
             <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('最近同步', 'Last sync')}</th>
             {actions && <th className="whitespace-nowrap px-4 py-2.5 text-right">{tr('排障', 'Triage')}</th>}
@@ -2945,24 +3087,112 @@ function WorkloadsTable({
         <tbody className="divide-y divide-zinc-800/40">
           {items.map((item) => {
             const issue = workloadResourceIssue(item, tr);
+            const replicaSets = item.replica_sets ?? [];
+            const deploymentKey = `${item.namespace}\u0000${item.name}`;
+            const expandable = item.kind.trim().toLowerCase() === 'deployment' && replicaSets.length > 0;
+            const expanded = expandable && expandedDeployments.has(deploymentKey);
+            const versionsID = `deployment-revisions-${item.id}`;
             return (
-              <tr key={item.id} className="hover:bg-zinc-900/40">
-                <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">{item.namespace || '—'}</td>
-                <td className="whitespace-nowrap px-4 py-2.5"><Chip>{item.kind}</Chip></td>
-                <td className="px-4 py-2.5 font-medium text-zinc-100">{item.name}</td>
-                <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
-                  {item.ready_replicas}/{item.desired_replicas}
-                </td>
-                <td className="whitespace-nowrap px-4 py-2.5">
-                  <ReplicaStatusChip ready={item.ready_replicas} desired={item.desired_replicas} />
-                </td>
-                <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">{relativeTime(item.last_seen_at)}</td>
-                {actions && (
-                  <td className="whitespace-nowrap px-4 py-2.5 text-right">
-                    <ResourceRowActions issue={issue} actions={actions} />
+              <Fragment key={item.id || deploymentKey}>
+                <tr className={cn('hover:bg-zinc-900/40', expanded && 'bg-indigo-500/5')}>
+                  <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">{item.namespace || '—'}</td>
+                  <td className="whitespace-nowrap px-4 py-2.5"><Chip>{item.kind}</Chip></td>
+                  <td className="px-4 py-2.5 font-medium text-zinc-100">
+                    <div className="flex min-w-[280px] items-center gap-2">
+                      <span>{item.name}</span>
+                      {expandable && (
+                        <Button
+                          className={cn(
+                            'h-7 px-2 text-[11px]',
+                            expanded
+                              ? 'border-indigo-500/30 bg-indigo-500/10 text-indigo-300 hover:bg-indigo-500/20 hover:text-indigo-200'
+                              : 'border-zinc-700/70 bg-zinc-950/30 text-zinc-400 hover:text-zinc-100',
+                          )}
+                          onClick={() => toggleDeployment(deploymentKey)}
+                          aria-expanded={expanded}
+                          aria-controls={versionsID}
+                          aria-label={expanded
+                            ? tr(`收起 ${item.name} 的发布版本`, `Collapse rollout versions for ${item.name}`)
+                            : tr(`展开 ${item.name} 的发布版本`, `Expand rollout versions for ${item.name}`)}
+                        >
+                          <ChevronDown size={12} className={cn('transition-transform', !expanded && '-rotate-90')} />
+                          {tr(`${replicaSets.length} 个版本`, `${replicaSets.length} version(s)`)}
+                        </Button>
+                      )}
+                    </div>
                   </td>
+                  <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-zinc-400">
+                    {workloadProgressText(item, tr)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2.5">
+                    <WorkloadStatusChip item={item} tr={tr} />
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2.5 text-zinc-400">{relativeTime(item.last_seen_at)}</td>
+                  {actions && (
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">
+                      <ResourceRowActions issue={issue} actions={actions} />
+                    </td>
+                  )}
+                </tr>
+                {expanded && (
+                  <tr id={versionsID}>
+                    <td colSpan={actions ? 7 : 6} className="bg-indigo-500/5 px-4 py-3">
+                      <div className="overflow-hidden rounded-lg border border-indigo-500/20 bg-zinc-950/20">
+                        <div className="flex items-center justify-between border-b border-indigo-500/15 bg-indigo-500/5 px-3 py-2">
+                          <div>
+                            <div className="text-xs font-medium text-indigo-300">{tr('ReplicaSet 发布版本', 'ReplicaSet rollout versions')}</div>
+                            <div className="mt-0.5 text-[11px] text-zinc-500">
+                              {tr('仅显示 Kubernetes 中仍保留的版本', 'Only versions still retained in Kubernetes are shown')}
+                            </div>
+                          </div>
+                          <Chip>{tr(`${replicaSets.length} 个版本`, `${replicaSets.length} version(s)`)}</Chip>
+                        </div>
+                        <div className="divide-y divide-indigo-500/10">
+                          {replicaSets.map((replicaSet) => {
+                            const currentRevision = (item.revision ?? 0) > 0 && replicaSet.revision === item.revision;
+                            const activeRevision = replicaSet.desired_replicas > 0;
+                            const versionStatus = currentRevision
+                              ? { label: tr('当前版本', 'Current'), tone: 'accent' as const }
+                              : activeRevision
+                                ? { label: tr('仍在运行', 'Active'), tone: 'info' as const }
+                                : { label: tr('历史版本', 'History'), tone: 'default' as const };
+                            return (
+                              <div
+                                key={replicaSet.uid || replicaSet.id || replicaSet.name}
+                                className={cn(
+                                  'grid grid-cols-[110px_minmax(260px,1fr)_120px_110px_190px_auto] items-center gap-3 px-3 py-2.5 text-xs',
+                                  currentRevision && 'bg-indigo-500/5',
+                                )}
+                              >
+                                <div className="font-mono font-medium text-zinc-200">
+                                  {replicaSet.revision ? `Revision ${replicaSet.revision}` : tr('Revision 未知', 'Revision unknown')}
+                                </div>
+                                <div className="min-w-0 truncate font-mono text-[11px] text-zinc-400" title={replicaSet.name}>
+                                  {replicaSet.name}
+                                </div>
+                                <Chip tone={versionStatus.tone} className="w-fit">{versionStatus.label}</Chip>
+                                <div className="font-mono text-zinc-400">{replicaSet.ready_replicas}/{replicaSet.desired_replicas}</div>
+                                <time
+                                  dateTime={replicaSet.creation_timestamp || undefined}
+                                  title={fullDateTime(replicaSet.creation_timestamp)}
+                                  className="text-zinc-400"
+                                >
+                                  {fullDateTime(replicaSet.creation_timestamp)}
+                                </time>
+                                {actions ? (
+                                  <div className="justify-self-end">
+                                    <ResourceRowActions issue={workloadResourceIssue(replicaSet, tr)} actions={actions} />
+                                  </div>
+                                ) : <span />}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
                 )}
-              </tr>
+              </Fragment>
             );
           })}
         </tbody>
@@ -2971,7 +3201,29 @@ function WorkloadsTable({
   );
 }
 
-function PodsTable({ items, loading, total, filtered, emptyHint, onClearFilters, onLoadMore, actions }: { items: KubernetesPod[]; loading: boolean; total: number; filtered?: boolean; emptyHint?: string; onClearFilters?: () => void; onLoadMore?: () => void; actions?: ResourceRowActionHandlers }) {
+function PodsTable({
+  items,
+  loading,
+  total,
+  page,
+  pageSize,
+  filtered,
+  emptyHint,
+  onClearFilters,
+  onPageChange,
+  actions,
+}: {
+  items: KubernetesPod[];
+  loading: boolean;
+  total: number;
+  page: number;
+  pageSize: number;
+  filtered?: boolean;
+  emptyHint?: string;
+  onClearFilters?: () => void;
+  onPageChange(page: number): void;
+  actions?: ResourceRowActionHandlers;
+}) {
   const { tr } = useI18n();
   if (loading && items.length === 0) return <LoadingRows colSpan={actions ? 9 : 8} />;
   if (items.length === 0) {
@@ -2987,7 +3239,7 @@ function PodsTable({ items, loading, total, filtered, emptyHint, onClearFilters,
   }
   return (
     <>
-      <TableLimitNotice shown={items.length} total={total} loading={loading} filtered={filtered} onLoadMore={onLoadMore} />
+      <ResourcePagination shown={items.length} total={total} page={page} pageSize={pageSize} loading={loading} filtered={filtered} onPageChange={onPageChange} />
       <table className="min-w-[1220px] w-full text-sm">
         <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
           <tr>
@@ -3035,19 +3287,23 @@ function EventsTable({
   items,
   loading,
   total,
+  page,
+  pageSize,
   filtered,
   emptyHint,
   onClearFilters,
-  onLoadMore,
+  onPageChange,
   actions,
 }: {
   items: KubernetesEvent[];
   loading: boolean;
   total: number;
+  page: number;
+  pageSize: number;
   filtered?: boolean;
   emptyHint?: string;
   onClearFilters?: () => void;
-  onLoadMore?: () => void;
+  onPageChange(page: number): void;
   actions?: ResourceRowActionHandlers;
 }) {
   const { tr } = useI18n();
@@ -3065,7 +3321,7 @@ function EventsTable({
   }
   return (
     <>
-      <TableLimitNotice shown={items.length} total={total} loading={loading} filtered={filtered} onLoadMore={onLoadMore} />
+      <ResourcePagination shown={items.length} total={total} page={page} pageSize={pageSize} loading={loading} filtered={filtered} onPageChange={onPageChange} />
       <table className="min-w-[1060px] w-full text-sm">
         <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
           <tr>
@@ -3332,9 +3588,10 @@ function ModeChip({ mode }: { mode?: string }) {
   return <Chip tone="accent">{mode || 'full-node'}</Chip>;
 }
 
-function ReplicaStatusChip({ ready, desired }: { ready: number; desired: number }) {
-  const ok = desired === 0 || ready >= desired;
-  return <Chip tone={ok ? 'success' : 'warning'}>{ok ? 'ready' : 'degraded'}</Chip>;
+function WorkloadStatusChip({ item, tr }: { item: KubernetesWorkload; tr: (zh: string, en: string) => string }) {
+  const state = workloadHealthState(item);
+  const tone = state === 'failed' ? 'danger' : state === 'degraded' ? 'warning' : state === 'running' ? 'info' : state === 'pending' ? 'default' : 'success';
+  return <Chip tone={tone}>{workloadHealthLabel(state, tr)}</Chip>;
 }
 
 function PodPhaseChip({ phase }: { phase?: string }) {
@@ -3362,37 +3619,74 @@ function LoadingRows({ colSpan }: { colSpan: number }) {
   );
 }
 
-function TableLimitNotice({
+function ResourcePagination({
   shown,
   total,
+  page,
+  pageSize,
   loading,
   filtered,
-  onLoadMore,
+  onPageChange,
 }: {
   shown: number;
   total: number;
+  page: number;
+  pageSize: number;
   loading?: boolean;
   filtered?: boolean;
-  onLoadMore?: () => void;
+  onPageChange(page: number): void;
 }) {
   const { tr } = useI18n();
-  if (shown >= total) return null;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const currentPage = Math.min(Math.max(page, 1), totalPages);
+  if (totalPages <= 1) return null;
+  const firstRow = total === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const lastRow = Math.min(total, firstRow + Math.max(0, shown - 1));
   return (
     <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-800/60 px-4 py-2 text-xs text-zinc-500">
       <span>
         {filtered
-          ? tr(`显示前 ${shown} 条匹配，共 ${total} 条匹配`, `Showing first ${shown} of ${total} matches`)
-          : tr(`显示前 ${shown} 条，共 ${total} 条`, `Showing first ${shown} of ${total}`)}
+          ? tr(
+              `${formatNumber(firstRow)}–${formatNumber(lastRow)} / 共 ${formatNumber(total)} 条匹配`,
+              `${formatNumber(firstRow)}–${formatNumber(lastRow)} of ${formatNumber(total)} matches`,
+            )
+          : tr(
+              `${formatNumber(firstRow)}–${formatNumber(lastRow)} / 共 ${formatNumber(total)} 条`,
+              `${formatNumber(firstRow)}–${formatNumber(lastRow)} of ${formatNumber(total)}`,
+            )}
       </span>
-      {onLoadMore && (
-        <Button className="h-7" disabled={loading} onClick={onLoadMore}>
-          {loading
-            ? tr('加载中…', 'Loading…')
-            : filtered
-              ? tr('加载更多匹配', 'Load more matches')
-              : tr('加载更多', 'Load more')}
+      <div className="flex items-center gap-2">
+        <span>{tr(`第 ${currentPage} / ${totalPages} 页`, `Page ${currentPage} of ${totalPages}`)}</span>
+        <Button
+          className="h-7 px-2"
+          disabled={loading || currentPage <= 1}
+          onClick={() => onPageChange(currentPage - 1)}
+          aria-label={tr('上一页', 'Previous page')}
+        >
+          <ChevronLeft size={12} />
+          {tr('上一页', 'Previous')}
         </Button>
-      )}
+        <select
+          value={currentPage}
+          onChange={(event) => onPageChange(Number(event.target.value))}
+          disabled={loading}
+          className="h-7 rounded-md border border-zinc-800 bg-zinc-950 px-2 text-xs text-zinc-200 outline-none transition-colors focus:border-zinc-600 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={tr('页码', 'Page')}
+        >
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map((item) => (
+            <option key={item} value={item}>{item}</option>
+          ))}
+        </select>
+        <Button
+          className="h-7 px-2"
+          disabled={loading || currentPage >= totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+          aria-label={tr('下一页', 'Next page')}
+        >
+          {tr('下一页', 'Next')}
+          <ChevronRight size={12} />
+        </Button>
+      </div>
     </div>
   );
 }
@@ -3678,10 +3972,10 @@ function resourceViewContext({
     return {
       title: tr('Workload 资源视图', 'Workload resource view'),
       count: tr(`${formatNumber(totals.workloads)} 个 workload`, `${formatNumber(totals.workloads)} workload(s)`),
-      description: tr('按 namespace 和 workload 查看副本就绪情况，异常副本优先关联 Pod 与 Event。', 'Inspect replica readiness by namespace and workload, then correlate degraded replicas with pods and events.'),
+      description: tr('按 namespace 和 workload 查看副本就绪与 Job 执行状态，异常项优先关联 Pod 与 Event。', 'Inspect replica readiness and Job execution by namespace and workload, then correlate issues with pods and events.'),
       tone: degradedWorkloads > 0 ? 'warning' : 'success',
       signals: [
-        { label: tr(`副本异常 ${formatNumber(degradedWorkloads)}`, `${formatNumber(degradedWorkloads)} degraded`), tone: degradedWorkloads > 0 ? 'warning' : 'default' },
+        { label: tr(`Workload 异常 ${formatNumber(degradedWorkloads)}`, `${formatNumber(degradedWorkloads)} workload issue(s)`), tone: degradedWorkloads > 0 ? 'warning' : 'default' },
         { label: tr(`异常 Pod ${formatNumber(abnormalPods)}`, `${formatNumber(abnormalPods)} abnormal pod(s)`), tone: abnormalPods > 0 ? 'warning' : 'default' },
       ],
       related: abnormalPods > 0 ? [{ tab: 'pods', label: tr('查看 Pods', 'Open Pods') }] : warningEventTotal > 0 ? [{ tab: 'events', label: tr('查看 Events', 'Open Events') }] : [],
@@ -3824,12 +4118,13 @@ function resourceSupportsServerFilter(tab: DetailTab) {
   return tab === 'nodes' || tab === 'workloads' || tab === 'pods' || tab === 'events';
 }
 
-function resourceAPIParams(filters: ResourceFilters, limit = RESOURCE_PAGE_SIZE) {
+function resourceAPIParams(filters: ResourceFilters, limit = RESOURCE_PAGE_SIZE, offset = 0) {
   return {
     q: filters.query.trim() || undefined,
     namespace: filters.namespace === 'all' ? undefined : filters.namespace,
     issue_only: filters.issueOnly || undefined,
     limit,
+    offset,
   };
 }
 
@@ -3845,8 +4140,8 @@ function filterWorkloads(items: KubernetesWorkload[], filters: ResourceFilters) 
   const query = normalizeFilterQuery(filters.query);
   return items.filter((item) => {
     if (!matchesNamespaceFilter(item.namespace, filters.namespace)) return false;
-    if (filters.issueOnly && item.ready_replicas >= item.desired_replicas) return false;
-    return matchesQuery(query, item.namespace, item.kind, item.name, `${item.ready_replicas}/${item.desired_replicas}`);
+    if (filters.issueOnly && !isDegradedWorkload(item)) return false;
+    return matchesQuery(query, item.namespace, item.kind, item.name, `${item.ready_replicas}/${item.desired_replicas}`, item.active_replicas, item.failed_replicas);
   });
 }
 
@@ -4014,17 +4309,18 @@ function buildTriageIssues({
   warningEvents: KubernetesEvent[];
   tr: (zh: string, en: string) => string;
 }) {
-  const degradedWorkloads = workloads.filter((item) => item.desired_replicas > item.ready_replicas);
+  const degradedWorkloads = workloads.filter(isDegradedWorkload).slice(0, 6);
   const abnormalPods = buildAbnormalPods(pods, crashLoopPods);
+  const degradedWorkloadOwners = buildDegradedWorkloadOwnerIndex(degradedWorkloads);
   const nodeIssues = buildNodeIssues(nodes);
-  const recentWarningEvents = sortEventsByRecent(dedupeEvents(warningEvents.filter(isWarningK8sEvent))).slice(0, 5);
+  const actionableWarningEvents = sortEventsByRecent(dedupeEvents(warningEvents.filter(isWarningK8sEvent))).slice(0, 5);
   const syncRisk = clusterSyncRisk(cluster, tr);
   return sortTriageIssues(aggregateTriageIssues([
-    ...degradedWorkloads.slice(0, 6).map((item) => workloadIssue(item, tr)),
-    ...abnormalPods.slice(0, 6).map((item) => podIssue(item, tr)),
+    ...degradedWorkloads.map((item) => workloadIssue(item, tr)),
+    ...abnormalPods.slice(0, 6).map((item) => podIssue(item, tr, owningDegradedWorkload(item, degradedWorkloadOwners))),
     ...nodeIssues.slice(0, 6),
     ...(syncRisk ? [syncRiskIssue(syncRisk, tr)] : []),
-    ...recentWarningEvents.map(eventIssue),
+    ...actionableWarningEvents.map(eventIssue),
   ]));
 }
 
@@ -4044,6 +4340,33 @@ function buildAbnormalPods(pods: KubernetesPod[], crashLoopPods: KubernetesPod[]
   return out;
 }
 
+function buildDegradedWorkloadOwnerIndex(items: KubernetesWorkload[]) {
+  const out = new Map<string, KubernetesWorkload>();
+  for (const item of items) {
+    out.set(workloadIdentityKey(item.namespace, item.kind, item.name), item);
+    if (item.kind.trim().toLowerCase() !== 'deployment') continue;
+    for (const replicaSet of item.replica_sets ?? []) {
+      out.set(
+        workloadIdentityKey(replicaSet.namespace || item.namespace, replicaSet.kind, replicaSet.name),
+        item,
+      );
+    }
+  }
+  return out;
+}
+
+function owningDegradedWorkload(
+  pod: KubernetesPod,
+  workloadOwners: ReadonlyMap<string, KubernetesWorkload>,
+) {
+  if (!pod.owner_kind || !pod.owner_name) return undefined;
+  return workloadOwners.get(workloadIdentityKey(pod.namespace, pod.owner_kind, pod.owner_name));
+}
+
+function workloadIdentityKey(namespace: string | undefined, kind: string, name: string) {
+  return `${namespace || 'default'}\u0000${kind.trim().toLowerCase()}\u0000${name.trim()}`;
+}
+
 function isAbnormalPod(pod: KubernetesPod) {
   return (
     pod.phase === 'Pending' ||
@@ -4056,34 +4379,115 @@ function isAbnormalPod(pod: KubernetesPod) {
 }
 
 function workloadIssue(item: KubernetesWorkload, tr: (zh: string, en: string) => string): K8sTriageIssue {
+  const state = workloadHealthState(item);
   return {
     key: `workload:${item.namespace}:${item.kind}:${item.name}`,
     kind: 'workload',
-    tone: 'warning',
+    tone: state === 'failed' ? 'danger' : 'warning',
     title: `${item.kind}/${item.name}`,
     subtitle: item.namespace || 'default',
-    detail: tr(`${item.ready_replicas}/${item.desired_replicas} 副本就绪`, `${item.ready_replicas}/${item.desired_replicas} replicas ready`),
+    detail: workloadProgressText(item, tr),
     namespace: item.namespace,
     resourceKind: item.kind,
     name: item.name,
-    labels: [`${item.ready_replicas}/${item.desired_replicas}`, tr('副本未就绪', 'degraded')],
+    labels: [workloadProgressText(item, tr), state === 'failed' ? tr('任务失败', 'job failed') : tr('副本未就绪', 'degraded')],
     tab: 'workloads',
   };
 }
 
 function workloadResourceIssue(item: KubernetesWorkload, tr: (zh: string, en: string) => string): K8sTriageIssue {
-  const degraded = item.desired_replicas > item.ready_replicas;
+  const state = workloadHealthState(item);
+  const degraded = state === 'degraded' || state === 'failed';
   return {
     ...workloadIssue(item, tr),
-    tone: degraded ? 'warning' : 'info',
+    tone: state === 'failed' ? 'danger' : degraded ? 'warning' : 'info',
     labels: [
-      `${item.ready_replicas}/${item.desired_replicas}`,
-      degraded ? tr('副本未就绪', 'degraded') : tr('副本就绪', 'ready'),
+      workloadProgressText(item, tr),
+      workloadHealthLabel(state, tr),
     ],
   };
 }
 
-function podIssue(item: KubernetesPod, tr: (zh: string, en: string) => string): K8sTriageIssue {
+type WorkloadHealthState = 'ready' | 'complete' | 'running' | 'pending' | 'degraded' | 'failed';
+
+const JOB_FAILED_CONDITION_TYPES = new Set(['failed', 'failuretarget']);
+const JOB_COMPLETE_CONDITION_TYPES = new Set(['complete', 'successcriteriamet']);
+
+function workloadHealthState(item: KubernetesWorkload): WorkloadHealthState {
+  const kind = item.kind.trim().toLowerCase();
+  if (kind === 'job') {
+    if (
+      workloadHasTrueCondition(item, JOB_FAILED_CONDITION_TYPES) ||
+      ((item.failed_replicas ?? 0) > 0 && (item.active_replicas ?? 0) === 0 && item.ready_replicas < item.desired_replicas)
+    ) {
+      return 'failed';
+    }
+    if (
+      workloadHasTrueCondition(item, JOB_COMPLETE_CONDITION_TYPES) ||
+      (item.desired_replicas > 0 && item.ready_replicas >= item.desired_replicas)
+    ) {
+      return 'complete';
+    }
+    if ((item.active_replicas ?? 0) > 0) return 'running';
+    return 'pending';
+  }
+  if (kind === 'cronjob') {
+    return (item.active_replicas ?? 0) > 0 ? 'running' : 'ready';
+  }
+  return item.desired_replicas === 0 || item.ready_replicas >= item.desired_replicas ? 'ready' : 'degraded';
+}
+
+function isDegradedWorkload(item: KubernetesWorkload) {
+  const state = workloadHealthState(item);
+  return state === 'degraded' || state === 'failed';
+}
+
+function workloadHasTrueCondition(item: KubernetesWorkload, wanted: ReadonlySet<string>) {
+  return (item.conditions ?? []).some((condition) => {
+    if (!condition || typeof condition !== 'object') return false;
+    const fields = condition as Record<string, unknown>;
+    return wanted.has(String(fields.type ?? '').toLowerCase()) && String(fields.status ?? '').toLowerCase() === 'true';
+  });
+}
+
+function workloadProgressText(item: KubernetesWorkload, tr: (zh: string, en: string) => string) {
+  const kind = item.kind.trim().toLowerCase();
+  const active = item.active_replicas ?? 0;
+  const failed = item.failed_replicas ?? 0;
+  if (kind === 'job') {
+    const parts = [tr(`${item.ready_replicas}/${item.desired_replicas} 完成`, `${item.ready_replicas}/${item.desired_replicas} complete`)];
+    if (active > 0) parts.push(tr(`${active} 运行`, `${active} active`));
+    if (failed > 0) parts.push(tr(`${failed} 失败`, `${failed} failed`));
+    return parts.join(' · ');
+  }
+  if (kind === 'cronjob') {
+    return active > 0 ? tr(`${active} 个运行中 Job`, `${active} active Job(s)`) : tr('无运行中 Job', 'No active Jobs');
+  }
+  return `${item.ready_replicas}/${item.desired_replicas}`;
+}
+
+function workloadHealthLabel(state: WorkloadHealthState, tr: (zh: string, en: string) => string) {
+  switch (state) {
+    case 'complete':
+      return tr('已完成', 'complete');
+    case 'running':
+      return tr('运行中', 'running');
+    case 'pending':
+      return tr('等待中', 'pending');
+    case 'failed':
+      return tr('失败', 'failed');
+    case 'degraded':
+      return tr('降级', 'degraded');
+    case 'ready':
+      return 'ready';
+  }
+}
+
+function podIssue(
+  item: KubernetesPod,
+  tr: (zh: string, en: string) => string,
+  relatedWorkload?: KubernetesWorkload,
+): K8sTriageIssue {
   const reason = item.reason || item.phase || 'Pod';
   return {
     key: `pod:${item.namespace}:${item.name}`,
@@ -4097,6 +4501,8 @@ function podIssue(item: KubernetesPod, tr: (zh: string, en: string) => string): 
     name: item.name,
     nodeName: item.node_name,
     reason,
+    relatedWorkloadKind: relatedWorkload?.kind,
+    relatedWorkloadName: relatedWorkload?.name,
     labels: [reason, tr(`${item.restart_count} 次重启`, `${item.restart_count} restarts`)],
     tab: 'pods',
   };
@@ -4175,9 +4581,29 @@ function sortTriageIssues(items: K8sTriageIssue[]) {
 }
 
 function aggregateTriageIssues(items: K8sTriageIssue[]) {
+  const workloadKeys = new Set<string>();
+  for (const item of items) {
+    if (item.kind === 'workload' && item.resourceKind && item.name) {
+      workloadKeys.add(workloadTriageResourceKey(item.namespace, item.resourceKind, item.name));
+    }
+  }
+  const podOwnerKeys = new Map<string, string>();
+  for (const item of items) {
+    if (item.kind !== 'pod' || !item.name || !item.relatedWorkloadKind || !item.relatedWorkloadName) continue;
+    const workloadKey = workloadTriageResourceKey(item.namespace, item.relatedWorkloadKind, item.relatedWorkloadName);
+    if (workloadKeys.has(workloadKey)) {
+      podOwnerKeys.set(podTriageResourceKey(item.namespace, item.name), workloadKey);
+    }
+  }
+
   const grouped = new Map<string, K8sTriageIssue>();
   for (const item of items) {
-    const key = triageIssueResourceKey(item);
+    const resourceKey = triageIssueResourceKey(item);
+    const key = item.kind === 'pod'
+      ? podOwnerKeys.get(resourceKey) ?? resourceKey
+      : item.kind === 'event'
+        ? podOwnerKeys.get(resourceKey) ?? resourceKey
+        : resourceKey;
     const current = grouped.get(key);
     grouped.set(key, current ? mergeTriageIssue(current, item) : item);
   }
@@ -4188,13 +4614,25 @@ function triageIssueResourceKey(item: K8sTriageIssue) {
   const namespace = item.namespace || 'default';
   const kind = item.resourceKind || item.kind;
   if (item.kind === 'node' || kind === 'Node') return `node:${item.nodeName || item.name || item.title}`;
-  if ((item.kind === 'pod' || kind === 'Pod') && item.name) return `pod:${namespace}:${item.name}`;
-  if ((item.kind === 'workload' || isWorkloadKind(kind)) && item.name) return `workload:${namespace}:${kind}:${item.name}`;
+  if ((item.kind === 'pod' || kind.toLowerCase() === 'pod') && item.name) return podTriageResourceKey(namespace, item.name);
+  if ((item.kind === 'workload' || isWorkloadKind(kind)) && item.name) return workloadTriageResourceKey(namespace, kind, item.name);
+  if (item.kind === 'event' && item.name) return `resource:${namespace}:${kind.trim().toLowerCase()}:${item.name}`;
   return item.key;
 }
 
+function podTriageResourceKey(namespace: string | undefined, name: string) {
+  return `pod:${namespace || 'default'}:${name}`;
+}
+
+function workloadTriageResourceKey(namespace: string | undefined, kind: string, name: string) {
+  return `workload:${namespace || 'default'}:${kind.trim().toLowerCase()}:${name}`;
+}
+
 function mergeTriageIssue(a: K8sTriageIssue, b: K8sTriageIssue): K8sTriageIssue {
-  const [primary, secondary] = sortTriageIssues([a, b]);
+  const ranked = sortTriageIssues([a, b]);
+  const workload = a.kind === 'workload' ? a : b.kind === 'workload' ? b : null;
+  const primary = workload ?? ranked[0];
+  const secondary = primary === a ? b : a;
   const secondarySignals = [
     secondary.kind === 'event' ? secondary.title : '',
     secondary.reason,
@@ -4204,6 +4642,7 @@ function mergeTriageIssue(a: K8sTriageIssue, b: K8sTriageIssue): K8sTriageIssue 
   const detail = uniqueStrings([primary.detail, secondary.detail]).join(' · ') || undefined;
   return {
     ...primary,
+    tone: ranked[0].tone,
     labels,
     detail,
   };
@@ -4222,7 +4661,7 @@ function uniqueStrings(values: Array<string | undefined | null>) {
 }
 
 function isWorkloadKind(kind: string) {
-  return kind === 'Deployment' || kind === 'StatefulSet' || kind === 'DaemonSet' || kind === 'Job' || kind === 'CronJob';
+  return ['deployment', 'statefulset', 'daemonset', 'replicaset', 'job', 'cronjob'].includes(kind.trim().toLowerCase());
 }
 
 function buildNodeIssues(nodes: KubernetesNode[]): K8sTriageIssue[] {
@@ -4450,14 +4889,14 @@ function buildWriteActionRecommendations({
     }
   }
 
-  const degradedWorkload = workloads.find((item) => item.desired_replicas > item.ready_replicas);
+  const degradedWorkload = workloads.find((item) => isDegradedWorkload(item) && ['Deployment', 'StatefulSet', 'DaemonSet'].includes(item.kind));
   if (restartSpec && degradedWorkload && !recommendations.some((item) => item.target.includes(`${degradedWorkload.kind}/${degradedWorkload.name}`))) {
     recommendations.push({
       key: `workload:${degradedWorkload.namespace}:${degradedWorkload.kind}:${degradedWorkload.name}:restart`,
       spec: restartSpec,
       title: tr('建议 restart rollout', 'Suggest restart rollout'),
       target: `${degradedWorkload.kind}/${degradedWorkload.name} namespace=${degradedWorkload.namespace} replicas=${degradedWorkload.ready_replicas}/${degradedWorkload.desired_replicas}`,
-      evidence: tr(`${degradedWorkload.ready_replicas}/${degradedWorkload.desired_replicas} 副本就绪`, `${degradedWorkload.ready_replicas}/${degradedWorkload.desired_replicas} replicas ready`),
+      evidence: workloadProgressText(degradedWorkload, tr),
       tone: recommendationTone(restartSpec),
     });
   }

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -331,8 +331,11 @@ export function KubernetesClusterDetailPage() {
   const detailTabs = useMemo(() => detailTabsForCluster(cluster), [cluster]);
   const awaitingConnection = isClusterAwaitingConnection(cluster);
   const [nodes, setNodes] = useState<KubernetesNode[]>([]);
+  const [issueNodes, setIssueNodes] = useState<KubernetesNode[]>([]);
   const [workloads, setWorkloads] = useState<KubernetesWorkload[]>([]);
+  const [issueWorkloads, setIssueWorkloads] = useState<KubernetesWorkload[]>([]);
   const [pods, setPods] = useState<KubernetesPod[]>([]);
+  const [issuePods, setIssuePods] = useState<KubernetesPod[]>([]);
   const [crashLoopPods, setCrashLoopPods] = useState<KubernetesPod[]>([]);
   const [events, setEvents] = useState<KubernetesEvent[]>([]);
   const [warningEvents, setWarningEvents] = useState<KubernetesEvent[]>([]);
@@ -342,6 +345,7 @@ export function KubernetesClusterDetailPage() {
   const [actionProposalTotal, setActionProposalTotal] = useState(0);
   const [actionAuditError, setActionAuditError] = useState<string | null>(null);
   const [totals, setTotals] = useState<ResourceTotals>({ nodes: 0, workloads: 0, pods: 0, events: 0 });
+  const [issueResourceTotals, setIssueResourceTotals] = useState({ nodes: 0, workloads: 0, pods: 0 });
   const [crashLoopTotal, setCrashLoopTotal] = useState(0);
   const [healthSummary, setHealthSummary] = useState<KubernetesClusterHealth | null>(null);
   const [loading, setLoading] = useState(true);
@@ -381,12 +385,29 @@ export function KubernetesClusterDetailPage() {
         : listEdges()
           .then((out) => buildEdgeVersionMap(out.items ?? []))
           .catch(() => ({}));
-      const [clusterOut, healthOut, nodesOut, workloadsOut, podsOut, crashLoopPodsOut, eventsOut, warningEventsOut, auditOut, edgeVersionMap] = await Promise.all([
+      const [
+        clusterOut,
+        healthOut,
+        nodesOut,
+        issueNodesOut,
+        workloadsOut,
+        issueWorkloadsOut,
+        podsOut,
+        issuePodsOut,
+        crashLoopPodsOut,
+        eventsOut,
+        warningEventsOut,
+        auditOut,
+        edgeVersionMap,
+      ] = await Promise.all([
         getKubernetesCluster(clusterId),
         getKubernetesClusterHealth(clusterId),
         listKubernetesNodes(clusterId, { limit: RESOURCE_PAGE_SIZE }),
+        listKubernetesNodes(clusterId, { issue_only: true, limit: RESOURCE_PAGE_SIZE }),
         listKubernetesWorkloads(clusterId, { group_replica_sets: true, limit: RESOURCE_PAGE_SIZE }),
+        listKubernetesWorkloads(clusterId, { issue_only: true, group_replica_sets: true, limit: RESOURCE_PAGE_SIZE }),
         listKubernetesPods(clusterId, { limit: RESOURCE_PAGE_SIZE }),
+        listKubernetesPods(clusterId, { issue_only: true, limit: RESOURCE_PAGE_SIZE }),
         listKubernetesPods(clusterId, { reason: 'CrashLoopBackOff', limit: 20 }),
         listKubernetesEvents(clusterId, { limit: RESOURCE_PAGE_SIZE }),
         listKubernetesEvents(clusterId, { issue_only: true, limit: 100 }),
@@ -396,8 +417,11 @@ export function KubernetesClusterDetailPage() {
       setCluster(clusterOut);
       setHealthSummary(healthOut);
       setNodes(nodesOut.items ?? []);
+      setIssueNodes(issueNodesOut.items ?? []);
       setWorkloads(workloadsOut.items ?? []);
+      setIssueWorkloads(issueWorkloadsOut.items ?? []);
       setPods(podsOut.items ?? []);
+      setIssuePods(issuePodsOut.items ?? []);
       setCrashLoopPods(crashLoopPodsOut.items ?? []);
       setEvents(eventsOut.items ?? []);
       const visibleWorkloadsTotal = workloadsOut.total ?? (workloadsOut.items?.length ?? 0);
@@ -411,6 +435,11 @@ export function KubernetesClusterDetailPage() {
         workloads: visibleWorkloadsTotal,
         pods: podsOut.total ?? (podsOut.items?.length ?? 0),
         events: eventsOut.total ?? (eventsOut.items?.length ?? 0),
+      });
+      setIssueResourceTotals({
+        nodes: issueNodesOut.total ?? (issueNodesOut.items?.length ?? 0),
+        workloads: issueWorkloadsOut.total ?? (issueWorkloadsOut.items?.length ?? 0),
+        pods: issuePodsOut.total ?? (issuePodsOut.items?.length ?? 0),
       });
       setCrashLoopTotal(crashLoopPodsOut.total ?? (crashLoopPodsOut.items?.length ?? 0));
       setResourceFilterRefreshNonce((value) => value + 1);
@@ -447,7 +476,11 @@ export function KubernetesClusterDetailPage() {
   }, [refresh]);
   usePoll(() => refresh({ silent: true }), POLL_INTERVAL_MS);
 
-  const namespaces = useMemo(() => collectNamespaces(workloads, pods, events), [workloads, pods, events]);
+  const namespaceRows = useMemo(
+    () => buildNamespaceRows(workloads, pods, events, warningEvents, healthSummary?.namespaces),
+    [events, healthSummary?.namespaces, pods, warningEvents, workloads],
+  );
+  const namespaces = useMemo(() => namespaceRows.map((row) => row.namespace), [namespaceRows]);
   const actionTypeOptions = useMemo(() => collectActionTypes(actionProposals), [actionProposals]);
   const resourceFilters = useMemo(
     () => ({
@@ -651,7 +684,6 @@ export function KubernetesClusterDetailPage() {
     const lastPage = Math.max(1, Math.ceil(activePaginatedTotal / RESOURCE_PAGE_SIZE));
     setResourcePage((current) => Math.min(current, lastPage));
   }, [activePaginatedTotal, activeTabSupportsServerFilter, needsServerResourceFetch, serverResourceActive]);
-  const namespaceRows = useMemo(() => buildNamespaceRows(workloads, pods, events, warningEvents), [events, pods, warningEvents, workloads]);
   const filteredNamespaceRows = useMemo(() => filterNamespaceRows(namespaceRows, localResourceFilters), [localResourceFilters, namespaceRows]);
   const filteredActionProposals = useMemo(() => filterActionProposals(actionProposals, localResourceFilters), [actionProposals, localResourceFilters]);
   const resourceFilterHint = useMemo(() => resourceFilterSummary(localResourceFilters, activeTab, tr), [activeTab, localResourceFilters, tr]);
@@ -665,12 +697,12 @@ export function KubernetesClusterDetailPage() {
     return { linked: coverage.edge_linked, total: coverage.total, pct: coverage.percent };
   }, [cluster?.node_edge_coverage]);
   const triageIssues = useMemo(
-    () => buildTriageIssues({ cluster, nodes: visibleNodes, workloads, pods, crashLoopPods, warningEvents, tr }),
-    [cluster, crashLoopPods, pods, tr, visibleNodes, warningEvents, workloads],
+    () => buildTriageIssues({ cluster, nodes: issueNodes, workloads: issueWorkloads, pods: issuePods, crashLoopPods, warningEvents, tr }),
+    [cluster, crashLoopPods, issueNodes, issuePods, issueWorkloads, tr, warningEvents],
   );
   const writeActionRecommendations = useMemo(
-    () => buildWriteActionRecommendations({ nodes: visibleNodes, workloads, pods, crashLoopPods, warningEvents, tr }),
-    [crashLoopPods, pods, tr, visibleNodes, warningEvents, workloads],
+    () => buildWriteActionRecommendations({ nodes: issueNodes, workloads: issueWorkloads, pods: issuePods, crashLoopPods, warningEvents, tr }),
+    [crashLoopPods, issueNodes, issuePods, issueWorkloads, tr, warningEvents],
   );
 
   const openResourceTab = useCallback((tab: DetailTab, opts?: { scroll?: boolean; resetFilters?: boolean }) => {
@@ -922,15 +954,11 @@ export function KubernetesClusterDetailPage() {
                 <ResourceViewHeader
                   activeTab={activeTab}
                   totals={totals}
-                  nodes={visibleNodes}
-                  workloads={workloads}
-                  pods={pods}
-                  crashLoopPods={crashLoopPods}
+                  issueTotals={issueResourceTotals}
                   crashLoopTotal={crashLoopTotal}
-                  events={events}
-                  warningEvents={warningEvents}
                   warningEventTotal={warningEventTotal}
                   namespaces={namespaces}
+                  namespaceRows={namespaceRows}
                   actionProposals={actionProposals}
                   actionProposalTotal={actionProposalTotal}
                   edgeAccess={edgeAccess}
@@ -2604,15 +2632,11 @@ type ServerFilteredResources = {
 function ResourceViewHeader({
   activeTab,
   totals,
-  nodes,
-  workloads,
-  pods,
-  crashLoopPods,
+  issueTotals,
   crashLoopTotal,
-  events,
-  warningEvents,
   warningEventTotal,
   namespaces,
+  namespaceRows,
   actionProposals,
   actionProposalTotal,
   edgeAccess,
@@ -2620,26 +2644,22 @@ function ResourceViewHeader({
 }: {
   activeTab: DetailTab;
   totals: ResourceTotals;
-  nodes: KubernetesNode[];
-  workloads: KubernetesWorkload[];
-  pods: KubernetesPod[];
-  crashLoopPods: KubernetesPod[];
+  issueTotals: { nodes: number; workloads: number; pods: number };
   crashLoopTotal: number;
-  events: KubernetesEvent[];
-  warningEvents: KubernetesEvent[];
   warningEventTotal: number;
   namespaces: string[];
+  namespaceRows: NamespaceRow[];
   actionProposals: MutatingProposal[];
   actionProposalTotal: number;
   edgeAccess: { linked: number; total: number; pct: number } | null;
   onOpenTab(tab: DetailTab): void;
 }) {
   const { tr } = useI18n();
-  const degradedWorkloads = workloads.filter(isDegradedWorkload).length;
-  const abnormalPods = buildAbnormalPods(pods, crashLoopPods).length;
-  const nodeIssues = buildNodeIssues(nodes).length;
+  const degradedWorkloads = issueTotals.workloads;
+  const abnormalPods = issueTotals.pods;
+  const nodeIssues = issueTotals.nodes;
   const missingEdgeNodes = edgeAccess ? edgeAccess.total - edgeAccess.linked : 0;
-  const namespaceWarnings = buildNamespaceRows(workloads, pods, events, warningEvents).filter((row) => row.warnings > 0).length;
+  const namespaceWarnings = namespaceRows.filter((row) => row.warnings > 0).length;
   const pendingActions = actionProposals.filter((item) => (item.decision || '').toLowerCase() === 'pending').length;
   const context = resourceViewContext({
     activeTab,
@@ -4259,18 +4279,6 @@ function matchesQuery(query: string, ...parts: unknown[]) {
     .includes(query);
 }
 
-function collectNamespaces(
-  workloads: KubernetesWorkload[],
-  pods: KubernetesPod[],
-  events: KubernetesEvent[],
-) {
-  const set = new Set<string>();
-  for (const item of workloads) if (item.namespace) set.add(item.namespace);
-  for (const item of pods) if (item.namespace) set.add(item.namespace);
-  for (const item of events) if (item.namespace) set.add(item.namespace);
-  return [...set].sort();
-}
-
 function buildIssueCounts(
   nodes: KubernetesNode[],
   pods: KubernetesPod[],
@@ -4416,10 +4424,7 @@ const JOB_COMPLETE_CONDITION_TYPES = new Set(['complete', 'successcriteriamet'])
 function workloadHealthState(item: KubernetesWorkload): WorkloadHealthState {
   const kind = item.kind.trim().toLowerCase();
   if (kind === 'job') {
-    if (
-      workloadHasTrueCondition(item, JOB_FAILED_CONDITION_TYPES) ||
-      ((item.failed_replicas ?? 0) > 0 && (item.active_replicas ?? 0) === 0 && item.ready_replicas < item.desired_replicas)
-    ) {
+    if (workloadHasTrueCondition(item, JOB_FAILED_CONDITION_TYPES)) {
       return 'failed';
     }
     if (
@@ -4754,7 +4759,20 @@ function buildNamespaceRows(
   pods: KubernetesPod[],
   events: KubernetesEvent[],
   warningEvents: KubernetesEvent[],
+  summaries?: KubernetesClusterHealth['namespaces'],
 ): NamespaceRow[] {
+  if (summaries !== undefined) {
+    return summaries
+      .map((summary) => ({
+        namespace: summary.namespace || 'default',
+        workloads: summary.workloads,
+        pods: summary.pods,
+        events: summary.events,
+        warnings: summary.warnings,
+        lastSeenAt: summary.last_seen_at ?? null,
+      }))
+      .sort((a, b) => a.namespace.localeCompare(b.namespace));
+  }
   const rows = new Map<string, NamespaceRow>();
   const ensure = (namespace: string) => {
     const key = namespace || 'default';

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -4317,7 +4317,7 @@ function buildTriageIssues({
   warningEvents: KubernetesEvent[];
   tr: (zh: string, en: string) => string;
 }) {
-  const degradedWorkloads = workloads.filter(isDegradedWorkload).slice(0, 6);
+  const degradedWorkloads = workloads.filter(isDegradedWorkload);
   const abnormalPods = buildAbnormalPods(pods, crashLoopPods);
   const degradedWorkloadOwners = buildDegradedWorkloadOwnerIndex(degradedWorkloads);
   const nodeIssues = buildNodeIssues(nodes);
@@ -4325,8 +4325,8 @@ function buildTriageIssues({
   const syncRisk = clusterSyncRisk(cluster, tr);
   return sortTriageIssues(aggregateTriageIssues([
     ...degradedWorkloads.map((item) => workloadIssue(item, tr)),
-    ...abnormalPods.slice(0, 6).map((item) => podIssue(item, tr, owningDegradedWorkload(item, degradedWorkloadOwners))),
-    ...nodeIssues.slice(0, 6),
+    ...abnormalPods.map((item) => podIssue(item, tr, owningDegradedWorkload(item, degradedWorkloadOwners))),
+    ...nodeIssues,
     ...(syncRisk ? [syncRiskIssue(syncRisk, tr)] : []),
     ...actionableWarningEvents.map(eventIssue),
   ]));

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -1196,7 +1196,7 @@ function TempoCard() {
         </button>
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
       </div>
-      <ProbeLine probe={probe} okLabel={tr('✓ Tempo 可达，/ready 返回成功', '✓ Tempo reachable, /ready returned success')} />
+      <ProbeLine probe={probe} okLabel={tr('✓ Tempo 连接测试成功', '✓ Tempo connection test succeeded')} />
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

- decode Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, and CronJob with resource-specific Kubernetes API shapes while preserving Job active/failed counts
- persist workload ownership, revision, and creation metadata; group Deployment-owned ReplicaSets into expandable rollout history while keeping standalone ReplicaSets visible
- add server-side workload, Pod, Node, and Event pagination for large clusters, plus corrected workload health and stale HPA warning handling
- preserve the manager public URL for Kubernetes telemetry TLS origin matching
- separate Tempo OTLP/HTTP ingest validation from the manager-side Tempo query readiness probe

This supersedes #249 with a complete per-resource schema fix instead of dropping the `active` signal.

## Root cause

The inventory collector decoded every workload kind through one shared status structure. Job exposes `status.active` as an integer, while CronJob exposes it as an array of object references, so one active CronJob could fail the whole workload snapshot. ReplicaSets also lacked controller UID and revision metadata, and the UI loaded resources cumulatively instead of paging them.

Tempo health checks had a separate listener mismatch: the edge-facing OTLP endpoint commonly runs on port 4318 at `/v1/traces`, while Tempo query readiness runs on port 3200 at `/ready`.

## Impact

- active CronJobs no longer break Kubernetes inventory ingestion
- Job execution state remains available instead of removing the `active` field
- retained ReplicaSets are associated with the correct Deployment UID and shown as rollout versions
- clusters with 1,500+ Pods can browse resources with bounded requests
- recovered HPA metric warnings expire based on Kubernetes event occurrence time
- local and external Tempo configurations are probed against the correct protocol and listener

The database change is additive and is applied by the existing GORM AutoMigrate path.

## Validation

- `git diff --check`
- `go list ./... | rg -v '/(output|web/node_modules)(/|$)' | xargs go test -race -count=1`
- `npm test -- --run` (17 files, 100 tests)
- `npm run build`
- targeted ESLint on changed frontend files (0 errors)
- live kubeadm coverage for Deployment, StatefulSet, DaemonSet, standalone/owned ReplicaSet, Job, and CronJob
- local native manager with Docker Prometheus, Tempo, and embedding dependencies: system health 12/12 ready

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
