### PR TITLE
fix(ui): handle optional sidebar settings failure

### DIFF
--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -22,6 +22,7 @@ describe('Sidebar configurable sections', () => {
     useUi.getState().setSidebarCollapsed(false);
     server.use(
       http.get('/api/v1/chat/sessions', () => HttpResponse.json({ items: [], total: 0 })),
+      http.get('/api/v1/system-settings', () => HttpResponse.json({ items: [], total: 0 })),
     );
   });
 
@@ -68,5 +69,19 @@ describe('Sidebar configurable sections', () => {
     expect(screen.getByRole('button', { name: '管理基础设施菜单' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '管理监控告警菜单' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '管理日常菜单' })).toBeInTheDocument();
+  });
+
+  it('可选升级菜单设置读取失败时仍保持默认导航', async () => {
+    server.use(
+      http.get('/api/v1/system-settings', () => HttpResponse.error()),
+    );
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('link', { name: '网络设备' })).toBeInTheDocument();
   });
 });

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -86,11 +86,15 @@ export function Sidebar() {
 	const [upgradeHiddenResources, setUpgradeHiddenResources] = useState<string[]>([]);
 	useEffect(() => {
 		if (localStorage.getItem('sidebar.infrastructure.upgrade.v0_10')) return;
-		void listSettings('ui').then((out) => {
-			const row = out.items.find((item) => item.key === 'infrastructure_menu_upgrade_v0_10');
-			if (!row) return;
-			try { const parsed = JSON.parse(row.value) as { hidden?: string[] }; setUpgradeHiddenResources(parsed.hidden ?? []); } catch { /* ignore malformed upgrade seed */ }
-		});
+		void listSettings('ui')
+			.then((out) => {
+				const row = out.items.find((item) => item.key === 'infrastructure_menu_upgrade_v0_10');
+				if (!row) return;
+				try { const parsed = JSON.parse(row.value) as { hidden?: string[] }; setUpgradeHiddenResources(parsed.hidden ?? []); } catch { /* ignore malformed upgrade seed */ }
+			})
+			.catch(() => {
+				// This upgrade seed is optional. Keep the default navigation when it is unavailable.
+			});
 	}, []);
   // Version + upgrade check moved to Settings → About / Upgrade (the brand mark
   // stays clean), so the sidebar no longer fetches version here.


### PR DESCRIPTION
## Summary
- ignore failure when loading the optional infrastructure-menu upgrade seed
- keep default navigation available when system settings cannot be read
- cover the failed request path and provide the default MSW handler

## Verification
- `cd web && npm test -- --run src/components/Sidebar.test.tsx`
- `cd web && npm test -- --run`
- `cd web && npm run build`

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

Closes #291