### PR TITLE
feat(knowledge): convert DOCX and PDF to Markdown for chunking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/casbin/casbin/v2 v2.103.0
 	github.com/casbin/gorm-adapter/v3 v3.32.0
 	github.com/cloudwego/eino v0.8.7
+	github.com/cloudwego/eino-ext/components/document/transformer/splitter/markdown v0.0.0-20260724103301-c9a5dc923462
+	github.com/cloudwego/eino-ext/components/document/transformer/splitter/recursive v0.0.0-20260724103301-c9a5dc923462
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.1.0
@@ -15,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.4
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
+	github.com/mattn/go-runewidth v0.0.15
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,10 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.8.7 h1:GlzrJa5hpovPdZ+loBvXs1W4D5gWC+a6PRqJmlj4iis=
 github.com/cloudwego/eino v0.8.7/go.mod h1:+2N4nsMPxA6kGBHpH+75JuTfEcGprAMTdsZESrShKpU=
+github.com/cloudwego/eino-ext/components/document/transformer/splitter/markdown v0.0.0-20260724103301-c9a5dc923462 h1:rkkatNXJFl+pkmlRKXYNdb5LjZoonhu6YFpBUPfy9DQ=
+github.com/cloudwego/eino-ext/components/document/transformer/splitter/markdown v0.0.0-20260724103301-c9a5dc923462/go.mod h1:KVOVct4e2BQ7epDONW2QE1qU5+ccoh91FzJTs9vIJj0=
+github.com/cloudwego/eino-ext/components/document/transformer/splitter/recursive v0.0.0-20260724103301-c9a5dc923462 h1:SzyZy7EaMd5WwLHfCnIp9t74PalUjFceKdBPTLzYvyo=
+github.com/cloudwego/eino-ext/components/document/transformer/splitter/recursive v0.0.0-20260724103301-c9a5dc923462/go.mod h1:9R0RQrQSpg1JaNnRtw7+RfRAAv0HgdE348YnrlZ6coo=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -250,6 +254,8 @@ github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.3/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
@@ -324,6 +330,7 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=
 github.com/rivo/uniseg v0.4.6/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -416,7 +423,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
-github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=

--- a/internal/manager/biz/knowledge/chunk_test.go
+++ b/internal/manager/biz/knowledge/chunk_test.go
@@ -1,8 +1,10 @@
 package knowledge
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestSplitForChunks_ShortDoc — a doc under chunkChars stays as one piece.
@@ -73,6 +75,248 @@ func TestSplitForChunks_MaxChunkCap(t *testing.T) {
 	got := splitForChunks(body)
 	if len(got) > maxChunksPerFile {
 		t.Errorf("expected cap at %d chunks, got %d", maxChunksPerFile, len(got))
+	}
+}
+
+func TestSplitMarkdown_PreservesCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "fenced",
+			content: "# Deploy\n\n```sh\nkubectl apply -f app.yaml\n```",
+			want:    "kubectl apply -f app.yaml",
+		},
+		{
+			name:    "indented",
+			content: "# Deploy\n\n    systemctl restart ongrid",
+			want:    "systemctl restart ongrid",
+		},
+		{
+			name:    "code_only",
+			content: "```go\nfunc main() {}\n```",
+			want:    "func main() {}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks, err := splitMarkdown(context.Background(), tt.content)
+			if err != nil {
+				t.Fatalf("split Markdown: %v", err)
+			}
+			if len(chunks) == 0 {
+				t.Fatal("code block was dropped")
+			}
+			if !strings.Contains(strings.Join(chunks, "\n"), tt.want) {
+				t.Fatalf("code block content missing from chunks: %#v", chunks)
+			}
+		})
+	}
+}
+
+func TestSplitMarkdown_PrependsHeadingHierarchy(t *testing.T) {
+	content := "# Platform\n\nroot body\n\n## Deploy\n\ndeploy body\n\n### Linux\n\nlinux body"
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	want := "# Platform\n\nroot body\n\n# Platform\n## Deploy\n\ndeploy body\n\n# Platform\n## Deploy\n### Linux\n\nlinux body"
+	if len(chunks) != 1 || chunks[0] != want {
+		t.Fatalf("short heading sections were not merged with hierarchy intact: %#v", chunks)
+	}
+}
+
+func TestSplitMarkdown_ShortTrailingSectionMergesBackward(t *testing.T) {
+	content := "# Deploy\n\n" + strings.Repeat("a", shortMarkdownSectionChars) + "\n\n## Notes\n\nshort"
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("want trailing section to merge into its predecessor, got %#v", chunks)
+	}
+	if !strings.Contains(chunks[0], "## Notes\n\nshort") {
+		t.Fatalf("trailing short section missing from predecessor: %#v", chunks)
+	}
+}
+
+func TestSplitMarkdown_DoesNotMergeWhenChunkCapWouldBeExceeded(t *testing.T) {
+	content := "# Intro\n\n" + strings.Repeat("a", shortMarkdownSectionChars-10) + "\n\n## Details\n\n" + strings.Repeat("b", chunkChars)
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) < 2 || chunks[0] != "# Intro\n\n"+strings.Repeat("a", shortMarkdownSectionChars-10) {
+		t.Fatalf("short section should remain separate when merging exceeds cap: %#v", chunks)
+	}
+	for i, chunk := range chunks {
+		if utf8.RuneCountInString(chunk) > chunkChars {
+			t.Errorf("chunk %d exceeds cap: %d", i, utf8.RuneCountInString(chunk))
+		}
+	}
+}
+
+func TestIsShortMarkdownHeadingChunk_Threshold(t *testing.T) {
+	tests := []struct {
+		name  string
+		chunk markdownChunk
+		want  bool
+	}{
+		{
+			name:  "at limit",
+			chunk: markdownChunk{content: strings.Repeat("a", shortMarkdownSectionChars), hasHeading: true, isHeadingSection: true},
+			want:  true,
+		},
+		{
+			name:  "above limit",
+			chunk: markdownChunk{content: strings.Repeat("a", shortMarkdownSectionChars+1), hasHeading: true, isHeadingSection: true},
+			want:  false,
+		},
+		{
+			name:  "without heading",
+			chunk: markdownChunk{content: "short body", isHeadingSection: true},
+			want:  false,
+		},
+		{
+			name:  "split heading section",
+			chunk: markdownChunk{content: "short final body part", hasHeading: true},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShortMarkdownHeadingChunk(tt.chunk); got != tt.want {
+				t.Errorf("isShortMarkdownHeadingChunk() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitMarkdown_LongSectionRepeatsHeadingAndOverlap(t *testing.T) {
+	prefix := "# Platform\n## Deploy"
+	body := strings.Repeat("abcdefghijklmnopqrst", 400)
+
+	chunks, err := splitMarkdown(context.Background(), prefix+"\n\n"+body)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("long section was not split: %#v", chunks)
+	}
+	bodyChunks := chunks
+	parts := make([]string, len(bodyChunks))
+	for i, chunk := range bodyChunks {
+		if !strings.HasPrefix(chunk, prefix+"\n\n") {
+			t.Errorf("chunk %d missing heading hierarchy: %q", i, chunk)
+		}
+		if len([]rune(chunk)) > chunkChars {
+			t.Errorf("chunk %d exceeds limit: %d", i, len([]rune(chunk)))
+		}
+		parts[i] = strings.TrimPrefix(chunk, prefix+"\n\n")
+	}
+	for i := 1; i < len(parts); i++ {
+		previous := []rune(parts[i-1])
+		current := []rune(parts[i])
+		if len(previous) < chunkOverlap || len(current) < chunkOverlap {
+			continue
+		}
+		if string(previous[len(previous)-chunkOverlap:]) != string(current[:chunkOverlap]) {
+			t.Errorf("body chunks %d/%d lost overlap", i-1, i)
+		}
+	}
+}
+
+func TestSplitMarkdown_HeadingsInsideFenceAreContent(t *testing.T) {
+	content := "# Deploy\n\n```md\n# Not a section\n```\n\n## Verify\n\ndone"
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("short heading sections were not merged: %#v", chunks)
+	}
+	if !strings.Contains(chunks[0], "# Not a section") {
+		t.Fatalf("fenced heading was dropped: %q", chunks[0])
+	}
+	if !strings.Contains(chunks[0], "# Deploy\n## Verify") {
+		t.Fatalf("child section lacks hierarchy: %q", chunks[0])
+	}
+}
+
+func TestSplitMarkdown_SetextUsesEinoNativeBehavior(t *testing.T) {
+	content := "preamble\n\nPlatform\n========\n\nbody"
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) != 1 || strings.HasPrefix(chunks[0], "# Platform") || !strings.Contains(chunks[0], "========") {
+		t.Fatalf("unexpected chunks: %#v", chunks)
+	}
+}
+
+func TestSplitMarkdown_WithoutHeadingsUsesChunkWindow(t *testing.T) {
+	content := strings.Repeat("无标题正文", chunkChars)
+	want := splitForChunks(content)
+
+	got, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("chunk count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("chunk %d differs from splitForChunks", i)
+		}
+	}
+}
+
+func TestSplitMarkdown_IndentedSetextMarkerStaysCode(t *testing.T) {
+	content := "paragraph\n\n    ---\n\nmore"
+
+	chunks, err := splitMarkdown(context.Background(), content)
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) != 1 || !strings.Contains(chunks[0], "---") {
+		t.Fatalf("indented code was treated as a heading: %#v", chunks)
+	}
+}
+
+func TestSplitMarkdown_HeadingWithoutBodyIsRetained(t *testing.T) {
+	chunks, err := splitMarkdown(context.Background(), "# Platform")
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) != 1 || chunks[0] != "# Platform" {
+		t.Fatalf("heading-only document was not retained: %#v", chunks)
+	}
+}
+
+func TestSplitMarkdown_MaxChunkCapAcrossSections(t *testing.T) {
+	var content strings.Builder
+	for i := 0; i < maxChunksPerFile+20; i++ {
+		content.WriteString("# Section\n\nbody\n\n")
+	}
+
+	chunks, err := splitMarkdown(context.Background(), content.String())
+	if err != nil {
+		t.Fatalf("split Markdown: %v", err)
+	}
+	if len(chunks) == 0 || len(chunks) > maxChunksPerFile {
+		t.Fatalf("chunk count = %d, want 1..%d", len(chunks), maxChunksPerFile)
+	}
+	if got := strings.Count(strings.Join(chunks, "\n"), "# Section"); got != maxChunksPerFile {
+		t.Fatalf("section count = %d, want capped source count %d", got, maxChunksPerFile)
 	}
 }
 

