### PR TITLE
fix(flow): guide AI generator to only emit sourcePort on condition nodes

### DIFF
--- a/internal/manager/biz/flow/generate.go
+++ b/internal/manager/biz/flow/generate.go
@@ -86,7 +86,8 @@ func genSystemPrompt(tools []ToolMeta) string {
 {"name":"<简短工作流名>","description":"<一句话说明>","graph":{"nodes":[...],"edges":[...]}}
 
 ## 图规则
-- nodes: [{"id":"<短id>","type":"<节点类型>","name":"<简短中文名>","config":{...}}]，edges: [{"id":"<短id>","source":"<id>","target":"<id>","sourcePort":"<可选>"}]
+- nodes: [{"id":"<短id>","type":"<节点类型>","name":"<简短中文名>","config":{...}}]，edges: [{"id":"<短id>","source":"<id>","target":"<id>","sourcePort":"<仅 condition 节点使用>"}]
+- 只有 condition 节点可以写 "sourcePort"（值为 "true" 或 "false"）；其他节点的边必须省略 sourcePort，程序会默认连到 "next" 端口。写错端口（例如给普通节点写 "false"）会导致整张图校验失败。
 - 每个节点都要给一个简短、能一眼看懂的 name（如「拉取设备摘要」「分析风险」「生成HTML」「托管网页」），它会显示在画布和运行记录里——不要省略，也不要只用单字母 id 当名字。
 - 必须有且仅有一个触发器节点做起点（默认 trigger.manual）。
 - 节点间用边连，下游用 {{nodes.<上游id>.output.<字段>}} 引用上游输出（写在 config 的字符串值里）。

--- a/internal/manager/biz/flow/generate_test.go
+++ b/internal/manager/biz/flow/generate_test.go
@@ -25,3 +25,24 @@ func TestGenSystemPrompt_WhenMessagingRequested_UsesSharedToolNodes(t *testing.T
 		t.Fatal("messaging tools must be listed as workflow tools")
 	}
 }
+
+func TestGenSystemPrompt_GuidesSourcePortUsageToConditionOnly(t *testing.T) {
+	prompt := genSystemPrompt([]ToolMeta{
+		{Name: "query_promql", Description: "query metrics"},
+	})
+	// The prompt must make it explicit that only condition nodes may carry a
+	// sourcePort, and that omitting it is the default for every other node.
+	// Without this guidance the model occasionally emits sourcePort:"false"
+	// on ordinary tool edges, which ParseGraph rejects with
+	// `port "false" not exposed` (issue #185).
+	for _, want := range []string{
+		"仅 condition 节点使用",
+		"只有 condition 节点可以写",
+		"其他节点的边必须省略 sourcePort",
+		"写错端口",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("generation prompt missing sourcePort-only-for-condition guidance %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #185

## Problem

When a user asks the AI to generate a workflow, the LLM occasionally emits `sourcePort: "false"` on edges leaving a **non-condition** node (e.g. a `tool` node). The graph validator rejects this with:

```
invalid argument: generated graph invalid: graph: edge 2 uses port "false" not exposed by tool node "load"
```

Root cause: the system prompt in `genSystemPrompt` described `sourcePort` only as `"<可选>"` (optional) and mentioned `true`/`false` in the `condition` node docs, so the model sometimes applied `sourcePort:"false"` to ordinary tool/llm edges. `ParseGraph` correctly enforces that non-condition nodes only expose `next` (and `error`), so the ill-formed edge fails validation.

## Fix

Sharpen the prompt's graph rules so the intent is unambiguous:

- `sourcePort` is now documented as **condition-node-only** in the edge schema.
- Added an explicit rule: only `condition` nodes may write `sourcePort` (`"true"`/`"false"`); every other node must **omit** it (defaults to `next`). Included a concrete warning that a wrong port fails the whole graph.

This is a prompt-level fix only — it does not relax the validator, so genuine malformed graphs are still caught.

## Test

Added `TestGenSystemPrompt_GuidesSourcePortUsageToConditionOnly` asserting the prompt carries the condition-only sourcePort guidance.

## Checklist

- [x] `go test ./...` passes (via CI)
- [x] Conventional commit message
- [x] Contribution terms acknowledged