### PR TITLE
fix(deploy): avoid recursive chown during upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh deploy/install/public-url.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-public-url.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
+        run: bash -n dist/package.sh dist/package-k8s-chart.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh deploy/install/public-url.sh deploy/install/data-permissions.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/test-publish-release-image.sh scripts/test-public-url.sh scripts/test-upgrade-data-permissions.sh scripts/test-compose-release-package.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
 
       - name: Verify Compose image routing
         run: make verify-compose-images

--- a/Makefile
+++ b/Makefile
@@ -643,6 +643,7 @@ package-all: ## [release] 打 amd64 + arm64 两个生产安装包到 dist/out/
 
 test-release-package: ## [test] 校验安装 URL 与 Compose 发布包内容
 	bash scripts/test-public-url.sh
+	bash scripts/test-upgrade-data-permissions.sh
 	bash scripts/test-compose-release-package.sh
 
 .PHONY: dist-clean

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -92,6 +92,8 @@ sudo ./upgrade.sh
 sudo ./upgrade.sh --repair-permissions
 ```
 
+显式修复中任一 `chown` / `chmod` 失败时，脚本不会安装新版，并会尝试恢复原有 Compose 服务。环境变量 `REPAIR_PERMISSIONS` 仅接受 `1/true/yes/on` 或 `0/false/no/off`；推荐直接使用上面的命令行参数。
+
 ## 卸载
 
 ```bash

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -92,7 +92,7 @@ sudo ./upgrade.sh
 sudo ./upgrade.sh --repair-permissions
 ```
 
-显式修复中任一 `chown` / `chmod` 失败时，脚本不会安装新版，并会尝试恢复原有 Compose 服务。环境变量 `REPAIR_PERMISSIONS` 仅接受 `1/true/yes/on` 或 `0/false/no/off`；推荐直接使用上面的命令行参数。
+普通升级若无法修正顶层目录权限，会核对实际 UID/GID 和目录模式：状态已经正确时继续，否则在停服务前退出；停栈后的迁移阶段再次校验失败时会恢复原有 Compose 服务。显式修复中任一 `chown` / `chmod` 失败时同样不会安装新版，并会尝试恢复原有服务。环境变量 `REPAIR_PERMISSIONS` 仅接受 `1/true/yes/on` 或 `0/false/no/off`；推荐直接使用上面的命令行参数。
 
 ## 卸载
 

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -78,12 +78,19 @@ sudo ./upgrade.sh
 升级脚本会：
 
 1. 使用新版本号渲染 Compose，并从 CNB 拉取全部运行镜像；任一镜像失败时旧栈保持运行。
-2. `docker compose down`（保留数据），随后覆盖 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION`。
-3. **不覆盖 `.env` 和 `certs/`**；只把 `.env` 中的 `ONGRID_VERSION` 更新为新版本，并补齐新版本必需的缺省项。
-4. `docker compose up -d` 启动新版。
-5. 轮询 `https://localhost:${ONGRID_HTTP_PORT}/healthz`（`-k` 跳过自签校验）最多 90 秒（库迁移可能稍慢）。
+2. 检查 legacy volume 迁移参数，并创建/修正各 bind-mount 的顶层目录；普通升级不会递归扫描已有数据。
+3. `docker compose down`（保留数据），随后覆盖 `docker-compose.yml`、`nginx.conf`、`prometheus.yml`、`grafana/`、`edge/`、`VERSION`。
+4. **不覆盖 `.env` 和 `certs/`**；只把 `.env` 中的 `ONGRID_VERSION` 更新为新版本，并补齐新版本必需的缺省项。
+5. `docker compose up -d` 启动新版。
+6. 轮询 `https://localhost:${ONGRID_HTTP_PORT}/healthz`（`-k` 跳过自签校验）最多 90 秒（库迁移可能稍慢）。
 
 数据库 schema 由 gorm AutoMigrate 在 ongrid 启动时自动处理。
+
+仅当数据目录被人工改乱、从不保留属主的备份恢复，或升级说明明确指出容器 UID 发生变化时，才执行显式权限修复。该操作会遍历历史数据，大目录可能耗时较长：
+
+```bash
+sudo ./upgrade.sh --repair-permissions
+```
 
 ## 卸载
 
