### PR TITLE
feat(aiops): enable approved Kubernetes writes in legacy kernel

### DIFF
--- a/api/manager/k8s/v1/k8s.proto
+++ b/api/manager/k8s/v1/k8s.proto
@@ -17,6 +17,7 @@ service KubernetesService {
     rpc ListWorkloads(ListWorkloadsRequest) returns (ListWorkloadsResponse);
     rpc ListPods(ListPodsRequest) returns (ListPodsResponse);
     rpc ListEvents(ListEventsRequest) returns (ListEventsResponse);
+    rpc ListActionAudits(ListActionAuditsRequest) returns (ListActionAuditsResponse);
     rpc RotateBootstrapToken(RotateBootstrapTokenRequest) returns (RotateBootstrapTokenResponse);
     rpc DeleteCluster(DeleteClusterRequest) returns (DeleteClusterResponse);
 
@@ -322,6 +323,44 @@ message ListEventsRequest {
 
 message ListEventsResponse {
     repeated KubernetesEvent items = 1 [json_name = "items"];
+    int32 total = 2 [json_name = "total"];
+    int32 limit = 3 [json_name = "limit"];
+    int32 offset = 4 [json_name = "offset"];
+}
+
+// KubernetesActionAudit is the sanitized, unified read model for Kubernetes
+// writes. It merges graph ReviewGate decisions and legacy human approvals;
+// args_json never contains the one-time preflight_token.
+message KubernetesActionAudit {
+    string id = 1 [json_name = "id"];
+    uint64 cluster_id = 2 [json_name = "cluster_id"];
+    string session_id = 3 [json_name = "session_id"];
+    string message_id = 4 [json_name = "message_id"];
+    string tool_call_id = 5 [json_name = "tool_call_id"];
+    string tool_name = 6 [json_name = "tool_name"];
+    string args_json = 7 [json_name = "args_json"];
+    string tool_class = 8 [json_name = "tool_class"];
+    string approval_mode = 9 [json_name = "approval_mode"];
+    string reviewer_agent = 10 [json_name = "reviewer_agent"];
+    string reviewer_task_id = 11 [json_name = "reviewer_task_id"];
+    string decision = 12 [json_name = "decision"];
+    string status = 13 [json_name = "status"];
+    string decision_reason = 14 [json_name = "decision_reason"];
+    uint64 operator_user_id = 15 [json_name = "operator_user_id"];
+    uint64 approver_user_id = 16 [json_name = "approver_user_id"];
+    google.protobuf.Timestamp created_at = 17 [json_name = "created_at"];
+    google.protobuf.Timestamp decided_at = 18 [json_name = "decided_at"];
+    google.protobuf.Timestamp executed_at = 19 [json_name = "executed_at"];
+}
+
+message ListActionAuditsRequest {
+    uint64 cluster_id = 1 [json_name = "cluster_id"];
+    int32 limit = 2 [json_name = "limit"];
+    int32 offset = 3 [json_name = "offset"];
+}
+
+message ListActionAuditsResponse {
+    repeated KubernetesActionAudit items = 1 [json_name = "items"];
     int32 total = 2 [json_name = "total"];
     int32 limit = 3 [json_name = "limit"];
     int32 offset = 4 [json_name = "offset"];

--- a/cmd/ongrid/k8s_action_audit_test.go
+++ b/cmd/ongrid/k8s_action_audit_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	managerbizaiops "github.com/ongridio/ongrid/internal/manager/biz/aiops"
+	aiopstools "github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+	manageraiopsmodel "github.com/ongridio/ongrid/internal/manager/model/aiops"
+	managerapprovalmodel "github.com/ongridio/ongrid/internal/manager/model/approval"
+)
+
+type fakeK8sActionProposalReader struct {
+	rows []*manageraiopsmodel.MutatingProposal
+}
+
+func (f fakeK8sActionProposalReader) ListMutatingProposals(_ context.Context, filter managerbizaiops.MutatingProposalFilter) ([]*manageraiopsmodel.MutatingProposal, error) {
+	if filter.Offset >= len(f.rows) {
+		return nil, nil
+	}
+	end := filter.Offset + filter.Limit
+	if end > len(f.rows) {
+		end = len(f.rows)
+	}
+	return f.rows[filter.Offset:end], nil
+}
+
+type fakeK8sActionApprovalReader struct {
+	rows []*managerapprovalmodel.Approval
+}
+
+func (f fakeK8sActionApprovalReader) ListKind(_ context.Context, _ string, limit, offset int) ([]*managerapprovalmodel.Approval, error) {
+	if offset >= len(f.rows) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(f.rows) {
+		end = len(f.rows)
+	}
+	return f.rows[offset:end], nil
+}
+
+func TestK8sActionAuditReaderMergesAndSanitizesBothApprovalPaths(t *testing.T) {
+	graphTime := time.Date(2026, time.August, 6, 8, 20, 0, 0, time.UTC)
+	humanTime := graphTime.Add(time.Minute)
+	executedAt := humanTime.Add(10 * time.Second)
+	reason := "operator approved"
+	graphArgs := `{"cluster_id":48,"action":"scale","kind":"Deployment","namespace":"ongrid-system","name":"gateway","replicas":3,"preflight_token":"graph-secret"}`
+	humanPayload, err := json.Marshal(k8sActionPayload{
+		Args: aiopstools.ExecuteK8sActionArgs{
+			ClusterID: 48, Action: "scale", Kind: "Deployment", Namespace: "ongrid-system",
+			Name: "metrics-scraper", Replicas: intPtr(2), PreflightToken: "human-secret",
+		},
+		UserID: 7, SessionID: "human-session",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	otherPayload, err := json.Marshal(k8sActionPayload{Args: aiopstools.ExecuteK8sActionArgs{
+		ClusterID: 49, Action: "cordon", Name: "worker-1", PreflightToken: "other-secret",
+	}})
+	if err != nil {
+		t.Fatalf("marshal other payload: %v", err)
+	}
+
+	reader := k8sActionAuditReader{
+		proposals: fakeK8sActionProposalReader{rows: []*manageraiopsmodel.MutatingProposal{{
+			ID: "graph-1", SessionID: "graph-session", ToolName: aiopstools.ToolNameExecuteK8sAction,
+			ArgsJSON: graphArgs, ToolClass: "write", ReviewerAgent: "reviewer",
+			Decision: manageraiopsmodel.DecisionApprove, OperatorUserID: 6,
+			CreatedAt: graphTime, DecidedAt: &graphTime, ExecutedAt: &graphTime,
+		}}},
+		approvals: fakeK8sActionApprovalReader{rows: []*managerapprovalmodel.Approval{
+			{
+				ID: "human-1", Kind: aiopstools.ToolNameExecuteK8sAction, PayloadJSON: string(humanPayload),
+				SessionID: "human-session", Status: managerapprovalmodel.StatusExecuted,
+				ProposedBy: 7, ApprovedBy: uint64Ptr(8), Reason: &reason,
+				CreatedAt: humanTime, DecidedAt: &humanTime, ExecutedAt: &executedAt,
+			},
+			{
+				ID: "other-cluster", Kind: aiopstools.ToolNameExecuteK8sAction,
+				PayloadJSON: string(otherPayload), Status: managerapprovalmodel.StatusPending,
+				CreatedAt: humanTime.Add(time.Minute),
+			},
+		}},
+	}
+
+	items, total, err := reader.ListK8sActionAudits(context.Background(), 48, 10, 0)
+	if err != nil {
+		t.Fatalf("ListK8sActionAudits: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("items/total = %d/%d, want 2/2", len(items), total)
+	}
+	if items[0].ID != "human-1" || items[0].ApprovalMode != "human" || items[0].Status != "executed" {
+		t.Fatalf("human record = %+v", items[0])
+	}
+	if items[1].ID != "graph-1" || items[1].ApprovalMode != "review_gate" || items[1].Status != "executed" {
+		t.Fatalf("graph record = %+v", items[1])
+	}
+	for _, item := range items {
+		if strings.Contains(item.ArgsJSON, "preflight_token") || strings.Contains(item.ArgsJSON, "secret") {
+			t.Fatalf("record leaks preflight credential: %s", item.ArgsJSON)
+		}
+	}
+}
+
+func intPtr(value int) *int { return &value }
+
+func uint64Ptr(value uint64) *uint64 { return &value }

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -146,6 +146,7 @@ import (
 	managerflowdata "github.com/ongridio/ongrid/internal/manager/data/flow/store"
 	managerreportdata "github.com/ongridio/ongrid/internal/manager/data/report/store"
 	manageraiopsmodel "github.com/ongridio/ongrid/internal/manager/model/aiops"
+	managerapprovalmodel "github.com/ongridio/ongrid/internal/manager/model/approval"
 	managerserveraiops "github.com/ongridio/ongrid/internal/manager/server/aiops"
 	managerserveralert "github.com/ongridio/ongrid/internal/manager/server/alert"
 	managerserverapproval "github.com/ongridio/ongrid/internal/manager/server/approval"
@@ -803,8 +804,6 @@ func main() {
 	k8sSvc := managersvck8s.New(k8sUC)
 	telemetryAuthn := managerbizk8s.NewTelemetryAuthenticator(k8sRepo)
 	edgeSvc.SetManagedEdgeGuard(k8sSvc)
-	k8sHandler := managerserverk8s.NewHandler(k8sSvc)
-
 	// Plugin runtime config storage. UC notifier
 	// (cloud → edge reload push) is back-filled after frontierbound is
 	// constructed below; until then SetEdge() etc. are no-ops on the wire
@@ -1262,6 +1261,9 @@ func main() {
 		aiopsagent.Config{Model: cfg.OpenAI.Model, Temperature: 0.1, MaxIterations: 30},
 		log,
 	)
+	aiopsAgent.SetAgentWriteEnabledProvider(func(ctx context.Context) bool {
+		return settingSvc.AgentWriteEnabled(ctx)
+	})
 	aiopsUsage := managerbizaiops.NewUsageUsecase(aiopsRepo, log)
 
 	// PR-9 of optional new graph-based agent kernel. Default
@@ -2018,6 +2020,16 @@ func main() {
 		tool := aiopstools.NewBashToolWithProposer(fbClient, edgeUC, deviceUC, nil, log)
 		return tool.RunApproved(ctx, p.DeviceIDs, p.Command, p.TimeoutSeconds)
 	})
+	approvalUC.RegisterExecutor(aiopstools.ToolNameExecuteK8sAction, func(ctx context.Context, payloadJSON string) (string, error) {
+		var p k8sActionPayload
+		if err := json.Unmarshal([]byte(payloadJSON), &p); err != nil {
+			return "", fmt.Errorf("decode %s approval payload: %w", aiopstools.ToolNameExecuteK8sAction, err)
+		}
+		if !settingSvc.AgentWriteEnabled(ctx) {
+			return "", fmt.Errorf("%s: Agent write actions are disabled", aiopstools.ToolNameExecuteK8sAction)
+		}
+		return toolsReg.RunApprovedK8sAction(ctx, p.Args, p.UserID, p.SessionID)
+	})
 	// HLD-018 P2: mcp_call executor — on approve, connect the server and run
 	// the tool. Trusted servers skip this and run synchronously in the tool.
 	approvalUC.RegisterExecutor("mcp_call", func(ctx context.Context, payloadJSON string) (string, error) {
@@ -2062,6 +2074,13 @@ func main() {
 	})
 	toolsReg.SetCloudBashProposer(cloudBashProposerShim{uc: approvalUC})
 	toolsReg.SetHostBashProposer(hostBashProposerShim{uc: approvalUC})
+	toolsReg.SetK8sActionProposer(k8sActionProposerShim{uc: approvalUC})
+	// The Actions page is a read-only projection over two immutable audit
+	// sources: graph ReviewGate decisions and legacy human approvals.
+	k8sHandler := managerserverk8s.NewHandler(k8sSvc, k8sActionAuditReader{
+		proposals: mutatingProposalRepo,
+		approvals: approvalUC,
+	})
 	// send_im_message: the assistant can proactively push to a configured
 	// channel (飞书/钉钉/…), reusing the same BuildSenderFromChannel path the
 	// alert notifier + flow notify node use.
@@ -3915,6 +3934,180 @@ type hostBashPayload struct {
 	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
 }
 
+// k8sActionPayload stores the exact preflight-validated action plus the
+// identity to which its one-time token was bound. The approval executor uses
+// this immutable payload after a human approves the card.
+type k8sActionPayload struct {
+	Args      aiopstools.ExecuteK8sActionArgs `json:"args"`
+	UserID    uint64                          `json:"user_id"`
+	SessionID string                          `json:"session_id"`
+}
+
+const (
+	k8sActionAuditSourcePageSize = 500
+	// The UI intentionally presents recent audit history. Keep aggregation
+	// bounded even if a long-lived installation accumulates millions of rows;
+	// the normalized table/index can replace this compatibility projection in
+	// a future migration without changing the HTTP contract.
+	k8sActionAuditMaxSourceRows = 5000
+)
+
+type k8sActionProposalReader interface {
+	ListMutatingProposals(context.Context, managerbizaiops.MutatingProposalFilter) ([]*manageraiopsmodel.MutatingProposal, error)
+}
+
+type k8sActionApprovalReader interface {
+	ListKind(context.Context, string, int, int) ([]*managerapprovalmodel.Approval, error)
+}
+
+// k8sActionAuditReader is the composition-root adapter for the Kubernetes
+// server's consumer-owned ActionAuditReader interface. Keeping the merge here
+// prevents the k8s domain from importing the aiops or approval domains.
+type k8sActionAuditReader struct {
+	proposals k8sActionProposalReader
+	approvals k8sActionApprovalReader
+}
+
+func (r k8sActionAuditReader) ListK8sActionAudits(ctx context.Context, clusterID uint64, limit, offset int) ([]managerserverk8s.ActionAuditRecord, int, error) {
+	if r.proposals == nil || r.approvals == nil {
+		return nil, 0, fmt.Errorf("kubernetes action audit readers are not configured")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	records := make([]managerserverk8s.ActionAuditRecord, 0, limit)
+	for sourceOffset := 0; sourceOffset < k8sActionAuditMaxSourceRows; sourceOffset += k8sActionAuditSourcePageSize {
+		rows, err := r.proposals.ListMutatingProposals(ctx, managerbizaiops.MutatingProposalFilter{
+			ToolName: aiopstools.ToolNameExecuteK8sAction,
+			Limit:    k8sActionAuditSourcePageSize,
+			Offset:   sourceOffset,
+		})
+		if err != nil {
+			return nil, 0, fmt.Errorf("list ReviewGate Kubernetes actions: %w", err)
+		}
+		for _, row := range rows {
+			if record, ok := k8sActionAuditFromProposal(row, clusterID); ok {
+				records = append(records, record)
+			}
+		}
+		if len(rows) < k8sActionAuditSourcePageSize {
+			break
+		}
+	}
+	for sourceOffset := 0; sourceOffset < k8sActionAuditMaxSourceRows; sourceOffset += k8sActionAuditSourcePageSize {
+		rows, err := r.approvals.ListKind(ctx, aiopstools.ToolNameExecuteK8sAction, k8sActionAuditSourcePageSize, sourceOffset)
+		if err != nil {
+			return nil, 0, fmt.Errorf("list human-approved Kubernetes actions: %w", err)
+		}
+		for _, row := range rows {
+			if record, ok := k8sActionAuditFromApproval(row, clusterID); ok {
+				records = append(records, record)
+			}
+		}
+		if len(rows) < k8sActionAuditSourcePageSize {
+			break
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].CreatedAt.Equal(records[j].CreatedAt) {
+			return records[i].ID > records[j].ID
+		}
+		return records[i].CreatedAt.After(records[j].CreatedAt)
+	})
+	total := len(records)
+	if offset >= total {
+		return []managerserverk8s.ActionAuditRecord{}, total, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return records[offset:end], total, nil
+}
+
+func k8sActionAuditFromProposal(row *manageraiopsmodel.MutatingProposal, clusterID uint64) (managerserverk8s.ActionAuditRecord, bool) {
+	if row == nil {
+		return managerserverk8s.ActionAuditRecord{}, false
+	}
+	args, argsJSON, ok := sanitizedK8sActionArgs(row.ArgsJSON)
+	if !ok || args.ClusterID != clusterID {
+		return managerserverk8s.ActionAuditRecord{}, false
+	}
+	status := "pending"
+	switch row.Decision {
+	case manageraiopsmodel.DecisionApprove:
+		status = "approved"
+		if row.ExecutedAt != nil {
+			status = "executed"
+		}
+	case manageraiopsmodel.DecisionReject:
+		status = "rejected"
+	}
+	return managerserverk8s.ActionAuditRecord{
+		ID: row.ID, ClusterID: args.ClusterID, SessionID: row.SessionID,
+		MessageID: row.MessageID, ToolCallID: row.ToolCallID,
+		ToolName: row.ToolName, ArgsJSON: argsJSON, ToolClass: row.ToolClass,
+		ApprovalMode: "review_gate", ReviewerAgent: row.ReviewerAgent,
+		ReviewerTaskID: row.ReviewerTaskID, Decision: row.Decision, Status: status,
+		DecisionReason: stringValue(row.DecisionReason), OperatorUserID: row.OperatorUserID,
+		ApproverUserID: row.ApproverUserID, CreatedAt: row.CreatedAt,
+		DecidedAt: row.DecidedAt, ExecutedAt: row.ExecutedAt,
+	}, true
+}
+
+func k8sActionAuditFromApproval(row *managerapprovalmodel.Approval, clusterID uint64) (managerserverk8s.ActionAuditRecord, bool) {
+	if row == nil {
+		return managerserverk8s.ActionAuditRecord{}, false
+	}
+	var payload k8sActionPayload
+	if err := json.Unmarshal([]byte(row.PayloadJSON), &payload); err != nil || payload.Args.ClusterID != clusterID {
+		return managerserverk8s.ActionAuditRecord{}, false
+	}
+	payload.Args.PreflightToken = ""
+	argsJSON, err := json.Marshal(payload.Args)
+	if err != nil {
+		return managerserverk8s.ActionAuditRecord{}, false
+	}
+	decision := manageraiopsmodel.DecisionPending
+	switch row.Status {
+	case managerapprovalmodel.StatusRejected:
+		decision = manageraiopsmodel.DecisionReject
+	case managerapprovalmodel.StatusApproved, managerapprovalmodel.StatusExecuted, managerapprovalmodel.StatusFailed:
+		decision = manageraiopsmodel.DecisionApprove
+	}
+	return managerserverk8s.ActionAuditRecord{
+		ID: row.ID, ClusterID: payload.Args.ClusterID, SessionID: row.SessionID,
+		ToolName: aiopstools.ToolNameExecuteK8sAction, ArgsJSON: string(argsJSON), ToolClass: "write",
+		ApprovalMode: "human", Decision: decision, Status: row.Status,
+		DecisionReason: stringValue(row.Reason), OperatorUserID: row.ProposedBy,
+		ApproverUserID: row.ApprovedBy, CreatedAt: row.CreatedAt,
+		DecidedAt: row.DecidedAt, ExecutedAt: row.ExecutedAt,
+	}, true
+}
+
+func sanitizedK8sActionArgs(raw string) (aiopstools.ExecuteK8sActionArgs, string, bool) {
+	var args aiopstools.ExecuteK8sActionArgs
+	if err := json.Unmarshal([]byte(raw), &args); err != nil || args.ClusterID == 0 {
+		return aiopstools.ExecuteK8sActionArgs{}, "", false
+	}
+	args.PreflightToken = ""
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		return aiopstools.ExecuteK8sActionArgs{}, "", false
+	}
+	return args, string(encoded), true
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
 // approvalWaitTimeout bounds how long a synchronous-blocking tool (HLD-021,
 // cloud_bash) waits for a human decision before giving up and returning a
 // terminal timeout blob. The decorator timeout that wraps the tool is set a
@@ -4068,6 +4261,78 @@ func (s hostBashProposerShim) ProposeAndAwait(ctx context.Context, deviceIDs []u
 		})
 	}
 	return cloudBashProposerShim{uc: s.uc}.awaitDecision(ctx, a.ID)
+}
+
+// k8sActionProposerShim gives the default legacy kernel the same synchronous
+// propose-confirm UX used by host_bash. The tool has already consumed a
+// matching dry-run token before this method is called; no Kubernetes write is
+// dispatched until the approval executor runs.
+type k8sActionProposerShim struct{ uc *managerbizapproval.Usecase }
+
+func (s k8sActionProposerShim) ProposeAndAwait(ctx context.Context, args aiopstools.ExecuteK8sActionArgs, sessionID, toolCallID string, userID uint64) (string, error) {
+	command := formatK8sActionApproval(args)
+	title := aiopstools.ToolNameExecuteK8sAction + " " + command
+	if len(title) > 120 {
+		title = title[:120] + "…"
+	}
+	summary := command
+	if reason := strings.TrimSpace(args.Reason); reason != "" {
+		summary += " reason=" + reason
+	}
+	a, err := s.uc.Propose(ctx, managerbizapproval.ProposeInput{
+		Kind:       aiopstools.ToolNameExecuteK8sAction,
+		Title:      title,
+		Summary:    summary,
+		Payload:    k8sActionPayload{Args: args, UserID: userID, SessionID: sessionID},
+		Source:     "agent",
+		SessionID:  sessionID,
+		ProposedBy: userID,
+	})
+	if err != nil {
+		return "", err
+	}
+	if emit := aiopschatruntime.EmitFromContext(ctx); emit != nil {
+		emit(aiopschatruntime.Event{
+			Type: aiopschatruntime.EventApprovalPending,
+			Approval: &aiopschatruntime.ApprovalPending{
+				ApprovalID: a.ID,
+				ToolCallID: toolCallID,
+				Kind:       aiopstools.ToolNameExecuteK8sAction,
+				Command:    command,
+			},
+		})
+	} else if emit := aiopsagent.EmitFromContext(ctx); emit != nil {
+		emit(aiopsagent.Event{
+			Type: aiopsagent.EventApprovalPending,
+			Approval: &aiopsagent.ApprovalPendingEvent{
+				ApprovalID: a.ID,
+				ToolCallID: toolCallID,
+				Kind:       aiopstools.ToolNameExecuteK8sAction,
+				Command:    command,
+			},
+		})
+	}
+	return cloudBashProposerShim{uc: s.uc}.awaitDecision(ctx, a.ID)
+}
+
+func formatK8sActionApproval(args aiopstools.ExecuteK8sActionArgs) string {
+	target := strings.TrimSpace(args.Name)
+	if namespace := strings.TrimSpace(args.Namespace); namespace != "" {
+		target = namespace + "/" + target
+	}
+	parts := []string{fmt.Sprintf("cluster_id=%d", args.ClusterID)}
+	for _, value := range []string{args.Action, args.Kind, target} {
+		if value = strings.TrimSpace(value); value != "" {
+			parts = append(parts, value)
+		}
+	}
+	if args.Replicas != nil {
+		parts = append(parts, fmt.Sprintf("replicas=%d", *args.Replicas))
+	}
+	if rv := strings.TrimSpace(args.ExpectedResourceVersion); rv != "" {
+		parts = append(parts, "resource_version="+rv)
+	}
+	return strings.Join(parts, " ")
 }
 
 // awaitDecision blocks until the approval row reaches a terminal state, then

--- a/internal/manager/biz/aiops/agent/agent.go
+++ b/internal/manager/biz/aiops/agent/agent.go
@@ -26,9 +26,11 @@ import (
 	biz "github.com/ongridio/ongrid/internal/manager/biz/aiops"
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/toolreplay"
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
 	model "github.com/ongridio/ongrid/internal/manager/model/aiops"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/llm"
+	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
 )
 
 // ErrMaxIterationsReached is returned from Run when cfg.MaxIterations elapse
@@ -83,11 +85,9 @@ const (
 	// through the same eventName / eventPayload translation as the rest.
 	EventTaskNotification EventType = "task_notification"
 	// EventApprovalPending fires when a synchronous-blocking tool
-	// (HLD-021, e.g. cloud_bash) queues a human-approval proposal and is
+	// (HLD-021, e.g. execute_k8s_action) queues a human-approval proposal and is
 	// about to block on the decision. Carries the live approve/reject card
-	// payload; the legacy agent never emits it, but the constant exists so
-	// the SSE layer carries the chatruntime kernel's approval_pending frame
-	// through the same eventName / eventPayload translation as the rest.
+	// payload. Both kernels translate this shape through the same SSE frame.
 	EventApprovalPending EventType = "approval_pending"
 )
 
@@ -159,6 +159,25 @@ type ToolEvent struct {
 // over SSE/etc.
 type Emit func(Event)
 
+type emitCtxKeyT struct{}
+
+var emitCtxKey = emitCtxKeyT{}
+
+func withEmit(ctx context.Context, emit Emit) context.Context {
+	if emit == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, emitCtxKey, emit)
+}
+
+// EmitFromContext returns the active legacy-kernel streaming callback. The
+// cmd-layer approval adapter uses it to surface the same inline confirmation
+// card that the graph kernel emits through chatruntime.EmitFromContext.
+func EmitFromContext(ctx context.Context) Emit {
+	v, _ := ctx.Value(emitCtxKey).(Emit)
+	return v
+}
+
 // MentionResolver hydrates a list of @-mention references into one
 // string per mention, formatted as a markdown bullet. The agent inlines
 // these into the user message prelude so the LLM has structured context
@@ -224,19 +243,33 @@ var legacyKernelMutatingTools = map[string]struct{}{
 	"host_restart_service": {},
 }
 
+const (
+	legacyApprovalToolTimeout          = 31 * time.Minute
+	legacyK8sDryRunTimeout             = 45 * time.Second
+	legacyK8sDefaultDrainTimeout       = 120 * time.Second
+	legacyK8sDryRunDrainTimeoutPadding = 30 * time.Second
+)
+
 // Agent wires the LLM client, tool registry, and session repo.
 type Agent struct {
-	llm      llm.Client
-	tools    *tools.Registry
-	sessions biz.SessionRepo
-	cfg      Config
-	log      *slog.Logger
-	resolver MentionResolver
+	llm          llm.Client
+	tools        *tools.Registry
+	sessions     biz.SessionRepo
+	cfg          Config
+	log          *slog.Logger
+	resolver     MentionResolver
+	writeEnabled func(ctx context.Context) bool
 }
 
 // SetMentionResolver wires the @-mention hydrator. Optional — when
 // unset the agent runs with no mention inlining (back-compat).
 func (a *Agent) SetMentionResolver(r MentionResolver) { a.resolver = r }
+
+// SetAgentWriteEnabledProvider wires the live admin setting used by the
+// default legacy kernel. A nil provider fails closed for write-tool exposure.
+func (a *Agent) SetAgentWriteEnabledProvider(fn func(ctx context.Context) bool) {
+	a.writeEnabled = fn
+}
 
 // New builds an Agent. Defaults are filled in here so callers can pass a
 // zero-value Config and get sane behaviour.
@@ -300,6 +333,7 @@ func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64
 	if emit == nil {
 		emit = func(Event) {}
 	}
+	ctx = withEmit(ctx, emit)
 
 	sess, err := a.sessions.GetSession(ctx, sessionID)
 	if err != nil {
@@ -312,6 +346,14 @@ func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64
 		// layer wants 404 not 403 per spec).
 		return nil, errs.ErrNotFound
 	}
+	ctx = basetool.WithSessionID(ctx, sess.ID)
+	writeEnabled := false
+	if a.writeEnabled != nil {
+		writeEnabled = a.writeEnabled(ctx)
+	}
+	ctx = basetool.WithAgentWriteAllowed(ctx, writeEnabled)
+	caller, hasCaller := tenantctx.From(ctx)
+	canExecuteK8sAction := writeEnabled && hasCaller && (caller.Role == "admin" || caller.IsSuperuser)
 
 	// Persist the new user turn first so it survives a downstream crash.
 	// When the SPA chat input attached @-mentions, hydrate them into
@@ -367,6 +409,9 @@ func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64
 	exposedSchemas := a.tools.Schemas()
 	if !opts.WebSearchEnabled {
 		exposedSchemas = filterToolSchemas(exposedSchemas, ToolWebSearch)
+	}
+	if !canExecuteK8sAction {
+		exposedSchemas = filterToolSchemas(exposedSchemas, tools.ToolNameExecuteK8sAction)
 	}
 
 	for i := 0; i < a.cfg.MaxIterations; i++ {
@@ -582,7 +627,8 @@ func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64
 				continue
 			}
 
-			toolCtx, cancel := context.WithTimeout(ctx, a.cfg.ToolTimeout)
+			toolCtx := basetool.WithToolCallID(ctx, tcRow.ID)
+			toolCtx, cancel := context.WithTimeout(toolCtx, legacyToolTimeout(a.cfg.ToolTimeout, tc.Name, tc.Args))
 			execResult, execErr := a.tools.Invoke(toolCtx, tc.Name, tc.Args)
 			cancel()
 
@@ -869,6 +915,31 @@ func filterToolSchemas(schemas []llm.ToolSchema, excludeNames ...string) []llm.T
 		out = append(out, s)
 	}
 	return out
+}
+
+func legacyToolTimeout(defaultTimeout time.Duration, name string, args json.RawMessage) time.Duration {
+	if name != tools.ToolNameExecuteK8sAction {
+		return defaultTimeout
+	}
+	var in struct {
+		Action              string `json:"action"`
+		DryRun              bool   `json:"dry_run"`
+		DrainTimeoutSeconds int    `json:"drain_timeout_seconds"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return defaultTimeout
+	}
+	if in.DryRun {
+		if strings.EqualFold(strings.TrimSpace(in.Action), "drain") {
+			drainTimeout := time.Duration(in.DrainTimeoutSeconds) * time.Second
+			if drainTimeout <= 0 {
+				drainTimeout = legacyK8sDefaultDrainTimeout
+			}
+			return drainTimeout + legacyK8sDryRunDrainTimeoutPadding
+		}
+		return legacyK8sDryRunTimeout
+	}
+	return legacyApprovalToolTimeout
 }
 
 // stringPtrIfSet returns &s when s is non-empty, otherwise nil. Used to

--- a/internal/manager/biz/aiops/agent/legacy_k8s_action_test.go
+++ b/internal/manager/biz/aiops/agent/legacy_k8s_action_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+)
+
+func TestLegacyToolTimeoutAllowsHumanApprovalWait(t *testing.T) {
+	defaultTimeout := 15 * time.Second
+	tests := []struct {
+		name string
+		tool string
+		args json.RawMessage
+		want time.Duration
+	}{
+		{name: "ordinary tool", tool: "query_devices", args: json.RawMessage(`{}`), want: defaultTimeout},
+		{name: "k8s dry-run", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{"dry_run":true}`), want: legacyK8sDryRunTimeout},
+		{name: "k8s drain dry-run default timeout", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{"action":"drain","dry_run":true}`), want: legacyK8sDefaultDrainTimeout + legacyK8sDryRunDrainTimeoutPadding},
+		{name: "k8s drain dry-run custom timeout", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{"action":"drain","dry_run":true,"drain_timeout_seconds":300}`), want: 330 * time.Second},
+		{name: "k8s approval", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{"dry_run":false}`), want: legacyApprovalToolTimeout},
+		{name: "k8s implicit write", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{}`), want: legacyApprovalToolTimeout},
+		{name: "malformed args", tool: tools.ToolNameExecuteK8sAction, args: json.RawMessage(`{`), want: defaultTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := legacyToolTimeout(defaultTimeout, tt.tool, tt.args); got != tt.want {
+				t.Fatalf("legacyToolTimeout()=%s want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLegacyEmitIsAvailableToApprovalAdapter(t *testing.T) {
+	want := Event{Type: EventApprovalPending, Approval: &ApprovalPendingEvent{ApprovalID: "approval-1"}}
+	var got Event
+	ctx := withEmit(context.Background(), func(event Event) { got = event })
+	emit := EmitFromContext(ctx)
+	if emit == nil {
+		t.Fatal("EmitFromContext returned nil")
+	}
+	emit(want)
+	if got.Type != EventApprovalPending || got.Approval == nil || got.Approval.ApprovalID != "approval-1" {
+		t.Fatalf("unexpected event: %+v", got)
+	}
+}

--- a/internal/manager/biz/aiops/tools/basetool/host_write.go
+++ b/internal/manager/biz/aiops/tools/basetool/host_write.go
@@ -3,9 +3,9 @@ package basetool
 import "context"
 
 // host_write.go — ctx propagation for the admin "allow Agent write actions"
-// gate as it applies to host_bash. The chat runtime resolves the live
-// AgentWriteEnabled setting once per request and stamps the result here; the
-// host_bash tool reads it back and forwards it to the edge as
+// gate. The active kernel resolves the live AgentWriteEnabled setting once per
+// request and stamps the result here; write tools read it before proposing or
+// dispatching work. host_bash also forwards it to the edge as
 // BashExecRequest.Unrestricted, which makes the edge bypass cmdpolicy and run
 // the raw command through a shell. Gate OFF (the default) leaves host_bash on
 // the locked read-only cmdpolicy path.
@@ -18,17 +18,24 @@ type hostWriteAllowedCtxKeyT struct{}
 
 var hostWriteAllowedCtxKey = hostWriteAllowedCtxKeyT{}
 
-// WithHostWriteAllowed tags ctx with whether host_bash may run unrestricted
-// (cmdpolicy bypassed). Only the chat runtime sets this, and only to the
-// resolved value of the admin write gate.
-func WithHostWriteAllowed(ctx context.Context, allowed bool) context.Context {
+// WithAgentWriteAllowed tags ctx with the resolved global write gate.
+func WithAgentWriteAllowed(ctx context.Context, allowed bool) context.Context {
 	return context.WithValue(ctx, hostWriteAllowedCtxKey, allowed)
 }
 
-// HostWriteAllowedFromContext reports whether the write gate authorized
-// unrestricted host commands for this request. Absent key → false (locked
-// read-only), so any path that forgets to stamp the flag fails safe.
-func HostWriteAllowedFromContext(ctx context.Context) bool {
+// AgentWriteAllowedFromContext reports whether the write gate authorized this
+// request. Absent key means false so incomplete wiring fails closed.
+func AgentWriteAllowedFromContext(ctx context.Context) bool {
 	v, _ := ctx.Value(hostWriteAllowedCtxKey).(bool)
 	return v
+}
+
+// WithHostWriteAllowed is the compatibility name used by the graph runtime.
+func WithHostWriteAllowed(ctx context.Context, allowed bool) context.Context {
+	return WithAgentWriteAllowed(ctx, allowed)
+}
+
+// HostWriteAllowedFromContext is the compatibility name used by host_bash.
+func HostWriteAllowedFromContext(ctx context.Context) bool {
+	return AgentWriteAllowedFromContext(ctx)
 }

--- a/internal/manager/biz/aiops/tools/basetool/tool_call.go
+++ b/internal/manager/biz/aiops/tools/basetool/tool_call.go
@@ -1,0 +1,22 @@
+package basetool
+
+import "context"
+
+// toolCallIDCtxKeyT stores the persisted tool-call row id for kernels that do
+// not use eino compose. The graph kernel gets its id from compose directly;
+// the legacy kernel stamps this value before invoking the closure registry so
+// approval cards can attach to the existing streaming tool card.
+type toolCallIDCtxKeyT struct{}
+
+var toolCallIDCtxKey = toolCallIDCtxKeyT{}
+
+// WithToolCallID tags ctx with the current persisted tool-call row id.
+func WithToolCallID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, toolCallIDCtxKey, id)
+}
+
+// ToolCallIDFromContext returns the legacy-kernel tool-call row id, if any.
+func ToolCallIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(toolCallIDCtxKey).(string)
+	return v
+}

--- a/internal/manager/biz/aiops/tools/execute_k8s_action.go
+++ b/internal/manager/biz/aiops/tools/execute_k8s_action.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudwego/eino/compose"
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
@@ -21,7 +22,7 @@ import (
 const ToolNameExecuteK8sAction = "execute_k8s_action"
 
 const ExecuteK8sActionDescription = "Execute a small, audited Kubernetes write through the cluster controller edge. " +
-	"MUTATING — calls trigger reviewer approval and require a successful dry-run preflight before dispatch."
+	"MUTATING — real writes require a successful dry-run preflight and kernel-specific approval before dispatch; the default legacy kernel always asks for human confirmation."
 
 var ExecuteK8sActionSchema = json.RawMessage(`{
   "type": "object",
@@ -114,7 +115,7 @@ var ExecuteK8sActionSchema = json.RawMessage(`{
 }`)
 
 const executeK8sActionWhenToUse = "Use ONLY when the user explicitly asks to mutate Kubernetes state: rollout restart a Deployment/StatefulSet/DaemonSet, " +
-	"scale a Deployment/StatefulSet, delete or evict one Pod, or cordon/uncordon/drain one Node. This tool is MUTATING and is approved by a reviewer before dispatch. " +
+	"scale a Deployment/StatefulSet, delete or evict one Pod, or cordon/uncordon/drain one Node. This tool is MUTATING: graph uses its ReviewGate and legacy asks the human operator to approve before dispatch. " +
 	"Always call it first with dry_run=true, then repeat the same action with the returned preflight_token and expected_resource_version; the manager rejects direct writes, changed parameters, stale versions, and reused tokens. " +
 	"For drain, keep ignore_daemonsets=true by default, set delete_emptydir_data or force only when the user explicitly accepts that risk, and avoid disable_eviction unless bypassing PDB is explicitly requested. " +
 	"Always prefer describe_k8s_resource first when the target or resourceVersion is unclear. " +
@@ -130,10 +131,18 @@ const (
 	maxK8sGracePeriodSeconds      = 3600
 )
 
+// K8sActionProposer queues a preflight-validated Kubernetes write for human
+// approval and returns the post-approval execution result. The legacy kernel
+// wires this seam because it does not have the graph kernel's ReviewGate.
+type K8sActionProposer interface {
+	ProposeAndAwait(ctx context.Context, args ExecuteK8sActionArgs, sessionID, toolCallID string, userID uint64) (string, error)
+}
+
 type ExecuteK8sActionTool struct {
-	caller Caller
-	reader K8sSnapshotReader
-	log    *slog.Logger
+	caller   Caller
+	reader   K8sSnapshotReader
+	proposer K8sActionProposer
+	log      *slog.Logger
 
 	preflightMu sync.Mutex
 	preflights  map[string]executeK8sActionPreflightGrant
@@ -147,12 +156,20 @@ type executeK8sActionPreflightGrant struct {
 }
 
 func NewExecuteK8sActionTool(caller Caller, reader K8sSnapshotReader, log *slog.Logger) *ExecuteK8sActionTool {
+	return NewExecuteK8sActionToolWithProposer(caller, reader, nil, log)
+}
+
+// NewExecuteK8sActionToolWithProposer builds the legacy-compatible variant.
+// A nil proposer preserves the graph-kernel path: ReviewGate authorizes the
+// call and InvokableRun dispatches directly after consuming its preflight.
+func NewExecuteK8sActionToolWithProposer(caller Caller, reader K8sSnapshotReader, proposer K8sActionProposer, log *slog.Logger) *ExecuteK8sActionTool {
 	if log == nil {
 		log = slog.Default()
 	}
 	return &ExecuteK8sActionTool{
 		caller:     caller,
 		reader:     reader,
+		proposer:   proposer,
 		log:        log,
 		preflights: make(map[string]executeK8sActionPreflightGrant),
 	}
@@ -218,9 +235,55 @@ func (t *ExecuteK8sActionTool) InvokableRun(ctx context.Context, argsJSON string
 		return "", err
 	}
 	if !req.DryRun {
+		if t.proposer != nil && !basetool.AgentWriteAllowedFromContext(ctx) {
+			return `{"status":"blocked","message":"Agent write actions are disabled; the Kubernetes action was not proposed or run."}`, nil
+		}
 		if err := t.consumePreflight(strings.TrimSpace(in.PreflightToken), req, caller.UserID, basetool.SessionIDFromContext(ctx)); err != nil {
 			return "", err
 		}
+		if t.proposer != nil {
+			toolCallID := compose.GetToolCallID(ctx)
+			if toolCallID == "" {
+				toolCallID = basetool.ToolCallIDFromContext(ctx)
+			}
+			result, err := t.proposer.ProposeAndAwait(ctx, in, basetool.SessionIDFromContext(ctx), toolCallID, caller.UserID)
+			if err != nil {
+				return "", fmt.Errorf("%s: propose: %w", ToolNameExecuteK8sAction, err)
+			}
+			return result, nil
+		}
+	}
+	return t.dispatch(ctx, req, caller.UserID, basetool.SessionIDFromContext(ctx))
+}
+
+// RunApproved dispatches the exact action payload stored in an approved inbox
+// row. InvokableRun already consumed and bound the one-time preflight token
+// before creating that row, so this method deliberately does not consume it a
+// second time. The expected_resource_version still gives the controller an
+// optimistic-lock guard if cluster state changed while approval was pending.
+func (t *ExecuteK8sActionTool) RunApproved(ctx context.Context, in ExecuteK8sActionArgs, userID uint64, sessionID string) (string, error) {
+	if userID == 0 || strings.TrimSpace(sessionID) == "" {
+		return "", fmt.Errorf("%s: approved action is missing proposer identity", ToolNameExecuteK8sAction)
+	}
+	if strings.TrimSpace(in.PreflightToken) == "" {
+		return "", fmt.Errorf("%s: approved action is missing preflight_token", ToolNameExecuteK8sAction)
+	}
+	req, err := normalizeExecuteK8sActionArgs(in)
+	if err != nil {
+		return "", err
+	}
+	if req.DryRun {
+		return "", fmt.Errorf("%s: approved action must not be a dry-run", ToolNameExecuteK8sAction)
+	}
+	return t.dispatch(ctx, req, userID, sessionID)
+}
+
+func (t *ExecuteK8sActionTool) dispatch(ctx context.Context, req tunnel.KubernetesActionRequest, userID uint64, sessionID string) (string, error) {
+	if t.caller == nil {
+		return "", fmt.Errorf("%s: tunnel caller not configured", ToolNameExecuteK8sAction)
+	}
+	if t.reader == nil {
+		return "", fmt.Errorf("%s: k8s snapshot reader not configured", ToolNameExecuteK8sAction)
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, executeK8sActionTimeout(req))
@@ -260,7 +323,7 @@ func (t *ExecuteK8sActionTool) InvokableRun(ctx context.Context, argsJSON string
 		approved := req
 		approved.DryRun = false
 		approved.ExpectedResourceVersion = strings.TrimSpace(resp.Preflight.ResourceVersion)
-		token, expiresAt, err := t.issuePreflight(approved, caller.UserID, basetool.SessionIDFromContext(ctx))
+		token, expiresAt, err := t.issuePreflight(approved, userID, sessionID)
 		if err != nil {
 			return "", err
 		}

--- a/internal/manager/biz/aiops/tools/execute_k8s_action_test.go
+++ b/internal/manager/biz/aiops/tools/execute_k8s_action_test.go
@@ -168,6 +168,103 @@ func TestExecuteK8sActionToolCallsControllerEdge(t *testing.T) {
 	}
 }
 
+type recordingK8sActionProposer struct {
+	calls      int
+	args       ExecuteK8sActionArgs
+	sessionID  string
+	toolCallID string
+	userID     uint64
+	result     string
+}
+
+func (p *recordingK8sActionProposer) ProposeAndAwait(_ context.Context, args ExecuteK8sActionArgs, sessionID, toolCallID string, userID uint64) (string, error) {
+	p.calls++
+	p.args = args
+	p.sessionID = sessionID
+	p.toolCallID = toolCallID
+	p.userID = userID
+	return p.result, nil
+}
+
+func TestExecuteK8sActionToolLegacyRequiresDryRunThenHumanApproval(t *testing.T) {
+	fc := &fakeCaller{respBody: mustMarshal(tunnel.KubernetesActionResponse{
+		ClusterID: 1, Action: "scale", Kind: "Deployment", APIVersion: "apps/v1",
+		Namespace: "default", Name: "api", DryRun: true,
+		Preflight: tunnel.KubernetesActionPreflight{
+			Kind: "Deployment", APIVersion: "apps/v1", Namespace: "default", Name: "api",
+			UID: "deploy-uid", ResourceVersion: "10", Exists: true,
+		},
+	})}
+	proposer := &recordingK8sActionProposer{result: `{"status":"executed","result":"approved"}`}
+	tool := NewExecuteK8sActionToolWithProposer(fc, newFakeK8sSnapshotReader(), proposer, slog.Default())
+	ctx := tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 7, Role: "admin"})
+	ctx = basetool.WithSessionID(ctx, "session-1")
+	ctx = basetool.WithToolCallID(ctx, "tool-row-1")
+
+	dryRunOut, err := tool.InvokableRun(ctx, `{"cluster_id":1,"action":"scale","kind":"Deployment","namespace":"default","name":"api","replicas":3,"dry_run":true,"reason":"capacity"}`)
+	if err != nil {
+		t.Fatalf("dry-run InvokableRun: %v", err)
+	}
+	var preflight executeK8sActionResponse
+	if err := json.Unmarshal([]byte(dryRunOut), &preflight); err != nil {
+		t.Fatalf("decode preflight: %v", err)
+	}
+	if preflight.PreflightToken == "" || preflight.ExpectedResourceVersion != "10" {
+		t.Fatalf("missing preflight grant: %+v", preflight)
+	}
+
+	replicas := 3
+	applyArgs := ExecuteK8sActionArgs{
+		ClusterID: 1, Action: "scale", Kind: "Deployment", Namespace: "default", Name: "api",
+		Replicas: &replicas, ExpectedResourceVersion: preflight.ExpectedResourceVersion,
+		PreflightToken: preflight.PreflightToken, Reason: "capacity",
+	}
+	applyBody := mustMarshal(applyArgs)
+
+	blocked, err := tool.InvokableRun(ctx, string(applyBody))
+	if err != nil {
+		t.Fatalf("write-disabled invocation: %v", err)
+	}
+	if !strings.Contains(blocked, `"status":"blocked"`) || proposer.calls != 0 || fc.calls != 1 {
+		t.Fatalf("write-disabled result=%s proposer.calls=%d controller.calls=%d", blocked, proposer.calls, fc.calls)
+	}
+
+	ctx = basetool.WithHostWriteAllowed(ctx, true)
+	result, err := tool.InvokableRun(ctx, string(applyBody))
+	if err != nil {
+		t.Fatalf("approval proposal: %v", err)
+	}
+	if result != proposer.result || proposer.calls != 1 {
+		t.Fatalf("proposal result=%s calls=%d", result, proposer.calls)
+	}
+	if proposer.sessionID != "session-1" || proposer.toolCallID != "tool-row-1" || proposer.userID != 7 {
+		t.Fatalf("proposal metadata: session=%q tool=%q user=%d", proposer.sessionID, proposer.toolCallID, proposer.userID)
+	}
+	if fc.calls != 1 {
+		t.Fatalf("write dispatched before approval: controller.calls=%d", fc.calls)
+	}
+	if _, err := tool.InvokableRun(ctx, string(applyBody)); err == nil || !strings.Contains(err.Error(), "already used") {
+		t.Fatalf("reused preflight error=%v", err)
+	}
+
+	fc.respBody = mustMarshal(tunnel.KubernetesActionResponse{
+		ClusterID: 1, Action: "scale", Kind: "Deployment", APIVersion: "apps/v1",
+		Namespace: "default", Name: "api", Applied: true,
+		Preflight: tunnel.KubernetesActionPreflight{
+			Kind: "Deployment", APIVersion: "apps/v1", Namespace: "default", Name: "api",
+			UID: "deploy-uid", ResourceVersion: "10", Exists: true,
+		},
+		ResultResourceVersion: "11",
+	})
+	approvedOut, err := tool.RunApproved(ctx, proposer.args, proposer.userID, proposer.sessionID)
+	if err != nil {
+		t.Fatalf("RunApproved: %v", err)
+	}
+	if !strings.Contains(approvedOut, `"applied":true`) || fc.calls != 2 {
+		t.Fatalf("approved output=%s controller.calls=%d", approvedOut, fc.calls)
+	}
+}
+
 func TestExecuteK8sActionToolRejectsWriteWithoutPreflight(t *testing.T) {
 	fc := &fakeCaller{}
 	tool := NewExecuteK8sActionTool(fc, newFakeK8sSnapshotReader(), slog.Default())
@@ -325,12 +422,16 @@ func TestNormalizeExecuteK8sActionRejectsDrainOptionBounds(t *testing.T) {
 	}
 }
 
-func TestExecuteK8sActionRegisteredOnlyAsBaseTool(t *testing.T) {
+func TestExecuteK8sActionRegisteredForLegacyOnlyWithApprovalProposer(t *testing.T) {
 	reg := NewRegistry(&fakeCaller{}, nil, nil, nil, nil, nil, nil, slog.Default())
 	reg.SetK8sSnapshotReader(newFakeK8sSnapshotReader())
 
 	if containsName(schemaNames(reg.Schemas()), ToolNameExecuteK8sAction) {
-		t.Fatalf("legacy closure registry should not expose mutating %q", ToolNameExecuteK8sAction)
+		t.Fatalf("legacy closure registry exposed %q without approval proposer", ToolNameExecuteK8sAction)
+	}
+	reg.SetK8sActionProposer(&recordingK8sActionProposer{})
+	if !containsName(schemaNames(reg.Schemas()), ToolNameExecuteK8sAction) {
+		t.Fatalf("legacy closure registry missing approval-protected %q", ToolNameExecuteK8sAction)
 	}
 	names := toolInfoNames(t, reg.BuildBaseTools().AllTools())
 	if !containsName(names, ToolNameExecuteK8sAction) {

--- a/internal/manager/biz/aiops/tools/registry.go
+++ b/internal/manager/biz/aiops/tools/registry.go
@@ -129,7 +129,9 @@ type Registry struct {
 
 	// k8sSnapshot feeds query_k8s_snapshot. It reads manager DB snapshots,
 	// not the live Kubernetes API.
-	k8sSnapshot K8sSnapshotReader
+	k8sSnapshot         K8sSnapshotReader
+	k8sActionProposer   K8sActionProposer
+	legacyK8sActionTool *ExecuteK8sActionTool
 
 	log   *slog.Logger
 	tools map[string]Tool
@@ -142,6 +144,15 @@ func (r *Registry) SetCloudBashProposer(p CloudBashProposer) { r.cloudBashPropos
 // SetHostBashProposer wires mutating host_bash commands to the approval inbox.
 func (r *Registry) SetHostBashProposer(p HostBashProposer) { r.hostBashProposer = p }
 
+// SetK8sActionProposer wires the default legacy kernel to the human approval
+// inbox. The tool is registered only when caller, snapshot reader, and
+// proposer are all available, so a partial boot never exposes an unfulfillable
+// or approval-bypassing Kubernetes write surface.
+func (r *Registry) SetK8sActionProposer(p K8sActionProposer) {
+	r.k8sActionProposer = p
+	r.registerLegacyK8sAction()
+}
+
 // SetIMSender wires send_im_message → channel store + notify router.
 func (r *Registry) SetIMSender(s IMSender) { r.imSender = s }
 
@@ -153,6 +164,7 @@ func (r *Registry) SetPageStore(p PageStore) { r.pageStore = p }
 // NewRegistry's already-heavy constructor.
 func (r *Registry) SetK8sSnapshotReader(k K8sSnapshotReader) {
 	r.k8sSnapshot = k
+	r.registerLegacyK8sAction()
 	if k != nil {
 		r.Register(Tool{
 			Name:        ToolNameQueryK8sSnapshot,
@@ -175,6 +187,38 @@ func (r *Registry) SetK8sSnapshotReader(k K8sSnapshotReader) {
 			})
 		}
 	}
+}
+
+func (r *Registry) registerLegacyK8sAction() {
+	delete(r.tools, ToolNameExecuteK8sAction)
+	r.legacyK8sActionTool = nil
+	if r.caller == nil || r.k8sSnapshot == nil || r.k8sActionProposer == nil {
+		return
+	}
+	tool := NewExecuteK8sActionToolWithProposer(r.caller, r.k8sSnapshot, r.k8sActionProposer, r.log)
+	r.legacyK8sActionTool = tool
+	r.Register(Tool{
+		Name:        ToolNameExecuteK8sAction,
+		Description: ExecuteK8sActionDescription,
+		Schema:      ExecuteK8sActionSchema,
+		Execute: func(ctx context.Context, args json.RawMessage) (ExecuteResult, error) {
+			out, err := tool.InvokableRun(ctx, string(args))
+			if err != nil {
+				return ExecuteResult{}, err
+			}
+			return ExecuteResult{ResultJSON: json.RawMessage(out)}, nil
+		},
+	})
+}
+
+// RunApprovedK8sAction executes an exact payload after the approval usecase
+// has recorded an admin decision. It deliberately reuses the same tool object
+// that issued and consumed the legacy preflight grant.
+func (r *Registry) RunApprovedK8sAction(ctx context.Context, args ExecuteK8sActionArgs, userID uint64, sessionID string) (string, error) {
+	if r.legacyK8sActionTool == nil {
+		return "", fmt.Errorf("%s: legacy approval executor is not configured", ToolNameExecuteK8sAction)
+	}
+	return r.legacyK8sActionTool.RunApproved(ctx, args, userID, sessionID)
 }
 
 // SetAuditLister wires the audit query seam consumed by

--- a/internal/manager/biz/approval/usecase.go
+++ b/internal/manager/biz/approval/usecase.go
@@ -23,6 +23,7 @@ type Repo interface {
 	Create(ctx context.Context, a *model.Approval) error
 	Get(ctx context.Context, id string) (*model.Approval, error)
 	List(ctx context.Context, status string, limit int) ([]*model.Approval, error)
+	ListKind(ctx context.Context, kind string, limit, offset int) ([]*model.Approval, error)
 	CountPending(ctx context.Context) (int64, error)
 	Decide(ctx context.Context, id string, fields map[string]any) error
 	SetResult(ctx context.Context, id, status, resultJSON string, executedAt time.Time) error
@@ -95,6 +96,9 @@ func (u *Usecase) Propose(ctx context.Context, in ProposeInput) (*model.Approval
 // List / Get / CountPending — inbox reads.
 func (u *Usecase) List(ctx context.Context, status string, limit int) ([]*model.Approval, error) {
 	return u.repo.List(ctx, status, limit)
+}
+func (u *Usecase) ListKind(ctx context.Context, kind string, limit, offset int) ([]*model.Approval, error) {
+	return u.repo.ListKind(ctx, kind, limit, offset)
 }
 func (u *Usecase) Get(ctx context.Context, id string) (*model.Approval, error) {
 	return u.repo.Get(ctx, id)

--- a/internal/manager/data/approval/store/repo.go
+++ b/internal/manager/data/approval/store/repo.go
@@ -51,6 +51,24 @@ func (r *Repo) List(ctx context.Context, status string, limit int) ([]*model.App
 	return out, nil
 }
 
+// ListKind returns one approval category newest first. Offset support lets
+// consumers build a bounded cross-source audit view without loading unrelated
+// approval payloads into memory.
+func (r *Repo) ListKind(ctx context.Context, kind string, limit, offset int) ([]*model.Approval, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	q := r.db.WithContext(ctx).Where("kind = ?", kind).Order("created_at DESC").Limit(limit)
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+	var out []*model.Approval
+	if err := q.Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CountPending returns the number of pending proposals (nav badge).
 func (r *Repo) CountPending(ctx context.Context) (int64, error) {
 	var n int64

--- a/internal/manager/server/k8s/http.go
+++ b/internal/manager/server/k8s/http.go
@@ -44,13 +44,50 @@ type Service interface {
 	RefreshTelemetryConfig(ctx context.Context, controllerEdgeID uint64, proof biz.TelemetryCredentialProof) (*biz.TelemetryConfig, error)
 }
 
+// ActionAuditRecord is the sanitized cross-kernel read model consumed by the
+// Kubernetes Actions page. ArgsJSON must not contain one-time credentials such
+// as execute_k8s_action.preflight_token.
+type ActionAuditRecord struct {
+	ID             string     `json:"id"`
+	ClusterID      uint64     `json:"cluster_id"`
+	SessionID      string     `json:"session_id,omitempty"`
+	MessageID      *string    `json:"message_id,omitempty"`
+	ToolCallID     *string    `json:"tool_call_id,omitempty"`
+	ToolName       string     `json:"tool_name"`
+	ArgsJSON       string     `json:"args_json"`
+	ToolClass      string     `json:"tool_class"`
+	ApprovalMode   string     `json:"approval_mode"`
+	ReviewerAgent  string     `json:"reviewer_agent,omitempty"`
+	ReviewerTaskID string     `json:"reviewer_task_id,omitempty"`
+	Decision       string     `json:"decision"`
+	Status         string     `json:"status"`
+	DecisionReason string     `json:"decision_reason,omitempty"`
+	OperatorUserID uint64     `json:"operator_user_id"`
+	ApproverUserID *uint64    `json:"approver_user_id,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	DecidedAt      *time.Time `json:"decided_at,omitempty"`
+	ExecutedAt     *time.Time `json:"executed_at,omitempty"`
+}
+
+// ActionAuditReader merges the graph ReviewGate and legacy human-approval
+// stores. The interface lives at the HTTP consumer boundary so the k8s domain
+// does not import either producer domain.
+type ActionAuditReader interface {
+	ListK8sActionAudits(ctx context.Context, clusterID uint64, limit, offset int) ([]ActionAuditRecord, int, error)
+}
+
 type Handler struct {
 	svc         Service
+	actionAudit ActionAuditReader
 	enrollSlots chan struct{}
 }
 
-func NewHandler(s Service) *Handler {
-	return &Handler{svc: s, enrollSlots: make(chan struct{}, 64)}
+func NewHandler(s Service, actionAudits ...ActionAuditReader) *Handler {
+	h := &Handler{svc: s, enrollSlots: make(chan struct{}, 64)}
+	if len(actionAudits) > 0 {
+		h.actionAudit = actionAudits[0]
+	}
+	return h
 }
 
 func (h *Handler) RegisterProtected(r chi.Router) {
@@ -63,8 +100,34 @@ func (h *Handler) RegisterProtected(r chi.Router) {
 	r.Get("/v1/k8s/clusters/{cluster_id}/workloads", h.listWorkloads)
 	r.Get("/v1/k8s/clusters/{cluster_id}/pods", h.listPods)
 	r.Get("/v1/k8s/clusters/{cluster_id}/events", h.listEvents)
+	r.With(h.requireAdmin).Get("/v1/k8s/clusters/{cluster_id}/actions", h.listActionAudits)
 	r.With(h.requireAdmin).Post("/v1/k8s/clusters/{cluster_id}/rotate-token", h.rotateToken)
 	r.With(h.requireAdmin).Delete("/v1/k8s/clusters/{cluster_id}", h.deleteCluster)
+}
+
+// @Summary List sanitized Kubernetes write-action audit records
+// @Router /api/v1/k8s/clusters/{cluster_id}/actions [get]
+// @Success 200 {object} listActionAuditsResponse
+func (h *Handler) listActionAudits(w http.ResponseWriter, r *http.Request) {
+	if h.actionAudit == nil {
+		writeErr(w, errors.Join(errs.ErrNotWiredYet, errors.New("kubernetes action audit is not configured")))
+		return
+	}
+	clusterID, err := parseClusterID(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	limit := parseListLimit(r.URL.Query().Get("limit"), 100)
+	offset := parseListOffset(r.URL.Query().Get("offset"))
+	items, total, err := h.actionAudit.ListK8sActionAudits(r.Context(), clusterID, limit, offset)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, listActionAuditsResponse{
+		Items: items, Total: total, Limit: limit, Offset: offset,
+	})
 }
 
 // @Summary List Kubernetes-managed Edge attachments
@@ -642,6 +705,13 @@ type edgeAttachmentDTO struct {
 type listEdgeAttachmentsResponse struct {
 	Items []edgeAttachmentDTO `json:"items"`
 	Total int                 `json:"total"`
+}
+
+type listActionAuditsResponse struct {
+	Items  []ActionAuditRecord `json:"items"`
+	Total  int                 `json:"total"`
+	Limit  int                 `json:"limit"`
+	Offset int                 `json:"offset"`
 }
 
 type nodeDTO struct {

--- a/internal/manager/server/k8s/http_test.go
+++ b/internal/manager/server/k8s/http_test.go
@@ -29,6 +29,22 @@ type workloadPageService struct {
 	countFilters []biz.ListWorkloadsFilter
 }
 
+type actionAuditReader struct {
+	clusterID uint64
+	limit     int
+	offset    int
+	items     []ActionAuditRecord
+	total     int
+	err       error
+}
+
+func (r *actionAuditReader) ListK8sActionAudits(_ context.Context, clusterID uint64, limit, offset int) ([]ActionAuditRecord, int, error) {
+	r.clusterID = clusterID
+	r.limit = limit
+	r.offset = offset
+	return r.items, r.total, r.err
+}
+
 func (s *workloadPageService) ListWorkloads(_ context.Context, f biz.ListWorkloadsFilter) ([]*model.Workload, error) {
 	s.listFilter = f
 	createdAt := time.Date(2026, time.July, 28, 8, 9, 10, 0, time.UTC)
@@ -113,6 +129,44 @@ func TestRefreshTelemetryConfigUsesAuthenticatedControllerIdentity(t *testing.T)
 		got.TracesBasicUser != "tempo-user" || got.TracesBasicPass != "tempo-pass" || !got.TracesTLSInsecure ||
 		got.LogsEndpoint != "https://loki.example/loki/api/v1/push" || got.LogsAuthMode != "backend" {
 		t.Fatalf("signal target response = %#v", got)
+	}
+}
+
+func TestListActionAuditsReturnsClusterScopedUnifiedRecords(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 8, 21, 22, 0, time.UTC)
+	reader := &actionAuditReader{
+		items: []ActionAuditRecord{{
+			ID: "approval-1", ClusterID: 48, SessionID: "session-1",
+			ToolName: "execute_k8s_action", ArgsJSON: `{"cluster_id":48,"action":"scale"}`,
+			ToolClass: "write", ApprovalMode: "human", Decision: "approve", Status: "executed",
+			OperatorUserID: 7, CreatedAt: now, ExecutedAt: &now,
+		}},
+		total: 3,
+	}
+	h := NewHandler(&telemetryRefreshService{}, reader)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/k8s/clusters/48/actions?limit=8&offset=1", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("cluster_id", "48")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	resp := httptest.NewRecorder()
+
+	h.listActionAudits(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	if reader.clusterID != 48 || reader.limit != 8 || reader.offset != 1 {
+		t.Fatalf("reader args = cluster:%d limit:%d offset:%d", reader.clusterID, reader.limit, reader.offset)
+	}
+	var got listActionAuditsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Total != 3 || got.Limit != 8 || got.Offset != 1 || len(got.Items) != 1 {
+		t.Fatalf("response = %+v", got)
+	}
+	if got.Items[0].ApprovalMode != "human" || got.Items[0].Status != "executed" {
+		t.Fatalf("record = %+v", got.Items[0])
 	}
 }
 

--- a/web/src/api/kubernetes.ts
+++ b/web/src/api/kubernetes.ts
@@ -121,6 +121,30 @@ export type KubernetesEvent = {
   last_seen_at?: string | null;
 };
 
+export type KubernetesActionAuditStatus = 'pending' | 'approved' | 'rejected' | 'executed' | 'failed' | string;
+
+export type KubernetesActionAudit = {
+  id: string;
+  cluster_id: number;
+  session_id?: string;
+  message_id?: string;
+  tool_call_id?: string;
+  tool_name: string;
+  args_json: string;
+  tool_class: string;
+  approval_mode: 'review_gate' | 'human' | string;
+  reviewer_agent?: string;
+  reviewer_task_id?: string;
+  decision: 'pending' | 'approve' | 'reject' | string;
+  status: KubernetesActionAuditStatus;
+  decision_reason?: string;
+  operator_user_id: number;
+  approver_user_id?: number;
+  created_at: string;
+  decided_at?: string;
+  executed_at?: string;
+};
+
 export type KubernetesRegistration = {
   cluster: KubernetesCluster;
   bootstrap_token: string;
@@ -259,6 +283,17 @@ export function listKubernetesEvents(
   return request<ListResponse<KubernetesEvent>>(
     'GET',
     `/k8s/clusters/${encodeURIComponent(String(clusterID))}/events${qs}`,
+  );
+}
+
+export function listKubernetesActionAudits(
+  clusterID: string | number,
+  params?: { limit?: number; offset?: number },
+) {
+  const qs = buildQuery(params);
+  return request<ListResponse<KubernetesActionAudit>>(
+    'GET',
+    `/k8s/clusters/${encodeURIComponent(String(clusterID))}/actions${qs}`,
   );
 }
 

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -227,11 +227,7 @@ describe('KubernetesPage', () => {
           offset: 0,
         });
       }),
-      http.get('/api/v1/aiops/mutating-proposals', ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get('tool_name') !== 'execute_k8s_action') {
-          return HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 });
-        }
+      http.get('/api/v1/k8s/clusters/:id/actions', () => {
         return HttpResponse.json({
           items: [
             {
@@ -249,9 +245,11 @@ describe('KubernetesPage', () => {
                 reason: '修复异常 Pod',
               }),
               tool_class: 'write',
+              approval_mode: 'review_gate',
               reviewer_agent: 'reviewer',
               reviewer_task_id: 'agent-1',
               decision: 'approve',
+              status: 'executed',
               decision_reason: '目标资源清晰，风险可控',
               operator_user_id: 7,
               created_at: '2026-06-29T10:02:00Z',
@@ -259,23 +257,26 @@ describe('KubernetesPage', () => {
               executed_at: '2026-06-29T10:03:10Z',
             },
             {
-              id: 'proposal-2',
+              id: 'approval-1',
               session_id: 'session-k8s-2',
               tool_name: 'execute_k8s_action',
               args_json: JSON.stringify({
-                cluster_id: 2,
+                cluster_id: 1,
                 action: 'scale',
                 kind: 'Deployment',
                 namespace: 'default',
-                name: 'other',
+                name: 'worker',
                 replicas: 2,
               }),
               tool_class: 'write',
-              reviewer_agent: 'reviewer',
-              reviewer_task_id: 'agent-2',
-              decision: 'pending',
+              approval_mode: 'human',
+              decision: 'approve',
+              status: 'executed',
               operator_user_id: 7,
-              created_at: '2026-06-29T10:02:00Z',
+              approver_user_id: 1,
+              created_at: '2026-06-29T10:04:00Z',
+              decided_at: '2026-06-29T10:04:10Z',
+              executed_at: '2026-06-29T10:04:12Z',
             },
           ],
           total: 2,
@@ -1690,7 +1691,7 @@ describe('KubernetesPage', () => {
       http.get('/api/v1/k8s/clusters/:id/workloads', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
       http.get('/api/v1/k8s/clusters/:id/pods', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
       http.get('/api/v1/k8s/clusters/:id/events', () => HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })),
-      http.get('/api/v1/aiops/mutating-proposals', () => HttpResponse.json({ items: [], total: 0 })),
+      http.get('/api/v1/k8s/clusters/:id/actions', () => HttpResponse.json({ items: [], total: 0 })),
     );
 
     renderKubernetesDetail('/kubernetes/99');
@@ -1863,29 +1864,26 @@ describe('KubernetesPage', () => {
     expect(await screen.findByText('K8S 写动作审计')).toBeInTheDocument();
     expect(screen.getByText('rollout_restart · default · Deployment/api')).toBeInTheDocument();
     expect(screen.getAllByText('已执行').length).toBeGreaterThan(0);
-    expect(screen.getByText('请求已记录')).toBeInTheDocument();
-    expect(screen.getByText('Dry run 要求')).toBeInTheDocument();
-    expect(screen.getByText('审批通过')).toBeInTheDocument();
-    expect(screen.getByText('执行完成')).toBeInTheDocument();
+    expect(screen.getAllByText('请求已记录').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Dry run 已验证').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('审批通过').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('执行完成').length).toBeGreaterThan(0);
     expect(screen.getByText(/回滚到上一 revision/)).toBeInTheDocument();
     expect(screen.getAllByText(/请求/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/审批/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/工具已返回/)).toBeInTheDocument();
+    expect(screen.getAllByText(/工具已返回/).length).toBeGreaterThan(0);
     expect(screen.getByText('会话 session-k8s-1')).toBeInTheDocument();
     expect(screen.getByText('消息 message-k8')).toBeInTheDocument();
     expect(screen.getByText('调用 call-k8s-1')).toBeInTheDocument();
     expect(screen.getByText('agent-1')).toBeInTheDocument();
+    expect(screen.getByText('人工审批')).toBeInTheDocument();
     expect(screen.getByText('目标资源清晰，风险可控')).toBeInTheDocument();
-    expect(screen.queryByText('scale · default · Deployment/other → 2')).not.toBeInTheDocument();
+    expect(screen.getByText('scale · default · Deployment/worker → 2')).toBeInTheDocument();
   });
 
   it('Actions 资源支持按审批状态和动作类型筛选', async () => {
     server.use(
-      http.get('/api/v1/aiops/mutating-proposals', ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get('tool_name') !== 'execute_k8s_action') {
-          return HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 });
-        }
+      http.get('/api/v1/k8s/clusters/:id/actions', () => {
         return HttpResponse.json({
           items: [
             {
@@ -1900,8 +1898,10 @@ describe('KubernetesPage', () => {
                 name: 'api',
               }),
               tool_class: 'write',
+              approval_mode: 'review_gate',
               reviewer_agent: 'reviewer',
               decision: 'approve',
+              status: 'executed',
               decision_reason: '已完成 rollout restart',
               operator_user_id: 7,
               created_at: '2026-06-29T10:02:00Z',
@@ -1920,8 +1920,9 @@ describe('KubernetesPage', () => {
                 name: 'api-crash-abc',
               }),
               tool_class: 'write',
-              reviewer_agent: 'reviewer',
+              approval_mode: 'human',
               decision: 'pending',
+              status: 'pending',
               operator_user_id: 7,
               created_at: '2026-06-29T10:04:00Z',
             },
@@ -1938,8 +1939,10 @@ describe('KubernetesPage', () => {
                 replicas: 2,
               }),
               tool_class: 'write',
+              approval_mode: 'review_gate',
               reviewer_agent: 'reviewer',
               decision: 'reject',
+              status: 'rejected',
               decision_reason: '副本风险未确认',
               operator_user_id: 7,
               created_at: '2026-06-29T10:05:00Z',

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -30,10 +30,6 @@ import { Modal } from '@/components/Modal';
 import { Button, Card, Chip, EmptyState, PageHeader } from '@/components/ui';
 import type { IconType } from '@/lib/icon';
 import { ApiError } from '@/api/client';
-import {
-  listMutatingProposals,
-  type MutatingProposal,
-} from '@/api/aiops';
 import { createSession } from '@/api/chat';
 import {
   listEdges,
@@ -44,6 +40,7 @@ import {
   deleteKubernetesCluster,
   getKubernetesCluster,
   getKubernetesClusterHealth,
+  listKubernetesActionAudits,
   listKubernetesClusters,
   listKubernetesEvents,
   listKubernetesNodes,
@@ -52,6 +49,7 @@ import {
   rotateKubernetesBootstrapToken,
   type KubernetesCluster,
   type KubernetesClusterHealth,
+  type KubernetesActionAudit,
   type KubernetesEvent,
   type KubernetesNode,
   type KubernetesPod,
@@ -354,7 +352,7 @@ export function KubernetesClusterDetailPage() {
   const [warningEvents, setWarningEvents] = useState<KubernetesEvent[]>([]);
   const [warningEventTotal, setWarningEventTotal] = useState(0);
   const [edgeVersionsByID, setEdgeVersionsByID] = useState<Record<number, string>>({});
-  const [actionProposals, setActionProposals] = useState<MutatingProposal[]>([]);
+  const [actionProposals, setActionProposals] = useState<KubernetesActionAudit[]>([]);
   const [actionProposalTotal, setActionProposalTotal] = useState(0);
   const [actionAuditError, setActionAuditError] = useState<string | null>(null);
   const [totals, setTotals] = useState<ResourceTotals>({ nodes: 0, workloads: 0, pods: 0, events: 0 });
@@ -388,7 +386,7 @@ export function KubernetesClusterDetailPage() {
     try {
       let auditLoadError: unknown = null;
       const auditPromise = isAdmin
-        ? listMutatingProposals({ tool_name: 'execute_k8s_action', limit: 100 }).catch((e) => {
+        ? listKubernetesActionAudits(clusterId, { limit: 100 }).catch((e) => {
             auditLoadError = e;
             return null;
           })
@@ -457,10 +455,8 @@ export function KubernetesClusterDetailPage() {
       setCrashLoopTotal(crashLoopPodsOut.total ?? (crashLoopPodsOut.items?.length ?? 0));
       setResourceFilterRefreshNonce((value) => value + 1);
       if (auditOut) {
-        const clusterIDNum = Number(clusterId);
-        const clusterItems = (auditOut.items ?? []).filter((item) => proposalClusterID(item) === clusterIDNum);
-        setActionProposals(clusterItems.slice(0, 8));
-        setActionProposalTotal(clusterItems.length);
+        setActionProposals((auditOut.items ?? []).slice(0, 8));
+        setActionProposalTotal(auditOut.total ?? (auditOut.items?.length ?? 0));
         setActionAuditError(null);
       } else {
         setActionProposals([]);
@@ -2263,7 +2259,7 @@ function K8sActionAudit({
   onClearFilters,
   embedded,
 }: {
-  proposals: MutatingProposal[];
+  proposals: KubernetesActionAudit[];
   total: number;
   loading: boolean;
   error: string | null;
@@ -2289,7 +2285,7 @@ function K8sActionAudit({
             </div>
           </div>
         </div>
-        <Chip tone={hasRows ? 'info' : 'default'}>{tr('ReviewGate', 'ReviewGate')}</Chip>
+        <Chip tone={hasRows ? 'info' : 'default'}>{tr('统一审计', 'Unified audit')}</Chip>
       </div>
       {error ? (
         <div className="px-4 py-3 text-xs text-amber-300">
@@ -2318,7 +2314,8 @@ function K8sActionAudit({
                 <div className="min-w-0 text-xs">
                   <div className="flex flex-wrap items-center gap-1.5">
                     <ProposalDecisionChip proposal={proposal} />
-                    <Chip dense>{proposal.reviewer_agent || 'reviewer'}</Chip>
+                    <Chip dense>{k8sActionApprovalModeLabel(proposal.approval_mode, tr)}</Chip>
+                    {proposal.reviewer_agent && <Chip dense>{proposal.reviewer_agent}</Chip>}
                     {proposal.reviewer_task_id && <Chip dense>{shortID(proposal.reviewer_task_id, 12)}</Chip>}
                   </div>
                   <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-zinc-500">
@@ -2343,7 +2340,7 @@ function K8sActionAudit({
                     {args.reason && <Chip tone="info" dense>{args.reason}</Chip>}
                   </div>
                   <div className="mt-1 truncate text-zinc-400">
-                    {proposal.decision_reason || tr('暂无 reviewer 说明', 'No reviewer note')}
+                    {proposal.decision_reason || tr('暂无审批说明', 'No approval note')}
                   </div>
                 </div>
                 <K8sActionAuditTrail proposal={proposal} args={args} />
@@ -2383,12 +2380,15 @@ function K8sActionAudit({
   );
 }
 
-function ProposalDecisionChip({ proposal }: { proposal: MutatingProposal }) {
+function ProposalDecisionChip({ proposal }: { proposal: KubernetesActionAudit }) {
   const { tr } = useI18n();
-  if (proposal.decision === 'approve' && proposal.executed_at) {
+  if (proposal.status === 'failed') {
+    return <Chip tone="danger">{tr('执行失败', 'Failed')}</Chip>;
+  }
+  if (proposal.status === 'executed' || (proposal.decision === 'approve' && proposal.executed_at)) {
     return <Chip tone="success">{tr('已执行', 'Executed')}</Chip>;
   }
-  if (proposal.decision === 'approve') {
+  if (proposal.status === 'approved' || proposal.decision === 'approve') {
     return <Chip tone="success">{tr('已批准', 'Approved')}</Chip>;
   }
   if (proposal.decision === 'reject') {
@@ -2397,8 +2397,15 @@ function ProposalDecisionChip({ proposal }: { proposal: MutatingProposal }) {
   return <Chip tone="warning">{tr('待审批', 'Pending')}</Chip>;
 }
 
-function proposalExecutionText(proposal: MutatingProposal, tr: (zh: string, en: string) => string) {
-  if (proposal.executed_at) return tr(`工具已返回 ${relativeTime(proposal.executed_at)}`, `tool returned ${relativeTime(proposal.executed_at)}`);
+function proposalExecutionText(proposal: KubernetesActionAudit, tr: (zh: string, en: string) => string) {
+  if (proposal.status === 'failed') return proposal.executed_at
+    ? tr(`执行失败 ${relativeTime(proposal.executed_at)}`, `failed ${relativeTime(proposal.executed_at)}`)
+    : tr('执行失败', 'execution failed');
+  if (proposal.status === 'executed' || proposal.executed_at) {
+    return proposal.executed_at
+      ? tr(`工具已返回 ${relativeTime(proposal.executed_at)}`, `tool returned ${relativeTime(proposal.executed_at)}`)
+      : tr('已执行', 'executed');
+  }
   if (proposal.decision === 'reject') return tr('已拒绝，未执行', 'rejected, not executed');
   if (proposal.decision === 'approve') return tr('已批准，等待执行结果', 'approved, awaiting execution result');
   return tr('未执行', 'not executed');
@@ -2411,7 +2418,7 @@ type K8sActionAuditStep = {
   tone: 'success' | 'warning' | 'danger' | 'default';
 };
 
-function K8sActionAuditTrail({ proposal, args }: { proposal: MutatingProposal; args: K8sActionArgs }) {
+function K8sActionAuditTrail({ proposal, args }: { proposal: KubernetesActionAudit; args: K8sActionArgs }) {
   const { tr } = useI18n();
   const steps = k8sActionAuditSteps(proposal, args, tr);
   return (
@@ -2447,10 +2454,11 @@ function K8sActionAuditTrail({ proposal, args }: { proposal: MutatingProposal; a
 }
 
 function k8sActionAuditSteps(
-  proposal: MutatingProposal,
+  proposal: KubernetesActionAudit,
   args: K8sActionArgs,
   tr: (zh: string, en: string) => string,
 ): K8sActionAuditStep[] {
+  const preflightVerified = Boolean(args.dry_run || proposal.approval_mode === 'human' || proposal.executed_at);
   return [
     {
       key: 'request',
@@ -2460,9 +2468,17 @@ function k8sActionAuditSteps(
     },
     {
       key: 'dry-run',
-      label: args.dry_run ? tr('Dry run 已记录', 'Dry run recorded') : tr('Dry run 要求', 'Dry run required'),
-      detail: args.dry_run ? tr('当前记录为 dry-run', 'This record is a dry-run') : tr('执行前必须先完成', 'Must complete before execution'),
-      tone: args.dry_run ? 'success' : 'default',
+      label: args.dry_run
+        ? tr('Dry run 已记录', 'Dry run recorded')
+        : preflightVerified
+          ? tr('Dry run 已验证', 'Dry run verified')
+          : tr('Dry run 要求', 'Dry run required'),
+      detail: args.dry_run
+        ? tr('当前记录为 dry-run', 'This record is a dry-run')
+        : preflightVerified
+          ? tr('写入前预检已通过', 'Preflight passed before the write')
+          : tr('执行前必须先完成', 'Must complete before execution'),
+      tone: preflightVerified ? 'success' : 'default',
     },
     {
       key: 'approval',
@@ -2471,25 +2487,29 @@ function k8sActionAuditSteps(
         : proposal.decision === 'reject'
           ? tr('审批拒绝', 'Rejected')
           : tr('等待审批', 'Awaiting approval'),
-      detail: proposal.decided_at ? relativeTime(proposal.decided_at) : tr('ReviewGate 未决策', 'ReviewGate pending'),
+      detail: proposal.decided_at
+        ? relativeTime(proposal.decided_at)
+        : tr(`${k8sActionApprovalModeLabel(proposal.approval_mode, tr)}未决策`, `${k8sActionApprovalModeLabel(proposal.approval_mode, tr)} pending`),
       tone: proposal.decision === 'approve' ? 'success' : proposal.decision === 'reject' ? 'danger' : 'warning',
     },
     {
       key: 'execution',
-      label: proposal.executed_at
+      label: proposal.status === 'failed'
+        ? tr('执行失败', 'Execution failed')
+        : proposal.executed_at
         ? tr('执行完成', 'Executed')
         : proposal.decision === 'approve'
           ? tr('等待执行结果', 'Awaiting result')
           : tr('未执行', 'Not executed'),
       detail: proposal.executed_at ? relativeTime(proposal.executed_at) : proposalExecutionText(proposal, tr),
-      tone: proposal.executed_at ? 'success' : proposal.decision === 'approve' ? 'warning' : 'default',
+      tone: proposal.status === 'failed' ? 'danger' : proposal.executed_at ? 'success' : proposal.decision === 'approve' ? 'warning' : 'default',
     },
   ];
 }
 
 function k8sActionRollbackHint(
   args: K8sActionArgs,
-  proposal: MutatingProposal,
+  proposal: KubernetesActionAudit,
   tr: (zh: string, en: string) => string,
 ) {
   if (proposal.decision === 'reject') {
@@ -2519,6 +2539,10 @@ function shortID(value: string | undefined, max = 8) {
   return value.length <= max ? value : value.slice(0, max);
 }
 
+function k8sActionApprovalModeLabel(mode: string | undefined, tr: (zh: string, en: string) => string) {
+  return mode === 'human' ? tr('人工审批', 'Human approval') : tr('ReviewGate', 'ReviewGate');
+}
+
 type K8sActionArgs = {
   cluster_id?: number | string;
   action?: string;
@@ -2537,16 +2561,6 @@ function parseK8sActionArgs(argsJSON: string): K8sActionArgs {
   } catch {
     return {};
   }
-}
-
-function proposalClusterID(proposal: MutatingProposal): number | null {
-  const raw = parseK8sActionArgs(proposal.args_json).cluster_id;
-  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
-  if (typeof raw === 'string') {
-    const n = Number(raw);
-    return Number.isFinite(n) ? n : null;
-  }
-  return null;
 }
 
 function k8sActionTitle(args: K8sActionArgs, tr: (zh: string, en: string) => string): string {
@@ -2625,9 +2639,9 @@ type ResourceFilters = {
   actionType: string;
 };
 
-type ActionDecisionFilter = 'all' | 'pending' | 'approved' | 'executed' | 'rejected';
+type ActionDecisionFilter = 'all' | 'pending' | 'approved' | 'executed' | 'failed' | 'rejected';
 
-const ACTION_DECISION_FILTERS: ActionDecisionFilter[] = ['all', 'pending', 'approved', 'executed', 'rejected'];
+const ACTION_DECISION_FILTERS: ActionDecisionFilter[] = ['all', 'pending', 'approved', 'executed', 'failed', 'rejected'];
 
 type ServerFilteredResources = {
   requestKey: string;
@@ -2662,7 +2676,7 @@ function ResourceViewHeader({
   warningEventTotal: number;
   namespaces: string[];
   namespaceRows: NamespaceRow[];
-  actionProposals: MutatingProposal[];
+  actionProposals: KubernetesActionAudit[];
   actionProposalTotal: number;
   edgeAccess: { linked: number; total: number; pct: number } | null;
   onOpenTab(tab: DetailTab): void;
@@ -2673,7 +2687,7 @@ function ResourceViewHeader({
   const nodeIssues = issueTotals.nodes;
   const missingEdgeNodes = edgeAccess ? edgeAccess.total - edgeAccess.linked : 0;
   const namespaceWarnings = namespaceRows.filter((row) => row.warnings > 0).length;
-  const pendingActions = actionProposals.filter((item) => (item.decision || '').toLowerCase() === 'pending').length;
+  const pendingActions = actionProposals.filter((item) => actionDecisionValue(item) === 'pending').length;
   const context = resourceViewContext({
     activeTab,
     totals,
@@ -4096,7 +4110,7 @@ function detailTabLoadedCount(
   pods: KubernetesPod[],
   events: KubernetesEvent[],
   namespaceRows: NamespaceRow[],
-  actionProposals: MutatingProposal[],
+  actionProposals: KubernetesActionAudit[],
 ) {
   switch (tab) {
     case 'nodes':
@@ -4223,7 +4237,7 @@ function filterNamespaceRows(items: NamespaceRow[], filters: ResourceFilters) {
   });
 }
 
-function filterActionProposals(items: MutatingProposal[], filters: ResourceFilters) {
+function filterActionProposals(items: KubernetesActionAudit[], filters: ResourceFilters) {
   const query = normalizeFilterQuery(filters.query);
   return items.filter((item) => {
     const args = parseK8sActionArgs(item.args_json);
@@ -4231,11 +4245,11 @@ function filterActionProposals(items: MutatingProposal[], filters: ResourceFilte
     if (filters.actionDecision !== 'all' && actionDecisionValue(item) !== filters.actionDecision) return false;
     if (filters.actionType !== 'all' && action !== filters.actionType) return false;
     if (!matchesNamespaceFilter(args.namespace, filters.namespace)) return false;
-    return matchesQuery(query, item.tool_name, item.tool_class, item.decision, item.decision_reason, item.reviewer_agent, action, k8sActionTitle(args, (zh) => zh), item.args_json);
+    return matchesQuery(query, item.tool_name, item.tool_class, item.decision, item.status, item.approval_mode, item.decision_reason, item.reviewer_agent, action, k8sActionTitle(args, (zh) => zh), item.args_json);
   });
 }
 
-function collectActionTypes(items: MutatingProposal[]) {
+function collectActionTypes(items: KubernetesActionAudit[]) {
   return Array.from(
     new Set(items.map((item) => normalizeActionType(parseK8sActionArgs(item.args_json).action)).filter(Boolean)),
   ).sort((a, b) => a.localeCompare(b));
@@ -4245,8 +4259,9 @@ function normalizeActionType(action?: string) {
   return (action || '').trim();
 }
 
-function actionDecisionValue(proposal: MutatingProposal): ActionDecisionFilter {
-  if (proposal.decision === 'approve' && proposal.executed_at) return 'executed';
+function actionDecisionValue(proposal: KubernetesActionAudit): ActionDecisionFilter {
+  if (proposal.status === 'failed') return 'failed';
+  if (proposal.status === 'executed' || (proposal.decision === 'approve' && proposal.executed_at)) return 'executed';
   if (proposal.decision === 'approve') return 'approved';
   if (proposal.decision === 'reject') return 'rejected';
   return 'pending';
@@ -4260,6 +4275,8 @@ function actionDecisionFilterLabel(value: ActionDecisionFilter, tr: (zh: string,
       return tr('已批准', 'Approved');
     case 'executed':
       return tr('已执行', 'Executed');
+    case 'failed':
+      return tr('执行失败', 'Failed');
     case 'rejected':
       return tr('已拒绝', 'Rejected');
     default:


### PR DESCRIPTION
## Summary

- expose `execute_k8s_action` to the default legacy agent kernel only for admin/superuser sessions when Agent write actions are enabled
- require a matching dry-run preflight before creating a human approval, consume the one-time preflight grant, and re-check the live write gate before approved execution
- stream the approval card through the existing chat flow and keep the graph-kernel ReviewGate path unchanged
- add a cluster-scoped, admin-only Kubernetes action audit API that merges ReviewGate proposals with legacy human approvals and redacts preflight tokens
- update the Kubernetes Actions UI to show unified approval modes, execution failures, and recent action history

## Why

The legacy kernel previously exposed only read-only Kubernetes tools, so it incorrectly told operators that no Kubernetes write channel was available. Legacy approvals were also stored separately from ReviewGate proposals, which meant recent approved actions were missing from the Kubernetes Actions page.

## Safety and compatibility

- real writes still require admin privileges, the global Agent write setting, dry-run preflight, exact action matching, optimistic resource-version checks, and explicit human approval
- the write setting is checked again when an approval is executed
- graph-kernel behavior remains protected by ReviewGate
- one-time preflight tokens are removed from the unified audit response
- the new audit endpoint is additive and admin-only

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `npm test -- --run src/pages/Kubernetes.test.tsx` (34 tests)
- `npm run build`
- `git diff --check`
- local dark/light UI validation and live cluster audit verification

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
