### PR TITLE
fix(installer): make Edge bundle readable by non-root containers on hardened hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,6 +801,7 @@ package-all: ## [release] 打 amd64 + arm64 两个生产安装包到 dist/out/
 test-release-package: ## [test] 校验安装 URL 与 Compose 发布包内容
 	bash scripts/test-public-url.sh
 	bash scripts/test-upgrade-data-permissions.sh
+	bash scripts/test-install-asset-modes.sh
 	$(MAKE) --no-print-directory test-edge-attachments
 	bash scripts/test-compose-release-package.sh
 	bash scripts/test-apply-pending-upgrade.sh

--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -232,3 +232,69 @@ ongrid_repair_data_permissions_or_restore() {
     fi
     return 1
 }
+
+# Run one command with a relaxed umask. Shared assets (config files, the nginx
+# static Edge directory, bundle tarballs and checksums) enter non-root
+# containers as root-owned read-only bind mounts, so they cannot be chown'd and
+# must stay group/other readable. Child processes inherit the umask, so this
+# also covers the tarball and .sha256 that build-edge-bundle.sh writes.
+# Saving and restoring instead of using a subshell keeps the caller's `set -e`
+# and ERR trap semantics intact for the wrapped command.
+ongrid_with_shared_asset_umask() {
+    local previous rc=0
+
+    previous=$(umask)
+    umask 022
+    "$@" || rc=$?
+    umask "$previous"
+    return "$rc"
+}
+
+# Normalize shared-asset modes inside an existing install directory.
+# This is not a belt-and-braces extra: `cp` leaves the mode of an existing
+# destination untouched, so an install created under a restrictive umask keeps
+# its 0640 config files forever, even once the installers relax their own umask.
+# `a+rX` only adds read bits, never write bits, and is idempotent on 0755.
+# The list is enumerated on purpose — recursing over the whole install dir would
+# turn .env (0600, database passwords) and certs/ (0700, TLS key) world-readable.
+ongrid_normalize_shared_asset_modes() {
+    local install_dir="$1" path
+
+    [[ -d "$install_dir" ]] || return 0
+
+    chmod 755 "$install_dir" 2>/dev/null || true
+    for path in \
+        "$install_dir/docker-compose.yml" \
+        "$install_dir"/prometheus*.yml \
+        "$install_dir/loki-config.yaml" \
+        "$install_dir/tempo-config.yaml" \
+        "$install_dir/frontier.yaml" \
+        "$install_dir/nginx.conf" \
+        "$install_dir/VERSION"; do
+        [[ -f "$path" ]] && { chmod 644 "$path" 2>/dev/null || true; }
+    done
+    for path in \
+        "$install_dir/edge" \
+        "$install_dir/searxng" \
+        "$install_dir/grafana" \
+        "$install_dir/prometheus"; do
+        [[ -d "$path" ]] && { chmod -R a+rX "$path" 2>/dev/null || true; }
+    done
+    return 0
+}
+
+# Remove Edge staging / backup directories left behind by an interrupted run.
+# The installers only ever cleaned up on ERR, so `exit 1` paths and SIGINT /
+# SIGTERM leaked a full bundle tree (~178 MB each) into the install directory.
+# Three guards keep this from touching anything else: depth 1 only, an anchored
+# name prefix, and an age floor so a concurrently running installer's staging
+# directory is never removed.
+ongrid_prune_stale_edge_staging() {
+    local install_dir="$1"
+
+    [[ -d "$install_dir" ]] || return 0
+    find "$install_dir" -maxdepth 1 -type d \
+        \( -name '.edge-stage.*' -o -name '.edge-backup.*' \) \
+        -mmin +120 -exec rm -rf {} + 2>/dev/null || true
+    return 0
+}

--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -283,18 +283,25 @@ ongrid_normalize_shared_asset_modes() {
     return 0
 }
 
-# Remove Edge staging / backup directories left behind by an interrupted run.
+# Remove Edge staging directories left behind by an interrupted run.
 # The installers only ever cleaned up on ERR, so `exit 1` paths and SIGINT /
 # SIGTERM leaked a full bundle tree (~178 MB each) into the install directory.
 # Three guards keep this from touching anything else: depth 1 only, an anchored
 # name prefix, and an age floor so a concurrently running installer's staging
 # directory is never removed.
+#
+# .edge-backup.* is deliberately NOT pruned here. After a health-check timeout
+# upgrade.sh keeps the previous Edge tree and prints it as the manual rollback
+# source, and install.sh keeps it when an automatic restore fails. That backup is
+# then the only known-good copy, and this function runs at startup before the
+# next Edge swap: pruning it by age would delete the operator's rollback source
+# out from under a retry. Backups are removed by the successful-upgrade cleanup
+# path, by a completed rollback, or by an explicit operator action.
 ongrid_prune_stale_edge_staging() {
     local install_dir="$1"
 
     [[ -d "$install_dir" ]] || return 0
-    find "$install_dir" -maxdepth 1 -type d \
-        \( -name '.edge-stage.*' -o -name '.edge-backup.*' \) \
+    find "$install_dir" -maxdepth 1 -type d -name '.edge-stage.*' \
         -mmin +120 -exec rm -rf {} + 2>/dev/null || true
     return 0
 }

