### PR TITLE
fix(web): keep device action menu within viewport

### DIFF
--- a/web/src/pages/Edges.test.tsx
+++ b/web/src/pages/Edges.test.tsx
@@ -201,7 +201,107 @@ describe("EdgesPage", () => {
       expect(screen.getByTestId("location")).toHaveTextContent("/devices/17"),
     );
   });
+
+  it("让设备操作菜单在视口内翻转或滚动", async () => {
+    const user = userEvent.setup();
+    const originalInnerHeight = window.innerHeight;
+    const originalGetBoundingClientRect =
+      Element.prototype.getBoundingClientRect;
+    let triggerRect = makeRect({
+      top: 540,
+      left: 1200,
+      width: 32,
+      height: 32,
+    });
+    const menuRect = makeRect({ top: 0, left: 0, width: 208, height: 315 });
+
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 600,
+    });
+    const rectSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element) {
+        if (this.getAttribute("aria-label") === "更多操作") return triggerRect;
+        if (this.getAttribute("role") === "menu") return menuRect;
+        return originalGetBoundingClientRect.call(this);
+      });
+
+    try {
+      render(
+        <MemoryRouter>
+          <EdgesPage />
+        </MemoryRouter>,
+      );
+
+      await screen.findByText("bare-metal-1");
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: "更多操作" }));
+      });
+
+      const menu = await screen.findByRole("menu");
+      await waitFor(() => {
+        const top = Number.parseFloat(menu.style.top);
+        expect(top).toBeLessThan(triggerRect.top);
+        expect(top).toBeGreaterThanOrEqual(8);
+        expect(top + menuRect.height).toBeLessThanOrEqual(
+          window.innerHeight - 8,
+        );
+      });
+
+      await act(async () => {
+        triggerRect = makeRect({
+          top: 100,
+          left: 1200,
+          width: 32,
+          height: 32,
+        });
+        Object.defineProperty(window, "innerHeight", {
+          configurable: true,
+          value: 240,
+        });
+        window.dispatchEvent(new Event("resize"));
+      });
+      await waitFor(() => {
+        const top = Number.parseFloat(menu.style.top);
+        const maxHeight = Number.parseFloat(menu.style.maxHeight);
+        expect(top).toBeGreaterThan(triggerRect.bottom);
+        expect(maxHeight).toBeLessThan(menuRect.height);
+        expect(top + maxHeight).toBeLessThanOrEqual(window.innerHeight - 8);
+      });
+    } finally {
+      rectSpy.mockRestore();
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+    }
+  });
 });
