### PR TITLE
fix(agent): make LLM timeout configurable

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -743,7 +743,10 @@ func main() {
 	// per-request Provider override flows through; absent that, behaviour
 	// matches the legacy single-provider path (router falls back to
 	// openaiClient when no providers are configured).
-	llmClient := llm.Client(llmRouter)
+	// Apply the live assistant timeout outside provider routing so every
+	// configured provider gets the same default deadline. Explicit callers
+	// (workflows/tools) keep their narrower or specialised deadlines.
+	llmClient := llm.WithDefaultTimeout(llmRouter, settingSvc.AgentLLMTimeout)
 
 	// manager/edge biz + service + server.
 	edgeRepo := manageredgedata.NewRepo(db)
@@ -1685,8 +1688,9 @@ func main() {
 			managerreportdata.NewFactsCollector(db, reportProm),
 			reportRT,
 			managerbizreport.GeneratorConfig{
-				DefaultLocale: firstNonEmpty(os.Getenv("ONGRID_DEFAULT_LOCALE"), "en"),
-				PublicURL:     cfg.PublicURL,
+				DefaultLocale:   firstNonEmpty(os.Getenv("ONGRID_DEFAULT_LOCALE"), "en"),
+				PublicURL:       cfg.PublicURL,
+				TimeoutProvider: settingSvc.AgentLLMTimeout,
 			},
 			log,
 		).

--- a/internal/manager/biz/report/generator.go
+++ b/internal/manager/biz/report/generator.go
@@ -29,6 +29,10 @@ type GeneratorConfig struct {
 	// Timeout caps a single report generation. 0 → 120s (the project-
 	// wide LLM timeout floor).
 	Timeout time.Duration
+	// TimeoutProvider optionally resolves the live assistant timeout for each
+	// report. A configured positive value overrides Timeout without requiring a
+	// manager restart.
+	TimeoutProvider func(context.Context) time.Duration
 	// DefaultLocale is used when a report has no owner-locale signal
 	// (scheduled reports run headless — there's no Accept-Language).
 	// Empty → "en" per feedback_ai_output_locale (auto-triggered LLM
@@ -125,7 +129,7 @@ func (g *workerGenerator) Generate(ctx context.Context, reportID string) {
 }
 
 func (g *workerGenerator) generate(ctx context.Context, rpt *model.Report) error {
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), g.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), g.timeout(ctx))
 	defer cancel()
 
 	period := Period{Start: rpt.PeriodStart, End: rpt.PeriodEnd}
@@ -204,6 +208,15 @@ func (g *workerGenerator) generate(ctx context.Context, rpt *model.Report) error
 	// fatal to the (already-persisted) ready report.
 	g.deliver(ctx, rpt)
 	return nil
+}
+
+func (g *workerGenerator) timeout(ctx context.Context) time.Duration {
+	if g.cfg.TimeoutProvider != nil {
+		if timeout := g.cfg.TimeoutProvider(ctx); timeout > 0 {
+			return timeout
+		}
+	}
+	return g.cfg.Timeout
 }
 
 // deliver pushes a ready report to the schedule's channels and records

--- a/internal/manager/biz/report/generator_test.go
+++ b/internal/manager/biz/report/generator_test.go
@@ -77,6 +77,28 @@ func newGenTestRepo(rpt *model.Report) *fakeRepo {
 	return r
 }
 
