### PR TITLE
feat(network): enable discovery by default

### DIFF
--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -210,7 +210,7 @@ func main() {
 	}
 	agent := edgebiz.NewAgent(client, collector, edgebiz.Config{
 		MetricsInterval:          cfg.Edge.CollectorInterval,
-		NetworkDiscoveryEnabled:  parseBoolEnv("ONGRID_NETWORK_DISCOVERY_ENABLED", false),
+		NetworkDiscoveryEnabled:  parseBoolEnv("ONGRID_NETWORK_DISCOVERY_ENABLED", true),
 		NetworkDiscoveryInterval: parseDurationEnv("ONGRID_NETWORK_DISCOVERY_INTERVAL", time.Minute),
 		AgentVersion:             version,
 		Kubernetes:               k8sInfo,

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -745,6 +745,7 @@ func main() {
 	deviceUC := managerbizdevice.NewUsecase(deviceRepo, edgeDeviceRepo, log)
 	networkDiscoveryRepo := managerdevicedata.NewNetworkDiscoveryRepo(db)
 	networkDiscoveryUC := managerbizdevice.NewNetworkDiscoveryUsecase(networkDiscoveryRepo)
+	networkDiscoveryUC.SetEnabledProvider(settingSvc.NetworkDiscoveryEnabled)
 	networkDiscoveryUC.SetPromotionDependencies(networkDiscoveryRepo, deviceRepo, edgeDeviceRepo)
 	deviceUC.SetNetworkDiscovery(networkDiscoveryUC)
 	edgeUC := managerbizedge.NewUsecase(edgeRepo, deviceRepo, edgeDeviceRepo, log)

--- a/deploy/install/edge/ongrid-edge.env.example
+++ b/deploy/install/edge/ongrid-edge.env.example
@@ -12,9 +12,9 @@ ONGRID_EDGE_SCRAPE_CONFIG_FILE=/etc/ongrid-edge/scrape.yaml
 ONGRID_EDGE_COLLECTOR_INTERVAL=10s
 
 # ---- Passive network discovery --------------------------------------
-# Off by default. Enable to report local gateway, ARP, and LLDP neighbors as
-# candidates for operator-controlled SNMP verification in the manager.
-ONGRID_NETWORK_DISCOVERY_ENABLED=false
+# Enabled by default. Set false to stop reporting local gateway, ARP, and
+# LLDP neighbors as candidates for operator-controlled SNMP verification.
+ONGRID_NETWORK_DISCOVERY_ENABLED=true
 ONGRID_NETWORK_DISCOVERY_INTERVAL=1m
 
 # ---- Plugin runtime (ADR-015) ----------------------------------------

--- a/docs/requirements/PRD-002-network-device-discovery.md
+++ b/docs/requirements/PRD-002-network-device-discovery.md
@@ -26,7 +26,7 @@
 
 ### 第一阶段
 
-- Edge 配置提供 `network_discovery.enabled` 开关，默认关闭。
+- Edge 配置提供 `network_discovery.enabled` 开关，默认开启；管理员可在 Edge 环境文件中显式关闭。
 - 默认发现默认网关、ARP/Neighbor、LLDP 邻居；不做 CIDR 全网扫描。
 - SNMP 使用管理员配置的只读凭据，仅查询 sysName、sysDescr 和 sysObjectID；一期凭据仅在单次扫描内存中使用，不落库、不回显，接口和 LLDP MIB enrichment 后续补齐。
 - SNMP 校验同时读取 IF-MIB 接口状态与 IPv4 地址归属；SNMPv3 支持 SHA-1/SHA-2 认证及 AES-128/192/256 隐私协议，配置项使用受控选项而非任意字符串。

--- a/docs/requirements/PRD-002-network-device-discovery.md
+++ b/docs/requirements/PRD-002-network-device-discovery.md
@@ -26,7 +26,7 @@
 
 ### 第一阶段
 
-- Edge 配置提供 `network_discovery.enabled` 开关，默认开启；管理员可在 Edge 环境文件中显式关闭。
+- 平台全局配置提供网络发现开关，默认开启；关闭后 Manager 忽略新的候选上报。Edge 环境文件仍可对单台主机显式关闭本地采集。
 - 默认发现默认网关、ARP/Neighbor、LLDP 邻居；不做 CIDR 全网扫描。
 - SNMP 使用管理员配置的只读凭据，仅查询 sysName、sysDescr 和 sysObjectID；一期凭据仅在单次扫描内存中使用，不落库、不回显，接口和 LLDP MIB enrichment 后续补齐。
 - SNMP 校验同时读取 IF-MIB 接口状态与 IPv4 地址归属；SNMPv3 支持 SHA-1/SHA-2 认证及 AES-128/192/256 隐私协议，配置项使用受控选项而非任意字符串。
@@ -58,7 +58,7 @@
 
 ## 验收标准
 
-- [ ] 开关关闭时 Edge 不执行网络发现。
+- [ ] 全局开关关闭时 Manager 不创建或更新网络发现候选。
 - [ ] 开关开启后能上报默认网关和 LLDP 邻居。
 - [ ] LLDP 与 SNMP 命中强身份时归并为同一个 `devices.id`。
 - [ ] 只有 IP/sysName 相同不会自动永久合并。

--- a/internal/edgeagent/biz/agent.go
+++ b/internal/edgeagent/biz/agent.go
@@ -64,9 +64,9 @@ type Config struct {
 	MetricsInterval time.Duration // default 10s
 	// MetricsBatchSize is how many points to buffer before push.
 	MetricsBatchSize int // default 30 (5min at 10s)
-	// NetworkDiscoveryEnabled explicitly enables passive gateway/ARP/LLDP
-	// reports. It defaults to false so installing an Edge does not start
-	// network discovery without operator intent.
+	// NetworkDiscoveryEnabled controls passive gateway/ARP/LLDP reports. The
+	// Edge entrypoint defaults it to true; an operator can disable one host via
+	// its local environment file.
 	NetworkDiscoveryEnabled bool
 	// NetworkDiscoveryInterval controls passive gateway/ARP/LLDP reports when
 	// discovery is enabled. Zero uses one minute.

--- a/internal/edgeagent/biz/agent_test.go
+++ b/internal/edgeagent/biz/agent_test.go
@@ -157,14 +157,14 @@ func (c *fakeCollector) CollectNetworkDiscovery(context.Context) (tunnel.Network
 	}, nil
 }
 
-func TestAgent_NetworkDiscoveryRequiresExplicitEnable(t *testing.T) {
+func TestAgent_NetworkDiscoveryHonorsLocalEnablement(t *testing.T) {
 	tests := []struct {
 		name    string
 		enabled bool
 		wantMin int32
 		wantMax int32
 	}{
-		{name: "disabled by default", wantMax: 0},
+		{name: "disabled locally", wantMax: 0},
 		{name: "enabled", enabled: true, wantMin: 1, wantMax: 10},
 	}
 	for _, tt := range tests {

--- a/internal/manager/biz/device/network_discovery.go
+++ b/internal/manager/biz/device/network_discovery.go
@@ -61,6 +61,10 @@ type NetworkSNMPCredentialResolver interface {
 	ResolveFields(ctx context.Context, name string) (map[string]string, error)
 }
 
+// NetworkDiscoveryEnabledProvider keeps the platform setting at the
+// composition boundary. The device domain does not import the setting domain.
+type NetworkDiscoveryEnabledProvider func(ctx context.Context) bool
+
 // NetworkDeviceDetail is the read model for a verified network device. The
 // candidate carries the latest protocol observation while Profile contains
 // the durable identity promoted into the device inventory.
@@ -85,6 +89,7 @@ type NetworkDiscoveryUsecase struct {
 	edgeCaller  NetworkSNMPCaller
 	credentials NetworkSNMPCredentialResolver
 	topology    NetworkTopologyMirror
+	enabled     NetworkDiscoveryEnabledProvider
 }
 
 func (u *NetworkDiscoveryUsecase) SetCredentialResolver(resolver NetworkSNMPCredentialResolver) {
@@ -107,6 +112,13 @@ func (u *NetworkDiscoveryUsecase) SetEdgeCaller(caller NetworkSNMPCaller) {
 
 func (u *NetworkDiscoveryUsecase) SetTopologyMirror(mirror NetworkTopologyMirror) {
 	u.topology = mirror
+}
+
+// SetEnabledProvider supplies the platform-wide discovery admission gate.
+// A nil provider preserves the default-enabled behavior for standalone tests
+// and older composition roots.
+func (u *NetworkDiscoveryUsecase) SetEnabledProvider(provider NetworkDiscoveryEnabledProvider) {
+	u.enabled = provider
 }
 
 func (u *NetworkDiscoveryUsecase) ListCandidates(ctx context.Context, filter NetworkCandidateFilter) ([]*model.NetworkDiscoveryCandidate, int64, error) {
@@ -534,6 +546,9 @@ var _ interface {
 // the same neighbor seen from two hosts remains explainable in the UI.
 func (u *NetworkDiscoveryUsecase) IngestNetworkDiscovery(ctx context.Context, edgeID uint64, in tunnel.NetworkDiscoveryRequest) (int, error) {
 	if u == nil || u.repo == nil || edgeID == 0 {
+		return 0, nil
+	}
+	if u.enabled != nil && !u.enabled(ctx) {
 		return 0, nil
 	}
 	if len(in.Candidates) == 0 {

--- a/internal/manager/biz/device/network_discovery_test.go
+++ b/internal/manager/biz/device/network_discovery_test.go
@@ -131,6 +131,21 @@ func TestNetworkDiscoveryUsecaseKeepsARPAsCandidate(t *testing.T) {
 	}
 }
 
+func TestNetworkDiscoveryUsecaseRespectsPlatformGate(t *testing.T) {
+	repo := &fakeNetworkDiscoveryRepo{}
+	uc := NewNetworkDiscoveryUsecase(repo)
+	uc.SetEnabledProvider(func(context.Context) bool { return false })
+
+	accepted, err := uc.IngestNetworkDiscovery(context.Background(), 7, tunnel.NetworkDiscoveryRequest{
+		Candidates: []tunnel.NetworkDiscoveryCandidateReport{{
+			IPAddress: "192.0.2.1", Source: "gateway",
+		}},
+	})
+	if err != nil || accepted != 0 || len(repo.rows) != 0 {
+		t.Fatalf("accepted=%d rows=%d err=%v", accepted, len(repo.rows), err)
+	}
+}
+
 func TestNetworkDiscoveryUsecaseDeduplicatesBatch(t *testing.T) {
 	repo := &fakeNetworkDiscoveryRepo{}
 	uc := NewNetworkDiscoveryUsecase(repo)

--- a/internal/manager/biz/setting/service.go
+++ b/internal/manager/biz/setting/service.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -168,6 +169,27 @@ func (s *Service) SetIfAbsent(ctx context.Context, category, key, value string, 
 		return err
 	}
 	return s.Set(ctx, category, key, value, sensitive)
+}
+
+// NetworkDiscoveryEnabled returns the platform-wide network discovery gate.
+// Missing or malformed values resolve to enabled, matching the new-install
+// default. An explicit false is the only opt-out, so an unavailable settings
+// store cannot silently disable inventory collection.
+func (s *Service) NetworkDiscoveryEnabled(ctx context.Context) bool {
+	value, found, err := s.Get(ctx, model.CategoryPlatform, model.KeyNetworkDiscoveryEnabled)
+	if err != nil {
+		s.log.Warn("read network discovery setting", slog.Any("err", err))
+		return true
+	}
+	if !found {
+		return true
+	}
+	enabled, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		s.log.Warn("invalid network discovery setting; using enabled default", slog.String("value", value))
+		return true
+	}
+	return enabled
 }
 
 // List returns all rows in the category, sensitive values masked.

--- a/internal/manager/biz/setting/service_test.go
+++ b/internal/manager/biz/setting/service_test.go
@@ -132,6 +132,33 @@ func TestServiceGetMissingReturnsFoundFalse(t *testing.T) {
 	}
 }
 
+func TestNetworkDiscoveryEnabled(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{name: "unset defaults enabled", want: true},
+		{name: "explicit enabled", value: "true", set: true, want: true},
+		{name: "explicit disabled", value: "false", set: true, want: false},
+		{name: "malformed defaults enabled", value: "not-a-bool", set: true, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newFakeRepo()
+			if test.set {
+				if _, err := repo.Set(ctx, model.CategoryPlatform, model.KeyNetworkDiscoveryEnabled, test.value, false); err != nil {
+					t.Fatalf("seed setting: %v", err)
+				}
+			}
+			if got := New(repo, nil).NetworkDiscoveryEnabled(ctx); got != test.want {
+				t.Fatalf("NetworkDiscoveryEnabled() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestServiceSetInvalidatesCache(t *testing.T) {
 	repo := newFakeRepo()
 	if _, err := repo.Set(context.Background(), "llm", "openai_model", "gpt-4o", false); err != nil {

--- a/internal/manager/model/setting/model.go
+++ b/internal/manager/model/setting/model.go
@@ -42,6 +42,15 @@ const (
 	CategoryTempo     = "tempo"     // external Tempo OTLP HTTP endpoint + auth
 	CategoryWebSearch = "websearch" // built-in web_search skill: Tavily key + future provider knobs
 	CategoryAgent     = "agent"     // AI agent behaviour toggles (write-action gate, …)
+	CategoryPlatform  = "platform"  // platform-wide infrastructure behaviour toggles
+)
+
+// Well-known keys under CategoryPlatform.
+const (
+	// KeyNetworkDiscoveryEnabled controls whether the manager accepts passive
+	// network-discovery reports from Edges. Unset defaults to enabled so a new
+	// installation discovers candidates without an additional configuration step.
+	KeyNetworkDiscoveryEnabled = "network_discovery_enabled"
 )
 
 // Well-known keys under CategoryAgent.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ const SettingsLLM = lazy(() => import('@/pages/settings/LLM'));
 const SettingsNotifications = lazy(() => import('@/pages/settings/Notifications'));
 const SettingsChannels = lazy(() => import('@/pages/settings/Channels'));
 const SettingsIntegrations = lazy(() => import('@/pages/settings/Integrations'));
+const SettingsGeneral = lazy(() => import('@/pages/settings/General'));
 const SettingsPreferences = lazy(() => import('@/pages/settings/Preferences'));
 const SettingsAgent = lazy(() => import('@/pages/settings/Agent'));
 const SettingsAbout = lazy(() => import('@/pages/settings/About'));
@@ -163,7 +164,6 @@ export default function App() {
         <Route path="/settings/im-apps" element={<Navigate to="/settings/channels" replace />} />
         <Route path="/settings/advanced" element={<Navigate to="/settings/integrations" replace />} />
         <Route path="/settings/monitor" element={<Navigate to="/settings/integrations" replace />} />
-        <Route path="/settings/general" element={<Navigate to="/settings/integrations" replace />} />
         <Route path="/settings" element={<SettingsLayout />}>
           <Route index element={<Navigate to="health" replace />} />
           <Route path="llm" element={<SettingsLLM />} />
@@ -171,6 +171,7 @@ export default function App() {
           <Route path="notifications" element={<SettingsNotifications />} />
           <Route path="channels" element={<SettingsChannels />} />
           <Route path="integrations" element={<SettingsIntegrations />} />
+          <Route path="general" element={<SettingsGeneral />} />
           <Route path="health" element={<SettingsHealth />} />
           <Route path="upgrade" element={<SettingsUpgrade />} />
           {/* /settings/marketplace retired (2026-05-19). Install surface

--- a/web/src/lib/routes.ts
+++ b/web/src/lib/routes.ts
@@ -47,6 +47,7 @@ const ROUTE_DEFS: RouteDef[] = [
   { path: '/settings/llm', zh: '设置 / LLM', en: 'Settings / LLM', keywords: ['llm', 'model', 'moxing'], group: '设置' },
   { path: '/settings/notifications', zh: '设置 / 通知', en: 'Settings / Notifications', keywords: ['notifications', 'tongzhi', 'communications'], group: '设置' },
   { path: '/settings/channels', zh: '设置 / 渠道', en: 'Settings / Channels', keywords: ['channels', 'qudao', 'bots', 'im'], group: '设置' },
+  { path: '/settings/general', zh: '设置 / 全局配置', en: 'Settings / Global', keywords: ['global', 'network discovery', 'wangluofaxian'], group: '设置' },
   { path: '/settings/preferences', zh: '设置 / 偏好', en: 'Settings / Preferences', keywords: ['preferences', 'pianhao'], group: '设置' },
 
   { path: '/admin/users', zh: '用户管理 / 用户', en: 'Admin / Users', keywords: ['users', 'yonghu', 'admin'], group: '用户管理' },

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -845,7 +845,7 @@ export default function EdgesPage() {
             </div>
           )}
 
-          <div className="w-full min-w-0 max-w-full overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+          <div className="device-list-table w-full min-w-0 max-w-full overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
             <table
               className={cn(
                 "min-w-full text-xs",
@@ -883,7 +883,7 @@ export default function EdgesPage() {
                   <col className="w-[190px]" />
                 </colgroup>
               )}
-              <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
+              <thead className="device-list-table__header border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
                 <tr>
                   <th className="px-2.5 py-2.5 text-left">
                     <input
@@ -949,7 +949,7 @@ export default function EdgesPage() {
                       <th className="px-2.5 py-2.5 text-left">Edge</th>
                     </>
                   )}
-                  <th className="sticky right-0 z-20 border-l border-zinc-800/60 bg-zinc-950 px-2.5 py-2.5 text-left">
+                  <th className="sticky right-0 z-20 border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-left">
                     {tr("操作", "Actions")}
                   </th>
                 </tr>
@@ -1582,9 +1582,9 @@ function NetworkDiscoveryTable({
     }
   };
   return (
-    <div className="overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+    <div className="network-discovery-table overflow-x-auto rounded-xl border border-zinc-800/60 bg-zinc-900/40">
       <table className="w-full min-w-[1040px] text-xs">
-        <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
+        <thead className="network-discovery-table__header border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
           <tr>
             <th className="px-3 py-2.5 text-left">IP</th>
             <th className="px-3 py-2.5 text-left">MAC</th>

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -12,6 +12,7 @@ import {
   Lock,
   Plug,
   Shield,
+  SlidersHorizontal,
   UploadCloud,
 } from 'lucide-react';
 import { cn } from '@/lib/cn';
@@ -36,6 +37,7 @@ const RAIL_ITEMS: RailItem[] = [
   { to: 'health', icon: HeartPulse, labelZh: '健康', labelEn: 'Health', hintZh: '平台自检 / 依赖状态', hintEn: 'Platform self-check / dependency status' },
   { to: 'upgrade', icon: UploadCloud, labelZh: '升级', labelEn: 'Upgrade', hintZh: '检测版本 / 复制命令', hintEn: 'Check version / copy command' },
   { to: 'integrations', icon: Plug, labelZh: '集成', labelEn: 'Integrations', hintZh: 'Prometheus / Grafana 等外部系统', hintEn: 'External systems — Prometheus / Grafana / etc.' },
+  { to: 'general', icon: SlidersHorizontal, labelZh: '全局配置', labelEn: 'Global', hintZh: '平台级基础能力开关', hintEn: 'Platform-wide capability controls' },
   // marketplace entry retired 2026-05-19 — install/uninstall moved to
   // /skills?tab=install so the whole skill story (loaded + installed)
   // lives on one page. The Settings route still redirects bookmarks.

--- a/web/src/pages/settings/General.tsx
+++ b/web/src/pages/settings/General.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, Network } from 'lucide-react';
+import { listSettings, setSetting } from '@/api/settings';
+import { useI18n } from '@/i18n/locale';
+import { cn } from '@/lib/cn';
+
+const CATEGORY = 'platform';
+const KEY = 'network_discovery_enabled';
+
+export default function SettingsGeneral() {
+  const { tr } = useI18n();
+  const [enabled, setEnabled] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await listSettings(CATEGORY);
+      const row = response.items.find((item) => item.key === KEY);
+      // Missing row follows the Manager default: enabled for new installs.
+      setEnabled(row ? row.value === 'true' : true);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onToggle = useCallback(async (next: boolean) => {
+    setSaving(true);
+    setError(null);
+    setEnabled(next);
+    try {
+      await setSetting(CATEGORY, KEY, next ? 'true' : 'false', false);
+    } catch (err) {
+      setEnabled(!next);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="mb-3 flex items-center gap-2">
+          <Network size={14} className="text-zinc-400" />
+          <h2 className="text-sm font-medium text-zinc-100">{tr('网络发现', 'Network discovery')}</h2>
+        </div>
+        <p className="mb-4 text-xs leading-relaxed text-zinc-500">
+          {tr(
+            '控制平台是否接收 Edge 上报的默认网关、ARP 邻居和 LLDP 邻居。关闭后不会再创建或更新候选设备，已有候选和正式网络设备不会被删除。',
+            'Controls whether the platform accepts gateway, ARP-neighbor, and LLDP-neighbor reports from Edges. When disabled, no candidates are created or updated; existing candidates and verified network devices remain.',
+          )}
+        </p>
+
+        {loading ? (
+          <div className="flex h-10 items-center text-xs text-zinc-500">
+            <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-4 rounded-lg border border-zinc-800 bg-zinc-950/40 px-4 py-3">
+            <div>
+              <div className="text-[13px] font-medium text-zinc-200">
+                {tr('启用网络发现', 'Enable network discovery')}
+              </div>
+              <div className="mt-0.5 text-[11px] text-zinc-500">
+                {enabled
+                  ? tr('当前：接收所有已启用 Edge 的发现上报', 'Current: accept discovery reports from enabled Edges')
+                  : tr('当前：忽略新的网络发现上报', 'Current: ignore new network discovery reports')}
+              </div>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              disabled={saving}
+              onClick={() => void onToggle(!enabled)}
+              className={cn(
+                'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50',
+                enabled ? 'bg-emerald-500/80' : 'bg-zinc-700',
+              )}
+            >
+              <span className={cn(
+                'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                enabled ? 'translate-x-6' : 'translate-x-1',
+              )} />
+            </button>
+          </div>
+        )}
+
+        {error && <div className="mt-3 text-xs text-red-400">{error}</div>}
+
+        <p className="mt-4 text-[11px] leading-relaxed text-zinc-600">
+          {tr(
+            '新安装的 Edge 默认开启本地采集。若只想停用某一台主机，可将其 /etc/ongrid-edge/ongrid-edge.env 中的 ONGRID_NETWORK_DISCOVERY_ENABLED 设为 false 后重启服务。',
+            'New Edges collect locally by default. To stop one host only, set ONGRID_NETWORK_DISCOVERY_ENABLED=false in /etc/ongrid-edge/ongrid-edge.env and restart its service.',
+          )}
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -149,6 +149,14 @@ html.light .bg-zinc-800\/40,
 html.light .bg-zinc-800\/60,
 html.light .bg-zinc-800\/80       { background-color: rgb(226 232 240 / 0.7); }
 
+/* Device and network-discovery tables need opaque light surfaces. Their
+   scrolling container and header otherwise inherit transparent zinc fills,
+   which can expose a dark background beneath an embedded table. */
+html.light .device-list-table,
+html.light .network-discovery-table { background-color: rgb(var(--card)); }
+html.light .device-list-table__header,
+html.light .network-discovery-table__header { background-color: rgb(248 250 252); }
+
 html.light .text-zinc-100         { color: rgb(var(--text)); }
 html.light .text-zinc-200         { color: rgb(var(--text)); }
 html.light .text-zinc-300         { color: rgb(var(--text-muted)); }


### PR DESCRIPTION
## Summary
- enable Edge network discovery by default
- add the Manager-side global discovery admission switch under Settings -> Global
- fix light-theme backgrounds for device and network-discovery tables

## Validation
- go test ./internal/manager/biz/setting ./internal/manager/biz/device ./cmd/ongrid-edge
- cd web && npm run build
- visual QA in light and dark themes

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md