### PR TITLE
fix(release): neutralize CNB uploader runner commands

### DIFF
--- a/scripts/publish-cnb-release-attachments.sh
+++ b/scripts/publish-cnb-release-attachments.sh
@@ -114,8 +114,9 @@ for file in "${files[@]}"; do
     attachment_list="${attachment_list:+$attachment_list,}$rel"
 done
 
-# Prefix every plugin line so legacy output such as `##[set-output ...]` cannot
-# be interpreted as a GitHub runner command. pipefail preserves docker errors.
+# Rewrite legacy command markers anywhere in plugin output before forwarding it
+# to the log. GitHub Runner recognizes `##[...]` even after a line prefix.
+# pipefail preserves docker errors through the sanitizing pipeline.
 docker run --rm \
     -e CNB_TOKEN \
     -e CNB_API_ENDPOINT="$API_ENDPOINT" \
@@ -126,7 +127,8 @@ docker run --rm \
     -e PLUGIN_ATTACHMENTS="$attachment_list" \
     -v "$repo_root:$repo_root" \
     -w "$repo_root" \
-    "$PLUGIN_IMAGE" 2>&1 | sed 's/^/[cnb-attachments] /'
+    "$PLUGIN_IMAGE" 2>&1 \
+    | sed -e 's/##\[/[runner-command /g' -e 's/^/[cnb-attachments] /'
 
 verify_remote_release || {
     echo "publish-cnb-attachments: uploaded attachment verification failed" >&2

--- a/scripts/test-publish-cnb-release-attachments.sh
+++ b/scripts/test-publish-cnb-release-attachments.sh
@@ -136,10 +136,10 @@ fi
 publisher_output=$(run_publisher)
 grep -Fq 'PLUGIN_TAG=vtest' "$tmp_dir/docker.log"
 grep -Fq "$plugin_image" "$tmp_dir/docker.log"
-grep -Fq '[cnb-attachments] ##[set-output FILES=one%2Cone.sha256]' \
+grep -Fq '[cnb-attachments] [runner-command set-output FILES=one%2Cone.sha256]' \
     <<<"$publisher_output" \
     || { echo "uploader output was not escaped from GitHub runner command parsing" >&2; exit 1; }
-if grep -Eq '^##\[' <<<"$publisher_output"; then
+if grep -Fq '##[' <<<"$publisher_output"; then
     echo "uploader output can still be parsed as a GitHub runner command" >&2
     exit 1
 fi


### PR DESCRIPTION
## What changed

- Rewrite every legacy `##[` GitHub Runner command marker emitted by the pinned CNB attachment uploader before forwarding its output.
- Keep `pipefail` so real uploader failures still fail the release job.
- Strengthen the regression test to reject command markers anywhere in the complete output, not only at the start of a line.

## Root cause

The CNB uploader successfully uploaded and verified all four Edge attachments, but emitted the deprecated malformed command `##[set-output FILES=...]`. GitHub Runner recognizes that marker even after a log prefix, then failed the job because the required `name` field was missing.

## Impact

Fresh Edge releases no longer fail after successful CNB uploads because of legacy uploader log output. Existing attachment immutability and verification behavior is unchanged.

## Validation

- `bash -n scripts/publish-cnb-release-attachments.sh scripts/test-publish-cnb-release-attachments.sh`
- `make test-edge-attachments`
- `make test-release-workflow`
- `git diff --check`

## Author checklist

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