+func TestGeneratorTimeoutUsesLiveProvider(t *testing.T) {
+	ctx := context.Background()
+	gen := NewWorkerGenerator(
+		newGenTestRepo(pendingReport()),
+		fakeFacts{facts: sampleFacts()},
+		&fakeSpawner{},
+		GeneratorConfig{
+			Timeout:         time.Minute,
+			TimeoutProvider: func(context.Context) time.Duration { return 5 * time.Minute },
+		},
+		nil,
+	)
+	if got := gen.timeout(ctx); got != 5*time.Minute {
+		t.Fatalf("timeout() = %s, want 5m", got)
+	}
+
+	gen.cfg.TimeoutProvider = func(context.Context) time.Duration { return 0 }
+	if got := gen.timeout(ctx); got != time.Minute {
+		t.Fatalf("timeout() fallback = %s, want 1m", got)
+	}
+}
+
 func TestGenerator_HappyPath_OverwritesNumbersFromFacts(t *testing.T) {
 	rpt := pendingReport()
 	repo := newGenTestRepo(rpt)

--- a/internal/manager/biz/setting/agent.go
+++ b/internal/manager/biz/setting/agent.go
@@ -2,8 +2,20 @@ package setting
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+const (
+	defaultAgentLLMTimeout = 120 * time.Second
+	minAgentLLMTimeout     = 30 * time.Second
+	maxAgentLLMTimeout     = 15 * time.Minute
 )
 
 // agent.go — typed accessor for CategoryAgent behaviour toggles. Mirrors the
@@ -22,4 +34,44 @@ func (s *Service) AgentWriteEnabled(ctx context.Context) bool {
 		return false
 	}
 	return v == "true"
+}
+
+// AgentLLMTimeout returns the live assistant LLM timeout. Missing, malformed,
+// or out-of-range values fall back to the stable 120 second default so a bad
+// setting cannot make assistant work unbounded or immediately fail.
+func (s *Service) AgentLLMTimeout(ctx context.Context) time.Duration {
+	v, found, err := s.Get(ctx, model.CategoryAgent, model.KeyAgentLLMTimeoutSeconds)
+	if err != nil || !found {
+		return defaultAgentLLMTimeout
+	}
+	d, err := parseAgentLLMTimeout(v)
+	if err != nil {
+		s.log.Warn("invalid agent LLM timeout; using default", slog.String("value", v), slog.Any("err", err))
+		return defaultAgentLLMTimeout
+	}
+	return d
+}
+
+// validateAgentSetting validates typed settings before persistence. Other
+// agent keys remain backwards-compatible with the generic setting store.
+func validateAgentSetting(key, value string) error {
+	if key != model.KeyAgentLLMTimeoutSeconds {
+		return nil
+	}
+	if _, err := parseAgentLLMTimeout(value); err != nil {
+		return fmt.Errorf("%w: %v", errs.ErrInvalid, err)
+	}
+	return nil
+}
+
+func parseAgentLLMTimeout(raw string) (time.Duration, error) {
+	seconds, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("LLM timeout must be an integer number of seconds")
+	}
+	d := time.Duration(seconds) * time.Second
+	if d < minAgentLLMTimeout || d > maxAgentLLMTimeout {
+		return 0, fmt.Errorf("LLM timeout must be between %d and %d seconds", int(minAgentLLMTimeout.Seconds()), int(maxAgentLLMTimeout.Seconds()))
+	}
+	return d, nil
 }

