### PR TITLE
fix(release): align packaged version metadata

### DIFF
--- a/dist/package.sh
+++ b/dist/package.sh
@@ -95,14 +95,12 @@ copy_opt() {
     fi
 }
 
-# --- VERSION file -----------------------------------------------------------
-if [ -f "${REPO_ROOT}/VERSION" ]; then
-    cp "${REPO_ROOT}/VERSION" "${STAGE_DIR}/VERSION"
-    log "  + VERSION"
-else
-    printf '%s\n' "${VERSION}" > "${STAGE_DIR}/VERSION"
-    warn "repo VERSION missing; synthesized from arg"
-fi
+# --- release version --------------------------------------------------------
+# The package argument is the release identity. Do not copy the repository
+# VERSION file here: release automation may provide VERSION on the command
+# line, and upgrade.sh reads the staged .env.example to choose the image tag.
+printf '%s\n' "${VERSION}" > "${STAGE_DIR}/VERSION"
+log "  + VERSION (${VERSION})"
 
 # --- top-level install-time assets (owned by parallel agent) ----------------
 copy_opt "${REPO_ROOT}/deploy/install/README.md"           "${STAGE_DIR}/README.md"
@@ -113,6 +111,10 @@ copy_opt "${REPO_ROOT}/deploy/install/public-url.sh"       "${STAGE_DIR}/public-
 copy_opt "${REPO_ROOT}/deploy/install/data-permissions.sh"  "${STAGE_DIR}/data-permissions.sh"  644
 copy_opt "${REPO_ROOT}/deploy/install/docker-compose.yml"  "${STAGE_DIR}/docker-compose.yml"
 copy_opt "${REPO_ROOT}/deploy/install/.env.example"        "${STAGE_DIR}/.env.example"
+if [[ -f "${STAGE_DIR}/.env.example" ]]; then
+    sed -i.bak -E "s|^ONGRID_VERSION=.*|ONGRID_VERSION=${VERSION}|" "${STAGE_DIR}/.env.example"
+    rm -f "${STAGE_DIR}/.env.example.bak"
+fi
 copy_opt "${REPO_ROOT}/deploy/install/frontier.yaml"       "${STAGE_DIR}/frontier.yaml"
 
 # --- nginx config + certs scaffold (ADR-008) --------------------------------

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -86,6 +86,8 @@ for arch in amd64 arm64; do
   extract_dir="$tmp_dir/extracted-$arch"
   mkdir -p "$extract_dir"
   tar -xf "$archive" -C "$extract_dir"
+  grep -Fqx 'vtest' "$extract_dir/$package_root/VERSION"
+  grep -Fqx 'ONGRID_VERSION=vtest' "$extract_dir/$package_root/.env.example"
   grep -Fxq 'ONGRID_EDGE_DEPS_TAG=edge-deps-test' \
     "$extract_dir/$package_root/edge/edge-artifacts.env"
   grep -Fxq 'ONGRID_EDGE_TARGETS=linux-amd64 linux-arm64' \


### PR DESCRIPTION
## Summary
- make the package VERSION argument the sole release identity for staged metadata
- render the same version into .env.example so upgrade.sh pulls the correct target image
- add release-package coverage for both staged version values

## Validation
- bash scripts/test-compose-release-package.sh

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md