+
+function makeRect({
+  top,
+  left,
+  width,
+  height,
+}: {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    left,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  };
+}
 
 function LocationProbe() {
   const location = useLocation();

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -74,6 +75,57 @@ const ROLE_FILTER_TITLES: Record<string, [string, string]> = {
 type DeviceRow = Device & {
   hostEdge?: Edge;
 };
+
+const ROW_MENU_GAP = 6;
+const ROW_MENU_VIEWPORT_PADDING = 8;
+
+type RowMenuPosition = {
+  top: number;
+  right: number;
+  maxHeight: number;
+};
+
+function calculateRowMenuPosition(
+  triggerRect: DOMRect,
+  menuHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): RowMenuPosition {
+  const viewportBottom = Math.max(
+    ROW_MENU_VIEWPORT_PADDING,
+    viewportHeight - ROW_MENU_VIEWPORT_PADDING,
+  );
+  const belowTop = Math.min(
+    Math.max(triggerRect.bottom + ROW_MENU_GAP, ROW_MENU_VIEWPORT_PADDING),
+    viewportBottom,
+  );
+  const aboveBottom = Math.min(
+    Math.max(ROW_MENU_VIEWPORT_PADDING, triggerRect.top - ROW_MENU_GAP),
+    viewportBottom,
+  );
+  const belowSpace = Math.max(
+    0,
+    viewportHeight - ROW_MENU_VIEWPORT_PADDING - belowTop,
+  );
+  const aboveSpace = Math.max(
+    0,
+    aboveBottom - ROW_MENU_VIEWPORT_PADDING,
+  );
+  const openAbove = menuHeight > belowSpace && aboveSpace > belowSpace;
+  const maxHeight = openAbove ? aboveSpace : belowSpace;
+  const visibleHeight = Math.min(menuHeight, maxHeight);
+
+  return {
+    top: openAbove
+      ? Math.max(ROW_MENU_VIEWPORT_PADDING, aboveBottom - visibleHeight)
+      : belowTop,
+    right: Math.max(
+      ROW_MENU_VIEWPORT_PADDING,
+      viewportWidth - triggerRect.right,
+    ),
+    maxHeight,
+  };
+}
 
 function selectHostEdgesByDevice(edges: Edge[]): Map<number, Edge> {
   const out = new Map<number, Edge>();
@@ -1591,27 +1643,34 @@ function RowMenu({
   const { tr } = useI18n();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const [position, setPosition] = useState<{
-    top: number;
-    right: number;
-  } | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<RowMenuPosition | null>(null);
 
   const syncPosition = useCallback(() => {
     const trigger = triggerRef.current;
-    if (!trigger) return;
-    const rect = trigger.getBoundingClientRect();
-    setPosition({
-      top: rect.bottom + 6,
-      right: window.innerWidth - rect.right,
-    });
+    const menuElement = menuRef.current;
+    if (!trigger || !menuElement) return;
+    const menuRect = menuElement.getBoundingClientRect();
+    const menuHeight = Math.max(menuElement.scrollHeight, menuRect.height);
+    setPosition(
+      calculateRowMenuPosition(
+        trigger.getBoundingClientRect(),
+        menuHeight,
+        window.innerWidth,
+        window.innerHeight,
+      ),
+    );
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!open) return;
     syncPosition();
     const onViewportChange = () => syncPosition();
     window.addEventListener("resize", onViewportChange);
-    window.addEventListener("scroll", onViewportChange, true);
+    window.addEventListener("scroll", onViewportChange, {
+      capture: true,
+      passive: true,
+    });
     return () => {
       window.removeEventListener("resize", onViewportChange);
       window.removeEventListener("scroll", onViewportChange, true);
@@ -1619,7 +1678,7 @@ function RowMenu({
   }, [open, syncPosition]);
 
   const menu = useMemo(() => {
-    if (!open || !position) return null;
+    if (!open) return null;
     return createPortal(
       <>
         <div
@@ -1628,9 +1687,15 @@ function RowMenu({
           aria-hidden
         />
         <div
+          ref={menuRef}
           role="menu"
-          className="fixed z-50 w-52 overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900 py-1 shadow-xl"
-          style={{ top: position.top, right: position.right }}
+          className="fixed z-50 w-52 max-w-[calc(100vw-1rem)] overflow-x-hidden overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-900 py-1 shadow-xl"
+          style={{
+            top: position?.top ?? 0,
+            right: position?.right ?? ROW_MENU_VIEWPORT_PADDING,
+            maxHeight: position?.maxHeight,
+            visibility: position ? "visible" : "hidden",
+          }}
         >
           <div className="px-3 pb-1 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">
             {tr("设备操作", "Device actions")}
@@ -1772,7 +1837,14 @@ function RowMenu({
       <button
         ref={triggerRef}
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (open) {
+            setOpen(false);
+            return;
+          }
+          setPosition(null);
+          setOpen(true);
+        }}
         aria-label={tr("更多操作", "More actions")}
         className="rounded-md p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
       >


### PR DESCRIPTION
## Summary

- measure the device action menu before positioning it instead of always opening below the trigger
- flip the menu above the trigger when that side has more room, and constrain it to a scrollable viewport-safe height when neither side fits
- keep the menu aligned during viewport resize and scroll, with regression coverage for both flip and constrained-scroll paths

Closes #198

## Validation

- `npm test -- --run src/pages/Kubernetes.test.tsx src/pages/Edges.test.tsx src/pages/Dashboard.test.tsx src/pages/settings/LLM.test.tsx src/pages/kubernetes/edgeAttachments.test.ts src/pages/kubernetes/registryCommands.test.ts`
- `npm run build`
- `npx eslint src/pages/Edges.tsx src/pages/Edges.test.tsx --max-warnings 0`
- Playwright verification at 1440x400 in light and dark themes; the menu remains within the viewport and its final action is reachable by scrolling

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
