### PR TITLE
fix(install): chmod bind-mounted config files for non-root containers

### DIFF
--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -344,6 +344,9 @@ docker compose version >/dev/null 2>&1 || { log_error "docker compose v2 not fou
 INSTALL_DIR="${ONGRID_INSTALL_DIR:-/opt/ongrid}"
 log_info "install dir: $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
+# Under a 077 root umask mkdir -p creates 0750; containers bind-mount paths
+# below this dir and run as non-root, so the dir itself must stay traversable.
+chmod 755 "$INSTALL_DIR"
 
 # ---------- copy assets ----------
 log_info "copying assets into $INSTALL_DIR"
@@ -416,6 +419,21 @@ if [[ -d "$SCRIPT_DIR/edge" ]]; then
         done
     fi
 fi
+
+# Config files are bind-mounted into containers that run as non-root users
+# (frontier, loki, tempo, prometheus, nginx). cp preserves the source mode,
+# so on a host where root's umask is 077 the copies land as 0600/0640 and the
+# containers fail to start with "permission denied". Normalize them to 0644 —
+# none of these files contain secrets (the .env with credentials is handled
+# separately and stays 0600).
+chmod 644 \
+    "$INSTALL_DIR/docker-compose.yml" \
+    "$INSTALL_DIR"/prometheus*.yml \
+    "$INSTALL_DIR"/loki-config.yaml \
+    "$INSTALL_DIR"/tempo-config.yaml \
+    "$INSTALL_DIR"/frontier.yaml \
+    "$INSTALL_DIR"/nginx.conf \
+    2>/dev/null || true
 
 # ---------- host data dirs (bind-mount targets) ----------
 # All stateful services bind-mount to host paths instead of docker named

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -513,6 +513,20 @@ if [[ -d "$SCRIPT_DIR/edge" ]]; then
     fi
 fi
 
+# Same rationale as install.sh: these config files are bind-mounted into
+# containers running as non-root (frontier, loki, tempo, prometheus, nginx).
+# cp preserves the source mode, so under a 077 umask the refreshed copies land
+# unreadable and the stack fails to start after upgrade. Normalize to 0644;
+# the .env with credentials stays 0600.
+chmod 644 \
+    "$INSTALL_DIR/docker-compose.yml" \
+    "$INSTALL_DIR"/prometheus*.yml \
+    "$INSTALL_DIR"/loki-config.yaml \
+    "$INSTALL_DIR"/tempo-config.yaml \
+    "$INSTALL_DIR"/frontier.yaml \
+    "$INSTALL_DIR"/nginx.conf \
+    2>/dev/null || true
+
 # Bump ONGRID_VERSION in .env only.
 sed -i.bak -E "s|^ONGRID_VERSION=.*|ONGRID_VERSION=${NEW_VERSION}|" "$ENV_FILE"
 rm -f "${ENV_FILE}.bak"


### PR DESCRIPTION
## Problem

`install.sh` and `upgrade.sh` copy the bind-mounted config files into `$INSTALL_DIR` with `cp -f` but never set their mode:

- `docker-compose.yml`, `frontier.yaml`, `loki-config.yaml`, `tempo-config.yaml`, `prometheus.yml`, `prometheus-rules.yml`, `nginx.conf`

`cp` preserves the source file's mode. On a host where **root's umask is `077`** (common on security-hardened / compliance-built images), the copies land as `0600`/`0640`. The containers that bind-mount these files — `frontier`, `loki`, `tempo`, `prometheus`, `nginx` — run as **non-root** (`USER 65532`), so they fail to start:

```
frontier  | parse flags err: open /usr/conf/frontier.yaml: permission denied
loki      | error loading config file /etc/loki/local-config.yaml: permission denied
nginx     | host not found in upstream "ongrid:8080"   (cascading: ongrid depends on frontier)
```

The whole stack crash-loops on a fresh install. `install.sh` then reports a healthy-looking failure ("did not become healthy within 60s") that points at the wrong layer.

## Root cause

Implicit assumption that umask is `022`. The scripts `chmod 600` the `.env` and `chmod 755` the edge `*.sh`, but the bind-mounted YAML/conf files are left at whatever the umask produced. `INSTALL_DIR` itself can also be created `0750` under umask 077, which non-root containers cannot traverse.

## Fix

After copying, normalize the bind-mounted config files to `0644` and keep `$INSTALL_DIR` at `0755`, in both `install.sh` and `upgrade.sh`. The `.env` with credentials is untouched and stays `0600`. No secrets are exposed by this change — these config files contain no credentials.

## Test

- `bash -n deploy/install/install.sh` and `bash -n deploy/install/upgrade.sh` pass.
- Verified against a real host with `umask 077`: before the fix, frontier/loki/tempo/prometheus/nginx crash-looped with `permission denied`; after `chmod 644` on the bind-mounted configs and `chmod 755` on the install dir, all 10 containers reach `running` and `/healthz` returns 200.