--- a/internal/manager/biz/knowledge/usecase.go
+++ b/internal/manager/biz/knowledge/usecase.go
@@ -29,7 +29,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
+	markdownsplitter "github.com/cloudwego/eino-ext/components/document/transformer/splitter/markdown"
+	"github.com/cloudwego/eino-ext/components/document/transformer/splitter/recursive"
+	"github.com/cloudwego/eino/schema"
 	model "github.com/ongridio/ongrid/internal/manager/model/knowledge"
 	"github.com/ongridio/ongrid/internal/pkg/embedding"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
@@ -170,7 +174,7 @@ func New(ctx context.Context, repo RepoStore, vec QdrantClient, embed embedding.
 
 // CreateManualDocInput is the form-shaped input for /knowledge POST.
 type CreateManualDocInput struct {
-	Title   string
+	Title string
 	// TitleEN is an optional English label shown when the operator's
 	// locale is en-US. Empty = UI falls back to Title.
 	TitleEN string
@@ -273,6 +277,25 @@ func (u *Usecase) UploadDoc(ctx context.Context, in UploadDocInput) (*model.Doc,
 // docs, and a vault re-sync never touches these (its delete is scoped to
 // source_type=vault). Returns the logical doc (head chunk id).
 func (u *Usecase) ingestUpload(ctx context.Context, d model.Doc) (*model.Doc, error) {
+	parts := make([]string, 0)
+
+	ext := strings.ToLower(filepath.Ext(d.URL))
+	switch ext {
+	case ".md", ".markdown", ".docx", ".pdf":
+		chunks, err := splitMarkdown(ctx, d.Content)
+		if err != nil {
+			return nil, fmt.Errorf("knowledge: split markdown: %w", err)
+		}
+		parts = chunks
+	default:
+		parts = splitForChunks(d.Content)
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("%w: empty file", errs.ErrInvalid)
+	}
+
+	// Split before deleting the previous version: a malformed replacement must
+	// not erase the already-indexed upload.
 	if err := u.vec.DeleteByFilter(ctx, CollectionName, map[string]any{
 		"source_type": model.SourceUpload,
 		"url":         d.URL,
@@ -280,7 +303,6 @@ func (u *Usecase) ingestUpload(ctx context.Context, d model.Doc) (*model.Doc, er
 		return nil, fmt.Errorf("knowledge: clear prior upload: %w", err)
 	}
 
-	parts := splitForChunks(d.Content)
 	const batch = 32
 	for i := 0; i < len(parts); i += batch {
 		end := i + batch
@@ -1597,8 +1619,8 @@ func isTransientGitErr(combinedOutput string) bool {
 		"i/o timeout",
 		"operation timed out",
 		"broken pipe",
-		"timeout, server",     // ssh ServerAlive teardown
-		"client_loop",         // ssh "client_loop: send disconnect: ..."
+		"timeout, server", // ssh ServerAlive teardown
+		"client_loop",     // ssh "client_loop: send disconnect: ..."
 	}
 	for _, p := range patterns {
 		if strings.Contains(s, p) {
@@ -1619,9 +1641,9 @@ func isTransientGitErr(combinedOutput string) bool {
 // future "code repo" mode lands (HLD TBD), it'll widen the allow-list
 // behind an explicit kind=code flag.
 var indexableExts = map[string]bool{
-	".md":   true,
-	".txt":  true,
-	".rst":  true,
+	".md":  true,
+	".txt": true,
+	".rst": true,
 }
 
 // skipDirNames are directories that scanRepoFiles drops without
@@ -1674,6 +1696,10 @@ const (
 	// chunk boundaries so a sentence isn't bisected at the cut.
 	chunkChars   = 2500
 	chunkOverlap = 250
+	// shortMarkdownSectionChars is the largest heading section worth
+	// attaching to an adjacent section. Standalone title-sized chunks add
+	// little retrieval context and unnecessarily consume an embedding.
+	shortMarkdownSectionChars = 500
 	// maxChunksPerFile prevents one pathologically large file from
 	// monopolising the embed budget. With chunkChars=2500 and overlap=250,
 	// stride is 2250 chars/chunk → 256 chunks ≈ 560 KB of content; the
@@ -1981,6 +2007,134 @@ func splitForChunks(content string) []string {
 		}
 	}
 	return chunks
+}
+
+type markdownChunk struct {
+	content          string
+	hasHeading       bool
+	isHeadingSection bool
+}
+
+func splitMarkdown(ctx context.Context, content string) ([]string, error) {
+	headerSplitter, err := markdownsplitter.NewHeaderSplitter(ctx, &markdownsplitter.HeaderConfig{
+		Headers: map[string]string{
+			"#": "h1", "##": "h2", "###": "h3",
+			"####": "h4", "#####": "h5", "######": "h6",
+		},
+		TrimHeaders: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("knowledge: create markdown header splitter: %w", err)
+	}
+	sections, err := headerSplitter.Transform(ctx, []*schema.Document{{Content: content}})
+	if err != nil {
+		return nil, fmt.Errorf("knowledge: split markdown headers: %w", err)
+	}
+
+	chunks := make([]markdownChunk, 0, len(sections))
+	for _, section := range sections {
+		if len(chunks) >= maxChunksPerFile {
+			break
+		}
+		prefix := markdownHeadingPrefix(section.MetaData)
+		body := strings.TrimSpace(section.Content)
+		if prefix == "" && body == "" {
+			continue
+		}
+		if body == "" {
+			chunks = append(chunks, markdownChunk{content: prefix, hasHeading: prefix != "", isHeadingSection: prefix != ""})
+			continue
+		}
+
+		bodyLimit := chunkChars
+		if prefix != "" {
+			bodyLimit -= utf8.RuneCountInString(prefix) + 2
+			if bodyLimit < 1 {
+				bodyLimit = 1
+			}
+		}
+		overlap := chunkOverlap
+		if overlap >= bodyLimit {
+			overlap = bodyLimit / 10
+		}
+		bodySplitter, err := recursive.NewSplitter(ctx, &recursive.Config{
+			ChunkSize:   bodyLimit,
+			OverlapSize: overlap,
+			Separators:  []string{"\n\n", "\n", "。", ".", "?", "!", " ", ""},
+			LenFunc:     utf8.RuneCountInString,
+			KeepType:    recursive.KeepTypeEnd,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("knowledge: create markdown body splitter: %w", err)
+		}
+		parts, err := bodySplitter.Transform(ctx, []*schema.Document{{Content: body}})
+		if err != nil {
+			return nil, fmt.Errorf("knowledge: split markdown body: %w", err)
+		}
+		for _, part := range parts {
+			if len(chunks) >= maxChunksPerFile {
+				break
+			}
+			partContent := strings.TrimSpace(part.Content)
+			if partContent == "" {
+				continue
+			}
+			if prefix != "" {
+				partContent = prefix + "\n\n" + partContent
+			}
+			chunks = append(chunks, markdownChunk{
+				content:          partContent,
+				hasHeading:       prefix != "",
+				isHeadingSection: prefix != "" && len(parts) == 1,
+			})
+		}
+	}
+	chunks = mergeShortMarkdownChunks(chunks)
+	result := make([]string, len(chunks))
+	for i, chunk := range chunks {
+		result[i] = chunk.content
+	}
+	return result, nil
+}
+
+// mergeShortMarkdownChunks folds short heading sections into the following
+// chunk when it fits. A trailing short section has no following context, so it
+// is folded into its predecessor. The chunk cap remains strict because it is
+// also the maximum safe embedding input size.
+func mergeShortMarkdownChunks(chunks []markdownChunk) []markdownChunk {
+	for i := 0; i+1 < len(chunks); {
+		if !isShortMarkdownHeadingChunk(chunks[i]) || utf8.RuneCountInString(chunks[i].content)+2+utf8.RuneCountInString(chunks[i+1].content) > chunkChars {
+			i++
+			continue
+		}
+		chunks[i+1].content = chunks[i].content + "\n\n" + chunks[i+1].content
+		chunks[i+1].hasHeading = chunks[i+1].hasHeading || chunks[i].hasHeading
+		chunks[i+1].isHeadingSection = false
+		chunks = append(chunks[:i], chunks[i+1:]...)
+	}
+
+	last := len(chunks) - 1
+	if last > 0 && isShortMarkdownHeadingChunk(chunks[last]) && utf8.RuneCountInString(chunks[last-1].content)+2+utf8.RuneCountInString(chunks[last].content) <= chunkChars {
+		chunks[last-1].content += "\n\n" + chunks[last].content
+		return chunks[:last]
+	}
+	return chunks
+}
+
+func isShortMarkdownHeadingChunk(chunk markdownChunk) bool {
+	return chunk.hasHeading && chunk.isHeadingSection && utf8.RuneCountInString(chunk.content) <= shortMarkdownSectionChars
+}
+
+func markdownHeadingPrefix(metadata map[string]any) string {
+	headings := make([]string, 0, 6)
+	for level := 1; level <= 6; level++ {
+		value, ok := metadata["h"+strconv.Itoa(level)].(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		headings = append(headings, strings.Repeat("#", level)+" "+strings.TrimSpace(value))
+	}
+	return strings.Join(headings, "\n")
 }
 
 // repoDocPoint builds the qdrantx.Point from a doc + its embedding.

--- a/internal/manager/server/knowledge/http.go
+++ b/internal/manager/server/knowledge/http.go
@@ -322,7 +322,8 @@ func (h *Handler) uploadDoc(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, errors.Join(errs.ErrInvalid, fmt.Errorf("file exceeds %d MiB", maxUploadBytes>>20)))
 		return
 	}
-	// Extract plain text per file type (md/txt passthrough; pdf/docx parsed).
+	// Extract Markdown/text per file type. PDF conversion retains headings
+	// inferred from its font sizes inside docextract.
 	text, err := docextract.Extract(name, body)
 	if err != nil {
 		writeErr(w, errors.Join(errs.ErrInvalid, err))

--- a/internal/pkg/docextract/docx2md.go
+++ b/internal/pkg/docextract/docx2md.go
@@ -1,0 +1,716 @@
+// This file is forked from https://github.com/mattn/docx2md.
+// Compared with upstream, it fixes heading-level detection and table-header
+// rendering, and adds zero-disk image handling and XML decompression limits
+// for uploaded documents.
+package docextract
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// Relationship is
+type Relationship struct {
+	Text       string `xml:",chardata"`
+	ID         string `xml:"Id,attr"`
+	Type       string `xml:"Type,attr"`
+	Target     string `xml:"Target,attr"`
+	TargetMode string `xml:"TargetMode,attr"`
+}
+
+// Relationships is
+type Relationships struct {
+	XMLName      xml.Name       `xml:"Relationships"`
+	Text         string         `xml:",chardata"`
+	Xmlns        string         `xml:"xmlns,attr"`
+	Relationship []Relationship `xml:"Relationship"`
+}
+
+// TextVal is
+type TextVal struct {
+	Text string `xml:",chardata"`
+	Val  string `xml:"val,attr"`
+}
+
+// NumberingLvl is
+type NumberingLvl struct {
+	Text      string  `xml:",chardata"`
+	Ilvl      string  `xml:"ilvl,attr"`
+	Tplc      string  `xml:"tplc,attr"`
+	Tentative string  `xml:"tentative,attr"`
+	Start     TextVal `xml:"start"`
+	NumFmt    TextVal `xml:"numFmt"`
+	LvlText   TextVal `xml:"lvlText"`
+	LvlJc     TextVal `xml:"lvlJc"`
+	PPr       struct {
+		Text string `xml:",chardata"`
+		Ind  struct {
+			Text    string `xml:",chardata"`
+			Left    string `xml:"left,attr"`
+			Hanging string `xml:"hanging,attr"`
+		} `xml:"ind"`
+	} `xml:"pPr"`
+	RPr struct {
+		Text string `xml:",chardata"`
+		U    struct {
+			Text string `xml:",chardata"`
+			Val  string `xml:"val,attr"`
+		} `xml:"u"`
+		RFonts struct {
+			Text string `xml:",chardata"`
+			Hint string `xml:"hint,attr"`
+		} `xml:"rFonts"`
+	} `xml:"rPr"`
+}
+
+// Numbering is
+type Numbering struct {
+	XMLName     xml.Name `xml:"numbering"`
+	Text        string   `xml:",chardata"`
+	Wpc         string   `xml:"wpc,attr"`
+	Cx          string   `xml:"cx,attr"`
+	Cx1         string   `xml:"cx1,attr"`
+	Mc          string   `xml:"mc,attr"`
+	O           string   `xml:"o,attr"`
+	R           string   `xml:"r,attr"`
+	M           string   `xml:"m,attr"`
+	V           string   `xml:"v,attr"`
+	Wp14        string   `xml:"wp14,attr"`
+	Wp          string   `xml:"wp,attr"`
+	W10         string   `xml:"w10,attr"`
+	W           string   `xml:"w,attr"`
+	W14         string   `xml:"w14,attr"`
+	W15         string   `xml:"w15,attr"`
+	W16se       string   `xml:"w16se,attr"`
+	Wpg         string   `xml:"wpg,attr"`
+	Wpi         string   `xml:"wpi,attr"`
+	Wne         string   `xml:"wne,attr"`
+	Wps         string   `xml:"wps,attr"`
+	Ignorable   string   `xml:"Ignorable,attr"`
+	AbstractNum []struct {
+		Text                       string         `xml:",chardata"`
+		AbstractNumID              string         `xml:"abstractNumId,attr"`
+		RestartNumberingAfterBreak string         `xml:"restartNumberingAfterBreak,attr"`
+		Nsid                       TextVal        `xml:"nsid"`
+		MultiLevelType             TextVal        `xml:"multiLevelType"`
+		Tmpl                       TextVal        `xml:"tmpl"`
+		Lvl                        []NumberingLvl `xml:"lvl"`
+	} `xml:"abstractNum"`
+	Num []struct {
+		Text          string  `xml:",chardata"`
+		NumID         string  `xml:"numId,attr"`
+		AbstractNumID TextVal `xml:"abstractNumId"`
+	} `xml:"num"`
+}
+
+// Styles holds paragraph outline levels keyed by Word style ID.
+type Styles struct {
+	Style []struct {
+		Type    string `xml:"type,attr"`
+		StyleID string `xml:"styleId,attr"`
+		PPr     struct {
+			OutlineLvl TextVal `xml:"outlineLvl"`
+		} `xml:"pPr"`
+	} `xml:"style"`
+}
+
+// Config holds conversion options.
+type Config struct {
+	HTMLTable bool
+}
+
+// maxDOCXXMLBytes bounds each XML part after ZIP decompression. The upload
+// limit only bounds compressed bytes, so it does not protect against ZIP bombs.
+const maxDOCXXMLBytes uint64 = 100 << 20
+
+type file struct {
+	rels   Relationships
+	num    Numbering
+	styles map[string]int
+	cfg    Config
+	list   map[string]int
+}
+
+// Node is
+type Node struct {
+	XMLName xml.Name
+	Attrs   []xml.Attr `xml:"-"`
+	Content string     `xml:",chardata"`
+	Nodes   []Node     `xml:",any"`
+}
+
+// UnmarshalXML is
+func (n *Node) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	n.XMLName = start.Name
+	n.Attrs = start.Attr
+	var content []byte
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			var child Node
+			if err := child.UnmarshalXML(d, t); err != nil {
+				return err
+			}
+			n.Nodes = append(n.Nodes, child)
+		case xml.CharData:
+			content = append(content, t...)
+		case xml.EndElement:
+			n.Content = string(content)
+			return nil
+		}
+	}
+}
+
+func escape(s, set string) string {
+	if !strings.ContainsAny(s, set) {
+		return s
+	}
+	var sb strings.Builder
+	sb.Grow(len(s) + 8)
+	for _, r := range s {
+		if strings.ContainsRune(set, r) {
+			sb.WriteByte('\\')
+		}
+		sb.WriteRune(r)
+	}
+	return sb.String()
+}
+
+func onOff(attrs []xml.Attr) bool {
+	val, ok := attr(attrs, "val")
+	if !ok {
+		return true
+	}
+	switch val {
+	case "0", "false", "none", "off":
+		return false
+	}
+	return true
+}
+
+func attr(attrs []xml.Attr, name string) (string, bool) {
+	for _, attr := range attrs {
+		if attr.Name.Local == name {
+			return attr.Value, true
+		}
+	}
+	return "", false
+}
+
+func (zf *file) walk(node *Node, w io.Writer) error {
+	switch node.XMLName.Local {
+	case "hyperlink":
+		var cbuf bytes.Buffer
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], &cbuf); err != nil {
+				return err
+			}
+		}
+		target := ""
+		if id, ok := attr(node.Attrs, "id"); ok {
+			for _, rel := range zf.rels.Relationship {
+				if id == rel.ID {
+					target = rel.Target
+					break
+				}
+			}
+		} else if anchor, ok := attr(node.Attrs, "anchor"); ok {
+			target = "#" + anchor
+		}
+		if target == "" {
+			fmt.Fprint(w, cbuf.String())
+		} else {
+			fmt.Fprintf(w, "[%s](%s)",
+				escape(cbuf.String(), "[]"), escape(target, "()"))
+		}
+	case "t":
+		fmt.Fprint(w, node.Content)
+	case "br", "cr":
+		fmt.Fprint(w, "\n")
+	case "tab":
+		fmt.Fprint(w, "\t")
+	case "tabs":
+		// tab stop definitions in paragraph properties, not content
+	case "pPr":
+		code := false
+		hasNumPr := false
+		for _, n := range node.Nodes {
+			if n.XMLName.Local == "numPr" {
+				hasNumPr = true
+				break
+			}
+		}
+		for _, n := range node.Nodes {
+			switch n.XMLName.Local {
+			case "ind":
+				if !hasNumPr {
+					if left, ok := attr(n.Attrs, "left"); ok {
+						if i, err := strconv.Atoi(left); err == nil && i > 0 {
+							fmt.Fprint(w, strings.Repeat("  ", i/360))
+						}
+					}
+				}
+			case "pStyle":
+				if val, ok := attr(n.Attrs, "val"); ok {
+					if level, ok := zf.styles[val]; ok {
+						fmt.Fprint(w, "\n"+strings.Repeat("#", level)+" ")
+					} else if strings.HasPrefix(val, "Heading") {
+						if i, err := strconv.Atoi(val[7:]); err == nil && i > 0 {
+							fmt.Fprint(w, "\n"+strings.Repeat("#", i)+" ")
+						}
+					} else if val == "Code" {
+						code = true
+					} else {
+						if i, err := strconv.Atoi(val); err == nil && i > 0 {
+							fmt.Fprint(w, "\n"+strings.Repeat("#", i)+" ")
+						}
+					}
+				}
+			case "numPr":
+				numID := ""
+				ilvl := ""
+				ilvlNum := 0
+				numFmt := ""
+				start := 1
+				for _, nn := range n.Nodes {
+					if nn.XMLName.Local == "numId" {
+						if val, ok := attr(nn.Attrs, "val"); ok {
+							numID = val
+						}
+					}
+					if nn.XMLName.Local == "ilvl" {
+						if val, ok := attr(nn.Attrs, "val"); ok {
+							ilvl = val
+							if i, err := strconv.Atoi(val); err == nil {
+								ilvlNum = i
+							}
+						}
+					}
+				}
+				for _, num := range zf.num.Num {
+					if numID != num.NumID {
+						continue
+					}
+					for _, abnum := range zf.num.AbstractNum {
+						if abnum.AbstractNumID != num.AbstractNumID.Val {
+							continue
+						}
+						for _, ablvl := range abnum.Lvl {
+							if ablvl.Ilvl != ilvl {
+								continue
+							}
+							if i, err := strconv.Atoi(ablvl.Start.Val); err == nil {
+								start = i
+							}
+							numFmt = ablvl.NumFmt.Val
+							break
+						}
+						break
+					}
+					break
+				}
+
+				key := fmt.Sprintf("%s:%d", numID, ilvlNum)
+				if _, ok := zf.list[key]; !ok {
+					fmt.Fprint(w, "\n")
+				}
+				fmt.Fprint(w, strings.Repeat("  ", ilvlNum))
+				switch numFmt {
+				case "decimal", "aiueoFullWidth":
+					cur, ok := zf.list[key]
+					if !ok {
+						zf.list[key] = start
+					} else {
+						zf.list[key] = cur + 1
+					}
+					fmt.Fprintf(w, "%d. ", zf.list[key])
+				case "bullet":
+					if _, ok := zf.list[key]; !ok {
+						zf.list[key] = 1
+					}
+					fmt.Fprint(w, "* ")
+				}
+			}
+		}
+		if code {
+			fmt.Fprint(w, "`")
+		}
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], w); err != nil {
+				return err
+			}
+		}
+		if code {
+			fmt.Fprint(w, "`")
+		}
+	case "tbl":
+		fmt.Fprint(w, "\n")
+
+		type cellInfo struct {
+			content  string
+			gridSpan int
+			vMerge   string // "restart", "continue", or ""
+		}
+
+		var cellRows [][]cellInfo
+		for _, tr := range node.Nodes {
+			if tr.XMLName.Local != "tr" {
+				continue
+			}
+			var cells []cellInfo
+			for _, tc := range tr.Nodes {
+				if tc.XMLName.Local != "tc" {
+					continue
+				}
+				ci := cellInfo{gridSpan: 1}
+				for _, n := range tc.Nodes {
+					if n.XMLName.Local != "tcPr" {
+						continue
+					}
+					for _, nn := range n.Nodes {
+						switch nn.XMLName.Local {
+						case "gridSpan":
+							if val, ok := attr(nn.Attrs, "val"); ok {
+								if v, err := strconv.Atoi(val); err == nil {
+									ci.gridSpan = v
+								}
+							}
+						case "vMerge":
+							if val, ok := attr(nn.Attrs, "val"); ok {
+								ci.vMerge = val
+							} else {
+								ci.vMerge = "continue"
+							}
+						}
+					}
+				}
+				var cbuf bytes.Buffer
+				if err := zf.walk(&tc, &cbuf); err != nil {
+					return err
+				}
+				ci.content = strings.Replace(cbuf.String(), "\n", "", -1)
+				cells = append(cells, ci)
+			}
+			cellRows = append(cellRows, cells)
+		}
+
+		// Check if table has any merged cells
+		hasMerge := false
+		for _, cells := range cellRows {
+			for _, ci := range cells {
+				if ci.gridSpan > 1 || ci.vMerge != "" {
+					hasMerge = true
+					break
+				}
+			}
+			if hasMerge {
+				break
+			}
+		}
+
+		if hasMerge && zf.cfg.HTMLTable {
+			// Calculate rowspan for vMerge cells
+			type htmlCell struct {
+				content string
+				colspan int
+				rowspan int
+				gridCol int
+				skip    bool
+			}
+			htmlRows := make([][]htmlCell, len(cellRows))
+			for i, cells := range cellRows {
+				htmlRows[i] = make([]htmlCell, len(cells))
+				col := 0
+				for j, ci := range cells {
+					htmlRows[i][j] = htmlCell{
+						content: ci.content,
+						colspan: ci.gridSpan,
+						rowspan: 1,
+						gridCol: col,
+					}
+					if ci.vMerge == "continue" {
+						htmlRows[i][j].skip = true
+						// Find the restart cell above in the same grid
+						// column and increment its rowspan
+					search:
+						for k := i - 1; k >= 0; k-- {
+							for m := range htmlRows[k] {
+								if htmlRows[k][m].gridCol == col {
+									if !htmlRows[k][m].skip {
+										htmlRows[k][m].rowspan++
+										break search
+									}
+									break
+								}
+							}
+						}
+					}
+					col += ci.gridSpan
+				}
+			}
+
+			fmt.Fprint(w, "<table>\n")
+			for i, row := range htmlRows {
+				fmt.Fprint(w, "  <tr>\n")
+				tag := "td"
+				if i == 0 {
+					tag = "th"
+				}
+				for _, cell := range row {
+					if cell.skip {
+						continue
+					}
+					fmt.Fprintf(w, "    <%s", tag)
+					if cell.colspan > 1 {
+						fmt.Fprintf(w, " colspan=\"%d\"", cell.colspan)
+					}
+					if cell.rowspan > 1 {
+						fmt.Fprintf(w, " rowspan=\"%d\"", cell.rowspan)
+					}
+					fmt.Fprintf(w, ">%s</%s>\n", html.EscapeString(cell.content), tag)
+				}
+				fmt.Fprint(w, "  </tr>\n")
+			}
+			fmt.Fprint(w, "</table>\n")
+		} else {
+			// Plain markdown table (no merged cells)
+			var rows [][]string
+			for _, cells := range cellRows {
+				var cols []string
+				for _, ci := range cells {
+					cols = append(cols, escape(ci.content, "|"))
+				}
+				rows = append(rows, cols)
+			}
+			maxcol := 0
+			for _, cols := range rows {
+				if len(cols) > maxcol {
+					maxcol = len(cols)
+				}
+			}
+			widths := make([]int, maxcol)
+			for _, row := range rows {
+				for i := 0; i < maxcol; i++ {
+					if i < len(row) {
+						width := runewidth.StringWidth(row[i])
+						if widths[i] < width {
+							widths[i] = width
+						}
+					}
+				}
+			}
+			for i, row := range rows {
+				for j := 0; j < maxcol; j++ {
+					fmt.Fprint(w, "|")
+					if j < len(row) {
+						width := runewidth.StringWidth(row[j])
+						fmt.Fprint(w, row[j])
+						fmt.Fprint(w, strings.Repeat(" ", widths[j]-width))
+					} else {
+						fmt.Fprint(w, strings.Repeat(" ", widths[j]))
+					}
+				}
+				fmt.Fprint(w, "|\n")
+				if i == 0 {
+					for j := 0; j < maxcol; j++ {
+						fmt.Fprint(w, "|")
+						fmt.Fprint(w, strings.Repeat("-", widths[j]))
+					}
+					fmt.Fprint(w, "|\n")
+				}
+			}
+		}
+		fmt.Fprint(w, "\n")
+	case "r":
+		bold := false
+		italic := false
+		strike := false
+		for _, n := range node.Nodes {
+			if n.XMLName.Local != "rPr" {
+				continue
+			}
+			for _, nn := range n.Nodes {
+				switch nn.XMLName.Local {
+				case "b":
+					bold = onOff(nn.Attrs)
+				case "i":
+					italic = onOff(nn.Attrs)
+				case "strike":
+					strike = onOff(nn.Attrs)
+				}
+			}
+		}
+		var cbuf bytes.Buffer
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], &cbuf); err != nil {
+				return err
+			}
+		}
+		content := escape(cbuf.String(), `*~\`)
+		if content == "" {
+			break
+		}
+		if strike {
+			fmt.Fprint(w, "~~")
+		}
+		if bold {
+			fmt.Fprint(w, "**")
+		}
+		if italic {
+			fmt.Fprint(w, "*")
+		}
+		fmt.Fprint(w, content)
+		if italic {
+			fmt.Fprint(w, "*")
+		}
+		if bold {
+			fmt.Fprint(w, "**")
+		}
+		if strike {
+			fmt.Fprint(w, "~~")
+		}
+	case "p":
+		var pbuf bytes.Buffer
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], &pbuf); err != nil {
+				return err
+			}
+		}
+		content := pbuf.String()
+		if strings.TrimSpace(content) != "" {
+			fmt.Fprint(w, content)
+			fmt.Fprintln(w)
+		}
+	case "blip":
+		// Images are intentionally omitted. Uploaded documents are converted to
+		// text in memory; extracting media would write untrusted artifacts to the
+		// process working directory and is not useful for knowledge chunking.
+	case "Fallback":
+	case "txbxContent":
+		var cbuf bytes.Buffer
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], &cbuf); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintln(w, "\n```\n"+cbuf.String()+"```")
+	default:
+		for i := range node.Nodes {
+			if err := zf.walk(&node.Nodes[i], w); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func decodeXMLFile(f *zip.File, dst interface{}) error {
+	if f.UncompressedSize64 > maxDOCXXMLBytes {
+		return fmt.Errorf("DOCX XML part %q exceeds %d-byte limit", f.Name, maxDOCXXMLBytes)
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("open DOCX XML part %q: %w", f.Name, err)
+	}
+	defer rc.Close()
+
+	limited := &io.LimitedReader{R: rc, N: int64(maxDOCXXMLBytes) + 1}
+	if err := xml.NewDecoder(limited).Decode(dst); err != nil {
+		if limited.N == 0 {
+			return fmt.Errorf("DOCX XML part %q exceeds %d-byte limit", f.Name, maxDOCXXMLBytes)
+		}
+		return fmt.Errorf("decode DOCX XML part %q: %w", f.Name, err)
+	}
+	return nil
+}
+
+func findFile(files []*zip.File, target string) *zip.File {
+	for _, f := range files {
+		if ok, _ := path.Match(target, f.Name); ok {
+			return f
+		}
+	}
+	return nil
+}
+
+func docx2md(data []byte) (string, error) {
+	cfg := Config{
+		HTMLTable: false,
+	}
+
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", err
+	}
+
+	var rels Relationships
+	var num Numbering
+	var styles Styles
+
+	for _, f := range r.File {
+		switch f.Name {
+		case "word/_rels/document.xml.rels", "word/_rels/document2.xml.rels":
+			if err := decodeXMLFile(f, &rels); err != nil {
+				return "", err
+			}
+		case "word/numbering.xml":
+			if err := decodeXMLFile(f, &num); err != nil {
+				return "", err
+			}
+		case "word/styles.xml":
+			if err := decodeXMLFile(f, &styles); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	f := findFile(r.File, "word/document*.xml")
+	if f == nil {
+		return "", errors.New("incorrect document")
+	}
+	var node Node
+	if err := decodeXMLFile(f, &node); err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	headingLevels := make(map[string]int)
+	for _, style := range styles.Style {
+		if style.Type != "paragraph" {
+			continue
+		}
+		if level, err := strconv.Atoi(style.PPr.OutlineLvl.Val); err == nil && level >= 0 {
+			headingLevels[style.StyleID] = level + 1
+		}
+	}
+
+	zf := &file{
+		rels:   rels,
+		num:    num,
+		styles: headingLevels,
+		cfg:    cfg,
+		list:   make(map[string]int),
+	}
+	err = zf.walk(&node, &buf)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/internal/pkg/docextract/docx2md_test.go
+++ b/internal/pkg/docextract/docx2md_test.go
@@ -1,0 +1,104 @@
+package docextract
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDOCX2MD_WithEmbeddedImage_DoesNotWriteFiles(t *testing.T) {
+	t.Chdir(t.TempDir())
+	document := `<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="urn:w" xmlns:a="urn:a" xmlns:r="urn:r">
+  <w:body><w:p><w:r><w:t>before</w:t></w:r><a:blip r:embed="rId1"/><w:r><w:t>after</w:t></w:r></w:p></w:body>
+</w:document>`
+	rels := `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships><Relationship Id="rId1" Type="image" Target="media/image1.png"/></Relationships>`
+	data := testDOCX(t, map[string]string{
+		"word/document.xml":            document,
+		"word/_rels/document.xml.rels": rels,
+		"word/media/image1.png":        "image bytes",
+		"[Content_Types].xml":          `<Types/>`,
+		"_rels/.rels":                  `<Relationships/>`,
+	})
+
+	got, err := docx2md(data)
+	if err != nil {
+		t.Fatalf("docx2md: %v", err)
+	}
+	if !strings.Contains(got, "beforeafter") {
+		t.Fatalf("surrounding text missing: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join("media", "image1.png")); !os.IsNotExist(err) {
+		t.Fatalf("embedded image was written to working directory: %v", err)
+	}
+}
+
+func TestDOCX2MD_WhenDocumentXMLExceedsLimit_ReturnsError(t *testing.T) {
+	document := `<w:document xmlns:w="urn:w"><w:body><w:p><w:r><w:t>` +
+		strings.Repeat("x", int(maxDOCXXMLBytes)) +
+		`</w:t></w:r></w:p></w:body></w:document>`
+	data := testDOCX(t, map[string]string{"word/document.xml": document})
+
+	_, err := docx2md(data)
+	if err == nil {
+		t.Fatal("oversized document.xml returned no error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDOCX2MD_UsesStyleOutlineLevelForHeading(t *testing.T) {
+	document := `<w:document xmlns:w="urn:w"><w:body><w:p><w:pPr><w:pStyle w:val="CustomHeading"/></w:pPr><w:r><w:t>Release notes</w:t></w:r></w:p></w:body></w:document>`
+	styles := `<w:styles xmlns:w="urn:w"><w:style w:type="paragraph" w:styleId="CustomHeading"><w:pPr><w:outlineLvl w:val="1"/></w:pPr></w:style></w:styles>`
+	data := testDOCX(t, map[string]string{
+		"word/document.xml": document,
+		"word/styles.xml":   styles,
+	})
+
+	got, err := docx2md(data)
+	if err != nil {
+		t.Fatalf("docx2md: %v", err)
+	}
+	if !strings.Contains(got, "## Release notes") {
+		t.Fatalf("custom outline level was not rendered as H2: %q", got)
+	}
+}
+
+func TestDOCX2MD_TableFirstRowBecomesHeader(t *testing.T) {
+	document := `<w:document xmlns:w="urn:w"><w:body><w:tbl>
+<w:tr><w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Version</w:t></w:r></w:p></w:tc></w:tr>
+<w:tr><w:tc><w:p><w:r><w:t>Manager</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>v1</w:t></w:r></w:p></w:tc></w:tr>
+</w:tbl></w:body></w:document>`
+
+	got, err := docx2md(testDOCX(t, map[string]string{"word/document.xml": document}))
+	if err != nil {
+		t.Fatalf("docx2md: %v", err)
+	}
+	if !strings.Contains(got, "|Name   |Version|") || !strings.Contains(got, "|-------|-------|") {
+		t.Fatalf("first table row was not rendered as a Markdown header: %q", got)
+	}
+}
+
+func testDOCX(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create ZIP part %q: %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("write ZIP part %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close ZIP: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/pkg/docextract/extract.go
+++ b/internal/pkg/docextract/extract.go
@@ -37,9 +37,9 @@ func Extract(filename string, data []byte) (string, error) {
 		}
 		return string(data), nil
 	case ".pdf":
-		return extractPDF(data)
+		return pdf2md(data)
 	case ".docx":
-		return extractDOCX(data)
+		return docx2md(data)
 	default:
 		return "", fmt.Errorf("unsupported file type %q (allowed: .md, .txt, .pdf, .docx)", filepath.Ext(filename))
 	}

--- a/internal/pkg/docextract/pdf2md.go
+++ b/internal/pkg/docextract/pdf2md.go
@@ -1,0 +1,127 @@
+package docextract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/ledongthuc/pdf"
+)
+
+const pdfHeadingRatio = 1.2
+
+// pdf2md converts an embedded PDF text layer to Markdown. Text whose font
+// size is at least pdfHeadingRatio times the document's dominant body size is
+// emitted as a heading; remaining text is emitted as ordinary paragraphs.
+func pdf2md(data []byte) (out string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = ""
+			err = fmt.Errorf("read styled pdf text: %v", r)
+		}
+	}()
+
+	r, err := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("read pdf: %w", err)
+	}
+	texts, err := r.GetStyledTexts()
+	if err != nil {
+		return "", fmt.Errorf("read styled pdf text: %w", err)
+	}
+	if len(texts) == 0 {
+		return pdfPlainText(r)
+	}
+
+	bodySize := pdfBodyFontSize(texts)
+	if bodySize == 0 {
+		return pdfPlainText(r)
+	}
+	headingSizes := pdfHeadingSizes(texts, bodySize)
+	if len(headingSizes) == 0 {
+		return pdfPlainText(r)
+	}
+
+	levels := make(map[float64]int, len(headingSizes))
+	for i, size := range headingSizes {
+		levels[size] = min(i+1, 3)
+	}
+
+	var b strings.Builder
+	for _, text := range texts {
+		line := strings.TrimSpace(text.S)
+		if line == "" {
+			continue
+		}
+		if level, ok := levels[pdfFontSizeKey(text.FontSize)]; ok {
+			b.WriteString(strings.Repeat("#", level))
+			b.WriteByte(' ')
+		}
+		b.WriteString(line)
+		b.WriteString("\n\n")
+	}
+	out = strings.TrimSpace(b.String())
+	if out == "" {
+		return pdfPlainText(r)
+	}
+	return out, nil
+}
+
+func pdfPlainText(r *pdf.Reader) (string, error) {
+	rc, err := r.GetPlainText()
+	if err != nil {
+		return "", fmt.Errorf("extract pdf text: %w", err)
+	}
+	var b strings.Builder
+	if _, err := io.Copy(&b, rc); err != nil {
+		return "", fmt.Errorf("read pdf text: %w", err)
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "", fmt.Errorf("no extractable text in pdf (scanned/image PDFs need OCR, not supported)")
+	}
+	return out, nil
+}
+
+func pdfBodyFontSize(texts []pdf.Text) float64 {
+	counts := make(map[float64]int)
+	for _, text := range texts {
+		if strings.TrimSpace(text.S) == "" || text.FontSize <= 0 {
+			continue
+		}
+		counts[pdfFontSizeKey(text.FontSize)] += utf8.RuneCountInString(text.S)
+	}
+	var (
+		bodySize float64
+		maxCount int
+	)
+	for size, count := range counts {
+		if count > maxCount || (count == maxCount && size < bodySize) {
+			bodySize, maxCount = size, count
+		}
+	}
+	return bodySize
+}
+
+func pdfHeadingSizes(texts []pdf.Text, bodySize float64) []float64 {
+	sizes := make(map[float64]struct{})
+	for _, text := range texts {
+		size := pdfFontSizeKey(text.FontSize)
+		if strings.TrimSpace(text.S) != "" && size >= bodySize*pdfHeadingRatio {
+			sizes[size] = struct{}{}
+		}
+	}
+	out := make([]float64, 0, len(sizes))
+	for size := range sizes {
+		out = append(out, size)
+	}
+	sort.Sort(sort.Reverse(sort.Float64Slice(out)))
+	return out
+}
+
+// PDF producers often encode harmless floating-point noise in a font size.
+func pdfFontSizeKey(size float64) float64 { return math.Round(size*10) / 10 }

--- a/internal/pkg/docextract/pdf2md_test.go
+++ b/internal/pkg/docextract/pdf2md_test.go
@@ -1,0 +1,96 @@
+package docextract
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPDF2MD_FontSizesBecomeHeadings(t *testing.T) {
+	data := testPDF(t, "BT\n/F1 24 Tf\n72 720 Td\n(Overview) Tj\n/F1 18 Tf\n0 -40 Td\n(Install) Tj\n/F1 12 Tf\n0 -30 Td\n(Install the agent on every node.) Tj\n0 -16 Td\n(The agent reports metrics.) Tj\nET")
+
+	got, err := pdf2md(data)
+	if err != nil {
+		t.Fatalf("pdf2md: %v", err)
+	}
+	if !strings.Contains(got, "# Overview") {
+		t.Fatalf("largest font was not an H1: %q", got)
+	}
+	if !strings.Contains(got, "## Install") {
+		t.Fatalf("second-largest font was not an H2: %q", got)
+	}
+	if !strings.Contains(got, "Install the agent on every node.") {
+		t.Fatalf("body text missing: %q", got)
+	}
+}
+
+func TestPDF2MD_WithoutHeadingsFallsBackToPlainText(t *testing.T) {
+	data := testPDF(t, "BT\n/F1 12 Tf\n72 720 Td\n(First body sentence.) Tj\n0 -16 Td\n(Second body sentence.) Tj\nET")
+
+	got, err := pdf2md(data)
+	if err != nil {
+		t.Fatalf("pdf2md: %v", err)
+	}
+	if strings.Contains(got, "# ") {
+		t.Fatalf("plain PDF unexpectedly gained headings: %q", got)
+	}
+	if !strings.Contains(got, "Second body sentence.") {
+		t.Fatalf("plain text missing: %q", got)
+	}
+}
+
+func TestPDF2MD_InvalidPDFReturnsError(t *testing.T) {
+	if _, err := pdf2md([]byte("not a pdf")); err == nil {
+		t.Fatal("invalid PDF returned no error")
+	}
+}
+
+func TestPDF2MD_CapsHeadingLevelAtH3(t *testing.T) {
+	data := testPDF(t, "BT\n/F1 36 Tf\n72 720 Td\n(Top) Tj\n/F1 30 Tf\n0 -40 Td\n(Second) Tj\n/F1 24 Tf\n0 -40 Td\n(Third) Tj\n/F1 18 Tf\n0 -40 Td\n(Fourth) Tj\n/F1 12 Tf\n0 -40 Td\n(Body text.) Tj\nET")
+
+	got, err := pdf2md(data)
+	if err != nil {
+		t.Fatalf("pdf2md: %v", err)
+	}
+	for _, want := range []string{"# Top", "## Second", "### Third", "### Fourth"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing heading %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "#### Fourth") {
+		t.Fatalf("heading level exceeds H3: %q", got)
+	}
+}
+
+func TestPDF2MD_WithoutTextReturnsError(t *testing.T) {
+	_, err := pdf2md(testPDF(t, ""))
+	if err == nil || !strings.Contains(err.Error(), "no extractable text") {
+		t.Fatalf("empty PDF error = %v, want no extractable text", err)
+	}
+}
+
+// testPDF builds a minimal one-page Helvetica PDF with caller-controlled
+// content, so font sizes are explicit without committing a binary fixture.
+func testPDF(t *testing.T, stream string) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	b.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 1, 6)
+	writeObject := func(n int, body string) {
+		offsets = append(offsets, b.Len())
+		fmt.Fprintf(&b, "%d 0 obj\n%s\nendobj\n", n, body)
+	}
+	writeObject(1, "<< /Type /Catalog /Pages 2 0 R >>")
+	writeObject(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+	writeObject(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>")
+	writeObject(4, fmt.Sprintf("<< /Length %d >>\nstream\n%s\nendstream", len(stream), stream))
+	writeObject(5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+	xref := b.Len()
+	fmt.Fprintf(&b, "xref\n0 %d\n0000000000 65535 f \n", len(offsets))
+	for _, offset := range offsets[1:] {
+		fmt.Fprintf(&b, "%010d 00000 n \n", offset)
+	}
+	fmt.Fprintf(&b, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(offsets), xref)
+	return b.Bytes()
+}


### PR DESCRIPTION
## Summary

- convert DOCX and PDF knowledge documents to Markdown before chunking
- add Markdown chunking coverage and document-extraction tests
- preserve the RAG retrieval evaluation results below

## RAG 切分召回率测试报告

- 生成时间：2026-08-05T06:57:13Z
- R@5 门槛：90.0%

## 汇总

| 策略 | 文档 | Chunks | R@1 | R@3 | R@5 | MRR | 状态 |
|---|---:|---:|---:|---:|---:|---:|---|
| splitForChunks | 96 | 199 | 80.0% | 90.0% | 95.0% | 0.860 | 通过 |
| splitMarkdown | 96 | 561 | 90.0% | 100.0% | 100.0% | 0.950 | 通过 |

## splitForChunks 逐题结果

| ID | 问题 | 期望文档 | Rank | 召回文档 |
|---|---|---|---:|---|
| dns-resolution | DNS 解析超时和 SERVFAIL 应该如何排查？ | `diagnostics/dns-resolution-failure.md` | 1 | diagnostics/dns-resolution-failure.md<br>diagnostics/network-slow-cn.md<br>reference/authoritative-docs-index.md<br>diagnostics/k8s-cni-pod-network.md<br>diagnostics/network-connectivity.md |
| conntrack-full | 日志提示 nf_conntrack table full 丢包，如何确认并处理？ | `diagnostics/conntrack-table-full.md` | 1 | diagnostics/conntrack-table-full.md<br>systems/network/conntrack.md<br>diagnostics/network-slow-cn.md<br>reference/linux-commands.md<br>diagnostics/tcp-retransmit-loss.md |
| disk-full-cn | 磁盘满了，如何定位占用空间最大的目录和文件？ | `diagnostics/disk-full-cn.md` | 1 | diagnostics/disk-full-cn.md<br>diagnostics/inode-exhaustion.md<br>diagnostics/disk-pressure.md<br>diagnostics/journal-disk-full.md<br>diagnostics/memory-pressure-cn.md |
| disk-iowait | 服务器 iowait 很高且磁盘延迟飙升怎么排查？ | `diagnostics/disk-io-saturation.md` | 1 | diagnostics/disk-io-saturation.md<br>diagnostics/disk-pressure.md<br>diagnostics/high-load-low-cpu.md<br>alerts/host-metrics.md<br>systems/storage/io-scheduling.md |
| memory-leak | 进程内存持续上涨，怎样排查内存泄漏？ | `diagnostics/memory-leak-hunt.md` | 2 | diagnostics/memory-pressure-cn.md<br>diagnostics/memory-leak-hunt.md<br>diagnostics/oom-killed.md<br>diagnostics/slab-cache-bloat.md<br>reference/authoritative-docs-index.md |
| oom-killed | 容器被 OOMKilled 后应检查哪些内存指标和日志？ | `diagnostics/oom-killed.md` | 1 | diagnostics/oom-killed.md<br>diagnostics/memory-leak-hunt.md<br>diagnostics/memory-pressure-cn.md<br>diagnostics/k8s-pod-stuck.md<br>reference/promql-snippets.md |
| cpu-throttling | Kubernetes Pod CPU 被 CFS quota 限流如何确认？ | `diagnostics/cpu-throttling.md` | 1 | diagnostics/cpu-throttling.md<br>reference/authoritative-docs-index.md<br>reference/index/databases-and-storage.md<br>reference/promql-snippets.md<br>systems/scheduling/cfs-and-cgroups.md |
| crashloop | 服务不断重启进入 CrashLoopBackOff，如何定位原因？ | `diagnostics/crashloop-restart.md` | 1 | diagnostics/crashloop-restart.md<br>diagnostics/k8s-pod-stuck.md<br>diagnostics/service-down-cn.md<br>systems/container/kubernetes.md<br>reference/authoritative-docs-index.md |
| tls-handshake | TLS 握手失败或证书校验错误怎么排查？ | `diagnostics/tls-handshake-failure.md` | 2 | diagnostics/network-slow-cn.md<br>diagnostics/tls-handshake-failure.md<br>diagnostics/network-connectivity.md<br>diagnostics/clock-skew-ntp.md<br>reference/authoritative-docs-index.md |
| db-pool | 数据库连接池耗尽导致请求失败，应该看什么？ | `diagnostics/db-connection-pool-exhaustion.md` | 1 | diagnostics/db-connection-pool-exhaustion.md<br>diagnostics/ephemeral-port-exhaustion.md<br>diagnostics/network-slow-cn.md<br>diagnostics/conntrack-table-full.md<br>diagnostics/error-rate-5xx.md |
| p99-latency | 服务 p99 延迟突然升高，如何从 Prometheus 定位？ | `diagnostics/high-latency-p99.md` | 1 | diagnostics/high-latency-p99.md<br>reference/authoritative-docs-index.md<br>systems/observability-stack/tempo.md<br>reference/promql-snippets.md<br>diagnostics/cluster-anomaly-cn.md |
| inode-full | 磁盘还有空间但无法创建文件，inode 用尽怎么处理？ | `diagnostics/inode-exhaustion.md` | 1 | diagnostics/inode-exhaustion.md<br>diagnostics/disk-full-cn.md<br>diagnostics/disk-pressure.md<br>systems/storage/block-devices-and-filesystems.md<br>diagnostics/k8s-pod-evicted-node-pressure.md |
| host-cpu-alert | 主机 CPU 高告警触发后有哪些安全的第一步检查？ | `alerts/host-metrics.md` | 1 | alerts/host-metrics.md<br>diagnostics/cluster-anomaly-cn.md<br>reference/authoritative-docs-index.md<br>diagnostics/cpu-steal-noisy-neighbor.md<br>diagnostics/memory-pressure-cn.md |
| alerting-model | 告警规则、分组、抑制和通知在系统中如何协作？ | `concepts/alerting.md` | 1 | concepts/alerting.md<br>diagnostics/cluster-anomaly-cn.md<br>concepts/observability.md<br>reference/authoritative-docs-index.md<br>concepts/incident-response.md |
| incident-sop | 发生生产事故时的标准响应流程是什么？ | `concepts/incident-response.md` | 1 | concepts/incident-response.md<br>reference/authoritative-docs-index.md<br>diagnostics/cluster-anomaly-cn.md<br>reference/index/sre-methodology.md<br>concepts/observability.md |
| observability | 可观测性的 metrics、logs 和 traces 分别解决什么问题？ | `concepts/observability.md` | 1 | concepts/observability.md<br>systems/observability-stack/tempo.md<br>reference/authoritative-docs-index.md<br>diagnostics/tempo-missing-spans.md<br>reference/index/observability-and-tracing.md |
| kubernetes-network | Kubernetes 集群网络、Service 和 DNS 的基本工作方式是什么？ | `systems/container/kubernetes.md` | 5 | diagnostics/dns-resolution-failure.md<br>reference/authoritative-docs-index.md<br>diagnostics/k8s-cni-pod-network.md<br>reference/index/databases-and-storage.md<br>systems/container/kubernetes.md |
| linux-memory | Linux 页缓存、swap 和 OOM 的内存管理机制是什么？ | `systems/linux/memory.md` | 1 | systems/linux/memory.md<br>diagnostics/memory-pressure-cn.md<br>diagnostics/memory-leak-hunt.md<br>diagnostics/swap-thrashing.md<br>reference/index/linux-kernel-internals.md |
| promql-reference | 我需要常用 PromQL 查询示例和指标表达式。 | `reference/promql-snippets.md` | 1 | reference/promql-snippets.md<br>systems/observability-stack/prometheus.md<br>systems/observability-stack/tempo.md<br>reference/authoritative-docs-index.md<br>diagnostics/prometheus-high-cardinality.md |
| systemd-reference | systemd 服务状态、日志和重启命令有哪些常用用法？ | `reference/linux-commands.md` | 未命中 | diagnostics/service-down-cn.md<br>diagnostics/crashloop-restart.md<br>reference/authoritative-docs-index.md<br>diagnostics/systemd-unit-failed-dependency.md<br>diagnostics/journal-disk-full.md |

## splitMarkdown 逐题结果

| ID | 问题 | 期望文档 | Rank | 召回文档 |
|---|---|---|---:|---|
| dns-resolution | DNS 解析超时和 SERVFAIL 应该如何排查？ | `diagnostics/dns-resolution-failure.md` | 1 | diagnostics/dns-resolution-failure.md<br>diagnostics/network-slow-cn.md<br>diagnostics/error-rate-5xx.md<br>diagnostics/network-connectivity.md<br>diagnostics/cluster-anomaly-cn.md |
| conntrack-full | 日志提示 nf_conntrack table full 丢包，如何确认并处理？ | `diagnostics/conntrack-table-full.md` | 1 | diagnostics/conntrack-table-full.md<br>diagnostics/network-slow-cn.md<br>systems/network/conntrack.md<br>diagnostics/dns-resolution-failure.md<br>diagnostics/network-connectivity.md |
| disk-full-cn | 磁盘满了，如何定位占用空间最大的目录和文件？ | `diagnostics/disk-full-cn.md` | 1 | diagnostics/disk-full-cn.md<br>diagnostics/disk-pressure.md<br>diagnostics/inode-exhaustion.md<br>diagnostics/journal-disk-full.md<br>reference/linux-commands.md |
| disk-iowait | 服务器 iowait 很高且磁盘延迟飙升怎么排查？ | `diagnostics/disk-io-saturation.md` | 1 | diagnostics/disk-io-saturation.md<br>diagnostics/disk-pressure.md<br>diagnostics/high-load-low-cpu.md<br>systems/storage/io-scheduling.md<br>diagnostics/high-latency-p99.md |
| memory-leak | 进程内存持续上涨，怎样排查内存泄漏？ | `diagnostics/memory-leak-hunt.md` | 1 | diagnostics/memory-leak-hunt.md<br>diagnostics/memory-pressure-cn.md<br>diagnostics/oom-killed.md<br>alerts/host-metrics.md<br>diagnostics/slab-cache-bloat.md |
| oom-killed | 容器被 OOMKilled 后应检查哪些内存指标和日志？ | `diagnostics/oom-killed.md` | 1 | diagnostics/oom-killed.md<br>diagnostics/memory-pressure-cn.md<br>diagnostics/crashloop-restart.md<br>diagnostics/k8s-pod-stuck.md<br>diagnostics/service-down-cn.md |
| cpu-throttling | Kubernetes Pod CPU 被 CFS quota 限流如何确认？ | `diagnostics/cpu-throttling.md` | 1 | diagnostics/cpu-throttling.md<br>reference/promql-snippets.md<br>reference/index/linux-kernel-internals.md<br>diagnostics/k8s-pod-evicted-node-pressure.md<br>diagnostics/oom-killed.md |
| crashloop | 服务不断重启进入 CrashLoopBackOff，如何定位原因？ | `diagnostics/crashloop-restart.md` | 1 | diagnostics/crashloop-restart.md<br>diagnostics/k8s-pod-stuck.md<br>diagnostics/service-down-cn.md<br>systems/container/kubernetes.md<br>diagnostics/k8s-probe-failures.md |
| tls-handshake | TLS 握手失败或证书校验错误怎么排查？ | `diagnostics/tls-handshake-failure.md` | 1 | diagnostics/tls-handshake-failure.md<br>diagnostics/network-slow-cn.md<br>diagnostics/network-connectivity.md<br>diagnostics/clock-skew-ntp.md<br>diagnostics/jwt-auth-failures.md |
| db-pool | 数据库连接池耗尽导致请求失败，应该看什么？ | `diagnostics/db-connection-pool-exhaustion.md` | 1 | diagnostics/db-connection-pool-exhaustion.md<br>diagnostics/conntrack-table-full.md<br>diagnostics/ephemeral-port-exhaustion.md<br>diagnostics/high-latency-p99.md<br>diagnostics/db-slow-queries-locks.md |
| p99-latency | 服务 p99 延迟突然升高，如何从 Prometheus 定位？ | `diagnostics/high-latency-p99.md` | 1 | diagnostics/high-latency-p99.md<br>reference/promql-snippets.md<br>diagnostics/prometheus-high-cardinality.md<br>diagnostics/prometheus-scrape-failures.md<br>diagnostics/error-rate-5xx.md |
| inode-full | 磁盘还有空间但无法创建文件，inode 用尽怎么处理？ | `diagnostics/inode-exhaustion.md` | 1 | diagnostics/inode-exhaustion.md<br>diagnostics/disk-full-cn.md<br>systems/storage/block-devices-and-filesystems.md<br>diagnostics/disk-pressure.md<br>diagnostics/lvm-thin-pool-full.md |
| host-cpu-alert | 主机 CPU 高告警触发后有哪些安全的第一步检查？ | `alerts/host-metrics.md` | 1 | alerts/host-metrics.md<br>diagnostics/cluster-anomaly-cn.md<br>diagnostics/softirq-ksoftirqd-high.md<br>diagnostics/cpu-steal-noisy-neighbor.md<br>diagnostics/thermal-cpu-frequency-throttle.md |
| alerting-model | 告警规则、分组、抑制和通知在系统中如何协作？ | `concepts/alerting.md` | 1 | concepts/alerting.md<br>diagnostics/cluster-anomaly-cn.md<br>systems/observability-stack/prometheus.md<br>concepts/incident-response.md<br>alerts/host-metrics.md |
| incident-sop | 发生生产事故时的标准响应流程是什么？ | `concepts/incident-response.md` | 1 | concepts/incident-response.md<br>reference/authoritative-docs-index.md<br>alerts/host-metrics.md<br>diagnostics/cluster-anomaly-cn.md<br>reference/index/sre-methodology.md |
| observability | 可观测性的 metrics、logs 和 traces 分别解决什么问题？ | `concepts/observability.md` | 1 | concepts/observability.md<br>systems/observability-stack/tempo.md<br>reference/index/observability-and-tracing.md<br>systems/observability-stack/loki.md<br>systems/observability-stack/prometheus.md |
| kubernetes-network | Kubernetes 集群网络、Service 和 DNS 的基本工作方式是什么？ | `systems/container/kubernetes.md` | 1 | systems/container/kubernetes.md<br>diagnostics/k8s-cni-pod-network.md<br>diagnostics/dns-resolution-failure.md<br>reference/index/observability-and-tracing.md<br>systems/scheduling/kubernetes-scheduler.md |
| linux-memory | Linux 页缓存、swap 和 OOM 的内存管理机制是什么？ | `systems/linux/memory.md` | 2 | diagnostics/memory-pressure-cn.md<br>systems/linux/memory.md<br>diagnostics/swap-thrashing.md<br>reference/index/linux-kernel-internals.md<br>diagnostics/page-cache-pressure.md |
| promql-reference | 我需要常用 PromQL 查询示例和指标表达式。 | `reference/promql-snippets.md` | 1 | reference/promql-snippets.md<br>systems/observability-stack/prometheus.md<br>systems/observability-stack/tempo.md<br>diagnostics/prometheus-scrape-failures.md<br>diagnostics/prometheus-high-cardinality.md |
| systemd-reference | systemd 服务状态、日志和重启命令有哪些常用用法？ | `reference/linux-commands.md` | 2 | diagnostics/service-down-cn.md<br>reference/linux-commands.md<br>diagnostics/crashloop-restart.md<br>diagnostics/systemd-unit-failed-dependency.md<br>diagnostics/journal-disk-full.md |

## A/B 差异

| ID | 期望文档 | splitForChunks | splitMarkdown | 结果 |
|---|---|---:|---:|---|
| dns-resolution | `diagnostics/dns-resolution-failure.md` | 1 | 1 | 共同命中 |
| conntrack-full | `diagnostics/conntrack-table-full.md` | 1 | 1 | 共同命中 |
| disk-full-cn | `diagnostics/disk-full-cn.md` | 1 | 1 | 共同命中 |
| disk-iowait | `diagnostics/disk-io-saturation.md` | 1 | 1 | 共同命中 |
| memory-leak | `diagnostics/memory-leak-hunt.md` | 2 | 1 | 共同命中 |
| oom-killed | `diagnostics/oom-killed.md` | 1 | 1 | 共同命中 |
| cpu-throttling | `diagnostics/cpu-throttling.md` | 1 | 1 | 共同命中 |
| crashloop | `diagnostics/crashloop-restart.md` | 1 | 1 | 共同命中 |
| tls-handshake | `diagnostics/tls-handshake-failure.md` | 2 | 1 | 共同命中 |
| db-pool | `diagnostics/db-connection-pool-exhaustion.md` | 1 | 1 | 共同命中 |
| p99-latency | `diagnostics/high-latency-p99.md` | 1 | 1 | 共同命中 |
| inode-full | `diagnostics/inode-exhaustion.md` | 1 | 1 | 共同命中 |
| host-cpu-alert | `alerts/host-metrics.md` | 1 | 1 | 共同命中 |
| alerting-model | `concepts/alerting.md` | 1 | 1 | 共同命中 |
| incident-sop | `concepts/incident-response.md` | 1 | 1 | 共同命中 |
| observability | `concepts/observability.md` | 1 | 1 | 共同命中 |
| kubernetes-network | `systems/container/kubernetes.md` | 5 | 1 | 共同命中 |
| linux-memory | `systems/linux/memory.md` | 1 | 2 | 共同命中 |
| promql-reference | `reference/promql-snippets.md` | 1 | 1 | 共同命中 |
| systemd-reference | `reference/linux-commands.md` | 未命中 | 2 | 仅右侧命中 |

## Author confirmation

- [x] I have read and agree to the project contribution guide in CONTRIBUTING.md.
