### PR TITLE
fix(aiops): scope named-device log and trace queries

### DIFF
--- a/internal/manager/biz/aiops/chatruntime/runtime.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime.go
@@ -1319,13 +1319,13 @@ func filterCoordinatorToolsForIntent(bag []basetool.BaseTool, userText string, i
 			continue
 		}
 		if logIntent && !traceIntent && !topologyIntent && !hostIntent {
-			if info.Name == "query_logql" {
+			if info.Name == "query_logql" || info.Name == "query_devices" {
 				out = append(out, t)
 			}
 			continue
 		}
 		if traceIntent && !logIntent && !topologyIntent && !hostIntent {
-			if info.Name == "query_traceql" {
+			if info.Name == "query_traceql" || info.Name == "query_devices" {
 				out = append(out, t)
 			}
 			continue
@@ -1338,7 +1338,7 @@ func filterCoordinatorToolsForIntent(bag []basetool.BaseTool, userText string, i
 		}
 		if logIntent && !hostIntent {
 			switch info.Name {
-			case "query_devices", "query_edges", "get_edge_summary", "get_host_load", "get_host_processes", "rank_edges", "find_outlier_edges":
+			case "query_edges", "get_edge_summary", "get_host_load", "get_host_processes", "rank_edges", "find_outlier_edges":
 				continue
 			}
 		}

--- a/internal/manager/biz/aiops/chatruntime/runtime_worker_test.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime_worker_test.go
@@ -440,8 +440,24 @@ func TestFilterCoordinatorToolsForIntent_HidesTopologyAndHostForPureLogs(t *test
 	if !containsName(names, "query_logql") {
 		t.Fatalf("query_logql should remain visible: %v", names)
 	}
-	if containsName(names, "query_traceql") || containsName(names, "get_topology") || containsName(names, "host_bash") || containsName(names, "query_devices") {
-		t.Fatalf("pure log intent should hide detours, got %v", names)
+	if containsName(names, "query_traceql") || containsName(names, "get_topology") || containsName(names, "host_bash") || !containsName(names, "query_devices") {
+		t.Fatalf("pure log intent should keep device resolution but hide unrelated detours, got %v", names)
+	}
+}
+
+func TestFilterCoordinatorToolsForIntent_KeepsDeviceResolutionForPureTraces(t *testing.T) {
+	bag := []basetool.BaseTool{
+		&fakeTool{name: "query_logql", schema: `{"type":"object"}`},
+		&fakeTool{name: "query_traceql", schema: `{"type":"object"}`},
+		&fakeTool{name: "query_devices", schema: `{"type":"object"}`},
+		&fakeTool{name: "get_topology", schema: `{"type":"object"}`},
+	}
+	names := toolNamesForTest(t, filterCoordinatorToolsForIntent(bag, "查询 VM-4-17-ubuntu 最近 1 小时的慢链路", true))
+	if !containsName(names, "query_traceql") || !containsName(names, "query_devices") {
+		t.Fatalf("trace intent should keep trace query and device resolution, got %v", names)
+	}
+	if containsName(names, "query_logql") || containsName(names, "get_topology") {
+		t.Fatalf("trace intent should hide unrelated tools, got %v", names)
 	}
 }
 

--- a/internal/manager/biz/aiops/graph/react.go
+++ b/internal/manager/biz/aiops/graph/react.go
@@ -310,6 +310,8 @@ func buildSystemReminder(in *Input) string {
 		lines = append(lines,
 			"- If the same tool fails twice, change approach instead of repeating it.",
 			"- device_id / alert_id must be numeric IDs (@-mentions have already been resolved).",
+			"- For logs or traces on a named device without a numeric device_id, call query_devices once first, then pass device_id to the query tool. Do not guess hostname/instance labels.",
+			"- For a device-scoped LogQL query, start with {} plus the requested line filter. After it returns matching lines, summarize instead of enumerating speculative labels.",
 			"- Tool results are facts; do not invent data when evidence is missing.",
 			"- call_budget_exceeded only applies to the current user turn; a new user message may call tools again.",
 		)
@@ -317,6 +319,8 @@ func buildSystemReminder(in *Input) string {
 		lines = append(lines,
 			"- 同一工具失败两次后请换思路，不要重复调用",
 			"- device_id / alert_id 必须是数字 ID（@-mention 已经为你解析）",
+			"- 按名称查询设备日志或链路时，若没有数字 device_id，先调用一次 query_devices，再把 device_id 传给查询工具；不要猜 hostname/instance 标签",
+			"- 设备范围的 LogQL 查询先使用 {} 加所需行过滤；已有命中日志后直接总结，不要继续枚举猜测性标签",
 			"- 工具结果是事实，不要在没有数据时编造",
 			"- call_budget_exceeded 只限制当前用户消息；新消息可重新调用工具",
 		)

--- a/internal/manager/biz/aiops/tools/correlate_incident.go
+++ b/internal/manager/biz/aiops/tools/correlate_incident.go
@@ -260,14 +260,16 @@ func (r *Registry) executeCorrelateIncident(ctx context.Context, args json.RawMe
 		bundle.Skipped["log_panel"] = "log query client not configured"
 	}
 
-	// Trace panel — needs Tempo + a service label on the incident.
+	// Trace panel — needs Tempo + a service label on the incident. Keep a
+	// device-scoped incident on that device: service names are commonly shared
+	// by workloads across hosts.
 	if r.traceQuery != nil {
 		service := strings.TrimSpace(labels["service"])
 		if service == "" {
 			service = strings.TrimSpace(annotations["service"])
 		}
 		if service != "" {
-			entries, err := r.queryTracePanel(callCtx, service, wStart, wEnd)
+			entries, err := r.queryTracePanel(callCtx, service, inc.DeviceID, wStart, wEnd)
 			if err != nil {
 				bundle.Skipped["trace_panel"] = "tempo query failed: " + err.Error()
 			} else {
@@ -487,13 +489,21 @@ func truncateLine(s string, n int) string {
 	return s[:n] + "…"
 }
 
-// queryTracePanel runs a Tempo search filtered by service.name plus a
-// status / latency hint so we surface the kind of traces the LLM cares
+// queryTracePanel runs a Tempo search filtered by service.name and, when the
+// incident has one, its stable device ID. This prevents a shared service name
+// from pulling traces from another host into the incident bundle.
+//
+// The status / latency hint helps surface the kind of traces the LLM cares
 // about. Tempo's response is OTLP-shaped; we lift the few fields that
 // matter and drop the rest to keep the bundle tight.
-func (r *Registry) queryTracePanel(ctx context.Context, service string, start, end time.Time) ([]traceEntry, error) {
+func (r *Registry) queryTracePanel(ctx context.Context, service string, deviceID *uint64, start, end time.Time) ([]traceEntry, error) {
+	query, tags, err := traceQLSearchFilters(QueryTraceQLArgs{DeviceID: deviceID, Service: service})
+	if err != nil {
+		return nil, fmt.Errorf("build incident trace filter: %w", err)
+	}
 	res, err := r.traceQuery.SearchTraces(ctx, tracequery.SearchOptions{
-		Tags:  map[string]string{"service.name": service},
+		Query: query,
+		Tags:  tags,
 		Limit: 20,
 		Start: start,
 		End:   end,

--- a/internal/manager/biz/aiops/tools/correlate_incident_basetool.go
+++ b/internal/manager/biz/aiops/tools/correlate_incident_basetool.go
@@ -213,7 +213,7 @@ func (t *CorrelateIncidentTool) singleCorrelate(ctx context.Context, incidentID 
 			service = strings.TrimSpace(annotations["service"])
 		}
 		if service != "" {
-			entries, err := t.queryTracePanel(callCtx, service, wStart, wEnd)
+			entries, err := t.queryTracePanel(callCtx, service, inc.DeviceID, wStart, wEnd)
 			if err != nil {
 				bundle.Skipped["trace_panel"] = "tempo query failed: " + err.Error()
 			} else {
@@ -350,10 +350,16 @@ func (t *CorrelateIncidentTool) queryLogPanel(ctx context.Context, edgeID uint64
 	return entries, nil
 }
 
-// queryTracePanel mirrors Registry.queryTracePanel.
-func (t *CorrelateIncidentTool) queryTracePanel(ctx context.Context, service string, start, end time.Time) ([]traceEntry, error) {
+// queryTracePanel mirrors Registry.queryTracePanel, including device scope
+// for incidents whose service names are shared across hosts.
+func (t *CorrelateIncidentTool) queryTracePanel(ctx context.Context, service string, deviceID *uint64, start, end time.Time) ([]traceEntry, error) {
+	query, tags, err := traceQLSearchFilters(QueryTraceQLArgs{DeviceID: deviceID, Service: service})
+	if err != nil {
+		return nil, fmt.Errorf("build incident trace filter: %w", err)
+	}
 	res, err := t.traceQuery.SearchTraces(ctx, tracequery.SearchOptions{
-		Tags:  map[string]string{"service.name": service},
+		Query: query,
+		Tags:  tags,
 		Limit: 20,
 		Start: start,
 		End:   end,

--- a/internal/manager/biz/aiops/tools/correlate_incident_basetool_test.go
+++ b/internal/manager/biz/aiops/tools/correlate_incident_basetool_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	alertmodel "github.com/ongridio/ongrid/internal/manager/model/alert"
+	"github.com/ongridio/ongrid/internal/pkg/tracequery"
 )
 
 func TestCorrelateIncidentTool_Info(t *testing.T) {
@@ -114,6 +115,22 @@ func TestCorrelateIncidentTool_NilAlert(t *testing.T) {
 	tool := NewCorrelateIncidentTool(nil, nil, nil, nil, nil, nil, nil)
 	if _, err := tool.InvokableRun(context.Background(), `{"incident_ids":[1]}`); err == nil {
 		t.Errorf("expected early error when alertUC nil")
+	}
+}
+
+func TestCorrelateIncidentTool_QueryTracePanelScopesToDevice(t *testing.T) {
+	tq := &fakeTraceQuerier{resp: &tracequery.SearchResult{Traces: json.RawMessage("[]")}}
+	tool := NewCorrelateIncidentTool(nil, nil, nil, tq, nil, nil, nil)
+	deviceID := uint64(24)
+
+	if _, err := tool.queryTracePanel(context.Background(), "web", &deviceID, time.Now().Add(-time.Hour), time.Now()); err != nil {
+		t.Fatalf("queryTracePanel: %v", err)
+	}
+	if got, want := tq.got.Query, `{ resource.device_id = "24" && resource.service.name = "web" }`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+	if tq.got.Tags != nil {
+		t.Errorf("Tags = %#v, want nil for device-scoped TraceQL", tq.got.Tags)
 	}
 }
 

--- a/internal/manager/biz/aiops/tools/query_logql.go
+++ b/internal/manager/biz/aiops/tools/query_logql.go
@@ -19,6 +19,8 @@ const ToolNameQueryLogQL = "query_logql"
 // is needed beyond what the metric-side tools can express.
 const QueryLogQLDescription = "Run a LogQL range query against Loki. " +
 	"Use this to investigate log patterns, error counts, or filter a specific device. " +
+	"When device_id is set, start with {} plus a line filter because the backend injects the device selector; do not guess job/hostname/instance labels. " +
+	"Once a scoped query returns matching lines, summarize them unless the user asks for a narrower follow-up. " +
 	"Returns the raw Loki response (streams or matrix)."
 
 var logQLDeviceIDMatcher = regexp.MustCompile(`(?:^|,)\s*device_id\s*(=|!=|=~|!~)\s*"([^"]*)"`)

--- a/internal/manager/biz/aiops/tools/query_logql.go
+++ b/internal/manager/biz/aiops/tools/query_logql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -17,8 +18,10 @@ const ToolNameQueryLogQL = "query_logql"
 // Phrased to push the model toward this tool whenever raw log inspection
 // is needed beyond what the metric-side tools can express.
 const QueryLogQLDescription = "Run a LogQL range query against Loki. " +
-	"Use this to investigate log patterns, error counts, or pipe into per-edge filters. " +
+	"Use this to investigate log patterns, error counts, or filter a specific device. " +
 	"Returns the raw Loki response (streams or matrix)."
+
+var logQLDeviceIDMatcher = regexp.MustCompile(`(?:^|,)\s*device_id\s*(=|!=|=~|!~)\s*"([^"]*)"`)
 
 func parseLogQLTime(value string, fallback time.Time) (time.Time, error) {
 	value = strings.TrimSpace(value)
@@ -48,7 +51,12 @@ var QueryLogQLSchema = json.RawMessage(`{
   "properties": {
     "query": {
       "type": "string",
-      "description": "LogQL expression. Example: \"{edge_id=\\\"1\\\"} |= \\\"error\\\"\"."
+      "description": "LogQL expression. Example: \"{unit=\\\"nginx.service\\\"} |= \\\"error\\\"\"."
+    },
+    "device_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional stable Device ID. The backend injects device_id into the LogQL stream selector and rejects a conflicting selector."
     },
     "start": {
       "type": "string",
@@ -75,11 +83,69 @@ var QueryLogQLSchema = json.RawMessage(`{
 
 // QueryLogQLArgs is the typed form of QueryLogQLSchema.
 type QueryLogQLArgs struct {
-	Query     string `json:"query"`
-	Start     string `json:"start,omitempty"`
-	End       string `json:"end,omitempty"`
-	Limit     int    `json:"limit,omitempty"`
-	Direction string `json:"direction,omitempty"`
+	Query     string  `json:"query"`
+	DeviceID  *uint64 `json:"device_id,omitempty"`
+	Start     string  `json:"start,omitempty"`
+	End       string  `json:"end,omitempty"`
+	Limit     int     `json:"limit,omitempty"`
+	Direction string  `json:"direction,omitempty"`
+}
+
+// scopeLogQLToDevice injects a stable device label into the leading stream
+// selector. LogQL's stream selector is the only safe place for this scope.
+func scopeLogQLToDevice(query string, deviceID uint64) (string, error) {
+	if deviceID == 0 {
+		return query, nil
+	}
+	trimmed := strings.TrimSpace(query)
+	if !strings.HasPrefix(trimmed, "{") {
+		return "", fmt.Errorf("query_logql: device_id requires a LogQL stream selector")
+	}
+	selectorEnd, ok := logQLStreamSelectorEnd(trimmed)
+	if !ok {
+		return "", fmt.Errorf("query_logql: device_id requires a valid LogQL stream selector")
+	}
+	selector := trimmed[1:selectorEnd]
+	matches := logQLDeviceIDMatcher.FindAllStringSubmatch(selector, -1)
+	if len(matches) > 0 {
+		want := fmt.Sprintf("%d", deviceID)
+		for _, match := range matches {
+			if match[1] != "=" || match[2] != want {
+				return "", fmt.Errorf("query_logql: device_id conflicts with the LogQL selector")
+			}
+		}
+		return trimmed, nil
+	}
+	prefix := `{device_id="` + fmt.Sprintf("%d", deviceID) + `"`
+	if strings.TrimSpace(selector) != "" {
+		prefix += `,` + selector
+	}
+	return prefix + `}` + trimmed[selectorEnd+1:], nil
+}
+
+func logQLStreamSelectorEnd(query string) (int, bool) {
+	inQuote := false
+	escaped := false
+	for i := 1; i < len(query); i++ {
+		switch query[i] {
+		case '\\':
+			if inQuote {
+				escaped = !escaped
+			}
+		case '"':
+			if !escaped {
+				inQuote = !inQuote
+			}
+			escaped = false
+		case '}':
+			if !inQuote {
+				return i, true
+			}
+		default:
+			escaped = false
+		}
+	}
+	return 0, false
 }
 
 // queryLogqlCallTimeout caps how long a single dispatch may wait. Mirrors
@@ -100,6 +166,17 @@ func (r *Registry) executeQueryLogQL(ctx context.Context, args json.RawMessage) 
 	}
 	if strings.TrimSpace(in.Query) == "" {
 		return ExecuteResult{}, fmt.Errorf("query_logql: query required")
+	}
+	query := in.Query
+	if in.DeviceID != nil {
+		if *in.DeviceID == 0 {
+			return ExecuteResult{}, fmt.Errorf("query_logql: device_id must be greater than zero")
+		}
+		var err error
+		query, err = scopeLogQLToDevice(in.Query, *in.DeviceID)
+		if err != nil {
+			return ExecuteResult{}, err
+		}
 	}
 
 	end := time.Now()
@@ -136,7 +213,7 @@ func (r *Registry) executeQueryLogQL(ctx context.Context, args json.RawMessage) 
 	defer cancel()
 
 	res, err := r.logQuery.QueryRange(callCtx, logquery.QueryRangeOptions{
-		Query:     in.Query,
+		Query:     query,
 		Start:     start,
 		End:       end,
 		Limit:     limit,

--- a/internal/manager/biz/aiops/tools/query_logql_basetool.go
+++ b/internal/manager/biz/aiops/tools/query_logql_basetool.go
@@ -59,6 +59,17 @@ func (t *QueryLogQLTool) InvokableRun(ctx context.Context, argsJSON string, _ ..
 	if strings.TrimSpace(in.Query) == "" {
 		return "", fmt.Errorf("query_logql: query required")
 	}
+	query := in.Query
+	if in.DeviceID != nil {
+		if *in.DeviceID == 0 {
+			return "", fmt.Errorf("query_logql: device_id must be greater than zero")
+		}
+		var err error
+		query, err = scopeLogQLToDevice(in.Query, *in.DeviceID)
+		if err != nil {
+			return "", err
+		}
+	}
 
 	end := time.Now()
 	start := end.Add(-time.Hour)
@@ -92,7 +103,7 @@ func (t *QueryLogQLTool) InvokableRun(ctx context.Context, argsJSON string, _ ..
 	defer cancel()
 
 	res, err := t.logQuery.QueryRange(callCtx, logquery.QueryRangeOptions{
-		Query:     in.Query,
+		Query:     query,
 		Start:     start,
 		End:       end,
 		Limit:     limit,

--- a/internal/manager/biz/aiops/tools/query_logql_basetool_test.go
+++ b/internal/manager/biz/aiops/tools/query_logql_basetool_test.go
@@ -60,6 +60,17 @@ func TestQueryLogQLTool_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestQueryLogQLTool_DeviceIDScopesQuery(t *testing.T) {
+	lq := &fakeLogQuerier{resp: &logquery.QueryRangeResult{ResultType: "streams", Result: json.RawMessage("[]")}}
+	tool := NewQueryLogQLTool(lq, nil)
+	if _, err := tool.InvokableRun(context.Background(), `{"query":"{} |= \"error\"","device_id":24}`); err != nil {
+		t.Fatalf("InvokableRun: %v", err)
+	}
+	if got, want := lq.got.Query, `{device_id="24"} |= "error"`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+}
+
 func TestQueryLogQLTool_BadArgs(t *testing.T) {
 	tool := NewQueryLogQLTool(&fakeLogQuerier{}, nil)
 	if _, err := tool.InvokableRun(context.Background(), `not json`); err == nil {

--- a/internal/manager/biz/aiops/tools/query_logql_test.go
+++ b/internal/manager/biz/aiops/tools/query_logql_test.go
@@ -89,6 +89,59 @@ func TestQueryLogQL_DefaultsLimitAndDirection(t *testing.T) {
 	}
 }
 
+func TestQueryLogQL_DeviceIDScopesStreamSelector(t *testing.T) {
+	lq := &fakeLogQuerier{resp: &logquery.QueryRangeResult{ResultType: "streams", Result: json.RawMessage("[]")}}
+	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())
+	reg := NewRegistry(&fakeCaller{}, uc, nil, nil, lq, nil, nil, slog.Default())
+
+	if _, err := reg.Invoke(context.Background(), ToolNameQueryLogQL,
+		json.RawMessage(`{"query":"{unit=\"nginx.service\"} |= \"error\"","device_id":24}`)); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got, want := lq.got.Query, `{device_id="24",unit="nginx.service"} |= "error"`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+}
+
+func TestQueryLogQL_DeviceIDScopesEmptyAndExistingSelectors(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "empty selector", query: `{}`, want: `{device_id="24"}`},
+		{name: "matching selector", query: `{device_id="24",unit="nginx.service"} |= "error"`, want: `{device_id="24",unit="nginx.service"} |= "error"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := scopeLogQLToDevice(tc.query, 24)
+			if err != nil {
+				t.Fatalf("scopeLogQLToDevice: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("query = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQueryLogQL_DeviceIDRejectsConflictingOrUnscopableQuery(t *testing.T) {
+	lq := &fakeLogQuerier{resp: &logquery.QueryRangeResult{ResultType: "streams", Result: json.RawMessage("[]")}}
+	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())
+	reg := NewRegistry(&fakeCaller{}, uc, nil, nil, lq, nil, nil, slog.Default())
+
+	for _, args := range []json.RawMessage{
+		json.RawMessage(`{"query":"{device_id=\"7\"} |= \"error\"","device_id":24}`),
+		json.RawMessage(`{"query":"{device_id=~\"2.*\"} |= \"error\"","device_id":24}`),
+		json.RawMessage(`{"query":"sum(count_over_time({job=\"syslog\"}[5m]))","device_id":24}`),
+		json.RawMessage(`{"query":"{}","device_id":0}`),
+	} {
+		if _, err := reg.Invoke(context.Background(), ToolNameQueryLogQL, args); err == nil {
+			t.Errorf("Invoke(%s) succeeded, want scope error", args)
+		}
+	}
+}
+
 func TestQueryLogQL_ExplicitTimeWindow(t *testing.T) {
 	lq := &fakeLogQuerier{resp: &logquery.QueryRangeResult{ResultType: "streams", Result: json.RawMessage("[]")}}
 	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())

--- a/internal/manager/biz/aiops/tools/query_logql_test.go
+++ b/internal/manager/biz/aiops/tools/query_logql_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -70,6 +71,12 @@ func TestQueryLogQL_RoundTrip(t *testing.T) {
 	}
 	if qr.ResultType != "streams" {
 		t.Errorf("resultType = %q", qr.ResultType)
+	}
+}
+
+func TestQueryLogQL_DescriptionGuidesScopedQueries(t *testing.T) {
+	if !strings.Contains(QueryLogQLDescription, "{}") || !strings.Contains(QueryLogQLDescription, "device_id") {
+		t.Fatalf("description must guide device-scoped LogQL calls: %q", QueryLogQLDescription)
 	}
 }
 

--- a/internal/manager/biz/aiops/tools/query_traceql.go
+++ b/internal/manager/biz/aiops/tools/query_traceql.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +21,10 @@ const ToolNameQueryTraceQL = "query_traceql"
 // don't pin down which request is slow.
 const QueryTraceQLDescription = "Run a TraceQL search against Tempo. " +
 	"Use this to find traces by service / operation / latency / status. " +
+	"When a named device has no numeric ID, call query_devices once first; then pass its stable device_id instead of guessing trace attributes. " +
 	"Returns trace summaries (id, service, root span name, duration, span count)."
+
+var traceQLDeviceIDMatcher = regexp.MustCompile(`(?i)\bresource\.device_id\s*(=|!=|=~|!~)\s*"([^"]*)"`)
 
 // QueryTraceQLSchema is the JSON Schema of the tool's argument object.
 // query may be empty when service/operation/duration filters are supplied —
@@ -30,6 +35,11 @@ var QueryTraceQLSchema = json.RawMessage(`{
     "query": {
       "type": "string",
       "description": "TraceQL expression. May be empty if service/operation/duration filters are given."
+    },
+    "device_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional stable Device ID. The backend injects resource.device_id into TraceQL and rejects a conflicting selector."
     },
     "service": {
       "type": "string",
@@ -66,14 +76,106 @@ var QueryTraceQLSchema = json.RawMessage(`{
 
 // QueryTraceQLArgs is the typed form of QueryTraceQLSchema.
 type QueryTraceQLArgs struct {
-	Query       string `json:"query,omitempty"`
-	Service     string `json:"service,omitempty"`
-	Operation   string `json:"operation,omitempty"`
-	Start       string `json:"start,omitempty"`
-	End         string `json:"end,omitempty"`
-	Limit       int    `json:"limit,omitempty"`
-	MinDuration string `json:"min_duration,omitempty"`
-	MaxDuration string `json:"max_duration,omitempty"`
+	Query       string  `json:"query,omitempty"`
+	DeviceID    *uint64 `json:"device_id,omitempty"`
+	Service     string  `json:"service,omitempty"`
+	Operation   string  `json:"operation,omitempty"`
+	Start       string  `json:"start,omitempty"`
+	End         string  `json:"end,omitempty"`
+	Limit       int     `json:"limit,omitempty"`
+	MinDuration string  `json:"min_duration,omitempty"`
+	MaxDuration string  `json:"max_duration,omitempty"`
+}
+
+// scopeTraceQLToDevice injects the stable host identity into the first
+// TraceQL spanset. device_id is an OTLP resource attribute, not a span
+// attribute, so keeping this at resource scope avoids cross-host matches.
+func scopeTraceQLToDevice(query string, deviceID uint64) (string, error) {
+	if deviceID == 0 {
+		return query, nil
+	}
+	trimmed := strings.TrimSpace(query)
+	if !strings.HasPrefix(trimmed, "{") {
+		return "", fmt.Errorf("query_traceql: device_id requires a TraceQL spanset")
+	}
+	selectorEnd, ok := traceQLSpanSetEnd(trimmed)
+	if !ok {
+		return "", fmt.Errorf("query_traceql: device_id requires a valid TraceQL spanset")
+	}
+	selector := trimmed[1:selectorEnd]
+	matches := traceQLDeviceIDMatcher.FindAllStringSubmatch(selector, -1)
+	if len(matches) > 0 {
+		want := strconv.FormatUint(deviceID, 10)
+		for _, match := range matches {
+			if match[1] != "=" || match[2] != want {
+				return "", fmt.Errorf("query_traceql: device_id conflicts with the TraceQL selector")
+			}
+		}
+		return trimmed, nil
+	}
+	predicate := `resource.device_id = "` + strconv.FormatUint(deviceID, 10) + `"`
+	if strings.TrimSpace(selector) == "" {
+		return "{ " + predicate + " }" + trimmed[selectorEnd+1:], nil
+	}
+	return "{ " + predicate + " && " + strings.TrimSpace(selector) + " }" + trimmed[selectorEnd+1:], nil
+}
+
+func traceQLSpanSetEnd(query string) (int, bool) {
+	inQuote := false
+	escaped := false
+	for i := 1; i < len(query); i++ {
+		switch query[i] {
+		case '\\':
+			if inQuote {
+				escaped = !escaped
+			}
+		case '"':
+			if !escaped {
+				inQuote = !inQuote
+			}
+			escaped = false
+		case '}':
+			if !inQuote {
+				return i, true
+			}
+		default:
+			escaped = false
+		}
+	}
+	return 0, false
+}
+
+func traceQLSearchFilters(in QueryTraceQLArgs) (string, map[string]string, error) {
+	if in.DeviceID != nil && *in.DeviceID == 0 {
+		return "", nil, fmt.Errorf("query_traceql: device_id must be greater than zero")
+	}
+	if in.DeviceID == nil {
+		tags := map[string]string{}
+		if in.Service != "" {
+			tags["service.name"] = in.Service
+		}
+		if in.Operation != "" {
+			tags["name"] = in.Operation
+		}
+		if len(tags) == 0 {
+			tags = nil
+		}
+		return in.Query, tags, nil
+	}
+
+	if strings.TrimSpace(in.Query) != "" {
+		query, err := scopeTraceQLToDevice(in.Query, *in.DeviceID)
+		return query, nil, err
+	}
+
+	predicates := []string{`resource.device_id = "` + strconv.FormatUint(*in.DeviceID, 10) + `"`}
+	if in.Service != "" {
+		predicates = append(predicates, "resource.service.name = "+strconv.Quote(in.Service))
+	}
+	if in.Operation != "" {
+		predicates = append(predicates, "name = "+strconv.Quote(in.Operation))
+	}
+	return "{ " + strings.Join(predicates, " && ") + " }", nil, nil
 }
 
 // queryTraceqlCallTimeout caps how long a single dispatch may wait. Mirrors
@@ -97,6 +199,7 @@ func (r *Registry) executeQueryTraceQL(ctx context.Context, args json.RawMessage
 	// operation), or a duration bound. An unfiltered Tempo search is too
 	// expensive to dump on the LLM by accident.
 	if strings.TrimSpace(in.Query) == "" &&
+		in.DeviceID == nil &&
 		strings.TrimSpace(in.Service) == "" &&
 		strings.TrimSpace(in.Operation) == "" &&
 		strings.TrimSpace(in.MinDuration) == "" &&
@@ -144,24 +247,16 @@ func (r *Registry) executeQueryTraceQL(ctx context.Context, args json.RawMessage
 		maxDur = d
 	}
 
-	tags := map[string]string{}
-	if in.Service != "" {
-		tags["service.name"] = in.Service
-	}
-	if in.Operation != "" {
-		tags["name"] = in.Operation
-	}
-	// Tempo's SearchTraces ignores Tags when Query is set — that's the
-	// desired precedence. We forward both and let the client choose.
-	if len(tags) == 0 {
-		tags = nil
+	query, tags, err := traceQLSearchFilters(in)
+	if err != nil {
+		return ExecuteResult{}, err
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, queryTraceqlCallTimeout)
 	defer cancel()
 
 	res, err := r.traceQuery.SearchTraces(callCtx, tracequery.SearchOptions{
-		Query:       in.Query,
+		Query:       query,
 		Tags:        tags,
 		Limit:       limit,
 		Start:       start,

--- a/internal/manager/biz/aiops/tools/query_traceql_basetool.go
+++ b/internal/manager/biz/aiops/tools/query_traceql_basetool.go
@@ -57,6 +57,7 @@ func (t *QueryTraceQLTool) InvokableRun(ctx context.Context, argsJSON string, _ 
 	}
 
 	if strings.TrimSpace(in.Query) == "" &&
+		in.DeviceID == nil &&
 		strings.TrimSpace(in.Service) == "" &&
 		strings.TrimSpace(in.Operation) == "" &&
 		strings.TrimSpace(in.MinDuration) == "" &&
@@ -104,22 +105,16 @@ func (t *QueryTraceQLTool) InvokableRun(ctx context.Context, argsJSON string, _ 
 		maxDur = d
 	}
 
-	tags := map[string]string{}
-	if in.Service != "" {
-		tags["service.name"] = in.Service
-	}
-	if in.Operation != "" {
-		tags["name"] = in.Operation
-	}
-	if len(tags) == 0 {
-		tags = nil
+	query, tags, err := traceQLSearchFilters(in)
+	if err != nil {
+		return "", err
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, queryTraceqlCallTimeout)
 	defer cancel()
 
 	res, err := t.traceQuery.SearchTraces(callCtx, tracequery.SearchOptions{
-		Query:       in.Query,
+		Query:       query,
 		Tags:        tags,
 		Limit:       limit,
 		Start:       start,

--- a/internal/manager/biz/aiops/tools/query_traceql_basetool_test.go
+++ b/internal/manager/biz/aiops/tools/query_traceql_basetool_test.go
@@ -44,6 +44,18 @@ func TestQueryTraceQLTool_TagMode(t *testing.T) {
 	}
 }
 
+func TestQueryTraceQLTool_DeviceScope(t *testing.T) {
+	tq := &fakeTraceQuerier{resp: &tracequery.SearchResult{Traces: json.RawMessage("[]")}}
+	tool := NewQueryTraceQLTool(tq, nil)
+
+	if _, err := tool.InvokableRun(context.Background(), `{"device_id":24,"query":"{ resource.service.name = \"web\" }"}`); err != nil {
+		t.Fatalf("InvokableRun: %v", err)
+	}
+	if got, want := tq.got.Query, `{ resource.device_id = "24" && resource.service.name = "web" }`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+}
+
 func TestQueryTraceQLTool_RequiresAFilter(t *testing.T) {
 	tool := NewQueryTraceQLTool(&fakeTraceQuerier{}, nil)
 	if _, err := tool.InvokableRun(context.Background(), `{}`); err == nil {

--- a/internal/manager/biz/aiops/tools/query_traceql_test.go
+++ b/internal/manager/biz/aiops/tools/query_traceql_test.go
@@ -125,6 +125,22 @@ func TestQueryTraceQL_DeviceScopeRejectsConflict(t *testing.T) {
 	}
 }
 
+func TestRegistry_QueryTracePanelScopesToDevice(t *testing.T) {
+	tq := &fakeTraceQuerier{resp: &tracequery.SearchResult{Traces: json.RawMessage("[]")}}
+	reg := &Registry{traceQuery: tq}
+	deviceID := uint64(24)
+
+	if _, err := reg.queryTracePanel(context.Background(), "web", &deviceID, time.Now().Add(-time.Hour), time.Now()); err != nil {
+		t.Fatalf("queryTracePanel: %v", err)
+	}
+	if got, want := tq.got.Query, `{ resource.device_id = "24" && resource.service.name = "web" }`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+	if tq.got.Tags != nil {
+		t.Errorf("Tags = %#v, want nil for device-scoped TraceQL", tq.got.Tags)
+	}
+}
+
 func TestQueryTraceQL_RequiresAFilter(t *testing.T) {
 	tq := &fakeTraceQuerier{}
 	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())

--- a/internal/manager/biz/aiops/tools/query_traceql_test.go
+++ b/internal/manager/biz/aiops/tools/query_traceql_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -92,6 +93,35 @@ func TestQueryTraceQL_TagMode(t *testing.T) {
 	}
 	if tq.got.Limit != 50 {
 		t.Errorf("default limit = %d, want 50", tq.got.Limit)
+	}
+}
+
+func TestQueryTraceQL_DeviceScope(t *testing.T) {
+	tq := &fakeTraceQuerier{resp: &tracequery.SearchResult{Traces: json.RawMessage("[]")}}
+	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())
+	reg := NewRegistry(&fakeCaller{}, uc, nil, nil, nil, tq, nil, slog.Default())
+
+	args := json.RawMessage(`{"device_id":24,"service":"web","operation":"GET /api"}`)
+	if _, err := reg.Invoke(context.Background(), ToolNameQueryTraceQL, args); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got, want := tq.got.Query, `{ resource.device_id = "24" && resource.service.name = "web" && name = "GET /api" }`; got != want {
+		t.Errorf("Query = %q, want %q", got, want)
+	}
+	if tq.got.Tags != nil {
+		t.Errorf("Tags = %#v, want nil when device scope builds TraceQL", tq.got.Tags)
+	}
+}
+
+func TestQueryTraceQL_DeviceScopeRejectsConflict(t *testing.T) {
+	tq := &fakeTraceQuerier{resp: &tracequery.SearchResult{Traces: json.RawMessage("[]")}}
+	uc := edgebiz.NewUsecase(newFakeEdgeRepo(), nil, nil, slog.Default())
+	reg := NewRegistry(&fakeCaller{}, uc, nil, nil, nil, tq, nil, slog.Default())
+
+	_, err := reg.Invoke(context.Background(), ToolNameQueryTraceQL,
+		json.RawMessage(`{"device_id":24,"query":"{ resource.device_id = \"7\" }"}`))
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("Invoke error = %v, want device scope conflict", err)
 	}
 }
 

--- a/web/src/pages/IncidentDetail.tsx
+++ b/web/src/pages/IncidentDetail.tsx
@@ -1280,7 +1280,7 @@ function useTempoExploreUrl(incident: Incident | null): string | null {
     const parts: string[] = [];
     if (service) parts.push(`resource.service.name="${service}"`);
     if (labels.operation) parts.push(`name="${labels.operation}"`);
-    if (labels.device_id && !service) parts.push(`resource.device_id="${labels.device_id}"`);
+    if (labels.device_id) parts.push(`resource.device_id="${labels.device_id}"`);
     const expr = `{${parts.join(' && ') || 'true'}}`;
     return buildGrafanaExploreUrl({
       base,


### PR DESCRIPTION
Closes #284
Closes #286

## Changes
- add an optional `device_id` to `query_logql` and inject it into the LogQL stream selector
- add an optional `device_id` to `query_traceql` and inject it as `resource.device_id` in TraceQL
- expose `query_devices` with direct log and trace intents so a named device resolves once to its stable Device ID
- guide device-scoped LogQL to begin with `{}` plus the requested line filter, then summarize on a match instead of guessing labels
- reject zero IDs and conflicting `device_id` selectors

## Verification
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/manager/biz/aiops/tools ./internal/manager/biz/aiops/chatruntime ./internal/manager/biz/aiops/graph`
- Test environment default assistant, named-device log query: exactly `query_devices` once, then `query_logql(device_id=24, query={})` once; matched and summarized logs.
- Test environment default assistant, named-device trace query: exactly `query_devices` once, then `query_traceql(device_id=24, min_duration=1s)` once. Tempo had no matching trace data, and the assistant did not enumerate labels or repeat the query.

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md