--- a/deploy/install/edge/build-edge-bundle.sh
+++ b/deploy/install/edge/build-edge-bundle.sh
@@ -80,5 +80,9 @@ fi
 tarball="$EDGE_DIR/edge-bundle-$ARCH-$VERSION.tar.gz"
 tar -C "$work" -czf "$tarball" .
 sha256sum "$tarball" | awk '{print $1}' > "$tarball.sha256"
+# Both are created subject to the caller's umask, which lands them at 0640 on a
+# hardened host. nginx workers and the Manager container read them as non-root
+# with a non-zero gid, so they must stay world-readable regardless of caller.
+chmod 0644 "$tarball" "$tarball.sha256"
 
 echo "build-edge-bundle(host): wrote $tarball ($staged file(s))"

--- a/deploy/install/edge/fetch-edge-assets.sh
+++ b/deploy/install/edge/fetch-edge-assets.sh
@@ -133,5 +133,8 @@ for target in "${TARGETS[@]}"; do
         "$BASE_URL" "$DEPS_TAG" "$deps_name" "$deps_sha" \
         "$BASE_URL" "$VERSION" "$edge_name" "$edge_sha" \
         > "$DEST_DIR/edge-assets-${target}.ref"
+    # Redirection applies the caller's umask, unlike the `install -m 0755` above.
+    # The Manager container reads this file as non-root, so pin it explicitly.
+    chmod 0644 "$DEST_DIR/edge-assets-${target}.ref"
     log "verified and staged $target"
 done

--- a/deploy/install/edge/fetch-edge-assets.sh
+++ b/deploy/install/edge/fetch-edge-assets.sh
@@ -24,9 +24,18 @@ DEPS_TAG=${ONGRID_EDGE_DEPS_TAG:-$CONFIG_DEPS_TAG}
 CACHE_DIR=${ONGRID_EDGE_ARTIFACT_CACHE_DIR:-/var/cache/ongrid/edge-artifacts}
 CURL_FLAGS=(
     --fail --location --show-error
-    --retry 3 --retry-all-errors --retry-delay 3
+    --retry 3 --retry-delay 3
     --connect-timeout 15 --speed-time 60 --speed-limit 1024
 )