--- a/internal/manager/biz/setting/service.go
+++ b/internal/manager/biz/setting/service.go
@@ -111,6 +111,11 @@ func (s *Service) Set(ctx context.Context, category, key, value string, sensitiv
 	if category == "" || key == "" {
 		return fmt.Errorf("%w: category/key required", errs.ErrInvalid)
 	}
+	if category == model.CategoryAgent {
+		if err := validateAgentSetting(key, value); err != nil {
+			return err
+		}
+	}
 	if _, err := s.repo.Set(ctx, category, key, value, sensitive); err != nil {
 		return err
 	}
@@ -136,6 +141,11 @@ func (s *Service) SetBatch(ctx context.Context, settings []model.Setting) error 
 	for i := range settings {
 		if settings[i].Category == "" || settings[i].Key == "" {
 			return fmt.Errorf("%w: category/key required", errs.ErrInvalid)
+		}
+		if settings[i].Category == model.CategoryAgent {
+			if err := validateAgentSetting(settings[i].Key, settings[i].Value); err != nil {
+				return err
+			}
 		}
 	}
 	if err := s.repo.SetBatch(ctx, settings); err != nil {

--- a/internal/manager/biz/setting/service_test.go
+++ b/internal/manager/biz/setting/service_test.go
@@ -159,6 +159,62 @@ func TestNetworkDiscoveryEnabled(t *testing.T) {
 	}
 }
 
+func TestAgentLLMTimeout(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name  string
+		value string
+		set   bool
+		want  time.Duration
+	}{
+		{name: "unset defaults to 120 seconds", want: defaultAgentLLMTimeout},
+		{name: "minimum accepted", value: "30", set: true, want: 30 * time.Second},
+		{name: "maximum accepted", value: "900", set: true, want: 15 * time.Minute},
+		{name: "malformed falls back", value: "slow", set: true, want: defaultAgentLLMTimeout},
+		{name: "out of range falls back", value: "901", set: true, want: defaultAgentLLMTimeout},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newFakeRepo()
+			if test.set {
+				if _, err := repo.Set(ctx, model.CategoryAgent, model.KeyAgentLLMTimeoutSeconds, test.value, false); err != nil {
+					t.Fatalf("seed setting: %v", err)
+				}
+			}
+			if got := New(repo, nil).AgentLLMTimeout(ctx); got != test.want {
+				t.Fatalf("AgentLLMTimeout() = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestServiceSetValidatesAgentLLMTimeout(t *testing.T) {
+	svc := New(newFakeRepo(), nil)
+	ctx := context.Background()
+	for _, value := range []string{"", "29", "901", "not-a-number"} {
+		if err := svc.Set(ctx, model.CategoryAgent, model.KeyAgentLLMTimeoutSeconds, value, false); !errors.Is(err, errs.ErrInvalid) {
+			t.Errorf("Set(%q) error = %v, want errs.ErrInvalid", value, err)
+		}
+	}
+	if err := svc.Set(ctx, model.CategoryAgent, model.KeyAgentLLMTimeoutSeconds, "300", false); err != nil {
+		t.Fatalf("Set(valid timeout): %v", err)
+	}
+	if got := svc.AgentLLMTimeout(ctx); got != 5*time.Minute {
+		t.Fatalf("AgentLLMTimeout() = %s, want 5m", got)
+	}
+}
+
+func TestServiceSetBatchValidatesAgentLLMTimeout(t *testing.T) {
+	svc := New(newFakeRepo(), nil)
+	err := svc.SetBatch(context.Background(), []model.Setting{{
+		Category: model.CategoryAgent,
+		Key:      model.KeyAgentLLMTimeoutSeconds,
+		Value:    "901",
+	}})
+	if !errors.Is(err, errs.ErrInvalid) {
+		t.Fatalf("SetBatch(invalid timeout) error = %v, want errs.ErrInvalid", err)
+	}
+}
+
 func TestServiceSetInvalidatesCache(t *testing.T) {
 	repo := newFakeRepo()
 	if _, err := repo.Set(context.Background(), "llm", "openai_model", "gpt-4o", false); err != nil {

--- a/internal/manager/model/setting/model.go
+++ b/internal/manager/model/setting/model.go
@@ -59,6 +59,10 @@ const (
 	// tools. Only "true" enables write tools; unset / any other value keeps the
 	// agent read-only (only Class=="read" tools exposed to the LLM).
 	KeyAgentWriteEnabled = "write_enabled"
+	// KeyAgentLLMTimeoutSeconds bounds an assistant LLM request and report
+	// generation in seconds. The typed setting accessor owns its default and
+	// range validation so callers cannot accidentally accept an unbounded value.
+	KeyAgentLLMTimeoutSeconds = "llm_timeout_seconds"
 )
 
 // (CategoryGit + KeyGitGitHubToken removed HTTPS git

--- a/internal/pkg/llm/client.go
+++ b/internal/pkg/llm/client.go
@@ -47,7 +47,7 @@ const defaultTimeout = 120 * time.Second
 //
 // BaseURL is optional and lets us point at Azure / Fireworks / a local vLLM
 // without reshaping the interface. Timeout applies when the caller's ctx has
-// no deadline; default is 30s.
+// no deadline; default is 120s.
 type Config struct {
 	APIKey  string
 	Model   string
@@ -125,6 +125,39 @@ type BudgetChecker interface {
 // Client is the LLM client surface consumed by the AIOps agent.
 type Client interface {
 	Chat(ctx context.Context, req ChatReq) (*ChatResp, error)
+}
+
+// TimeoutProvider returns the current default LLM request timeout. It is used
+// only when the caller did not already establish a deadline; explicit workflow
+// and tool deadlines remain authoritative.
+type TimeoutProvider func(ctx context.Context) time.Duration
+
+// WithDefaultTimeout wraps a client with a runtime-configurable default
+// deadline. The wrapper is deliberately outside provider routing, so one
+// setting applies equally to every configured OpenAI-compatible provider.
+func WithDefaultTimeout(inner Client, provider TimeoutProvider) Client {
+	if inner == nil || provider == nil {
+		return inner
+	}
+	return timeoutClient{inner: inner, provider: provider}
+}
+
+type timeoutClient struct {
+	inner    Client
+	provider TimeoutProvider
+}
+
+func (c timeoutClient) Chat(ctx context.Context, req ChatReq) (*ChatResp, error) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return c.inner.Chat(ctx, req)
+	}
+	timeout := c.provider(ctx)
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.inner.Chat(callCtx, req)
 }
 
 // Resolver supplies the LLM credentials at call time. The seam exists so

--- a/internal/pkg/llm/router_test.go
+++ b/internal/pkg/llm/router_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // stubClient records the last ChatReq and returns a canned response.
@@ -18,6 +19,48 @@ func (s *stubClient) Chat(_ context.Context, req ChatReq) (*ChatResp, error) {
 	s.last = req
 	c := "from-" + s.id
 	return &ChatResp{Assistant: Message{Role: "assistant", Content: c}}, nil
+}
+
+type deadlineClient struct {
+	hasDeadline bool
+	deadline    time.Time
+}
+
+func (c *deadlineClient) Chat(ctx context.Context, _ ChatReq) (*ChatResp, error) {
+	c.deadline, c.hasDeadline = ctx.Deadline()
+	return &ChatResp{Assistant: Message{Role: "assistant"}}, nil
+}
+
+func TestWithDefaultTimeoutAddsConfiguredDeadline(t *testing.T) {
+	inner := &deadlineClient{}
+	client := WithDefaultTimeout(inner, func(context.Context) time.Duration { return 2 * time.Second })
+	before := time.Now()
+	if _, err := client.Chat(context.Background(), ChatReq{}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !inner.hasDeadline {
+		t.Fatal("wrapped request has no deadline")
+	}
+	if got := inner.deadline.Sub(before); got < 1900*time.Millisecond || got > 2100*time.Millisecond {
+		t.Fatalf("deadline delta = %s, want about 2s", got)
+	}
+}
+
+func TestWithDefaultTimeoutPreservesExistingDeadline(t *testing.T) {
+	inner := &deadlineClient{}
+	client := WithDefaultTimeout(inner, func(context.Context) time.Duration { return time.Second })
+	want := time.Now().Add(5 * time.Second).Round(0)
+	ctx, cancel := context.WithDeadline(context.Background(), want)
+	defer cancel()
+	if _, err := client.Chat(ctx, ChatReq{}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !inner.hasDeadline {
+		t.Fatal("request has no deadline")
+	}
+	if !inner.deadline.Equal(want) {
+		t.Fatalf("deadline = %s, want existing deadline %s", inner.deadline, want)
+	}
 }
 
 type stubProvidersResolver struct {

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -49,7 +49,7 @@ const RAIL_ITEMS: RailItem[] = [
   // the previous /communications and /bots paths live in App.tsx.
   { to: 'notifications', icon: Bell, labelZh: '通知', labelEn: 'Notifications', hintZh: '飞书 / 钉钉 / 企业微信 / Slack / Telegram / Webhook（告警推送）', hintEn: 'Slack / Telegram / Larksuite / DingTalk / WeCom / Webhook (alert delivery)' },
   { to: 'channels', icon: MessagesSquare, labelZh: 'IM', labelEn: 'Channels', hintZh: '飞书 / 钉钉 / Telegram / Slack 双向多轮', hintEn: 'Slack / Telegram / Larksuite / DingTalk — two-way multi-turn' },
-  { to: 'agent', icon: Bot, labelZh: '助理', labelEn: 'Agent', hintZh: 'AI 助理行为 — 写操作权限', hintEn: 'AI assistant behaviour — write-action gate' },
+  { to: 'agent', icon: Bot, labelZh: '助理', labelEn: 'Agent', hintZh: 'AI 助理行为 — 写操作与超时', hintEn: 'AI assistant behaviour — writes and timeouts' },
   { to: 'preferences', icon: Gauge, labelZh: '偏好', labelEn: 'Preferences', hintZh: '默认时间窗 / 自动刷新', hintEn: 'Default time window / auto-refresh' },
   { to: 'about', icon: Info, labelZh: '关于', labelEn: 'About', hintZh: '版本 / GitHub / 许可证', hintEn: 'Version / GitHub / license' },
 ];

--- a/web/src/pages/settings/Agent.test.tsx
+++ b/web/src/pages/settings/Agent.test.tsx
@@ -1,0 +1,81 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import SettingsAgent from './Agent';
+import { server } from '@/test/msw-server';
+
+beforeEach(() => {
+  localStorage.setItem('ongrid-locale', 'en-US');
+});
+
+describe('SettingsAgent LLM timeout', () => {
+  it('loads the default and persists a validated timeout', async () => {
+    let saved: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/v1/system-settings', () => HttpResponse.json({ items: [], total: 0 })),
+      http.put('/api/v1/system-settings/agent/llm_timeout_seconds', async ({ request }) => {
+        saved = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({
+          category: 'agent',
+          key: 'llm_timeout_seconds',
+          value: '300',
+          sensitive: false,
+          updated_at: '2026-08-07T00:00:00Z',
+        });
+      }),
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <SettingsAgent />
+        </MemoryRouter>,
+      );
+    });
+
+    const input = await screen.findByRole('spinbutton', { name: 'Timeout seconds' });
+    expect(input).toHaveValue(120);
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.clear(input);
+      await user.type(input, '300');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    await waitFor(() => expect(saved).toEqual({ value: '300', sensitive: false }));
+  });
+
+  it('rejects values outside the supported range before persistence', async () => {
+    let calls = 0;
+    server.use(
+      http.get('/api/v1/system-settings', () => HttpResponse.json({ items: [], total: 0 })),
+      http.put('/api/v1/system-settings/agent/llm_timeout_seconds', () => {
+        calls++;
+        return HttpResponse.json({});
+      }),
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <SettingsAgent />
+        </MemoryRouter>,
+      );
+    });
+
+    const input = await screen.findByRole('spinbutton', { name: 'Timeout seconds' });
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.clear(input);
+      await user.type(input, '29');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    expect(await screen.findByText(/Timeout must be a whole number/)).toBeInTheDocument();
+    expect(calls).toBe(0);
+  });
+});

--- a/web/src/pages/settings/Agent.tsx
+++ b/web/src/pages/settings/Agent.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Bot, Loader2, ShieldCheck } from 'lucide-react';
+import { Bot, Clock3, Loader2, ShieldCheck } from 'lucide-react';
 import { listSettings, setSetting } from '@/api/settings';
 import { useI18n } from '@/i18n/locale';
 import { cn } from '@/lib/cn';
 
-// SettingsAgent — admin controls for AI-agent behaviour. Today it hosts a
-// single gate: whether the assistant may use write/mutating tools. The whole
+// SettingsAgent — admin controls for AI-agent behaviour. It hosts the
+// write-action gate and the assistant LLM request timeout. The whole
 // /settings area is already admin-only (SettingsLayout gates on isAdmin), so no
 // extra role check is needed here.
 //
@@ -14,20 +14,29 @@ import { cn } from '@/lib/cn';
 // server (fail-safe default), so we treat a missing row as OFF.
 const CATEGORY = 'agent';
 const KEY = 'write_enabled';
+const LLM_TIMEOUT_KEY = 'llm_timeout_seconds';
+const DEFAULT_LLM_TIMEOUT_SECONDS = 120;
+const MIN_LLM_TIMEOUT_SECONDS = 30;
+const MAX_LLM_TIMEOUT_SECONDS = 900;
 
 export default function SettingsAgent() {
   const { tr } = useI18n();
   const [writeEnabled, setWriteEnabled] = useState(false);
+  const [llmTimeoutSeconds, setLLMTimeoutSeconds] = useState(String(DEFAULT_LLM_TIMEOUT_SECONDS));
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingTimeout, setSavingTimeout] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
       const res = await listSettings(CATEGORY);
       const row = res.items.find((i) => i.key === KEY);
+      const timeoutRow = res.items.find((i) => i.key === LLM_TIMEOUT_KEY);
       // Missing row → server default is DISABLED (fail-safe).
       setWriteEnabled(row ? row.value === 'true' : false);
+      // Missing timeout row → server and UI both use the stable 120s default.
+      setLLMTimeoutSeconds(timeoutRow?.value || String(DEFAULT_LLM_TIMEOUT_SECONDS));
       setErr(null);
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -58,8 +67,32 @@ export default function SettingsAgent() {
     [],
   );
 
+  const onSaveTimeout = useCallback(async () => {
+    const seconds = Number(llmTimeoutSeconds);
+    if (!Number.isInteger(seconds) || seconds < MIN_LLM_TIMEOUT_SECONDS || seconds > MAX_LLM_TIMEOUT_SECONDS) {
+      setErr(
+        tr(
+          `超时时间必须是 ${MIN_LLM_TIMEOUT_SECONDS} 到 ${MAX_LLM_TIMEOUT_SECONDS} 的整数秒数。`,
+          `Timeout must be a whole number between ${MIN_LLM_TIMEOUT_SECONDS} and ${MAX_LLM_TIMEOUT_SECONDS} seconds.`,
+        ),
+      );
+      return;
+    }
+    setSavingTimeout(true);
+    setErr(null);
+    try {
+      await setSetting(CATEGORY, LLM_TIMEOUT_KEY, String(seconds), false);
+      setLLMTimeoutSeconds(String(seconds));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingTimeout(false);
+    }
+  }, [llmTimeoutSeconds, tr]);
+
   return (
     <div className="space-y-4">
+      {err && <div className="text-xs text-red-400">{err}</div>}
       <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
         <div className="mb-3 flex items-center gap-2">
           <ShieldCheck size={14} className="text-zinc-400" />
@@ -117,13 +150,58 @@ export default function SettingsAgent() {
             </button>
           </div>
         )}
-
-        {err && <div className="mt-3 text-xs text-red-400">{err}</div>}
-
         <p className="mt-4 text-[11px] leading-relaxed text-zinc-600">
           {tr(
             '提示：改动立即生效，对所有用户的新对话轮次生效，无需重启。已在进行中的工具调用不受影响。',
             'Note: takes effect immediately on the next chat turn for every user, no restart needed. Tool calls already in flight are unaffected.',
+          )}
+        </p>
+      </section>
+
+      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="mb-3 flex items-center gap-2">
+          <Clock3 size={14} className="text-zinc-400" />
+          <h2 className="text-sm font-medium text-zinc-100">{tr('LLM 超时', 'LLM timeout')}</h2>
+        </div>
+        <p className="mb-4 text-xs leading-relaxed text-zinc-500">
+          {tr(
+            '设置助理单次 LLM 请求的最长等待时间，也用作巡检报告的总生成窗口。默认 120 秒；工作流和工具的专用超时不受影响。',
+            'Sets the longest wait for one assistant LLM request and the total inspection-report generation window. Defaults to 120 seconds; workflow and tool-specific timeouts are unchanged.',
+          )}
+        </p>
+        {loading ? (
+          <div className="flex h-10 items-center text-xs text-zinc-500">
+            <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
+          </div>
+        ) : (
+          <div className="flex items-end gap-3">
+            <label htmlFor="agent-llm-timeout-seconds" className="block">
+              <span className="mb-1.5 block text-[11px] font-medium text-zinc-400">{tr('超时秒数', 'Timeout seconds')}</span>
+              <input
+                id="agent-llm-timeout-seconds"
+                type="number"
+                min={MIN_LLM_TIMEOUT_SECONDS}
+                max={MAX_LLM_TIMEOUT_SECONDS}
+                step={1}
+                value={llmTimeoutSeconds}
+                onChange={(event) => setLLMTimeoutSeconds(event.target.value)}
+                className="h-10 w-36 rounded-md border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition focus:border-indigo-500"
+              />
+            </label>
+            <button
+              type="button"
+              disabled={savingTimeout}
+              onClick={() => void onSaveTimeout()}
+              className="h-10 rounded-md bg-indigo-600 px-3 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {savingTimeout ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+            </button>
+          </div>
+        )}
+        <p className="mt-3 text-[11px] text-zinc-600">
+          {tr(
+            `允许范围 ${MIN_LLM_TIMEOUT_SECONDS}–${MAX_LLM_TIMEOUT_SECONDS} 秒；保存后对新任务立即生效。`,
+            `Allowed range: ${MIN_LLM_TIMEOUT_SECONDS}–${MAX_LLM_TIMEOUT_SECONDS} seconds; applies to new work immediately after saving.`,
           )}
         </p>
       </section>

--- a/web/src/pages/settings/Agent.tsx
+++ b/web/src/pages/settings/Agent.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Bot, Clock3, Loader2, ShieldCheck } from 'lucide-react';
+import { Bot, Clock3, Loader2, Save, ShieldCheck } from 'lucide-react';
 import { listSettings, setSetting } from '@/api/settings';
+import { Button } from '@/components/ui';
 import { useI18n } from '@/i18n/locale';
 import { cn } from '@/lib/cn';
 
@@ -161,12 +162,12 @@ export default function SettingsAgent() {
       <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
         <div className="mb-3 flex items-center gap-2">
           <Clock3 size={14} className="text-zinc-400" />
-          <h2 className="text-sm font-medium text-zinc-100">{tr('LLM 超时', 'LLM timeout')}</h2>
+          <h2 className="text-sm font-medium text-zinc-100">{tr('LLM 请求超时', 'LLM request timeout')}</h2>
         </div>
         <p className="mb-4 text-xs leading-relaxed text-zinc-500">
           {tr(
-            '设置助理单次 LLM 请求的最长等待时间，也用作巡检报告的总生成窗口。默认 120 秒；工作流和工具的专用超时不受影响。',
-            'Sets the longest wait for one assistant LLM request and the total inspection-report generation window. Defaults to 120 seconds; workflow and tool-specific timeouts are unchanged.',
+            '设置助理单次 LLM 请求的最长等待时间，也用作巡检报告的总生成窗口。默认 120 秒；工作流和工具的专用超时保持不变。',
+            'Sets the longest wait for one assistant LLM request and the total inspection-report generation window. Defaults to 120 seconds; workflow and tool-specific timeouts stay unchanged.',
           )}
         </p>
         {loading ? (
@@ -174,9 +175,19 @@ export default function SettingsAgent() {
             <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
           </div>
         ) : (
-          <div className="flex items-end gap-3">
-            <label htmlFor="agent-llm-timeout-seconds" className="block">
-              <span className="mb-1.5 block text-[11px] font-medium text-zinc-400">{tr('超时秒数', 'Timeout seconds')}</span>
+          <div className="flex items-center justify-between gap-4 rounded-lg border border-zinc-800 bg-zinc-950/40 px-4 py-3">
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium text-zinc-200">
+                {tr('助理默认超时', 'Assistant default timeout')}
+              </div>
+              <div className="mt-0.5 text-[11px] text-zinc-500">
+                {tr('保存后仅影响新发起的 LLM 请求', 'Applies to newly started LLM requests after saving')}
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <label htmlFor="agent-llm-timeout-seconds" className="sr-only">
+                {tr('超时秒数', 'Timeout seconds')}
+              </label>
               <input
                 id="agent-llm-timeout-seconds"
                 type="number"
@@ -185,17 +196,19 @@ export default function SettingsAgent() {
                 step={1}
                 value={llmTimeoutSeconds}
                 onChange={(event) => setLLMTimeoutSeconds(event.target.value)}
-                className="h-10 w-36 rounded-md border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition focus:border-indigo-500"
+                className="h-8 w-20 rounded-md border border-zinc-700 bg-zinc-950 px-2 text-right font-mono text-sm text-zinc-100 outline-none transition focus:border-accent"
               />
-            </label>
-            <button
-              type="button"
-              disabled={savingTimeout}
-              onClick={() => void onSaveTimeout()}
-              className="h-10 rounded-md bg-indigo-600 px-3 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:opacity-50"
-            >
-              {savingTimeout ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
-            </button>
+              <span className="text-xs text-zinc-500">{tr('秒', 'sec')}</span>
+              <Button
+                variant="primary"
+                disabled={savingTimeout}
+                onClick={() => void onSaveTimeout()}
+                className="h-8"
+              >
+                <Save size={13} />
+                {savingTimeout ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+              </Button>
+            </div>
           </div>
         )}
         <p className="mt-3 text-[11px] text-zinc-600">

--- a/web/src/pages/settings/Agent.tsx
+++ b/web/src/pages/settings/Agent.tsx
@@ -175,19 +175,11 @@ export default function SettingsAgent() {
             <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
           </div>
         ) : (
-          <div className="flex items-center justify-between gap-4 rounded-lg border border-zinc-800 bg-zinc-950/40 px-4 py-3">
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium text-zinc-200">
-                {tr('助理默认超时', 'Assistant default timeout')}
-              </div>
-              <div className="mt-0.5 text-[11px] text-zinc-500">
-                {tr('保存后仅影响新发起的 LLM 请求', 'Applies to newly started LLM requests after saving')}
-              </div>
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <label htmlFor="agent-llm-timeout-seconds" className="sr-only">
-                {tr('超时秒数', 'Timeout seconds')}
-              </label>
+          <>
+            <label htmlFor="agent-llm-timeout-seconds" className="mb-1.5 block text-sm text-zinc-300">
+              {tr('超时秒数', 'Timeout seconds')}
+            </label>
+            <div className="flex items-center gap-2">
               <input
                 id="agent-llm-timeout-seconds"
                 type="number"
@@ -196,20 +188,24 @@ export default function SettingsAgent() {
                 step={1}
                 value={llmTimeoutSeconds}
                 onChange={(event) => setLLMTimeoutSeconds(event.target.value)}
-                className="h-8 w-20 rounded-md border border-zinc-700 bg-zinc-950 px-2 text-right font-mono text-sm text-zinc-100 outline-none transition focus:border-accent"
+                className="h-10 w-48 rounded-md border border-zinc-700 bg-zinc-950 px-3 font-mono text-sm text-zinc-100 outline-none transition focus:border-zinc-600"
               />
-              <span className="text-xs text-zinc-500">{tr('秒', 'sec')}</span>
+              <span className="text-sm text-zinc-500">{tr('秒', 'seconds')}</span>
+            </div>
+            <div className="mt-4 flex items-center gap-3">
               <Button
-                variant="primary"
+                variant="subtle"
                 disabled={savingTimeout}
                 onClick={() => void onSaveTimeout()}
-                className="h-8"
               >
-                <Save size={13} />
+                <Save size={14} />
                 {savingTimeout ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
               </Button>
+              <span className="text-xs text-zinc-500">
+                {tr('保存后仅影响新发起的 LLM 请求', 'Applies to newly started LLM requests after saving')}
+              </span>
             </div>
-          </div>
+          </>
         )}
         <p className="mt-3 text-[11px] text-zinc-600">
           {tr(


### PR DESCRIPTION
## Summary
- add an Assistant setting for the default LLM timeout (30–900 seconds; default 120)
- apply the live value to standard assistant LLM calls and inspection-report generation
- preserve explicit workflow and tool deadlines
- align the setting control with the existing LLM settings form pattern

Fixes #173

## Validation
- go test -race ./internal/manager/biz/setting ./internal/pkg/llm ./internal/manager/biz/report ./cmd/ongrid
- cd web && npm test -- --run src/pages/settings/Agent.test.tsx
- cd web && npm run build
- deployed to the test environment; healthz and readyz are healthy

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md