@@ -152,7 +159,7 @@ v0.7.45 起所有有状态服务（MySQL / Prometheus / Loki / Tempo / qdrant / 
 /var/log/ongrid/  # manager slog 输出，可被宿主机 promtail / vector / fluent-bit 直接抓取
 ```
 
-`install.sh` / `upgrade.sh` 会自动 `mkdir -p` + `chown` 到对应 uid。生产环境推荐：
+`install.sh` 会在首次安装时初始化目录权限；`upgrade.sh` 只修正挂载点目录本身，不递归扫描已有 MySQL、Prometheus、Loki、Tempo 或 Grafana 数据。生产环境推荐：
 
 - 把 `ONGRID_DATA_DIR` 指向独立 SSD / NVMe / NFS 挂载点；
 - 关键卷（`mysql`、`prometheus`）单独走快速本地盘，`loki` / `tempo` 走容量盘。
@@ -193,7 +200,7 @@ sudo ./upgrade.sh --migrate-volumes
 
 1. `docker compose down` 停掉旧栈；
 2. 使用已拉取的新版 manager 镜像作为临时工具容器，对每个 legacy named volume 执行 `cp -a` 到对应 bind path；
-3. `chown` 到正确 uid；
+3. `cp -a` 保留原有数值 uid，并修正目标挂载点目录本身；
 4. `docker compose up -d` 起新栈。
 
 迁移结束后旧 named volume 仍然保留（不会被自动删），人工 review 完用 `docker volume rm ongrid_mysql_data prometheus_data loki_data tempo_data qdrant_data grafana_data ongrid_logs` 清理。

--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -1,16 +1,71 @@
 #!/usr/bin/env bash
-# Shared data-directory ownership helpers for the Compose installer.
+# Shared data-directory ownership and recovery helpers for Compose upgrades.
 #
 # Normal upgrades must stay O(number of top-level directories): files already
 # written by a running service have the correct numeric owner, and recursively
 # walking a large Loki/Tempo tree turns that invariant check into downtime.
 
-ongrid_chown_path_best_effort() {
-    local owner="$1" path="$2"
-    if ! chown "$owner" "$path" 2>/dev/null; then
-        printf '[WARN] could not set owner %s on %s; verify storage permissions before startup\n' \
-            "$owner" "$path" >&2
+ongrid_stat_path_owner() {
+    local path="$1" owner
+
+    if owner=$(stat -c '%u:%g' "$path" 2>/dev/null) \
+        && [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]]; then
+        printf '%s\n' "$owner"
+        return 0
     fi
+    if owner=$(stat -f '%u:%g' "$path" 2>/dev/null) \
+        && [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]]; then
+        printf '%s\n' "$owner"
+        return 0
+    fi
+    return 1
+}
+
+ongrid_stat_path_mode() {
+    local path="$1" mode
+
+    if mode=$(stat -c '%a' "$path" 2>/dev/null) \
+        && [[ "$mode" =~ ^[0-7]+$ ]]; then
+        printf '%s\n' "$mode"
+        return 0
+    fi
+    if mode=$(stat -f '%Lp' "$path" 2>/dev/null) \
+        && [[ "$mode" =~ ^[0-7]+$ ]]; then
+        printf '%s\n' "$mode"
+        return 0
+    fi
+    return 1
+}
+
+ongrid_ensure_path_owner() {
+    local expected="$1" path="$2" actual=""
+
+    if chown "$expected" "$path" 2>/dev/null; then
+        return 0
+    fi
+    if actual=$(ongrid_stat_path_owner "$path") && [[ "$actual" == "$expected" ]]; then
+        return 0
+    fi
+
+    printf '[ERROR] could not set owner %s on %s (current owner: %s)\n' \
+        "$expected" "$path" "${actual:-unknown}" >&2
+    return 1
+}
+
+ongrid_ensure_path_mode() {
+    local expected="$1" path="$2" actual=""
+    local normalized_expected="${expected#0}"
+
+    if chmod "$expected" "$path" 2>/dev/null; then
+        return 0
+    fi
+    if actual=$(ongrid_stat_path_mode "$path") && [[ "$actual" == "$normalized_expected" ]]; then
+        return 0
+    fi
+
+    printf '[ERROR] could not set mode %s on %s (current mode: %s)\n' \
+        "$expected" "$path" "${actual:-unknown}" >&2
+    return 1
 }
 
 ongrid_normalize_boolean() {
@@ -34,8 +89,9 @@ ongrid_chown_tree_required() {
 
 ongrid_prepare_data_directories() {
     local data_dir="$1" log_dir="$2"
+    local failed=0
 
-    mkdir -p \
+    if ! mkdir -p \
         "$data_dir/mysql" \
         "$data_dir/prometheus" \
         "$data_dir/loki" \
@@ -47,23 +103,31 @@ ongrid_prepare_data_directories() {
         "$data_dir/pages" \
         "$data_dir/workspace" \
         "$data_dir/tools" \
-        "$log_dir"
+        "$log_dir"; then
+        printf '[ERROR] could not create one or more data directories under %s\n' \
+            "$data_dir" >&2
+        return 1
+    fi
 
     # Only the mount-point directories need ownership initialization. Existing
     # descendants were created by these same container UIDs and must not be
     # traversed during every upgrade.
-    ongrid_chown_path_best_effort 999:999 "$data_dir/mysql"
-    ongrid_chown_path_best_effort 65534:65534 "$data_dir/prometheus"
-    ongrid_chown_path_best_effort 10001:10001 "$data_dir/loki"
-    ongrid_chown_path_best_effort 10001:10001 "$data_dir/tempo"
-    ongrid_chown_path_best_effort 472:472 "$data_dir/grafana"
-    ongrid_chown_path_best_effort 65532:65532 "$data_dir/embeddings"
-    ongrid_chown_path_best_effort 65532:65532 "$data_dir/skills"
-    ongrid_chown_path_best_effort 65532:65532 "$data_dir/pages"
-    ongrid_chown_path_best_effort 65532:65532 "$data_dir/workspace"
-    ongrid_chown_path_best_effort 65532:65532 "$data_dir/tools"
+    ongrid_ensure_path_owner 999:999 "$data_dir/mysql" || failed=1
+    ongrid_ensure_path_owner 65534:65534 "$data_dir/prometheus" || failed=1
+    ongrid_ensure_path_owner 10001:10001 "$data_dir/loki" || failed=1
+    ongrid_ensure_path_owner 10001:10001 "$data_dir/tempo" || failed=1
+    ongrid_ensure_path_owner 472:472 "$data_dir/grafana" || failed=1
+    ongrid_ensure_path_owner 65532:65532 "$data_dir/embeddings" || failed=1
+    ongrid_ensure_path_owner 65532:65532 "$data_dir/skills" || failed=1
+    ongrid_ensure_path_owner 65532:65532 "$data_dir/pages" || failed=1
+    ongrid_ensure_path_owner 65532:65532 "$data_dir/workspace" || failed=1
+    ongrid_ensure_path_owner 65532:65532 "$data_dir/tools" || failed=1
 
-    chmod 0755 "$data_dir" "$data_dir/embeddings" "$log_dir" 2>/dev/null || true
+    ongrid_ensure_path_mode 0755 "$data_dir" || failed=1
+    ongrid_ensure_path_mode 0755 "$data_dir/embeddings" || failed=1
+    ongrid_ensure_path_mode 0755 "$log_dir" || failed=1
+
+    return "$failed"
 }
 
 ongrid_repair_data_permissions() {
@@ -102,4 +166,47 @@ ongrid_repair_data_permissions_if_enabled() {
             return 2
             ;;
     esac
+}
+
+ongrid_restore_existing_stack() {
+    local install_dir="$1"
+
+    printf '[WARN] attempting to restore the existing stack\n' >&2
+    if (
+        cd "$install_dir" && docker compose --env-file .env up -d
+    ); then
+        printf '[INFO] existing stack restore requested successfully\n'
+        return 0
+    fi
+
+    printf '[ERROR] failed to restore the existing stack; inspect docker compose status\n' >&2
+    return 1
+}
+
+ongrid_prepare_data_directories_or_restore() {
+    local data_dir="$1" log_dir="$2" install_dir="$3"
+
+    if ongrid_prepare_data_directories "$data_dir" "$log_dir"; then
+        return 0
+    fi
+
+    printf '[ERROR] data directory preparation failed after stopping the stack\n' >&2
+    if ! ongrid_restore_existing_stack "$install_dir"; then
+        printf '[ERROR] automatic recovery failed\n' >&2
+    fi
+    return 1
+}
+
+ongrid_repair_data_permissions_or_restore() {
+    local enabled="$1" data_dir="$2" install_dir="$3"
+
+    if ongrid_repair_data_permissions_if_enabled "$enabled" "$data_dir"; then
+        return 0
+    fi
+
+    printf '[ERROR] permission repair failed; the new release was not installed\n' >&2
+    if ! ongrid_restore_existing_stack "$install_dir"; then
+        printf '[ERROR] automatic recovery failed\n' >&2
+    fi
+    return 1
 }

--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared data-directory ownership helpers for the Compose installer.
+#
+# Normal upgrades must stay O(number of top-level directories): files already
+# written by a running service have the correct numeric owner, and recursively
+# walking a large Loki/Tempo tree turns that invariant check into downtime.
+
+ongrid_chown_path_best_effort() {
+    local owner="$1" path="$2"
+    if ! chown "$owner" "$path" 2>/dev/null; then
+        printf '[WARN] could not set owner %s on %s; verify storage permissions before startup\n' \
+            "$owner" "$path" >&2
+    fi
+}
+
+ongrid_chown_tree_best_effort() {
+    local owner="$1" path="$2"
+    if ! chown -R "$owner" "$path" 2>/dev/null; then
+        printf '[WARN] could not recursively set owner %s on %s\n' "$owner" "$path" >&2
+    fi
+}
+
+ongrid_prepare_data_directories() {
+    local data_dir="$1" log_dir="$2"
+
+    mkdir -p \
+        "$data_dir/mysql" \
+        "$data_dir/prometheus" \
+        "$data_dir/loki" \
+        "$data_dir/tempo" \
+        "$data_dir/qdrant" \
+        "$data_dir/grafana" \
+        "$data_dir/embeddings" \
+        "$data_dir/skills" \
+        "$data_dir/pages" \
+        "$data_dir/workspace" \
+        "$data_dir/tools" \
+        "$log_dir"
+
+    # Only the mount-point directories need ownership initialization. Existing
+    # descendants were created by these same container UIDs and must not be
+    # traversed during every upgrade.
+    ongrid_chown_path_best_effort 999:999 "$data_dir/mysql"
+    ongrid_chown_path_best_effort 65534:65534 "$data_dir/prometheus"
+    ongrid_chown_path_best_effort 10001:10001 "$data_dir/loki"
+    ongrid_chown_path_best_effort 10001:10001 "$data_dir/tempo"
+    ongrid_chown_path_best_effort 472:472 "$data_dir/grafana"
+    ongrid_chown_path_best_effort 65532:65532 "$data_dir/embeddings"
+    ongrid_chown_path_best_effort 65532:65532 "$data_dir/skills"
+    ongrid_chown_path_best_effort 65532:65532 "$data_dir/pages"
+    ongrid_chown_path_best_effort 65532:65532 "$data_dir/workspace"
+    ongrid_chown_path_best_effort 65532:65532 "$data_dir/tools"
+
+    chmod 0755 "$data_dir" "$data_dir/embeddings" "$log_dir" 2>/dev/null || true
+}
+
+ongrid_repair_data_permissions() {
+    local data_dir="$1"
+
+    # Explicit recovery path only. This can walk every inode and therefore must
+    # never be called by a normal upgrade.
+    ongrid_chown_tree_best_effort 999:999 "$data_dir/mysql"
+    ongrid_chown_tree_best_effort 65534:65534 "$data_dir/prometheus"
+    ongrid_chown_tree_best_effort 10001:10001 "$data_dir/loki"
+    ongrid_chown_tree_best_effort 10001:10001 "$data_dir/tempo"
+    ongrid_chown_tree_best_effort 472:472 "$data_dir/grafana"
+    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/embeddings"
+    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/skills"
+    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/pages"
+    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/workspace"
+    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/tools"
+    chmod -R 0755 "$data_dir/embeddings" 2>/dev/null || true
+}

--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -13,10 +13,22 @@ ongrid_chown_path_best_effort() {
     fi
 }
 
-ongrid_chown_tree_best_effort() {
+ongrid_normalize_boolean() {
+    local value
+    value=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+    case "$value" in
+        ''|0|false|no|off) printf '0\n' ;;
+        1|true|yes|on) printf '1\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+ongrid_chown_tree_required() {
     local owner="$1" path="$2"
     if ! chown -R "$owner" "$path" 2>/dev/null; then
-        printf '[WARN] could not recursively set owner %s on %s\n' "$owner" "$path" >&2
+        printf '[ERROR] could not recursively set owner %s on %s\n' "$owner" "$path" >&2
+        return 1
     fi
 }
 
@@ -56,18 +68,38 @@ ongrid_prepare_data_directories() {
 
 ongrid_repair_data_permissions() {
     local data_dir="$1"
+    local failed=0
 
     # Explicit recovery path only. This can walk every inode and therefore must
     # never be called by a normal upgrade.
-    ongrid_chown_tree_best_effort 999:999 "$data_dir/mysql"
-    ongrid_chown_tree_best_effort 65534:65534 "$data_dir/prometheus"
-    ongrid_chown_tree_best_effort 10001:10001 "$data_dir/loki"
-    ongrid_chown_tree_best_effort 10001:10001 "$data_dir/tempo"
-    ongrid_chown_tree_best_effort 472:472 "$data_dir/grafana"
-    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/embeddings"
-    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/skills"
-    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/pages"
-    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/workspace"
-    ongrid_chown_tree_best_effort 65532:65532 "$data_dir/tools"
-    chmod -R 0755 "$data_dir/embeddings" 2>/dev/null || true
+    ongrid_chown_tree_required 999:999 "$data_dir/mysql" || failed=1
+    ongrid_chown_tree_required 65534:65534 "$data_dir/prometheus" || failed=1
+    ongrid_chown_tree_required 10001:10001 "$data_dir/loki" || failed=1
+    ongrid_chown_tree_required 10001:10001 "$data_dir/tempo" || failed=1
+    ongrid_chown_tree_required 472:472 "$data_dir/grafana" || failed=1
+    ongrid_chown_tree_required 65532:65532 "$data_dir/embeddings" || failed=1
+    ongrid_chown_tree_required 65532:65532 "$data_dir/skills" || failed=1
+    ongrid_chown_tree_required 65532:65532 "$data_dir/pages" || failed=1
+    ongrid_chown_tree_required 65532:65532 "$data_dir/workspace" || failed=1
+    ongrid_chown_tree_required 65532:65532 "$data_dir/tools" || failed=1
+    if ! chmod -R 0755 "$data_dir/embeddings" 2>/dev/null; then
+        printf '[ERROR] could not recursively set mode 0755 on %s\n' \
+            "$data_dir/embeddings" >&2
+        failed=1
+    fi
+
+    return "$failed"
+}
+
+ongrid_repair_data_permissions_if_enabled() {
+    local enabled="$1" data_dir="$2"
+
+    case "$enabled" in
+        0) return 0 ;;
+        1) ongrid_repair_data_permissions "$data_dir" ;;
+        *)
+            printf '[ERROR] invalid normalized permission-repair flag: %s\n' "$enabled" >&2
+            return 2
+            ;;
+    esac
 }

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -18,6 +18,20 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+restore_existing_stack() {
+    log_warn "attempting to restore the existing stack"
+    if (
+        cd "$INSTALL_DIR"
+        docker compose --env-file .env up -d
+    ); then
+        log_info "existing stack restore requested successfully"
+        return 0
+    fi
+
+    log_error "failed to restore the existing stack; inspect docker compose status"
+    return 1
+}
+
 usage() {
     cat <<'EOF'
 Usage: sudo ./upgrade.sh [options]
@@ -210,17 +224,22 @@ trap 'log_error "upgrade failed at line $LINENO"' ERR
 UPGRADE_ARGS=("$@")
 MIGRATE_VOLUMES="${MIGRATE_VOLUMES:-}"
 NO_MIGRATE_VOLUMES="${NO_MIGRATE_VOLUMES:-}"
-REPAIR_PERMISSIONS="${REPAIR_PERMISSIONS:-}"
+REPAIR_PERMISSIONS_RAW="${REPAIR_PERMISSIONS:-}"
 while (( $# > 0 )); do
     case "$1" in
         --migrate-volumes) MIGRATE_VOLUMES=1 ;;
         --no-migrate-volumes) NO_MIGRATE_VOLUMES=1 ;;
-        --repair-permissions) REPAIR_PERMISSIONS=1 ;;
+        --repair-permissions) REPAIR_PERMISSIONS_RAW=1 ;;
         -h|--help) usage; exit 0 ;;
         *) log_error "unknown flag: $1"; usage; exit 2 ;;
     esac
     shift
 done
+if ! REPAIR_PERMISSIONS=$(ongrid_normalize_boolean "$REPAIR_PERMISSIONS_RAW"); then
+    log_error "invalid REPAIR_PERMISSIONS value: ${REPAIR_PERMISSIONS_RAW}"
+    log_error "expected one of: 1/true/yes/on or 0/false/no/off"
+    exit 2
+fi
 if [[ -n "$MIGRATE_VOLUMES" && -n "$NO_MIGRATE_VOLUMES" ]]; then
     log_error "--migrate-volumes and --no-migrate-volumes are mutually exclusive"
     exit 2
@@ -335,7 +354,7 @@ if (( ${#LEGACY_FOUND[@]} > 0 )) && [[ -z "$MIGRATE_VOLUMES" && -z "$NO_MIGRATE_
     exit 1
 fi
 
-if [[ -n "$REPAIR_PERMISSIONS" ]]; then
+if (( REPAIR_PERMISSIONS == 1 )); then
     log_warn "recursive permission repair requested; large data directories may take a long time"
 fi
 
@@ -347,11 +366,10 @@ if ! (
     cd "$INSTALL_DIR"
     docker compose --env-file .env down
 ); then
-    log_error "failed to stop the existing stack; attempting to restore it"
-    (
-        cd "$INSTALL_DIR"
-        docker compose --env-file .env up -d
-    ) || log_error "failed to restore the existing stack; inspect docker compose status"
+    log_error "failed to stop the existing stack"
+    if ! restore_existing_stack; then
+        log_error "automatic recovery failed"
+    fi
     exit 1
 fi
 
@@ -414,9 +432,15 @@ fi
 # reassert only the mount-point owners in constant time. Full-tree repair is an
 # explicit recovery action and never part of a normal upgrade.
 ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
-if [[ -n "$REPAIR_PERMISSIONS" ]]; then
+if (( REPAIR_PERMISSIONS == 1 )); then
     log_warn "repairing data ownership recursively"
-    ongrid_repair_data_permissions "$ONGRID_DATA_DIR"
+fi
+if ! ongrid_repair_data_permissions_if_enabled "$REPAIR_PERMISSIONS" "$ONGRID_DATA_DIR"; then
+    log_error "permission repair failed; the new release was not installed"
+    if ! restore_existing_stack; then
+        log_error "automatic recovery failed"
+    fi
+    exit 1
 fi
 
 export ONGRID_DATA_DIR ONGRID_LOG_DIR

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -18,6 +18,18 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
+usage() {
+    cat <<'EOF'
+Usage: sudo ./upgrade.sh [options]
+
+Options:
+  --migrate-volumes       Copy legacy Docker named volumes into host bind mounts
+  --no-migrate-volumes    Leave legacy named volumes untouched
+  --repair-permissions    Recursively repair data ownership (slow; recovery only)
+  -h, --help              Show this help
+EOF
+}
+
 PUBLIC_URL_LIB="$SCRIPT_DIR/public-url.sh"
 if [[ ! -r "$PUBLIC_URL_LIB" ]]; then
     log_error "upgrade package is missing public-url.sh"
@@ -25,6 +37,14 @@ if [[ ! -r "$PUBLIC_URL_LIB" ]]; then
 fi
 # shellcheck source=public-url.sh
 source "$PUBLIC_URL_LIB"
+
+DATA_PERMISSIONS_LIB="$SCRIPT_DIR/data-permissions.sh"
+if [[ ! -r "$DATA_PERMISSIONS_LIB" ]]; then
+    log_error "upgrade package is missing data-permissions.sh"
+    exit 1
+fi
+# shellcheck source=data-permissions.sh
+source "$DATA_PERMISSIONS_LIB"
 
 generate_self_signed_tls_cert() {
     local cert_dir="$1"
@@ -187,9 +207,28 @@ preflight_runtime_images() {
 
 trap 'log_error "upgrade failed at line $LINENO"' ERR
 
+UPGRADE_ARGS=("$@")
+MIGRATE_VOLUMES="${MIGRATE_VOLUMES:-}"
+NO_MIGRATE_VOLUMES="${NO_MIGRATE_VOLUMES:-}"
+REPAIR_PERMISSIONS="${REPAIR_PERMISSIONS:-}"
+while (( $# > 0 )); do
+    case "$1" in
+        --migrate-volumes) MIGRATE_VOLUMES=1 ;;
+        --no-migrate-volumes) NO_MIGRATE_VOLUMES=1 ;;
+        --repair-permissions) REPAIR_PERMISSIONS=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "unknown flag: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+if [[ -n "$MIGRATE_VOLUMES" && -n "$NO_MIGRATE_VOLUMES" ]]; then
+    log_error "--migrate-volumes and --no-migrate-volumes are mutually exclusive"
+    exit 2
+fi
+
 if [[ $EUID -ne 0 ]]; then
     log_warn "not running as root; re-executing via sudo"
-    exec sudo -E bash "$0" "$@"
+    exec sudo -E bash "$0" "${UPGRADE_ARGS[@]}"
 fi
 
 command -v docker >/dev/null 2>&1 || { log_error "docker CLI not found"; exit 1; }
@@ -237,66 +276,15 @@ fi
 # running untouched.
 preflight_runtime_images
 
-# Stop stack first so legacy named volumes (if any) aren't being written
-# to during migration, and so bind-mount paths can be safely chowned.
-log_info "stopping stack"
-(
-    cd "$INSTALL_DIR"
-    # No explicit -f so docker-compose.override.yml (if present) auto-loads.
-    # Naming -f docker-compose.yml disables override discovery, which silently
-    # dropped operator env overrides (the 2026-05-19 ONGRID_INVESTIGATOR_ENABLED
-    # regression where the structured RCA investigator was unwired after every
-    # upgrade and only the legacy investigator ran).
-    docker compose --env-file .env down || true
-)
-
 # ---------- host data dirs (bind-mount targets) ----------
-# Same shape as install.sh — every upgrade re-asserts dir ownership in
-# case the operator deleted/renamed a dir or the image uid changed.
+# Prepare mount-point directories while the current stack is still available.
+# This is deliberately non-recursive: existing descendants were written by the
+# same container UIDs, while walking large Loki/Tempo trees can take minutes.
 ONGRID_DATA_DIR="${ONGRID_DATA_DIR:-/var/lib/ongrid}"
 ONGRID_LOG_DIR="${ONGRID_LOG_DIR:-/var/log/ongrid}"
 log_info "data dir: $ONGRID_DATA_DIR  (override via ONGRID_DATA_DIR)"
 log_info "log dir:  $ONGRID_LOG_DIR  (override via ONGRID_LOG_DIR)"
-
-mkdir -p \
-    "$ONGRID_DATA_DIR/mysql" \
-    "$ONGRID_DATA_DIR/prometheus" \
-    "$ONGRID_DATA_DIR/loki" \
-    "$ONGRID_DATA_DIR/tempo" \
-    "$ONGRID_DATA_DIR/qdrant" \
-    "$ONGRID_DATA_DIR/grafana" \
-    "$ONGRID_DATA_DIR/embeddings" \
-    "$ONGRID_DATA_DIR/skills" \
-    "$ONGRID_DATA_DIR/pages" \
-    "$ONGRID_DATA_DIR/workspace" \
-    "$ONGRID_DATA_DIR/tools" \
-    "$ONGRID_LOG_DIR"
-
-# Embedding model cache (ADR-027 Phase-2). Same staging logic as
-# install.sh so the bundled BGE model lands on the host the first
-# time an upgrade includes it. Idempotent — skip if already there.
-chown -R 65532:65532 "$ONGRID_DATA_DIR/embeddings" 2>/dev/null || true
-chmod -R 0755 "$ONGRID_DATA_DIR/embeddings" 2>/dev/null || true
-# HLD-017 marketplace skills dir must be writable by the manager (uid 65532),
-# else pack install fails with "permission denied" moving staging → install.
-chown -R 65532:65532 "$ONGRID_DATA_DIR/skills" 2>/dev/null || true
-# Manager-written runtime dirs (uid 65532), bind-mounted into the container.
-# An upgrade from a pre-existing install may predate these dirs, so create +
-# chown here too: serve_page (pages), cloud_bash scratch (workspace) +
-# installed tools (tools). Without it docker creates them root-owned → the
-# nonroot manager hits "mkdir page dir: permission denied".
-chown -R 65532:65532 "$ONGRID_DATA_DIR/pages" 2>/dev/null || true
-chown -R 65532:65532 "$ONGRID_DATA_DIR/workspace" 2>/dev/null || true
-chown -R 65532:65532 "$ONGRID_DATA_DIR/tools" 2>/dev/null || true
-if [[ -d "$SCRIPT_DIR/embeddings/fast-bge-small-zh-v1.5" ]]; then
-    target="$ONGRID_DATA_DIR/embeddings/fast-bge-small-zh-v1.5"
-    if [[ ! -f "$target/model_optimized.onnx" ]]; then
-        log_info "staging bundled embedding model → $target"
-        mkdir -p "$target"
-        cp -rf "$SCRIPT_DIR/embeddings/fast-bge-small-zh-v1.5/." "$target/"
-        chown -R 65532:65532 "$target"
-    fi
-fi
+ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
 
 # Detect legacy docker named volumes from pre-bind-mount installs. If
 # any are still around, the new compose would start with empty bind
@@ -338,14 +326,46 @@ for v in "${!LEGACY_VOL_TO_DST[@]}"; do
     fi
 done
 
-MIGRATE_VOLUMES="${MIGRATE_VOLUMES:-}"
-NO_MIGRATE_VOLUMES="${NO_MIGRATE_VOLUMES:-}"
-for arg in "$@"; do
-    case "$arg" in
-        --migrate-volumes) MIGRATE_VOLUMES=1 ;;
-        --no-migrate-volumes) NO_MIGRATE_VOLUMES=1 ;;
-    esac
-done
+if (( ${#LEGACY_FOUND[@]} > 0 )) && [[ -z "$MIGRATE_VOLUMES" && -z "$NO_MIGRATE_VOLUMES" ]]; then
+    log_error "legacy docker named volumes detected: ${LEGACY_FOUND[*]}"
+    log_error "v0.7.45+ uses host bind mounts. Pick one:"
+    log_error "  - re-run with --migrate-volumes to auto-copy data into $ONGRID_DATA_DIR"
+    log_error "  - re-run with --no-migrate-volumes if you'll migrate by hand (see README '数据卷迁移')"
+    log_error "the existing stack was not stopped"
+    exit 1
+fi
+
+if [[ -n "$REPAIR_PERMISSIONS" ]]; then
+    log_warn "recursive permission repair requested; large data directories may take a long time"
+fi
+
+# All failure-prone validation above runs while the old stack remains online.
+# Stop only when migration/repair decisions are complete. No explicit -f so an
+# operator's docker-compose.override.yml continues to auto-load.
+log_info "stopping stack"
+if ! (
+    cd "$INSTALL_DIR"
+    docker compose --env-file .env down
+); then
+    log_error "failed to stop the existing stack; attempting to restore it"
+    (
+        cd "$INSTALL_DIR"
+        docker compose --env-file .env up -d
+    ) || log_error "failed to restore the existing stack; inspect docker compose status"
+    exit 1
+fi
+
+# Embedding model cache (ADR-027 Phase-2). Only a newly staged, bounded model
+# tree is recursively chowned; accumulated service data is never traversed here.
+if [[ -d "$SCRIPT_DIR/embeddings/fast-bge-small-zh-v1.5" ]]; then
+    target="$ONGRID_DATA_DIR/embeddings/fast-bge-small-zh-v1.5"
+    if [[ ! -f "$target/model_optimized.onnx" ]]; then
+        log_info "staging bundled embedding model → $target"
+        mkdir -p "$target"
+        cp -rf "$SCRIPT_DIR/embeddings/fast-bge-small-zh-v1.5/." "$target/"
+        chown -R 65532:65532 "$target"
+    fi
+fi
 
 if (( ${#LEGACY_FOUND[@]} > 0 )); then
     if [[ -n "$MIGRATE_VOLUMES" ]]; then
@@ -387,23 +407,17 @@ if (( ${#LEGACY_FOUND[@]} > 0 )); then
     elif [[ -n "$NO_MIGRATE_VOLUMES" ]]; then
         log_warn "legacy volumes left as-is (--no-migrate-volumes): ${LEGACY_FOUND[*]}"
         log_warn "new stack will start with empty data; you MUST migrate manually before users see it"
-    else
-        log_error "legacy docker named volumes detected: ${LEGACY_FOUND[*]}"
-        log_error "v0.7.45+ uses host bind mounts. Pick one:"
-        log_error "  - re-run with --migrate-volumes to auto-copy data into $ONGRID_DATA_DIR"
-        log_error "  - re-run with --no-migrate-volumes if you'll migrate by hand (see README '数据卷迁移')"
-        exit 1
     fi
 fi
 
-# uids must match what the upstream images run as — re-chown every
-# upgrade so a tampered/renamed dir still works.
-chown -R 999:999       "$ONGRID_DATA_DIR/mysql"      2>/dev/null || true
-chown -R 65534:65534   "$ONGRID_DATA_DIR/prometheus" 2>/dev/null || true
-chown -R 10001:10001   "$ONGRID_DATA_DIR/loki"       2>/dev/null || true
-chown -R 10001:10001   "$ONGRID_DATA_DIR/tempo"      2>/dev/null || true
-chown -R 472:472       "$ONGRID_DATA_DIR/grafana"    2>/dev/null || true
-chmod 755 "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
+# cp -a may reapply source-directory metadata during a legacy migration, so
+# reassert only the mount-point owners in constant time. Full-tree repair is an
+# explicit recovery action and never part of a normal upgrade.
+ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
+if [[ -n "$REPAIR_PERMISSIONS" ]]; then
+    log_warn "repairing data ownership recursively"
+    ongrid_repair_data_permissions "$ONGRID_DATA_DIR"
+fi
 
 export ONGRID_DATA_DIR ONGRID_LOG_DIR
 

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -18,20 +18,6 @@ log_info()  { printf '%s[INFO]%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 log_warn()  { printf '%s[WARN]%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
 log_error() { printf '%s[ERROR]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
 
-restore_existing_stack() {
-    log_warn "attempting to restore the existing stack"
-    if (
-        cd "$INSTALL_DIR"
-        docker compose --env-file .env up -d
-    ); then
-        log_info "existing stack restore requested successfully"
-        return 0
-    fi
-
-    log_error "failed to restore the existing stack; inspect docker compose status"
-    return 1
-}
-
 usage() {
     cat <<'EOF'
 Usage: sudo ./upgrade.sh [options]
@@ -303,7 +289,10 @@ ONGRID_DATA_DIR="${ONGRID_DATA_DIR:-/var/lib/ongrid}"
 ONGRID_LOG_DIR="${ONGRID_LOG_DIR:-/var/log/ongrid}"
 log_info "data dir: $ONGRID_DATA_DIR  (override via ONGRID_DATA_DIR)"
 log_info "log dir:  $ONGRID_LOG_DIR  (override via ONGRID_LOG_DIR)"
-ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
+if ! ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"; then
+    log_error "data directory permissions are not usable; the existing stack was not stopped"
+    exit 1
+fi
 
 # Detect legacy docker named volumes from pre-bind-mount installs. If
 # any are still around, the new compose would start with empty bind
@@ -367,7 +356,7 @@ if ! (
     docker compose --env-file .env down
 ); then
     log_error "failed to stop the existing stack"
-    if ! restore_existing_stack; then
+    if ! ongrid_restore_existing_stack "$INSTALL_DIR"; then
         log_error "automatic recovery failed"
     fi
     exit 1
@@ -431,15 +420,15 @@ fi
 # cp -a may reapply source-directory metadata during a legacy migration, so
 # reassert only the mount-point owners in constant time. Full-tree repair is an
 # explicit recovery action and never part of a normal upgrade.
-ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"
+if ! ongrid_prepare_data_directories_or_restore \
+    "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR" "$INSTALL_DIR"; then
+    exit 1
+fi
 if (( REPAIR_PERMISSIONS == 1 )); then
     log_warn "repairing data ownership recursively"
 fi
-if ! ongrid_repair_data_permissions_if_enabled "$REPAIR_PERMISSIONS" "$ONGRID_DATA_DIR"; then
-    log_error "permission repair failed; the new release was not installed"
-    if ! restore_existing_stack; then
-        log_error "automatic recovery failed"
-    fi
+if ! ongrid_repair_data_permissions_or_restore \
+    "$REPAIR_PERMISSIONS" "$ONGRID_DATA_DIR" "$INSTALL_DIR"; then
     exit 1
 fi
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -24,6 +24,8 @@ ongrid-v<VERSION>-linux-<arch>/
   install.sh             (from deploy/install/install.sh)
   uninstall.sh
   upgrade.sh
+  public-url.sh          (installer URL validation helper)
+  data-permissions.sh    (upgrade ownership helper)
   docker-compose.yml     (prod compose, from deploy/install/)
   .env.example
   prometheus.yml         (Compose scrape config)

--- a/dist/package.sh
+++ b/dist/package.sh
@@ -107,6 +107,7 @@ copy_opt "${REPO_ROOT}/deploy/install/install.sh"          "${STAGE_DIR}/install
 copy_opt "${REPO_ROOT}/deploy/install/uninstall.sh"        "${STAGE_DIR}/uninstall.sh"        755
 copy_opt "${REPO_ROOT}/deploy/install/upgrade.sh"          "${STAGE_DIR}/upgrade.sh"          755
 copy_opt "${REPO_ROOT}/deploy/install/public-url.sh"       "${STAGE_DIR}/public-url.sh"       644
+copy_opt "${REPO_ROOT}/deploy/install/data-permissions.sh"  "${STAGE_DIR}/data-permissions.sh"  644
 copy_opt "${REPO_ROOT}/deploy/install/docker-compose.yml"  "${STAGE_DIR}/docker-compose.yml"
 copy_opt "${REPO_ROOT}/deploy/install/.env.example"        "${STAGE_DIR}/.env.example"
 copy_opt "${REPO_ROOT}/deploy/install/frontier.yaml"       "${STAGE_DIR}/frontier.yaml"

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -50,6 +50,7 @@ for required in \
   ongrid-vtest-linux-amd64/uninstall.sh \
   ongrid-vtest-linux-amd64/upgrade.sh \
   ongrid-vtest-linux-amd64/public-url.sh \
+  ongrid-vtest-linux-amd64/data-permissions.sh \
   ongrid-vtest-linux-amd64/docker-compose.yml \
   ongrid-vtest-linux-amd64/prometheus.yml; do
   grep -Fxq "$required" "$tmp_dir/archive.list"
@@ -58,6 +59,7 @@ done
 mkdir -p "$tmp_dir/extracted"
 tar -xf "$archive" -C "$tmp_dir/extracted"
 bash "$tmp_dir/extracted/ongrid-vtest-linux-amd64/install.sh" --help >/dev/null
+bash "$tmp_dir/extracted/ongrid-vtest-linux-amd64/upgrade.sh" --help >/dev/null
 
 for forbidden in \
   ongrid-vtest-linux-amd64/bin/ \

--- a/scripts/test-upgrade-data-permissions.sh
+++ b/scripts/test-upgrade-data-permissions.sh
@@ -20,6 +20,10 @@ source "$permissions_lib"
 command_log="$tmp_dir/commands.log"
 chown_should_fail=0
 chmod_should_fail=0
+stat_owner_state=expected
+stat_mode_state=expected
+docker_should_fail=0
+docker_log="$tmp_dir/docker.log"
 chown() {
     printf 'chown' >>"$command_log"
     printf ' %s' "$@" >>"$command_log"
@@ -31,6 +35,44 @@ chmod() {
     printf ' %s' "$@" >>"$command_log"
     printf '\n' >>"$command_log"
     [[ "$chmod_should_fail" == 0 ]]
+}
+expected_owner_for_path() {
+    case "$1" in
+        "$data_dir/mysql") printf '999:999\n' ;;
+        "$data_dir/prometheus") printf '65534:65534\n' ;;
+        "$data_dir/loki"|"$data_dir/tempo") printf '10001:10001\n' ;;
+        "$data_dir/grafana") printf '472:472\n' ;;
+        "$data_dir/embeddings"|"$data_dir/skills"|"$data_dir/pages"|\
+            "$data_dir/workspace"|"$data_dir/tools") printf '65532:65532\n' ;;
+        *) printf '0:0\n' ;;
+    esac
+}
+stat() {
+    local format="$2" path="${!#}"
+
+    case "$format" in
+        %u:%g)
+            case "$stat_owner_state" in
+                expected) expected_owner_for_path "$path" ;;
+                wrong) printf '0:0\n' ;;
+                *) return 1 ;;
+            esac
+            ;;
+        %a|%Lp)
+            case "$stat_mode_state" in
+                expected) printf '755\n' ;;
+                wrong) printf '700\n' ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+}
+docker() {
+    printf '%s|docker' "$PWD" >>"$docker_log"
+    printf ' %s' "$@" >>"$docker_log"
+    printf '\n' >>"$docker_log"
+    [[ "$docker_should_fail" == 0 ]]
 }
 
 data_dir="$tmp_dir/data"
@@ -48,6 +90,34 @@ grep -Fqx "chown 65532:65532 $data_dir/skills" "$command_log" \
 if grep -Eq '^(chown|chmod) -R ' "$command_log"; then
     fail "normal preparation recursively traversed a data directory"
 fi
+
+chown_should_fail=1
+stat_owner_state=expected
+ongrid_prepare_data_directories "$data_dir" "$log_dir" \
+    || fail "normal preparation rejected directories whose owners were already correct"
+
+stat_owner_state=wrong
+if ongrid_prepare_data_directories "$data_dir" "$log_dir" 2>"$tmp_dir/owner-error.log"; then
+    fail "normal preparation ignored incorrect owners after chown failures"
+fi
+grep -Fq '[ERROR] could not set owner' "$tmp_dir/owner-error.log" \
+    || fail "incorrect top-level owner did not produce an error"
+chown_should_fail=0
+stat_owner_state=expected
+
+chmod_should_fail=1
+stat_mode_state=expected
+ongrid_prepare_data_directories "$data_dir" "$log_dir" \
+    || fail "normal preparation rejected directories whose modes were already correct"
+
+stat_mode_state=wrong
+if ongrid_prepare_data_directories "$data_dir" "$log_dir" 2>"$tmp_dir/mode-error.log"; then
+    fail "normal preparation ignored incorrect modes after chmod failures"
+fi
+grep -Fq '[ERROR] could not set mode 0755' "$tmp_dir/mode-error.log" \
+    || fail "incorrect top-level mode did not produce an error"
+chmod_should_fail=0
+stat_mode_state=expected
 
 : >"$command_log"
 ongrid_repair_data_permissions_if_enabled 0 "$data_dir"
@@ -93,6 +163,47 @@ grep -Fq '[ERROR] could not recursively set mode 0755' "$tmp_dir/chmod-error.log
     || fail "recursive chmod failure did not produce an error"
 chmod_should_fail=0
 
+install_dir="$tmp_dir/install root"
+mkdir -p "$install_dir"
+: >"$docker_log"
+chown_should_fail=1
+if ongrid_repair_data_permissions_or_restore \
+    1 "$data_dir" "$install_dir" \
+    >"$tmp_dir/recovery.out" 2>"$tmp_dir/recovery.log"; then
+    fail "permission repair failure returned success after recovery"
+fi
+grep -Fqx "$install_dir|docker compose --env-file .env up -d" "$docker_log" \
+    || fail "permission repair failure did not start the existing Compose stack"
+
+: >"$docker_log"
+ongrid_repair_data_permissions_or_restore 0 "$data_dir" "$install_dir" \
+    || fail "disabled permission repair unexpectedly failed"
+[[ ! -s "$docker_log" ]] \
+    || fail "disabled permission repair unnecessarily restored the Compose stack"
+chown_should_fail=0
+
+: >"$docker_log"
+docker_should_fail=1
+if ongrid_restore_existing_stack "$install_dir" 2>"$tmp_dir/restore-error.log"; then
+    fail "Compose recovery ignored docker failure"
+fi
+grep -Fq '[ERROR] failed to restore the existing stack' "$tmp_dir/restore-error.log" \
+    || fail "Compose recovery failure did not produce an error"
+docker_should_fail=0
+
+: >"$docker_log"
+chown_should_fail=1
+stat_owner_state=wrong
+if ongrid_prepare_data_directories_or_restore \
+    "$data_dir" "$log_dir" "$install_dir" \
+    >"$tmp_dir/prepare-recovery.out" 2>"$tmp_dir/prepare-recovery.log"; then
+    fail "post-stop directory preparation failure returned success after recovery"
+fi
+grep -Fqx "$install_dir|docker compose --env-file .env up -d" "$docker_log" \
+    || fail "post-stop directory preparation failure did not restore the existing stack"
+chown_should_fail=0
+stat_owner_state=expected
+
 grep -Fq -- '--repair-permissions' "$upgrade_script" \
     || fail "upgrade.sh does not expose the explicit repair flag"
 grep -Fq 'REPAIR_PERMISSIONS=$(ongrid_normalize_boolean "$REPAIR_PERMISSIONS_RAW")' "$upgrade_script" \
@@ -101,11 +212,13 @@ if grep -Fq '[[ -n "$REPAIR_PERMISSIONS" ]]' "$upgrade_script"; then
     fail "upgrade.sh still treats every non-empty permission-repair value as enabled"
 fi
 grep -Fq 'ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"' "$upgrade_script" \
-    || fail "upgrade.sh does not use non-recursive directory preparation"
-grep -Fq 'ongrid_repair_data_permissions_if_enabled "$REPAIR_PERMISSIONS" "$ONGRID_DATA_DIR"' "$upgrade_script" \
-    || fail "upgrade.sh does not use the tested permission-repair gate"
-grep -Fq 'restore_existing_stack' "$upgrade_script" \
-    || fail "upgrade.sh does not expose a recovery path after repair failure"
+    || fail "upgrade.sh does not validate directories before stopping the stack"
+grep -Fq 'ongrid_prepare_data_directories_or_restore' "$upgrade_script" \
+    || fail "upgrade.sh does not use the tested post-stop preparation recovery path"
+grep -Fq 'ongrid_repair_data_permissions_or_restore' "$upgrade_script" \
+    || fail "upgrade.sh does not use the tested repair-and-recovery path"
+grep -Fq 'ongrid_restore_existing_stack "$INSTALL_DIR"' "$upgrade_script" \
+    || fail "upgrade.sh does not restore the existing stack after preparation failure"
 for persistent_dir in mysql prometheus loki tempo grafana skills pages workspace tools; do
     if grep -Eq "chown -R .*ONGRID_DATA_DIR/${persistent_dir}" "$upgrade_script"; then
         fail "upgrade.sh directly recurses through $persistent_dir outside the repair helper"

--- a/scripts/test-upgrade-data-permissions.sh
+++ b/scripts/test-upgrade-data-permissions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+permissions_lib="$repo_root/deploy/install/data-permissions.sh"
+upgrade_script="$repo_root/deploy/install/upgrade.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+    printf 'upgrade data-permissions test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -f "$permissions_lib" ]] || fail "missing data-permissions.sh"
+
+# shellcheck source=../deploy/install/data-permissions.sh
+source "$permissions_lib"
+
+command_log="$tmp_dir/commands.log"
+chown() {
+    printf 'chown' >>"$command_log"
+    printf ' %s' "$@" >>"$command_log"
+    printf '\n' >>"$command_log"
+}
+chmod() {
+    printf 'chmod' >>"$command_log"
+    printf ' %s' "$@" >>"$command_log"
+    printf '\n' >>"$command_log"
+}
+
+data_dir="$tmp_dir/data"
+log_dir="$tmp_dir/log"
+mkdir -p "$data_dir/loki/chunks"
+printf 'existing data\n' >"$data_dir/loki/chunks/000001"
+
+ongrid_prepare_data_directories "$data_dir" "$log_dir"
+
+[[ -f "$data_dir/loki/chunks/000001" ]] || fail "normal preparation touched existing Loki data"
+grep -Fqx "chown 10001:10001 $data_dir/loki" "$command_log" \
+    || fail "normal preparation did not set the Loki root directory owner"
+grep -Fqx "chown 65532:65532 $data_dir/skills" "$command_log" \
+    || fail "normal preparation did not set the skills root directory owner"
+if grep -Eq '^(chown|chmod) -R ' "$command_log"; then
+    fail "normal preparation recursively traversed a data directory"
+fi
+
+: >"$command_log"
+ongrid_repair_data_permissions "$data_dir"
+grep -Fqx "chown -R 10001:10001 $data_dir/loki" "$command_log" \
+    || fail "explicit repair did not recursively repair Loki"
+grep -Fqx "chown -R 65532:65532 $data_dir/skills" "$command_log" \
+    || fail "explicit repair did not recursively repair skills"
+
+grep -Fq -- '--repair-permissions' "$upgrade_script" \
+    || fail "upgrade.sh does not expose the explicit repair flag"
+grep -Fq 'ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"' "$upgrade_script" \
+    || fail "upgrade.sh does not use non-recursive directory preparation"
+grep -Fq 'ongrid_repair_data_permissions "$ONGRID_DATA_DIR"' "$upgrade_script" \
+    || fail "upgrade.sh does not gate recursive repair behind the explicit flag"
+for persistent_dir in mysql prometheus loki tempo grafana skills pages workspace tools; do
+    if grep -Eq "chown -R .*ONGRID_DATA_DIR/${persistent_dir}" "$upgrade_script"; then
+        fail "upgrade.sh directly recurses through $persistent_dir outside the repair helper"
+    fi
+done
+
+printf 'upgrade data-permissions tests passed\n'

--- a/scripts/test-upgrade-data-permissions.sh
+++ b/scripts/test-upgrade-data-permissions.sh
@@ -18,15 +18,19 @@ fail() {
 source "$permissions_lib"
 
 command_log="$tmp_dir/commands.log"
+chown_should_fail=0
+chmod_should_fail=0
 chown() {
     printf 'chown' >>"$command_log"
     printf ' %s' "$@" >>"$command_log"
     printf '\n' >>"$command_log"
+    [[ "$chown_should_fail" == 0 ]]
 }
 chmod() {
     printf 'chmod' >>"$command_log"
     printf ' %s' "$@" >>"$command_log"
     printf '\n' >>"$command_log"
+    [[ "$chmod_should_fail" == 0 ]]
 }
 
 data_dir="$tmp_dir/data"
@@ -46,18 +50,62 @@ if grep -Eq '^(chown|chmod) -R ' "$command_log"; then
 fi
 
 : >"$command_log"
-ongrid_repair_data_permissions "$data_dir"
+ongrid_repair_data_permissions_if_enabled 0 "$data_dir"
+[[ ! -s "$command_log" ]] \
+    || fail "disabled permission repair still traversed a data directory"
+
+: >"$command_log"
+ongrid_repair_data_permissions_if_enabled 1 "$data_dir"
 grep -Fqx "chown -R 10001:10001 $data_dir/loki" "$command_log" \
     || fail "explicit repair did not recursively repair Loki"
 grep -Fqx "chown -R 65532:65532 $data_dir/skills" "$command_log" \
     || fail "explicit repair did not recursively repair skills"
 
+[[ "$(ongrid_normalize_boolean '')" == 0 ]] \
+    || fail "empty boolean did not disable permission repair"
+[[ "$(ongrid_normalize_boolean 0)" == 0 ]] \
+    || fail "boolean 0 did not disable permission repair"
+[[ "$(ongrid_normalize_boolean false)" == 0 ]] \
+    || fail "boolean false did not disable permission repair"
+[[ "$(ongrid_normalize_boolean OFF)" == 0 ]] \
+    || fail "boolean OFF did not disable permission repair"
+[[ "$(ongrid_normalize_boolean 1)" == 1 ]] \
+    || fail "boolean 1 did not enable permission repair"
+[[ "$(ongrid_normalize_boolean TRUE)" == 1 ]] \
+    || fail "boolean TRUE did not enable permission repair"
+if ongrid_normalize_boolean invalid >/dev/null; then
+    fail "invalid boolean value was accepted"
+fi
+
+chown_should_fail=1
+if ongrid_repair_data_permissions_if_enabled 1 "$data_dir" 2>"$tmp_dir/chown-error.log"; then
+    fail "explicit repair ignored recursive chown failures"
+fi
+grep -Fq '[ERROR] could not recursively set owner' "$tmp_dir/chown-error.log" \
+    || fail "recursive chown failure did not produce an error"
+chown_should_fail=0
+
+chmod_should_fail=1
+if ongrid_repair_data_permissions_if_enabled 1 "$data_dir" 2>"$tmp_dir/chmod-error.log"; then
+    fail "explicit repair ignored recursive chmod failures"
+fi
+grep -Fq '[ERROR] could not recursively set mode 0755' "$tmp_dir/chmod-error.log" \
+    || fail "recursive chmod failure did not produce an error"
+chmod_should_fail=0
+
 grep -Fq -- '--repair-permissions' "$upgrade_script" \
     || fail "upgrade.sh does not expose the explicit repair flag"
+grep -Fq 'REPAIR_PERMISSIONS=$(ongrid_normalize_boolean "$REPAIR_PERMISSIONS_RAW")' "$upgrade_script" \
+    || fail "upgrade.sh does not normalize the permission-repair setting"
+if grep -Fq '[[ -n "$REPAIR_PERMISSIONS" ]]' "$upgrade_script"; then
+    fail "upgrade.sh still treats every non-empty permission-repair value as enabled"
+fi
 grep -Fq 'ongrid_prepare_data_directories "$ONGRID_DATA_DIR" "$ONGRID_LOG_DIR"' "$upgrade_script" \
     || fail "upgrade.sh does not use non-recursive directory preparation"
-grep -Fq 'ongrid_repair_data_permissions "$ONGRID_DATA_DIR"' "$upgrade_script" \
-    || fail "upgrade.sh does not gate recursive repair behind the explicit flag"
+grep -Fq 'ongrid_repair_data_permissions_if_enabled "$REPAIR_PERMISSIONS" "$ONGRID_DATA_DIR"' "$upgrade_script" \
+    || fail "upgrade.sh does not use the tested permission-repair gate"
+grep -Fq 'restore_existing_stack' "$upgrade_script" \
+    || fail "upgrade.sh does not expose a recovery path after repair failure"
 for persistent_dir in mysql prometheus loki tempo grafana skills pages workspace tools; do
     if grep -Eq "chown -R .*ONGRID_DATA_DIR/${persistent_dir}" "$upgrade_script"; then
         fail "upgrade.sh directly recurses through $persistent_dir outside the repair helper"


### PR DESCRIPTION
## Summary

- avoid recursively changing ownership across accumulated MySQL, Prometheus, Loki, Tempo, and Grafana data during routine upgrades
- validate and repair only the data mount-point metadata on the normal path, aborting before downtime when required permissions cannot be established
- add an explicit `--repair-permissions` recovery path with strict option parsing and old-stack recovery on permission-repair failures
- package the shared permission helper, document the behavior, and add fault-injection coverage for ownership, mode, and command failures

## Testing

- `bash -n deploy/install/upgrade.sh deploy/install/data-permissions.sh scripts/test-upgrade-data-permissions.sh`
- `scripts/test-upgrade-data-permissions.sh`
- `make test-release-package`
- `git diff --check origin/main...HEAD`

## Follow-up

A pre-existing recovery gap remains unchanged: failures in model staging or legacy volume migration after `docker compose down` do not automatically restart the previous stack. This is outside the recursive-`chown` path addressed here.

Closes #248

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
