### PR TITLE
fix(ui): correct network discovery light hover

### DIFF
--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -205,6 +205,7 @@ html.light .hover\:bg-zinc-800\/60:hover   { background-color: rgb(226 232 240 /
 html.light .hover\:bg-zinc-900:hover       { background-color: rgb(241 245 249); }  /* slate-100 */
 html.light .hover\:bg-zinc-900\/30:hover,
 html.light .hover\:bg-zinc-900\/40:hover   { background-color: rgb(241 245 249 / 0.7); }
+html.light .hover\:bg-zinc-900\/60:hover   { background-color: rgb(248 250 252); }
 html.light .hover\:bg-zinc-700:hover       { background-color: rgb(203 213 225); }
 html.light .hover\:bg-red-900\/30:hover    { background-color: rgb(254 226 226); }
 html.light .hover\:text-zinc-100:hover     { color: rgb(var(--text)); }


### PR DESCRIPTION
## Summary
- Fixes #289.
- Map the missing light-theme hover:bg-zinc-900/60 variant used by network discovery table rows.
- Keeps dark-theme behavior unchanged.

## Verification
- npm test -- --run src/pages/Edges.test.tsx
- npm run build
- Deployed to the test environment and verified the hovered network-discovery row resolves to rgb(248, 250, 252) in light theme.

## Rollback
- Revert commit 48a96ec.

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md