### PR TITLE
fix(test): avoid chatruntime session data race

### DIFF
--- a/internal/manager/biz/aiops/chatruntime/runtime_test.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime_test.go
@@ -93,7 +93,8 @@ func (m *memSessions) GetSession(_ context.Context, id string) (*model.Session, 
 	if !ok {
 		return nil, errs.ErrNotFound
 	}
-	return s, nil
+	cp := *s
+	return &cp, nil
 }
 func (m *memSessions) ListSessions(_ context.Context, _ uint64, _, _ int, _ *uint64) ([]*model.Session, error) {
 	return nil, nil
@@ -167,6 +168,25 @@ func (m *memSessions) UpdateToolCallResult(_ context.Context, id string, status 
 }
 func (m *memSessions) SumTokensSince(_ context.Context, _ time.Time) (biz.TokenSums, error) {
 	return biz.TokenSums{}, nil
+}
+
+func TestMemSessions_GetSessionReturnsSnapshot(t *testing.T) {
+	store := newMemSessions(&model.Session{ID: "session-1"})
+
+	row, err := store.GetSession(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	now := time.Now().UTC()
+	row.ClosedAt = &now
+
+	stored, err := store.GetSession(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("GetSession after mutating snapshot: %v", err)
+	}
+	if stored.ClosedAt != nil {
+		t.Fatalf("stored ClosedAt = %v after mutating snapshot, want nil", stored.ClosedAt)
+	}
 }
 
 var idCounter atomic.Int64


### PR DESCRIPTION
## Summary

- return a snapshot from the in-memory chat session test repository instead of exposing its shared session pointer
- add a deterministic regression test that verifies callers cannot mutate the stored session through a value returned by `GetSession`

## Root cause

The async worker test read `Session.ClosedAt` through a shared pointer while the worker goroutine updated the same field during deferred session cleanup. Whether the race detector observed the overlap depended on goroutine scheduling, which made the main CI check flaky.

## Validation

- [x] `go test -race ./internal/manager/biz/aiops/chatruntime -run '^(TestMemSessions_GetSessionReturnsSnapshot|TestSpawnWorker_ClosesSession)$' -count=100`
- [x] `go test -race ./internal/manager/biz/aiops/chatruntime -count=1`
- [x] `git diff --check`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
