### PR TITLE
test(web): stabilize device navigation E2E

### DIFF
--- a/web/e2e/live-navigation.spec.ts
+++ b/web/e2e/live-navigation.spec.ts
@@ -14,7 +14,7 @@ test.describe('live frontend interaction', () => {
     const page = await context.newPage();
     await login(page);
     await expect(page.getByRole('link', { name: /仪表盘|Dashboard/ })).toBeVisible();
-    await expect(page.getByRole('link', { name: /设备|Devices/ })).toBeVisible();
+    await expect(page.locator('a[href="/devices"]')).toBeVisible();
     await context.close();
   });
 


### PR DESCRIPTION
## Summary
- make the workbench navigation test select the exact `/devices` link
- avoid strict-mode collisions with Network devices and session titles

## Validation
- `npm run test:e2e` against https://101.34.63.91: 26/26 passed

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md