+# --retry-all-errors widens `--retry` to cover non-transient HTTP errors, but it
+# only exists in curl 7.71+. AliOS / CentOS 8 ship 7.61, where an unknown option
+# makes curl exit 2 and every download fail. Ask curl whether it accepts the flag
+# rather than parsing versions: on 7.71+ the flag set is unchanged, and on older
+# curl we keep plain `--retry 3` instead of failing outright. The checksum gate in
+# download_verified is unaffected either way, so a bad download still fails hard.
+if curl --retry-all-errors --version >/dev/null 2>&1; then
+    CURL_FLAGS+=(--retry-all-errors)
+fi
 
 if (( $# > 0 )); then
     TARGETS=("$@")

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -31,6 +31,14 @@ fi
 # shellcheck source=public-url.sh
 source "$PUBLIC_URL_LIB"
 
+DATA_PERMISSIONS_LIB="$SCRIPT_DIR/data-permissions.sh"
+if [[ ! -r "$DATA_PERMISSIONS_LIB" ]]; then
+    log_error "install package is missing data-permissions.sh"
+    exit 1
+fi
+# shellcheck source=data-permissions.sh
+source "$DATA_PERMISSIONS_LIB"
+
 generate_self_signed_tls_cert() {
     local cert_dir="$1"
     local cert_file="$cert_dir/tls.crt"
@@ -183,6 +191,19 @@ on_error() {
     log_error "check output above; fix and re-run sudo ./install.sh"
 }
 trap 'on_error $LINENO' ERR
+
+# The ERR trap above does not fire on `exit 1` or on SIGINT / SIGTERM, so those
+# paths used to leak the Edge staging tree. On the success path EDGE_STAGE_DIR is
+# already cleared after the atomic swap, which makes this a no-op.
+cleanup_edge_stage() {
+    if [[ -n "${EDGE_STAGE_DIR:-}" && -d "${EDGE_STAGE_DIR:-}" ]]; then
+        rm -rf "$EDGE_STAGE_DIR"
+    fi
+    return 0
+}
+trap cleanup_edge_stage EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Prompt for a value with a 30s countdown; on timeout or empty Enter return
 # the default ($2). Mirrors liaison's read_with_countdown: all UI goes to
@@ -362,6 +383,12 @@ docker compose version >/dev/null 2>&1 || { log_error "docker compose v2 not fou
 INSTALL_DIR="${ONGRID_INSTALL_DIR:-/opt/ongrid}"
 log_info "install dir: $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
+# A restrictive root umask makes mkdir produce 0750 or 0700 here. Containers are
+# unaffected (bind-mount sources are resolved by the daemon, not through this
+# directory), but non-root tooling on the host needs to be able to enter it, and
+# install / upgrade must agree on the mode.
+chmod 755 "$INSTALL_DIR"
+ongrid_prune_stale_edge_staging "$INSTALL_DIR"
 
 EDGE_ASSET_VERSION=$(tr -d '[:space:]' < "$SCRIPT_DIR/VERSION" 2>/dev/null || true)
 if [[ -z "$EDGE_ASSET_VERSION" ]]; then
@@ -386,7 +413,11 @@ prepare_edge_assets() {
         log_error "could not make the prepared Edge directory readable by Manager and nginx containers"
         return 1
     fi
-    cp -rf "$source_dir/." "$EDGE_STAGE_DIR/"
+    ongrid_with_shared_asset_umask cp -rf "$source_dir/." "$EDGE_STAGE_DIR/"
+    # This only reaches the *.sh that exist right now. The tarball, its .sha256
+    # and the .ref files are written further below by fetch-edge-assets.sh and
+    # build-edge-bundle.sh, which is why those need the relaxed umask rather
+    # than a chmod here.
     find "$EDGE_STAGE_DIR" -maxdepth 1 -name '*.sh' -exec chmod 755 {} \;
     [[ -r "$EDGE_STAGE_DIR/edge-assets-lib.sh" ]] || {
         log_error "package is missing edge/edge-assets-lib.sh"
@@ -412,8 +443,8 @@ prepare_edge_assets() {
             return 1
         }
         log_info "prefetching checksum-verified Edge assets from CNB for $resolved_targets"
-        "$EDGE_STAGE_DIR/fetch-edge-assets.sh" "$EDGE_STAGE_DIR" "$EDGE_ASSET_VERSION" \
-            "${edge_targets[@]}"
+        ongrid_with_shared_asset_umask "$EDGE_STAGE_DIR/fetch-edge-assets.sh" \
+            "$EDGE_STAGE_DIR" "$EDGE_ASSET_VERSION" "${edge_targets[@]}"
     else
         log_info "using complete Edge binaries embedded for $resolved_targets"
         ongrid_validate_embedded_edge_assets "$EDGE_STAGE_DIR" "$resolved_targets" || return 1
@@ -424,7 +455,8 @@ prepare_edge_assets() {
     ongrid_write_edge_artifact_config "$EDGE_STAGE_DIR/edge-artifacts.env" \
         "$deps_tag" "$resolved_targets"
     for target in "${edge_targets[@]}"; do
-        "$EDGE_STAGE_DIR/build-edge-bundle.sh" "$EDGE_STAGE_DIR" "$EDGE_ASSET_VERSION" "$target"
+        ongrid_with_shared_asset_umask "$EDGE_STAGE_DIR/build-edge-bundle.sh" \
+            "$EDGE_STAGE_DIR" "$EDGE_ASSET_VERSION" "$target"
     done
 }
 
@@ -822,6 +854,12 @@ while IFS= read -r image; do
         exit 1
     fi
 done <<<"$RUNTIME_IMAGES"
+
+# Everything the installer writes is in place by now (config files, edge/,
+# searxng/, grafana/, nginx.conf). Normalize before the containers start: the
+# consumers run as non-root with a non-zero gid, so they read these files
+# through the other-permission bits.
+ongrid_normalize_shared_asset_modes "$INSTALL_DIR"
 
 log_info "starting stack: docker compose ${COMPOSE_ARGS[*]} up -d"
 (

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -218,7 +218,11 @@ prepare_edge_assets() {
         log_error "could not make the prepared Edge directory readable by Manager and nginx containers"
         return 1
     fi
-    cp -rf "$source_dir/." "$EDGE_STAGE_DIR/"
+    ongrid_with_shared_asset_umask cp -rf "$source_dir/." "$EDGE_STAGE_DIR/"
+    # This only reaches the *.sh that exist right now. The tarball, its .sha256
+    # and the .ref files are written further below by fetch-edge-assets.sh and
+    # build-edge-bundle.sh, which is why those need the relaxed umask rather
+    # than a chmod here.
     find "$EDGE_STAGE_DIR" -maxdepth 1 -name '*.sh' -exec chmod 755 {} \;
     [[ -r "$EDGE_STAGE_DIR/edge-assets-lib.sh" ]] || {
         log_error "package is missing edge/edge-assets-lib.sh"
@@ -244,8 +248,8 @@ prepare_edge_assets() {
             return 1
         }
         log_info "prefetching checksum-verified Edge assets for $resolved_targets before stopping the old stack"
-        "$EDGE_STAGE_DIR/fetch-edge-assets.sh" "$EDGE_STAGE_DIR" "$NEW_VERSION" \
-            "${edge_targets[@]}"
+        ongrid_with_shared_asset_umask "$EDGE_STAGE_DIR/fetch-edge-assets.sh" \
+            "$EDGE_STAGE_DIR" "$NEW_VERSION" "${edge_targets[@]}"
     else
         log_info "using complete Edge binaries embedded for $resolved_targets"
         ongrid_validate_embedded_edge_assets "$EDGE_STAGE_DIR" "$resolved_targets" || return 1
@@ -256,7 +260,8 @@ prepare_edge_assets() {
     ongrid_write_edge_artifact_config "$EDGE_STAGE_DIR/edge-artifacts.env" \
         "$deps_tag" "$resolved_targets"
     for target in "${edge_targets[@]}"; do
-        "$EDGE_STAGE_DIR/build-edge-bundle.sh" "$EDGE_STAGE_DIR" "$NEW_VERSION" "$target"
+        ongrid_with_shared_asset_umask "$EDGE_STAGE_DIR/build-edge-bundle.sh" \
+            "$EDGE_STAGE_DIR" "$NEW_VERSION" "$target"
     done
 }
 
@@ -276,6 +281,21 @@ on_upgrade_error() {
     log_error "upgrade failed at line $line (exit $exit_code)"
 }
 trap 'on_upgrade_error $LINENO' ERR
+
+# The ERR trap above does not fire on `exit 1` or on SIGINT / SIGTERM. There are
+# five explicit `exit 1` paths between staging the Edge assets and the atomic
+# swap, all of them after the full bundle has been downloaded, so those leaked a
+# ~178 MB tree per attempt. The later `trap - ERR` only clears ERR, leaving this
+# EXIT trap in place; by then EDGE_STAGE_DIR is empty and this is a no-op.
+cleanup_edge_stage() {
+    if [[ -n "${EDGE_STAGE_DIR:-}" && -d "${EDGE_STAGE_DIR:-}" ]]; then
+        rm -rf "$EDGE_STAGE_DIR"
+    fi
+    return 0
+}
+trap cleanup_edge_stage EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 UPGRADE_ARGS=("$@")
 MIGRATE_VOLUMES="${MIGRATE_VOLUMES:-}"
@@ -320,6 +340,12 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 log_info "upgrading ongrid at $INSTALL_DIR"
+# Symmetry with install.sh: an install created under a restrictive umask keeps a
+# 0750/0700 install dir, which blocks non-root tooling on the host. Doing it here
+# means the old stack is still running if it fails. The stale-staging prune
+# reclaims trees left by earlier interrupted upgrades.
+chmod 755 "$INSTALL_DIR"
+ongrid_prune_stale_edge_staging "$INSTALL_DIR"
 
 # Determine new version from tarball.
 NEW_VERSION=""
@@ -617,6 +643,11 @@ ensure_tunnel_addr_env
 ensure_host_gateway_env
 
 chmod 600 "$ENV_FILE"
+
+# Refreshed assets are all in place. This is the step that actually repairs an
+# existing install: `cp -f` leaves the mode of an existing destination alone, so
+# config files created under a restrictive umask stay 0640 until chmod'd here.
+ongrid_normalize_shared_asset_modes "$INSTALL_DIR"
 
 # Bring stack back up; gorm AutoMigrate handles schema diff.
 log_info "starting stack with new version"

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -10,7 +10,42 @@ for installer in install.sh upgrade.sh; do
     echo "$installer does not make the staged Edge directory container-readable" >&2
     exit 1
   }
+  grep -Fq 'ongrid_with_shared_asset_umask' "$repo_root/deploy/install/$installer" || {
+    echo "$installer stages Edge assets under the caller's umask; bundles land unreadable on a hardened host" >&2
+    exit 1
+  }
+  grep -Fq 'ongrid_normalize_shared_asset_modes' "$repo_root/deploy/install/$installer" || {
+    echo "$installer does not normalize shared asset modes; an existing install keeps its 0640 configs" >&2
+    exit 1
+  }
+  grep -Fq 'trap cleanup_edge_stage EXIT' "$repo_root/deploy/install/$installer" || {
+    echo "$installer leaks the Edge staging tree on explicit exits and signals" >&2
+    exit 1
+  }
 done
+
+grep -Fq 'chmod 0644 "$tarball" "$tarball.sha256"' \
+  "$repo_root/deploy/install/edge/build-edge-bundle.sh" || {
+  echo "build-edge-bundle.sh leaves bundle modes at the caller's umask" >&2
+  exit 1
+}
+grep -Fq 'chmod 0644 "$DEST_DIR/edge-assets-${target}.ref"' \
+  "$repo_root/deploy/install/edge/fetch-edge-assets.sh" || {
+  echo "fetch-edge-assets.sh leaves the .ref mode at the caller's umask" >&2
+  exit 1
+}
+
+# curl 7.61 (AliOS / CentOS 8) exits 2 on an unknown option, which turns every
+# asset download into a failure. The flag has to be probed, never hardcoded.
+if grep -Eq '^\s+--retry 3 --retry-all-errors' "$repo_root/deploy/install/edge/fetch-edge-assets.sh"; then
+  echo "fetch-edge-assets.sh hardcodes --retry-all-errors; curl 7.61 hosts cannot download Edge assets" >&2
+  exit 1
+fi
+grep -Fq 'curl --retry-all-errors --version' \
+  "$repo_root/deploy/install/edge/fetch-edge-assets.sh" || {
+  echo "fetch-edge-assets.sh does not probe curl for --retry-all-errors support" >&2
+  exit 1
+}
 
 install_help=$(bash "$repo_root/deploy/install/install.sh" --help)
 uninstall_help=$(bash "$repo_root/deploy/install/uninstall.sh" --help)

--- a/scripts/test-edge-assets.sh
+++ b/scripts/test-edge-assets.sh
@@ -80,14 +80,27 @@ cat > "$fake_bin/curl" <<'EOF'
 set -euo pipefail
 out=""
 url=""
+probe=0
 while (( $# > 0 )); do
     case "$1" in
         -o) out=$2; shift 2 ;;
+        --version|--help) probe=1; shift ;;
         http://*|https://*) url=$1; shift ;;
         *) shift ;;
     esac
 done
-[[ -n "$out" && -n "$url" ]]
+# Capability probes do not touch the network, so they must not land in the log the
+# no-network assertions check. Model real curl: --version succeeds and prints.
+if (( probe )); then
+    printf 'curl 8.0.0 (fake)\n'
+    exit 0
+fi
+# Explicit exit: `set -e` does not abort on a failing `[[ a && b ]]`, so a bare
+# test here would fall through and log an empty line for non-download calls.
+if [[ -z "$out" || -z "$url" ]]; then
+    printf 'fake curl: expected -o <file> and a URL\n' >&2
+    exit 2
+fi
 printf '%s\n' "$url" >> "$FAKE_CURL_LOG"
 relative=${url#*releases/download/}
 cp "$FAKE_RELEASE_ROOT/$relative" "$out"

--- a/scripts/test-install-asset-modes.sh
+++ b/scripts/test-install-asset-modes.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Behaviour test for the shared-asset mode helpers in data-permissions.sh.
+#
+# Reproduces the failure this guards against: on a host whose root umask is
+# restrictive, `cp` and shell redirection create 0640 files, and the containers
+# that bind-mount them run as non-root with a non-zero gid, so they resolve
+# against the other-permission bits and cannot read them at all.
+#
+# The negative assertions matter as much as the positive ones: normalizing must
+# never widen .env (database passwords) or certs/ (TLS key).
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+permissions_lib="$repo_root/deploy/install/data-permissions.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+    printf 'install asset-modes test failed: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -f "$permissions_lib" ]] || fail "missing data-permissions.sh"
+# shellcheck source=../deploy/install/data-permissions.sh
+source "$permissions_lib"
+
+mode_of() {
+    local path="$1" mode
+    if mode=$(stat -c '%a' "$path" 2>/dev/null) && [[ "$mode" =~ ^[0-7]+$ ]]; then
+        printf '%s\n' "$mode"
+        return 0
+    fi
+    if mode=$(stat -f '%Lp' "$path" 2>/dev/null) && [[ "$mode" =~ ^[0-7]+$ ]]; then
+        printf '%s\n' "$mode"
+        return 0
+    fi
+    fail "could not stat mode of $path"
+}
+
+assert_mode() {
+    local expected="$1" path="$2" actual
+    actual=$(mode_of "$path")
+    [[ "$actual" == "$expected" ]] \
+        || fail "expected mode $expected on $path, got $actual"
+}
+
+install_dir="$tmp_dir/opt/ongrid"
+
+# Build a fake install the way a hardened host would: everything created under
+# umask 027 so files land 0640 and directories 0750.
+(
+    umask 027
+    mkdir -p "$install_dir/edge" "$install_dir/searxng" \
+        "$install_dir/grafana/provisioning/datasources" \
+        "$install_dir/prometheus"
+    for f in docker-compose.yml prometheus.yml prometheus-rules.yml \
+        loki-config.yaml tempo-config.yaml frontier.yaml nginx.conf VERSION; do
+        printf 'x\n' > "$install_dir/$f"
+    done
+    printf 'x\n' > "$install_dir/searxng/settings.yml"
+    printf 'x\n' > "$install_dir/grafana/provisioning/datasources/loki.yml"
+    printf 'x\n' > "$install_dir/prometheus/prometheus.yml"
+    # Edge directory: a bundle + checksum + ref written by redirection/tar, and a
+    # binary that fetch-edge-assets.sh installs with an explicit exec mode.
+    printf 'bundle\n' > "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz"
+    printf 'sha\n' > "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz.sha256"
+    printf 'ref\n' > "$install_dir/edge/edge-assets-linux-amd64.ref"
+    printf 'bin\n' > "$install_dir/edge/ongrid-edge-linux-amd64"
+    chmod 0755 "$install_dir/edge/ongrid-edge-linux-amd64"
+)
+
+# Credentials, created the way the installer does.
+printf 'ONGRID_MYSQL_PASSWORD=secret\n' > "$install_dir/.env"
+chmod 600 "$install_dir/.env"
+mkdir -p "$install_dir/certs"
+chmod 700 "$install_dir/certs"
+printf 'key\n' > "$install_dir/certs/tls.key"
+chmod 600 "$install_dir/certs/tls.key"
+
+# Sanity-check the fixture actually reproduces the bug, otherwise the test would
+# pass vacuously on a host whose umask is already 022.
+assert_mode 640 "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz"
+assert_mode 640 "$install_dir/frontier.yaml"
+assert_mode 750 "$install_dir/grafana/provisioning"
+
+ongrid_normalize_shared_asset_modes "$install_dir"
+
+# Bind-mounted files must be readable by a non-root, non-zero-gid container.
+for f in docker-compose.yml prometheus.yml prometheus-rules.yml \
+    loki-config.yaml tempo-config.yaml frontier.yaml nginx.conf VERSION; do
+    assert_mode 644 "$install_dir/$f"
+done
+assert_mode 644 "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz"
+assert_mode 644 "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz.sha256"
+assert_mode 644 "$install_dir/edge/edge-assets-linux-amd64.ref"
+assert_mode 644 "$install_dir/searxng/settings.yml"
+assert_mode 644 "$install_dir/grafana/provisioning/datasources/loki.yml"
+assert_mode 644 "$install_dir/prometheus/prometheus.yml"
+
+# Directories need the traversal bit, and executables must keep theirs.
+assert_mode 755 "$install_dir"
+assert_mode 755 "$install_dir/edge"
+assert_mode 755 "$install_dir/grafana/provisioning"
+assert_mode 755 "$install_dir/edge/ongrid-edge-linux-amd64"
+
+# Credentials must be untouched — a recursive chmod over the install dir would
+# have widened both of these.
+assert_mode 600 "$install_dir/.env"
+assert_mode 700 "$install_dir/certs"
+assert_mode 600 "$install_dir/certs/tls.key"
+
+# Idempotent: a second pass must not change anything.
+ongrid_normalize_shared_asset_modes "$install_dir"
+assert_mode 644 "$install_dir/edge/edge-bundle-linux-amd64-v9.9.9.tar.gz"
+assert_mode 755 "$install_dir/edge/ongrid-edge-linux-amd64"
+assert_mode 600 "$install_dir/.env"
+
+# Missing install dir is a no-op, not an error.
+ongrid_normalize_shared_asset_modes "$tmp_dir/absent" \
+    || fail "normalizing a missing install dir should succeed"
+
+# The umask wrapper must relax modes for the wrapped command and restore after.
+outer_umask=$(umask)
+(
+    umask 027
+    ongrid_with_shared_asset_umask bash -c "printf 'x\n' > '$tmp_dir/wrapped.conf'"
+    printf 'x\n' > "$tmp_dir/unwrapped.conf"
+    [[ "$(umask)" == "0027" ]] || fail "umask not restored inside subshell: $(umask)"
+)
+assert_mode 644 "$tmp_dir/wrapped.conf"
+assert_mode 640 "$tmp_dir/unwrapped.conf"
+[[ "$(umask)" == "$outer_umask" ]] || fail "umask leaked into the caller"
+
+# A failing wrapped command must propagate its status so `set -e` and the ERR
+# trap still fire in the installers.
+set +e
+ongrid_with_shared_asset_umask bash -c 'exit 7'
+wrapped_rc=$?
+set -e
+[[ "$wrapped_rc" == 7 ]] || fail "wrapper swallowed the exit status: $wrapped_rc"
+
+# Stale-staging prune: anchored name, depth 1, age floor.
+mkdir -p "$install_dir/.edge-stage.OLDONE" "$install_dir/.edge-backup.OLDTWO" \
+    "$install_dir/.edge-stage.FRESH" "$install_dir/keepme" \
+    "$install_dir/edge/.edge-stage.NESTED"
+touch -d '3 hours ago' "$install_dir/.edge-stage.OLDONE" \
+    "$install_dir/.edge-backup.OLDTWO" "$install_dir/keepme" \
+    "$install_dir/edge/.edge-stage.NESTED" 2>/dev/null \
+    || touch -A -030000 "$install_dir/.edge-stage.OLDONE" \
+        "$install_dir/.edge-backup.OLDTWO" "$install_dir/keepme" \
+        "$install_dir/edge/.edge-stage.NESTED"
+
+ongrid_prune_stale_edge_staging "$install_dir"
+
+[[ ! -d "$install_dir/.edge-stage.OLDONE" ]] || fail "stale staging dir was not pruned"
+[[ ! -d "$install_dir/.edge-backup.OLDTWO" ]] || fail "stale backup dir was not pruned"
+[[ -d "$install_dir/.edge-stage.FRESH" ]] || fail "a fresh staging dir must survive (concurrent installer)"
+[[ -d "$install_dir/keepme" ]] || fail "prune matched a directory outside the name prefix"
+[[ -d "$install_dir/edge/.edge-stage.NESTED" ]] || fail "prune must not recurse below depth 1"
+
+echo "install asset-modes test passed"

--- a/scripts/test-install-asset-modes.sh
+++ b/scripts/test-install-asset-modes.sh
@@ -140,22 +140,36 @@ set -e
 [[ "$wrapped_rc" == 7 ]] || fail "wrapper swallowed the exit status: $wrapped_rc"
 
 # Stale-staging prune: anchored name, depth 1, age floor.
-mkdir -p "$install_dir/.edge-stage.OLDONE" "$install_dir/.edge-backup.OLDTWO" \
+# Regression guard: a retained .edge-backup.* must survive. After a health-check
+# timeout upgrade.sh keeps that tree as the manual rollback source, and this
+# prune runs at the start of the next upgrade attempt, before a new Edge swap.
+# Pruning it by age would delete the operator's only known-good Edge tree.
+mkdir -p "$install_dir/.edge-stage.OLDONE" "$install_dir/.edge-backup.RETAINED" \
     "$install_dir/.edge-stage.FRESH" "$install_dir/keepme" \
     "$install_dir/edge/.edge-stage.NESTED"
+printf 'edge\n' > "$install_dir/.edge-backup.RETAINED/marker"
 touch -d '3 hours ago' "$install_dir/.edge-stage.OLDONE" \
-    "$install_dir/.edge-backup.OLDTWO" "$install_dir/keepme" \
+    "$install_dir/.edge-backup.RETAINED" "$install_dir/keepme" \
     "$install_dir/edge/.edge-stage.NESTED" 2>/dev/null \
     || touch -A -030000 "$install_dir/.edge-stage.OLDONE" \
-        "$install_dir/.edge-backup.OLDTWO" "$install_dir/keepme" \
+        "$install_dir/.edge-backup.RETAINED" "$install_dir/keepme" \
         "$install_dir/edge/.edge-stage.NESTED"
 
 ongrid_prune_stale_edge_staging "$install_dir"
 
 [[ ! -d "$install_dir/.edge-stage.OLDONE" ]] || fail "stale staging dir was not pruned"
-[[ ! -d "$install_dir/.edge-backup.OLDTWO" ]] || fail "stale backup dir was not pruned"
+[[ -d "$install_dir/.edge-backup.RETAINED" ]] \
+    || fail "a retained Edge backup must survive the next upgrade's startup prune (manual rollback source)"
+[[ -f "$install_dir/.edge-backup.RETAINED/marker" ]] \
+    || fail "retained Edge backup survived as an empty directory; its contents are the rollback source"
 [[ -d "$install_dir/.edge-stage.FRESH" ]] || fail "a fresh staging dir must survive (concurrent installer)"
 [[ -d "$install_dir/keepme" ]] || fail "prune matched a directory outside the name prefix"
 [[ -d "$install_dir/edge/.edge-stage.NESTED" ]] || fail "prune must not recurse below depth 1"
+
+# Repeated startups must keep leaving the backup alone, since an operator may
+# take several attempts before deciding to roll back.
+ongrid_prune_stale_edge_staging "$install_dir"
+[[ -f "$install_dir/.edge-backup.RETAINED/marker" ]] \
+    || fail "retained Edge backup was pruned on a second startup"
 
 echo "install asset-modes test passed"


### PR DESCRIPTION
## Summary

Fixes #296.

On a host whose root umask is 027 the Edge upgrade bundle ends up mode 0640, so
nginx returns 403 for it and the Manager cannot read its checksum. Independently,
`--retry-all-errors` makes every Edge asset download fail on curl 7.61. And an
interrupted upgrade leaves its staging tree behind, ~178 MB per attempt.

Six commits, split by concern:

| commit | what |
|---|---|
| `feat(installer): add shared-asset umask and mode helpers` | three helpers in `data-permissions.sh` |
| `fix(install): make bind-mounted assets readable and clean up staging` | wire them into `install.sh` |
| `fix(upgrade): repair asset modes on existing installs` | wire them into `upgrade.sh` |
| `fix(edge): pin bundle and ref modes at creation time` | `build-edge-bundle.sh`, `fetch-edge-assets.sh` |
| `fix(edge): probe curl for --retry-all-errors support` | curl 7.61 compatibility |
| `test(installer): cover asset modes, staging cleanup and curl probe` | new behaviour test + static assertions |

371 added lines, of which 85 are functional code, 63 comments and 211 tests.

## Why the change looks bigger than the bug

The minimal fix for the 403 is two lines - `chmod -R a+rX "$INSTALL_DIR/edge"` in
each installer. The rest addresses why this keeps recurring.

**The mode is wrong because the chmod runs before the files exist.**
`prepare_edge_assets` does its `find ... -name '*.sh' -exec chmod 755` at
`install.sh:390`, but the tarball, its `.sha256` and the `.ref` are generated
further down at `:415` and `:427`. `tar -czf` and shell redirection both apply
the caller's umask, so under 027 they land 0640. The loose binaries are fine
because `fetch-edge-assets.sh` writes them with `install -m 0755`. That is
exactly the pattern on the affected host: only those three file types are wrong.

So the fix relaxes the umask around the three call sites that produce assets, and
also pins the modes inside the two generating scripts, which are documented to be
runnable standalone. Enumerating filenames in a chmod list has already failed
once - #263 listed six files and the broken ones were not among them.

**Existing installs need an explicit chmod; a corrected umask is not enough.**
`cp` leaves the mode of an existing destination untouched:

```
$ chmod 640 dst.conf
$ ( umask 022; cp -f src.conf dst.conf )   # umask already relaxed
$ stat -c %a dst.conf
640
```

`ongrid_normalize_shared_asset_modes` is therefore the part that actually repairs
an affected host, not a redundant safety net.

**The normalization is path-enumerated on purpose.** `chmod -R a+rX "$INSTALL_DIR"`
would take `.env` from 0600 to 0644 and expose the database passwords - verified
locally. `.env` and `certs/` are excluded, and the test asserts they stay 0600 and
0700 so a future refactor cannot regress into leaking credentials.

**Which containers break depends on gid, not uid.** `user: 472` in compose sets
only the uid, so grafana inherits gid 0 and reads 0640 files through the group
bits. `USER 65532:65532`, `10001:10001` and `nobody` carry explicit gids and
resolve against the other-permission bits instead. That is why the same install
had a working grafana and a 403 from nginx.

## Verification

Reproduced and verified on the host from #296 (AliOS 8, umask 027, curl 7.61),
using the stock `ongrid-v0.11.1-linux-amd64.tar.xz` release with these scripts
swapped in.

Asset fetch, stock script vs this branch, same host:

| | stock | this branch |
|---|---|---|
| exit code | 1 | 0 |
| output | `checksum verification failed` | `verified and staged linux-amd64` |
| artifacts | none | 10 binaries + `.ref`, verified |
| `.ref` mode | - | 0644 |
| binary modes | - | 0755 |

Full same-version refresh upgrade on the live install, exit 0 in 2m01s, health
check green in 4s:

- bundle download `HTTP 200`, `size=165883547` - a real 158 MB transfer, both
  amd64 and arm64 bundles built at 0644
- Manager (65532:65532) reads the `.sha256`; nginx worker (101:101),
  grafana (472:0), prometheus (65534) and frontier (65532) all read their mounts
- executables kept 0755, `edge-artifacts.env` normalized 0640 -> 0644
- `.env` 0600, `certs/` 0700, `certs/tls.key` untouched
- no `.edge-stage.*` residue; the 523 MB of pre-existing residue was reclaimed
- zero `permission denied` in nginx and Manager logs

Local: `bash -n` on every touched script, every intermediate commit syntax-checked,
and `make test-release-package` green (including the new
`scripts/test-install-asset-modes.sh`).

## Why #263 is closed rather than updated

#263 was the first attempt at this and it did land on the affected host - the six
files it listed are 0644 there now. But it does not fix the failure, and it cannot
be rebased into something that does:

1. **Wrong location.** Its `chmod 644` list covers six top-level config files and
   no path under `edge/`, which is where the unreadable files are. After #263 ran
   on that host the bundle was still 0640 and still 403.
2. **The branch predates a rewrite.** `main` has since replaced the Edge handling
   with `prepare_edge_assets` / `EDGE_STAGE_DIR` / `EDGE_BACKUP_DIR` and an atomic
   swap with rollback (6 commits after the merge-base). #263 still carries the old
   in-place rebuild loop, so its changes have nowhere to apply.
3. **Its comments state the mechanism incorrectly**, and those comments are now in
   the tree on that host: it says `mkdir -p` yields 0750 under umask 077 (it
   yields 0700; 0750 corresponds to umask 027), that `cp` "preserves the source
   mode" (it applies the umask when creating, and keeps the destination's mode when
   overwriting), and that the containers cannot traverse `$INSTALL_DIR` (no service
   bind-mounts `$INSTALL_DIR` itself, and it was already 0755 on the host while the
   failure persisted).

On the review comment asking for `chmod 755` on `INSTALL_DIR`: it is included
here, but with a corrected rationale. It is not what fixes the 403 - the affected
host already had `/opt/ongrid` at 0755. It is worth having for symmetry between
the installers, for rootless/userns-remap daemons that resolve mount sources
themselves, and so non-root tooling on the host can inspect the directory.

## Not included, on purpose

- `--retry-all-errors` in `deploy/Dockerfile.ongrid-edge` and
  `scripts/verify-cnb-release-attachments.sh` - build/CI only, newer curl; changing
  the Dockerfile would trigger image rebuilds, which belongs in its own change.
- `upgrade.sh` falls back to reading `ONGRID_VERSION` from `.env.example` when the
  package has no `VERSION` file, and the published `.env.example` still says
  `v0.7.113`. A package with a complete `edge/` but no `VERSION` would silently
  downgrade a host. Unrelated to permissions - happy to file it separately.
- The Manager error text discussed in #296 (`"checksum file is missing or invalid"`
  for EACCES) - a one-line `os.IsPermission` branch, but it is Go-side and would
  muddy this PR.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
