### PR TITLE
fix(ui): improve light RCA report contrast

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -439,6 +439,12 @@ func main() {
 	if err := settingSvc.SetIfAbsent(rootCtx, settingmodel.CategoryLLM, settingmodel.KeyOpenAIBaseURL, cfg.OpenAI.BaseURL, false); err != nil {
 		log.Warn("seed llm base url", slog.Any("err", err))
 	}
+	// Seed the platform default once so discovery ingestion reads the cached
+	// setting instead of querying for an absent row on every Edge report.
+	// SetIfAbsent preserves an administrator's explicit global opt-out.
+	if err := settingSvc.SetIfAbsent(rootCtx, settingmodel.CategoryPlatform, settingmodel.KeyNetworkDiscoveryEnabled, "true", false); err != nil {
+		log.Warn("seed network discovery setting", slog.Any("err", err))
+	}
 	// Prom seeds. URLs are first-boot only — admin edits in UI persist;
 	// auth fields are blank by default (env can override at boot).
 	for _, seed := range []struct {

--- a/web/src/pages/settings/General.tsx
+++ b/web/src/pages/settings/General.tsx
@@ -7,6 +7,12 @@ import { cn } from '@/lib/cn';
 const CATEGORY = 'platform';
 const KEY = 'network_discovery_enabled';
 
+// Match the manager's fail-open default: only an explicit false disables
+// admission. This keeps the displayed state correct for old or malformed rows.
+function isDiscoveryEnabled(value?: string): boolean {
+  return value?.trim().toLowerCase() !== 'false';
+}
+
 export default function SettingsGeneral() {
   const { tr } = useI18n();
   const [enabled, setEnabled] = useState(true);
@@ -19,7 +25,7 @@ export default function SettingsGeneral() {
       const response = await listSettings(CATEGORY);
       const row = response.items.find((item) => item.key === KEY);
       // Missing row follows the Manager default: enabled for new installs.
-      setEnabled(row ? row.value === 'true' : true);
+      setEnabled(isDiscoveryEnabled(row?.value));
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -259,6 +259,7 @@ html.light .ring-fuchsia-500\/30     { --tw-ring-color: rgb(240 171 252); }    /
 
 html.light .bg-emerald-500\/10       { background-color: rgb(209 250 229); }   /* emerald-100 */
 html.light .bg-emerald-500\/15       { background-color: rgb(209 250 229); }
+html.light .text-emerald-100,
 html.light .text-emerald-200,
 html.light .text-emerald-300         { color: rgb(4 120 87); }                 /* emerald-700 */
 html.light .border-emerald-500\/30,


### PR DESCRIPTION
## Summary
- make the root-cause report title readable in light mode
- keep the global network-discovery UI aligned with the Manager fail-open default
- seed the discovery setting once to avoid a database lookup for every Edge report

## Validation
- go test ./internal/manager/biz/setting ./internal/manager/biz/device ./cmd/ongrid
- cd web && npm run build

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md