### PR TITLE
docs(readme): update install links to v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Choose the command for your server architecture:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Product Tour

--- a/README_DE.md
+++ b/README_DE.md
@@ -48,15 +48,15 @@ Wählen Sie den Befehl für Ihre Serverarchitektur:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Produkttour

--- a/README_ES.md
+++ b/README_ES.md
@@ -48,15 +48,15 @@ Elige el comando para la arquitectura de tu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Recorrido del producto

--- a/README_FR.md
+++ b/README_FR.md
@@ -48,15 +48,15 @@ Choisissez la commande adaptée à l’architecture de votre serveur :
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Tour du produit

--- a/README_JA.md
+++ b/README_JA.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## 製品ツアー

--- a/README_KO.md
+++ b/README_KO.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## 제품 둘러보기

--- a/README_PT.md
+++ b/README_PT.md
@@ -48,15 +48,15 @@ Escolha o comando para a arquitetura do seu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Tour do produto

--- a/README_RU.md
+++ b/README_RU.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## Обзор продукта

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,15 +48,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-amd64.tar.xz
-tar -xf ongrid-v0.10.2-linux-amd64.tar.xz && cd ongrid-v0.10.2-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-amd64.tar.xz
+tar -xf ongrid-v0.11.0-linux-amd64.tar.xz && cd ongrid-v0.11.0-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.10.2/ongrid-v0.10.2-linux-arm64.tar.xz
-tar -xf ongrid-v0.10.2-linux-arm64.tar.xz && cd ongrid-v0.10.2-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.11.0/ongrid-v0.11.0-linux-arm64.tar.xz
+tar -xf ongrid-v0.11.0-linux-arm64.tar.xz && cd ongrid-v0.11.0-linux-arm64
 sudo ./install.sh
 ```
 
@@ -64,10 +64,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.10.2-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.11.0-linux-arm64.tar.xz
 ```
 
 ## 产品导览


### PR DESCRIPTION
## Summary

- update all nine multilingual README installation examples from v0.10.2 to v0.11.0
- update the matching GitHub Release and Mainland China CDN links for AMD64 and ARM64 packages
- keep the installation instructions and translations otherwise unchanged

## Validation

- [x] `git diff --check`
- [x] confirmed all nine intended README files contain the v0.11.0 references and no v0.10.2 installation references remain
- [x] confirmed both v0.11.0 GitHub Release package URLs return HTTP 200
- [x] confirmed both v0.11.0 CDN package objects exist and return HTTP 200 when queried without certificate verification

## Operational note

The `ongrid.cloud` certificate expired on 2026-08-03 at 00:11:06 UTC. The v0.11.0 CDN objects are present, but standard HTTPS clients will reject the mirror until the certificate is renewed. This is an external infrastructure issue that also affects the pre-existing README links; the documented HTTPS paths remain the intended canonical mirror URLs.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
