### PR TITLE
fix(edge): 看门狗错误分类——网络不可达不退出，卡死类维持阈值

### DIFF
--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -228,6 +228,7 @@ func main() {
 		NetworkDiscoveryEnabled:  parseBoolEnv("ONGRID_NETWORK_DISCOVERY_ENABLED", true),
 		NetworkDiscoveryInterval: parseDurationEnv("ONGRID_NETWORK_DISCOVERY_INTERVAL", time.Minute),
 		AgentVersion:             version,
+		CloudAddr:                cfg.Edge.CloudAddr,
 		Kubernetes:               k8sInfo,
 		UpgradeStageDir:          stageDir,
 		PacketCaptureDir:         envOr("ONGRID_PACKET_CAPTURE_DIR", "/var/lib/ongrid-edge/pcap"),

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/jumboframes/armorigo v0.4.1 // indirect
+	github.com/jumboframes/armorigo v0.4.1
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/edgeagent/biz/agent.go
+++ b/internal/edgeagent/biz/agent.go
@@ -77,6 +77,12 @@ type Config struct {
 	// AgentVersion is reported on register_edge (optional).
 	AgentVersion string
 
+	// CloudAddr is the manager/frontier address the tunnel dials. It is
+	// only used in unreachable-class WARN logs so operators can tell
+	// "network down, process alive" from "process dead" without digging
+	// through config files.
+	CloudAddr string
+
 	// Kubernetes is set when this edge is deployed by the Kubernetes chart.
 	Kubernetes *tunnel.KubernetesInfo
 
@@ -533,6 +539,12 @@ func applyKubernetesHostIdentity(k8sInfo *tunnel.KubernetesInfo, host *tunnel.Ho
 // If the initial registration failed, the same loop retries it before
 // sending heartbeats so a transient startup dependency does not leave the
 // edge permanently at edge_id=0.
+//
+// Failures are classified by the tunnel's typed errors: unreachable-class
+// failures keep the process alive, retry on the next tick, and reset the
+// stuck streak; only stuck-class failures (network reachable but the
+// tunnel keeps failing) count toward tunnelStuckThreshold, after which
+// the process exits so the service manager can restart it.
 func (a *Agent) heartbeatLoop(ctx context.Context) error {
 	t := time.NewTicker(a.cfg.HeartbeatInterval)
 	defer t.Stop()
@@ -547,6 +559,17 @@ func (a *Agent) heartbeatLoop(ctx context.Context) error {
 				err := a.registerEdge(rctx)
 				cancel()
 				if err != nil {
+					if isUnreachableError(err) {
+						// Same verdict as the heartbeat path: an
+						// unreachable cloud is not stuck-tunnel evidence,
+						// so it neither counts nor keeps an old streak
+						// alive.
+						consecutiveFail = 0
+						a.log.Warn("agent: register_edge retry failed, cloud unreachable; staying alive",
+							slog.String("cloud_addr", a.cfg.CloudAddr),
+							slog.Any("err", err))
+						continue
+					}
 					consecutiveFail++
 					a.log.Warn("agent: register_edge retry failed",
 						slog.Int("consecutive_fail", consecutiveFail),
@@ -573,6 +596,22 @@ func (a *Agent) heartbeatLoop(ctx context.Context) error {
 				}, nil)
 			cancel()
 			if err != nil {
+				// A network-unreachable failure (DNS, dial, or a red
+				// reachability probe) is not evidence of a stuck tunnel:
+				// stay alive and retry on the next tick, mirroring the
+				// unlimited retry of the initial dial path. It also
+				// resets the stuck streak: counting across an unreachable
+				// gap turns a DNS outage into a restart storm. The cost
+				// is that a flapping network can postpone the exit
+				// indefinitely; manager-side device_offline alerting
+				// covers that residual.
+				if isUnreachableError(err) {
+					consecutiveFail = 0
+					a.log.Warn("agent: heartbeat failed, cloud unreachable; staying alive",
+						slog.String("cloud_addr", a.cfg.CloudAddr),
+						slog.Any("err", err))
+					continue
+				}
 				consecutiveFail++
 				a.log.Warn("agent: heartbeat failed",
 					slog.Int("consecutive_fail", consecutiveFail),
@@ -584,6 +623,17 @@ func (a *Agent) heartbeatLoop(ctx context.Context) error {
 				rerr := a.registerEdge(rctx)
 				rcancel()
 				if rerr != nil {
+					// Classify re-register failures the same way: when the
+					// network itself is unreachable, exiting gains nothing —
+					// the restarted process would fail the same dial. The
+					// streak resets for the same reason as above.
+					if isUnreachableError(rerr) {
+						consecutiveFail = 0
+						a.log.Warn("agent: re-register failed, cloud unreachable; staying alive",
+							slog.String("cloud_addr", a.cfg.CloudAddr),
+							slog.Any("err", rerr))
+						continue
+					}
 					a.log.Warn("agent: re-register after heartbeat failure failed",
 						slog.Any("err", rerr))
 					if consecutiveFail >= tunnelStuckThreshold {
@@ -604,6 +654,17 @@ func (a *Agent) heartbeatLoop(ctx context.Context) error {
 const tunnelStuckThreshold = 5
 
 var errTunnelStuck = errors.New("tunnel stuck")
+
+// isUnreachableError reports whether err carries the tunnel's own
+// unreachable verdict. The tunnel Call exit is the single
+// classification point: it inspects the net error shapes (DNS / dial
+// failures, red reachability probes) and wraps them with
+// tunnel.ErrCloudUnreachable, so this layer only matches the sentinel
+// and stays independent of the underlying error forms the transport
+// may evolve to produce.
+func isUnreachableError(err error) bool {
+	return errors.Is(err, tunnel.ErrCloudUnreachable)
+}
 
 // metricsLoop samples the collector every MetricsInterval and fans out
 // the result to the legacy push_host_metrics path and the new

--- a/internal/edgeagent/biz/agent_test.go
+++ b/internal/edgeagent/biz/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -340,6 +341,244 @@ func TestAgent_PersistentHeartbeatAndRegistrationFailuresRestartProcess(t *testi
 	}
 	if got := fc.countOf(tunnel.MethodRegisterEdge); got < 6 {
 		t.Fatalf("register_edge called %d times, want initial registration plus >=5 recovery attempts", got)
+	}
+}
+
+// --- heartbeat failure classification: unreachable vs stuck ---
+//
+// The tunnel Call exit is the single classification point: it wraps
+// unreachable-class failures (DNS / dial / red reachability probe) with
+// tunnel.ErrCloudUnreachable, probe-green timeouts with
+// tunnel.ErrRPCTimeout, and passes everything else through with one %w
+// layer. The helpers below reproduce those exit shapes so the biz
+// layer sees exactly what the real tunnel returns.
+
+func dnsUnreachableExit() error {
+	return fmt.Errorf("tunnel call %q: %w: %w", tunnel.MethodHeartbeat,
+		tunnel.ErrCloudUnreachable,
+		&net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &net.DNSError{Err: "no such host", Name: "cloud.example.com", IsNotFound: true},
+		})
+}
+
+func dialRefusedExit() error {
+	return fmt.Errorf("tunnel call %q: %w: %w", tunnel.MethodHeartbeat,
+		tunnel.ErrCloudUnreachable,
+		&net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connect: connection refused")})
+}
+
+// connWriteExit mimics a failure on an established connection: the
+// tunnel passes it through unclassified, which is stuck-class evidence.
+func connWriteExit() error {
+	return fmt.Errorf("tunnel call %q: %w", tunnel.MethodHeartbeat,
+		&net.OpError{Op: "write", Net: "tcp", Err: fmt.Errorf("connection reset by peer")})
+}
+
+// timeoutExit is the probe-green shape: the cloud answered the
+// reachability probe, the tunnel recycled the transport, and the
+// caller's streak accounting decides whether this warrants an exit.
+func timeoutExit() error {
+	return fmt.Errorf("tunnel call %q: %w: %w", tunnel.MethodHeartbeat,
+		tunnel.ErrRPCTimeout, context.DeadlineExceeded)
+}
+
+// errScript consumes errs in call order; once exhausted it keeps
+// returning tail (nil = success).
+type errScript struct {
+	errs []error
+	tail error
+}
+
+func (s *errScript) next(count int32) error {
+	if int(count) <= len(s.errs) {
+		return s.errs[count-1]
+	}
+	return s.tail
+}
+
+// TestAgent_HeartbeatErrorClassification verifies how the heartbeat loop
+// classifies failures: unreachable-class errors (DNS / dial failures)
+// are not counted and the process stays alive; stuck-class failures keep
+// counting toward the 5-failure exit. Only externally observable
+// behavior is asserted: exit / heartbeat call count / WARN log output.
+func TestAgent_HeartbeatErrorClassification(t *testing.T) {
+	stuckErr := fmt.Errorf("heartbeat unavailable")
+	tests := []struct {
+		name              string
+		heartbeat         errScript
+		register          error // persistent re-register failure (nil = success; the initial registration always succeeds)
+		registerFromStart bool  // fail the initial registration too, driving the EdgeID==0 retry path
+		runFor            time.Duration
+		wantStuck         bool
+		wantHbExact       int32 // exact heartbeat call count when wantStuck
+		wantHbMin         int32
+		wantLogContain    string
+	}{
+		{
+			name:           "dns failure stays alive, not counted",
+			heartbeat:      errScript{tail: dnsUnreachableExit()},
+			runFor:         250 * time.Millisecond,
+			wantHbMin:      7,
+			wantLogContain: "unreachable",
+		},
+		{
+			name:           "dial failure stays alive, not counted",
+			heartbeat:      errScript{tail: dialRefusedExit()},
+			runFor:         250 * time.Millisecond,
+			wantHbMin:      7,
+			wantLogContain: "unreachable",
+		},
+		{
+			name:      "stuck-class failures still exit (regression)",
+			heartbeat: errScript{tail: stuckErr},
+			register:  stuckErr,
+			runFor:    time.Second,
+			wantStuck: true,
+		},
+		{
+			name:      "write-stage OpError counts as stuck, not unreachable",
+			heartbeat: errScript{tail: connWriteExit()},
+			register:  stuckErr,
+			runFor:    time.Second,
+			wantStuck: true,
+		},
+		{
+			name:      "recovery after unreachable resets and continues",
+			heartbeat: errScript{errs: []error{dnsUnreachableExit(), dnsUnreachableExit(), dnsUnreachableExit()}},
+			runFor:    250 * time.Millisecond,
+			wantHbMin: 6,
+		},
+		{
+			name: "mixed sequence counts only stuck-class failures",
+			heartbeat: errScript{
+				errs: []error{
+					dnsUnreachableExit(), dnsUnreachableExit(), dnsUnreachableExit(),
+					stuckErr, stuckErr, stuckErr, stuckErr, stuckErr,
+				},
+				tail: stuckErr,
+			},
+			register:    stuckErr,
+			runFor:      time.Second,
+			wantStuck:   true,
+			wantHbExact: 8,
+		},
+		{
+			name:           "stuck heartbeat + unreachable re-register stays alive",
+			heartbeat:      errScript{tail: stuckErr},
+			register:       dnsUnreachableExit(),
+			runFor:         250 * time.Millisecond,
+			wantHbMin:      7,
+			wantLogContain: "unreachable",
+		},
+		{
+			// A probe-green timeout streak, one unreachable gap, then a
+			// single timeout: the unreachable gap resets the streak, so
+			// the post-gap failure must not ride on the old count and
+			// tip over the threshold.
+			name: "unreachable gap resets the stuck streak",
+			heartbeat: errScript{
+				errs: []error{
+					timeoutExit(), timeoutExit(), timeoutExit(), timeoutExit(),
+					dnsUnreachableExit(),
+					timeoutExit(),
+				},
+			},
+			register: stuckErr,
+			runFor:   250 * time.Millisecond,
+			// The sixth call must not ride on the pre-gap count of four;
+			// with the reset it lands at one and the agent keeps running.
+			wantHbMin: 7,
+		},
+		{
+			// Probe-green timeouts count toward the streak, a successful
+			// redial zeroes it, and a later timeout starts a fresh count
+			// instead of inheriting the pre-recovery one.
+			name: "recovery after probe-green timeouts starts a new streak",
+			heartbeat: errScript{
+				errs: []error{timeoutExit(), timeoutExit(), timeoutExit(), timeoutExit(), nil, timeoutExit()},
+			},
+			runFor:    250 * time.Millisecond,
+			wantHbMin: 7,
+		},
+		{
+			// The initial-registration retry path classifies the same
+			// way: an unreachable cloud keeps the process alive. The
+			// message, not the error text, is asserted — the typed
+			// error itself contains "unreachable" in its chain.
+			name:              "unreachable register retry stays alive",
+			register:          dnsUnreachableExit(),
+			registerFromStart: true,
+			runFor:            250 * time.Millisecond,
+			wantLogContain:    "staying alive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := newFakeClient()
+			register := tt.register
+			fc.callError = func(method string, count int32) error {
+				switch method {
+				case tunnel.MethodHeartbeat:
+					return tt.heartbeat.next(count)
+				case tunnel.MethodRegisterEdge:
+					// count==1 is the initial registration at Run startup.
+					// It must succeed so EdgeID != 0 and the heartbeat
+					// loop reaches the code under test, unless the case
+					// explicitly drives the EdgeID==0 retry path.
+					if register != nil && (count > 1 || tt.registerFromStart) {
+						return register
+					}
+				}
+				return nil
+			}
+			logBuf := &strings.Builder{}
+			a := biz.NewAgent(fc, &fakeCollector{}, biz.Config{
+				HeartbeatInterval: 10 * time.Millisecond,
+				MetricsInterval:   time.Second,
+				CloudAddr:         "cloud.example.com:443",
+			}, slog.New(slog.NewTextHandler(logBuf, nil)))
+
+			ctx, cancel := context.WithTimeout(context.Background(), tt.runFor+2*time.Second)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- a.Run(ctx) }()
+			var exitErr error
+			select {
+			case exitErr = <-done:
+			case <-time.After(tt.runFor):
+			}
+			if tt.wantStuck {
+				if exitErr == nil || !strings.Contains(exitErr.Error(), "tunnel stuck") {
+					t.Fatalf("Run error = %v, want tunnel stuck", exitErr)
+				}
+				if tt.wantHbExact > 0 {
+					if got := fc.countOf(tunnel.MethodHeartbeat); got != tt.wantHbExact {
+						t.Fatalf("heartbeat calls = %d, want exactly %d (unreachable failures must not count)", got, tt.wantHbExact)
+					}
+				}
+				return
+			}
+			if exitErr != nil {
+				t.Fatalf("Run exited early: %v", exitErr)
+			}
+			// Stop the agent and wait for Run to return before reading
+			// the log buffer or call counters: the heartbeat goroutine
+			// writes both, and strings.Builder is not thread-safe.
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("Run did not stop after cancel")
+			}
+			if got := fc.countOf(tunnel.MethodHeartbeat); got < tt.wantHbMin {
+				t.Fatalf("heartbeat calls = %d, want >= %d", got, tt.wantHbMin)
+			}
+			if tt.wantLogContain != "" && !strings.Contains(logBuf.String(), tt.wantLogContain) {
+				t.Fatalf("logs missing %q; got:\n%s", tt.wantLogContain, logBuf.String())
+			}
+		})
 	}
 }
 

--- a/internal/pkg/tunnel/client.go
+++ b/internal/pkg/tunnel/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/singchia/geminio"
 	gclient "github.com/singchia/geminio/client"
 	"github.com/singchia/geminio/delegate"
+	"golang.org/x/sync/singleflight"
 )
 
 // NewClient returns a Client backed by github.com/singchia/geminio. The
@@ -61,6 +62,16 @@ type geminioClient struct {
 	pendingConn       net.Conn
 	pendingGeneration uint64
 	nextGeneration    uint64
+
+	// Reachability probe state. probeFn is the injection seam for tests;
+	// nil means the real probeCloud. probeSF merges concurrent probes and
+	// probeLastErr/probeLastAt cache the latest conclusion for probeTTL.
+	probeFn      func(ctx context.Context) error
+	probeSF      singleflight.Group
+	probeMu      sync.Mutex
+	probeLastErr error
+	probeLastAt  time.Time
+	probeTTL     time.Duration
 
 	closeOnce sync.Once
 	closed    atomic.Bool
@@ -164,13 +175,15 @@ func (c *geminioClient) Dial(ctx context.Context) error {
 	}
 }
 
-// buildDialer wraps net.Dial (or tls.Dial if a TLS CA is set).
-func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
-	addr := c.cfg.resolvedServerAddr()
+// dialTimeout is the TCP dial budget shared by the tunnel dialer and
+// the reachability probe so the two paths cannot drift.
+const dialTimeout = 10 * time.Second
+
+// loadTLSConfig returns the TLS material used to verify the server, or
+// nil when the deployment runs plain TCP. Shared by the tunnel dialer
+// and the reachability probe for the same reason as dialTimeout.
+func (c *geminioClient) loadTLSConfig() (*tls.Config, error) {
 	caFile := c.cfg.resolvedTLSCA()
-	if addr == "" {
-		return nil, errors.New("tunnel: ServerAddr (or CloudAddr) is required")
-	}
 	if caFile == "" {
 		// Fail closed: TLS was configured at install time (the installer
 		// records ONGRID_EDGE_TLS_REQUIRED=1 alongside the CA path), but the
@@ -180,14 +193,7 @@ func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
 		if c.cfg.TLSRequired {
 			return nil, errors.New("tunnel: TLS required (installed with --tls-ca-file) but ONGRID_EDGE_TLS_CA_FILE is unset; refusing plaintext downgrade")
 		}
-		d := &net.Dialer{Timeout: 10 * time.Second}
-		return func() (net.Conn, error) {
-			conn, err := d.Dial("tcp", addr)
-			if err == nil {
-				c.trackConnection(conn)
-			}
-			return conn, err
-		}, nil
+		return nil, nil
 	}
 	pem, err := os.ReadFile(caFile)
 	if err != nil {
@@ -197,29 +203,58 @@ func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
 	if !pool.AppendCertsFromPEM(pem) {
 		return nil, errors.New("tunnel: TLS CA file contains no valid PEM cert")
 	}
-	tlsCfg := &tls.Config{
+	return &tls.Config{
 		RootCAs:    pool,
 		MinVersion: tls.VersionTLS12,
-	}
-	// Derive the TLS ServerName from the address (required for cert
-	// verification). When the address is an IP literal but the cert's
-	// CN is a DNS name, the caller must override it via
-	// ONGRID_EDGE_TLS_SERVER_NAME.
+	}, nil
+}
+
+// applyTLSServerName derives the TLS ServerName from the address
+// (required for cert verification) — an explicit TLSServerName override
+// wins, otherwise the host part of addr is used when it is a DNS name.
+// Fail closed: a TLS config with an unresolved ServerName (IP-literal
+// address and no override) refuses to proceed, otherwise the TLS
+// handshake would fail later with a cryptic error ("certificate signed
+// by unknown authority" or "x509: cannot validate certificate") that
+// operators tend to misread as a CA misconfiguration.
+func (c *geminioClient) applyTLSServerName(tlsCfg *tls.Config, addr string) error {
 	if c.cfg.TLSServerName != "" {
 		tlsCfg.ServerName = c.cfg.TLSServerName
 	} else if host, _, err := net.SplitHostPort(addr); err == nil && net.ParseIP(host) == nil {
 		tlsCfg.ServerName = host
 	}
-	// Fail closed: a non-empty TLSCAFile with an unresolved ServerName
-	// (IP-literal address and no TLSServerName override) refuses to
-	// start. Otherwise the TLS handshake would fail later with a
-	// cryptic error ("certificate signed by unknown authority" or
-	// "x509: cannot validate certificate") that operators tend to
-	// misread as a CA misconfiguration.
 	if tlsCfg.ServerName == "" {
-		return nil, fmt.Errorf("tunnel: TLS ServerName unresolved (addr=%q is IP literal; set ONGRID_EDGE_TLS_SERVER_NAME)", addr)
+		return fmt.Errorf("tunnel: TLS ServerName unresolved (addr=%q is IP literal; set ONGRID_EDGE_TLS_SERVER_NAME)", addr)
 	}
-	d := &net.Dialer{Timeout: 10 * time.Second}
+	return nil
+}
+
+// buildDialer wraps net.Dial (or tls.Client if a TLS CA is set).
+func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
+	addr := c.cfg.resolvedServerAddr()
+	if addr == "" {
+		return nil, errors.New("tunnel: ServerAddr (or CloudAddr) is required")
+	}
+	tlsCfg, err := c.loadTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	d := &net.Dialer{Timeout: dialTimeout}
+	if tlsCfg == nil {
+		return func() (net.Conn, error) {
+			conn, err := d.Dial("tcp", addr)
+			if err == nil {
+				c.trackConnection(conn)
+			}
+			return conn, err
+		}, nil
+	}
+	// Derive the TLS ServerName and fail closed when it cannot be
+	// resolved. Shared with the probe so both paths verify certificates
+	// against the same name.
+	if err := c.applyTLSServerName(tlsCfg, addr); err != nil {
+		return nil, err
+	}
 	return func() (net.Conn, error) {
 		raw, err := d.Dial("tcp", addr)
 		if err != nil {
@@ -229,6 +264,79 @@ func (c *geminioClient) buildDialer() (gclient.Dialer, error) {
 		c.trackConnection(conn)
 		return conn, nil
 	}, nil
+}
+
+// Probe budgets: the TCP leg reuses the tunnel's dialTimeout; the TLS
+// handshake leg gets its own budget because a SYN-answering middlebox
+// (reverse proxy or transparent proxy) accepts TCP but goes silent at
+// the first TLS byte — the handshake deadline is what turns that into a
+// red conclusion instead of an endless wait.
+const (
+	probeHandshakeTimeout = 10 * time.Second
+	defaultProbeTTL       = 30 * time.Second
+)
+
+// probeCloud dials the server address with the same transport semantics
+// as the tunnel dialer (resolved address, shared dial budget, shared
+// TLS material and certificate verification) and reports whether the
+// cloud endpoint answered. The connection is deliberately NOT fed
+// through trackConnection: a probe must never disturb the
+// pendingConn/generation state machine that mirrors the live tunnel.
+func (c *geminioClient) probeCloud(ctx context.Context) error {
+	addr := c.cfg.resolvedServerAddr()
+	if addr == "" {
+		return errors.New("tunnel: probe: ServerAddr (or CloudAddr) is required")
+	}
+	tlsCfg, err := c.loadTLSConfig()
+	if err != nil {
+		return err
+	}
+	if tlsCfg != nil {
+		// Same certificate-verification name as the tunnel dialer, so
+		// the probe conclusion cannot diverge from the live transport.
+		if err := c.applyTLSServerName(tlsCfg, addr); err != nil {
+			return err
+		}
+	}
+	d := &net.Dialer{Timeout: dialTimeout}
+	raw, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer raw.Close()
+	if tlsCfg == nil {
+		return nil
+	}
+	hctx, cancel := context.WithTimeout(ctx, probeHandshakeTimeout)
+	defer cancel()
+	if err := tls.Client(raw, tlsCfg).HandshakeContext(hctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// recycleTransport closes the current active connection so the
+// underlying RetryEnd redials on it. Used when a timed-out call's probe
+// says the cloud is reachable: the transport is half-open, and a fresh
+// dial recovers the next tick instead of waiting for TCP keepalives to
+// notice. Stale generations are ignored, mirroring recycleBrokenRoute.
+func (c *geminioClient) recycleTransport(generation uint64) {
+	if c.closed.Load() {
+		return
+	}
+	c.connMu.Lock()
+	if generation == 0 || generation != c.activeGeneration || c.activeConn == nil {
+		c.connMu.Unlock()
+		return
+	}
+	conn := c.activeConn
+	c.activeConn = nil
+	c.connMu.Unlock()
+
+	c.log.Warn("tunnel: rpc timed out but cloud reachable; recycling transport for redial")
+	if err := conn.Close(); err != nil {
+		c.log.Debug("tunnel: close timed-out transport", slog.Any("err", err))
+	}
 }
 
 // RegisterHandler installs a handler for cloud->edge RPCs. Safe to call
@@ -280,7 +388,7 @@ func (c *geminioClient) Call(ctx context.Context, method string, req, resp any) 
 	rsp, callErr := end.Call(ctx, method, end.NewRequest(body))
 	if callErr != nil {
 		c.recycleBrokenRoute(method, callErr, connGeneration)
-		return fmt.Errorf("tunnel call %q: %w", method, callErr)
+		return c.wrapCallFailure(method, callErr, connGeneration)
 	}
 	if rerr := rsp.Error(); rerr != nil {
 		c.recycleBrokenRoute(method, rerr, connGeneration)

--- a/internal/pkg/tunnel/probe.go
+++ b/internal/pkg/tunnel/probe.go
@@ -1,0 +1,158 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+)
+
+// Sentinel errors the caller can branch on with errors.Is. They always
+// wrap the original failure so logs keep the full evidence chain.
+var (
+	// ErrCloudUnreachable means the network stack could not reach the
+	// cloud: either the RPC itself failed with a dial/DNS error, or a
+	// timed-out RPC was followed by a red reachability probe. Retrying
+	// later can fix this; restarting the process cannot.
+	ErrCloudUnreachable = errors.New("tunnel: cloud unreachable")
+	// ErrRPCTimeout means the RPC timed out while the cloud was still
+	// reachable (green probe): the transport is half-open rather than
+	// down, so the wrapper recycles it for a redial and lets the
+	// caller's own accounting decide when a stuck tunnel warrants a
+	// process exit.
+	ErrRPCTimeout = errors.New("tunnel: rpc timeout")
+)
+
+// callErrClass buckets a failed Call so the response ladder stays
+// table-driven: the mapping from error shape to bucket must not be
+// widened or narrowed casually, which is why the full table lives in
+// probe_test.go.
+type callErrClass int
+
+const (
+	callErrUnclassified callErrClass = iota
+	callErrUnreachable
+	callErrTimeout
+)
+
+// classifyCallError inspects a transport-level Call failure.
+//
+//   - DNS and dial-stage errors are direct evidence the cloud was never
+//     reached; they map straight to unreachable with no probe, keeping
+//     the fast path.
+//   - Context-deadline errors (raw or wrapped by retry loops that abort
+//     on caller deadlines) mean the connection went silent mid-flight.
+//     That alone cannot distinguish a network blackhole from a wedged
+//     cloud, so it triggers the reachability probe instead of deciding.
+//   - An actively cancelled context is a local shutdown decision, not
+//     evidence about the cloud, and is excluded even when a deadline
+//     error is embedded in the same chain.
+//   - Everything else (established-then-broke write errors, forced
+//     close of pending calls, remote errors) keeps the original
+//     pass-through semantics.
+func classifyCallError(err error) callErrClass {
+	if errors.Is(err, context.Canceled) {
+		return callErrUnclassified
+	}
+	if isDialStageError(err) {
+		return callErrUnreachable
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return callErrTimeout
+	}
+	return callErrUnclassified
+}
+
+// isDialStageError reports whether err is a DNS resolution or TCP dial
+// failure. Only dial-stage OpErrors count: read/write errors imply a
+// connection that was established and then broke, which is stuck-class
+// evidence.
+func isDialStageError(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "dial"
+}
+
+// wrapCallFailure is the response ladder for a failed transport-level
+// Call. Direct unreachable errors keep the fast path; timeout-shaped
+// errors consult the throttled reachability probe, whose outcome picks
+// between "cloud unreachable" (stay alive) and "rpc timeout with a
+// recycled transport" (let the caller count it).
+func (c *geminioClient) wrapCallFailure(method string, err error, generation uint64) error {
+	switch classifyCallError(err) {
+	case callErrUnreachable:
+		return fmt.Errorf("tunnel call %q: %w: %w", method, ErrCloudUnreachable, err)
+	case callErrTimeout:
+		probeErr := c.probeCloudThrottled()
+		if probeErr != nil {
+			c.log.Warn("tunnel: rpc timed out and probe says cloud unreachable",
+				slog.String("method", method),
+				slog.String("server_addr", c.cfg.resolvedServerAddr()),
+				slog.Any("probe_err", probeErr),
+			)
+			return fmt.Errorf("tunnel call %q: %w: probe: %w (rpc: %w)",
+				method, ErrCloudUnreachable, probeErr, err)
+		}
+		// The cloud answered the probe but not the RPC: the transport is
+		// half-open, not down. Close it so the underlying RetryEnd redials;
+		// a fresh connection recovers on the next tick, while a genuinely
+		// wedged cloud keeps the caller's timeout accounting intact.
+		c.recycleTransport(generation)
+		return fmt.Errorf("tunnel call %q: %w: %w", method, ErrRPCTimeout, err)
+	default:
+		return fmt.Errorf("tunnel call %q: %w", method, err)
+	}
+}
+
+// probeCloudThrottled returns the cloud reachability conclusion,
+// merging concurrent callers into at most one in-flight probe
+// (singleflight) and reusing a fresh conclusion for probeTTL. Without
+// the throttle, a partition would turn every failing call into its own
+// dial attempt — a probe storm on monitored networks that track
+// connection rates.
+func (c *geminioClient) probeCloudThrottled() error {
+	ttl := c.probeTTL
+	if ttl <= 0 {
+		ttl = defaultProbeTTL
+	}
+	if err, ok := c.cachedProbeConclusion(ttl); ok {
+		return err
+	}
+	v, _, _ := c.probeSF.Do("cloud-reachability", func() (any, error) {
+		// Queued callers re-check the cache: the leader may have stored
+		// a conclusion while they waited for the singleflight slot.
+		if err, ok := c.cachedProbeConclusion(ttl); ok {
+			return err, nil
+		}
+		pctx, cancel := context.WithTimeout(
+			context.Background(), dialTimeout+probeHandshakeTimeout)
+		defer cancel()
+		probe := c.probeFn
+		if probe == nil {
+			probe = c.probeCloud
+		}
+		probeErr := probe(pctx)
+		c.probeMu.Lock()
+		c.probeLastErr, c.probeLastAt = probeErr, time.Now()
+		c.probeMu.Unlock()
+		return probeErr, nil
+	})
+	// A green conclusion is a nil error, so the plain assertion would
+	// panic on the nil interface — use the comma-ok form.
+	probeErr, _ := v.(error)
+	return probeErr
+}
+
+func (c *geminioClient) cachedProbeConclusion(ttl time.Duration) (error, bool) {
+	c.probeMu.Lock()
+	defer c.probeMu.Unlock()
+	if c.probeLastAt.IsZero() || time.Since(c.probeLastAt) >= ttl {
+		return nil, false
+	}
+	return c.probeLastErr, true
+}

--- a/internal/pkg/tunnel/probe_integration_test.go
+++ b/internal/pkg/tunnel/probe_integration_test.go
@@ -1,0 +1,296 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/application"
+	gconn "github.com/singchia/geminio/conn"
+	"github.com/singchia/geminio/multiplexer"
+	"github.com/singchia/geminio/packet"
+	"github.com/singchia/geminio/pkg/id"
+	timer "github.com/singchia/go-timer/v2"
+)
+
+// silentGeminioLogger drops all geminio-internal output; the default
+// logger would spam reconnect chatter into the test output.
+type silentGeminioLogger struct{}
+
+func (silentGeminioLogger) Trace(...interface{})          {}
+func (silentGeminioLogger) Tracef(string, ...interface{}) {}
+func (silentGeminioLogger) Debug(...interface{})          {}
+func (silentGeminioLogger) Debugf(string, ...interface{}) {}
+func (silentGeminioLogger) Info(...interface{})           {}
+func (silentGeminioLogger) Infof(string, ...interface{})  {}
+func (silentGeminioLogger) Warn(...interface{})           {}
+func (silentGeminioLogger) Warnf(string, ...interface{})  {}
+func (silentGeminioLogger) Error(...interface{})          {}
+func (silentGeminioLogger) Errorf(string, ...interface{}) {}
+
+// ladderTestServer is a real three-layer geminio server (conn ->
+// multiplexer -> application, mirroring the client assembly) used to
+// anchor the response ladder against real geminio error chains.
+//
+// In live mode the heartbeat handler answers normally. In silent mode
+// the handler blocks forever while the connection stays open — the
+// "handshake alive, RPC silent, connection held" failure shape. Unlike
+// an accept-without-answer blackhole, this variant reaches the
+// in-flight RPC and lets the caller deadline fire, which is the only
+// form the probe is designed to arbitrate.
+type ladderTestServer struct {
+	ln net.Listener
+
+	silent atomic.Bool
+
+	mu        sync.Mutex
+	rawConns  []net.Conn
+	timers    []timer.Timer
+	accepts   atomic.Int32
+	blockHold chan struct{}
+	closeOnce sync.Once
+}
+
+func newLadderTestServer(t *testing.T) *ladderTestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &ladderTestServer{ln: ln, blockHold: make(chan struct{})}
+	t.Cleanup(s.Close)
+	go s.acceptLoop()
+	return s
+}
+
+func (s *ladderTestServer) Addr() string { return s.ln.Addr().String() }
+
+func (s *ladderTestServer) Close() {
+	// Tests may shut the server down mid-run and the cleanup hook fires
+	// again afterwards; both paths must be safe.
+	s.closeOnce.Do(func() {
+		// Close errors on a tearing-down test server carry no signal.
+		_ = s.ln.Close()
+		s.closeAllConns()
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for _, tmr := range s.timers {
+			tmr.Close()
+		}
+		close(s.blockHold)
+	})
+}
+
+func (s *ladderTestServer) closeAllConns() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Best-effort teardown: per-conn close errors carry no signal.
+	for _, c := range s.rawConns {
+		_ = c.Close()
+	}
+}
+
+func (s *ladderTestServer) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		s.accepts.Add(1)
+		s.mu.Lock()
+		s.rawConns = append(s.rawConns, conn)
+		s.mu.Unlock()
+		go s.serveLive(conn)
+	}
+}
+
+// serveLive assembles the three server layers the same way the client
+// end does, so the tunnel speaks the full real protocol.
+func (s *ladderTestServer) serveLive(raw net.Conn) {
+	tmr := timer.NewTimer()
+	pf := packet.NewPacketFactory(id.NewIDCounter(id.Even))
+	s.mu.Lock()
+	s.timers = append(s.timers, tmr)
+	s.mu.Unlock()
+
+	cn, err := gconn.NewServerConn(raw,
+		gconn.OptionServerConnPacketFactory(pf),
+		gconn.OptionServerConnTimer(tmr),
+		gconn.OptionServerConnLogger(silentGeminioLogger{}),
+	)
+	if err != nil {
+		tmr.Close()
+		return
+	}
+	mp, err := multiplexer.NewDialogueMgr(cn,
+		multiplexer.OptionPacketFactory(pf),
+		multiplexer.OptionTimer(tmr),
+		multiplexer.OptionLogger(silentGeminioLogger{}),
+		multiplexer.OptionMultiplexerAcceptDialogue(),
+	)
+	if err != nil {
+		tmr.Close()
+		return
+	}
+	ep, err := application.NewEnd(cn, mp,
+		application.OptionPacketFactory(pf),
+		application.OptionTimer(tmr),
+		application.OptionLogger(silentGeminioLogger{}),
+	)
+	if err != nil {
+		tmr.Close()
+		return
+	}
+	// A failed registration only means that connection serves no RPCs;
+	// the client under test never depends on the server-side handler
+	// registration succeeding.
+	_ = ep.Register(context.Background(), MethodHeartbeat,
+		func(ctx context.Context, req geminio.Request, rsp geminio.Response) {
+			if s.silent.Load() {
+				// Hold the RPC forever: transport healthy, answers never
+				// arrive. Released only on server shutdown so the blocked
+				// handler goroutines do not leak for the whole test run.
+				<-s.blockHold
+				return
+			}
+			rsp.SetData([]byte(`{}`))
+		})
+}
+
+func dialLadderClient(t *testing.T, s *ladderTestServer) (*geminioClient, *atomic.Int32) {
+	t.Helper()
+	tc := NewClient(ClientConfig{
+		ServerAddr: s.Addr(),
+		AccessKey:  "AK-TEST",
+		SecretKey:  "SK-TEST",
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	c := tc.(*geminioClient)
+	var probes atomic.Int32
+	c.probeFn = func(ctx context.Context) error {
+		probes.Add(1)
+		return c.probeCloud(ctx)
+	}
+	dctx, dcancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer dcancel()
+	if err := tc.Dial(dctx); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Cleanup-close errors carry no assertion value.
+	t.Cleanup(func() { _ = tc.Close() })
+	return c, &probes
+}
+
+func callHeartbeat(t *testing.T, c Client, timeout time.Duration) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return c.Call(ctx, MethodHeartbeat,
+		HeartbeatRequest{EdgeID: 9, Ts: time.Now().Unix()}, nil)
+}
+
+func waitForCond(t *testing.T, cond func() bool, what string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestCallLadderSilentHandlerProbesAndRecycles covers the three
+// transport states against real geminio on both ends:
+//
+//  1. fully alive — the heartbeat round-trips;
+//  2. handshake alive + RPC silent + connection held — the call
+//     deadline fires, one probe runs, the probe dials the live listener
+//     and goes green, the half-open transport is recycled, and the
+//     tunnel redials back to a working heartbeat;
+//  3. port refused — the redial surfaces a dial OpError which maps
+//     straight to unreachable without ever consulting the probe.
+func TestCallLadderSilentHandlerProbesAndRecycles(t *testing.T) {
+	s := newLadderTestServer(t)
+	c, probes := dialLadderClient(t, s)
+
+	// State 1: fully alive.
+	if err := callHeartbeat(t, c, 5*time.Second); err != nil {
+		t.Fatalf("live heartbeat failed: %v", err)
+	}
+
+	// State 2: handler-blocked silence on a healthy transport.
+	s.silent.Store(true)
+	err := callHeartbeat(t, c, 800*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("silent heartbeat err = %v, want wrapped deadline", err)
+	}
+	if !errors.Is(err, ErrRPCTimeout) {
+		t.Fatalf("silent heartbeat err = %v, want ErrRPCTimeout after green probe", err)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probe ran %d times, want 1", got)
+	}
+
+	// The recycle side-effect: the tunnel redials (initial conn + probe
+	// conn already counted), proving the transport was rebuilt rather
+	// than just annotated.
+	waitForCond(t, func() bool { return s.accepts.Load() >= 3 },
+		"redial after transport recycle", 15*time.Second)
+
+	// Recovery: with the handler answering again, the recycled tunnel
+	// serves heartbeats on the next call.
+	s.silent.Store(false)
+	if err := callHeartbeat(t, c, 5*time.Second); err != nil {
+		t.Fatalf("heartbeat after redial failed: %v", err)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probe count changed to %d after recovery, want 1", got)
+	}
+}
+
+// TestCallLadderPortRefusedMapsDirectUnreachable shuts the whole server
+// down so redials hit a refused port: the dial OpError must map straight
+// to unreachable on the fast path, with the probe never invoked.
+func TestCallLadderPortRefusedMapsDirectUnreachable(t *testing.T) {
+	s := newLadderTestServer(t)
+	c, probes := dialLadderClient(t, s)
+
+	if err := callHeartbeat(t, c, 5*time.Second); err != nil {
+		t.Fatalf("live heartbeat failed: %v", err)
+	}
+
+	// Refuse every future dial: close the listener AND the established
+	// connections so nothing keeps the port bound.
+	s.Close()
+
+	var last error
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		last = callHeartbeat(t, c, 5*time.Second)
+		if errors.Is(last, ErrCloudUnreachable) {
+			break
+		}
+		// Intermediate shapes (forced close of pending calls, EOF) pass
+		// through unclassified until the redial itself fails.
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !errors.Is(last, ErrCloudUnreachable) {
+		t.Fatalf("call after server shutdown err = %v, want ErrCloudUnreachable", last)
+	}
+	var opErr *net.OpError
+	if !errors.As(last, &opErr) || opErr.Op != "dial" {
+		t.Fatalf("err = %v, want a dial-stage OpError preserved in the chain", last)
+	}
+	if got := probes.Load(); got != 0 {
+		t.Fatalf("probe ran %d times for a direct unreachable error, want 0", got)
+	}
+}

--- a/internal/pkg/tunnel/probe_test.go
+++ b/internal/pkg/tunnel/probe_test.go
@@ -1,0 +1,221 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jumboframes/armorigo/synchub"
+)
+
+func TestClassifyCallErrorIsTableLocked(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "cloud.example.com", IsNotFound: true}
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: os.ErrPermission}
+	writeErr := &net.OpError{Op: "write", Net: "tcp", Err: errors.New("broken pipe")}
+	tests := []struct {
+		name string
+		err  error
+		want callErrClass
+	}{
+		// Timeout bucket: the established-connection blackhole surfaces as
+		// a context deadline from the in-flight RPC select, both raw and
+		// wrapped by the call exit (and by the same-conn retry loop when a
+		// caller-side deadline aborts an in-progress retry).
+		{name: "raw deadline", err: context.DeadlineExceeded, want: callErrTimeout},
+		{name: "deadline wrapped by call exit",
+			err:  fmt.Errorf("tunnel call %q: %w", MethodHeartbeat, context.DeadlineExceeded),
+			want: callErrTimeout},
+		{name: "deadline wrapped by retry abort",
+			err:  fmt.Errorf("tunnel call %q: retry aborted: %w", MethodHeartbeat, context.DeadlineExceeded),
+			want: callErrTimeout},
+
+		// Unreachable bucket: the network stack never reached the cloud.
+		{name: "dns failure", err: dnsErr, want: callErrUnreachable},
+		{name: "dns failure wrapped",
+			err:  fmt.Errorf("tunnel call %q: %w", MethodRegisterEdge, dnsErr),
+			want: callErrUnreachable},
+		{name: "dial refused", err: dialErr, want: callErrUnreachable},
+		{name: "dial refused wrapped",
+			err:  fmt.Errorf("tunnel call %q: %w", MethodRegisterEdge, dialErr),
+			want: callErrUnreachable},
+
+		// Everything else stays stuck-class:
+		// only established-then-broke evidence or unknown forms.
+		{name: "write stage failure stays stuck-class", err: writeErr, want: callErrUnclassified},
+		{name: "conn force close stays stuck-class", err: synchub.ErrSyncHubForceClosed, want: callErrUnclassified},
+		{name: "remote eof stays stuck-class", err: io.EOF, want: callErrUnclassified},
+		{name: "remote error stays stuck-class", err: errors.New("no such rpc: heartbeat"), want: callErrUnclassified},
+
+		// An actively cancelled parent context is a local shutdown
+		// decision, not evidence about the cloud — never probe for it.
+		{name: "parent cancel excluded", err: context.Canceled, want: callErrUnclassified},
+		{name: "cancel wins over embedded deadline",
+			err:  fmt.Errorf("outer: %w: %w", context.Canceled, context.DeadlineExceeded),
+			want: callErrUnclassified},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyCallError(tt.err); got != tt.want {
+				t.Fatalf("classifyCallError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newProbeTestClient(probe func(context.Context) error) *geminioClient {
+	c := &geminioClient{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	c.probeFn = probe
+	return c
+}
+
+func TestWrapCallFailureDirectUnreachableSkipsProbe(t *testing.T) {
+	var probes atomic.Int32
+	c := newProbeTestClient(func(context.Context) error {
+		probes.Add(1)
+		return nil
+	})
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: os.ErrPermission}
+
+	err := c.wrapCallFailure(MethodHeartbeat, dialErr, 0)
+
+	if !errors.Is(err, ErrCloudUnreachable) {
+		t.Fatalf("err = %v, want ErrCloudUnreachable", err)
+	}
+	if !errors.Is(err, dialErr) {
+		t.Fatalf("err = %v, original dial error not preserved", err)
+	}
+	if got := probes.Load(); got != 0 {
+		t.Fatalf("probe ran %d times for a direct unreachable error, want 0", got)
+	}
+}
+
+func TestWrapCallFailureTimeoutProbeRedMapsUnreachable(t *testing.T) {
+	probeErr := errors.New("probe: connection refused")
+	var probes atomic.Int32
+	c := newProbeTestClient(func(context.Context) error {
+		probes.Add(1)
+		return probeErr
+	})
+
+	err := c.wrapCallFailure(MethodHeartbeat, context.DeadlineExceeded, 0)
+
+	if !errors.Is(err, ErrCloudUnreachable) {
+		t.Fatalf("err = %v, want ErrCloudUnreachable after red probe", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, original rpc timeout not preserved", err)
+	}
+	if !errors.Is(err, probeErr) {
+		t.Fatalf("err = %v, probe evidence not preserved", err)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probe ran %d times, want 1", got)
+	}
+}
+
+func TestWrapCallFailureTimeoutProbeGreenRecyclesTransport(t *testing.T) {
+	var probes atomic.Int32
+	c := newProbeTestClient(func(context.Context) error {
+		probes.Add(1)
+		return nil
+	})
+	conn := &closeSpyConn{}
+	c.trackConnection(conn)
+	c.promotePendingConnection()
+	generation := c.connectionGeneration()
+
+	err := c.wrapCallFailure(MethodHeartbeat, context.DeadlineExceeded, generation)
+
+	if !errors.Is(err, ErrRPCTimeout) {
+		t.Fatalf("err = %v, want ErrRPCTimeout after green probe", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, original rpc timeout not preserved", err)
+	}
+	if !conn.closed.Load() {
+		t.Fatal("green probe did not close the active transport for redial")
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probe ran %d times, want 1", got)
+	}
+}
+
+func TestWrapCallFailureProbeGreenIgnoresStaleGeneration(t *testing.T) {
+	c := newProbeTestClient(func(context.Context) error { return nil })
+	old := &closeSpyConn{}
+	c.trackConnection(old)
+	c.promotePendingConnection()
+	stale := c.connectionGeneration()
+	current := &closeSpyConn{}
+	c.trackConnection(current)
+	c.promotePendingConnection()
+
+	err := c.wrapCallFailure(MethodHeartbeat, context.DeadlineExceeded, stale)
+
+	if !errors.Is(err, ErrRPCTimeout) {
+		t.Fatalf("err = %v, want ErrRPCTimeout", err)
+	}
+	if current.closed.Load() {
+		t.Fatal("recycle closed a connection from a newer generation")
+	}
+}
+
+func TestProbeConclusionReusedWithinTTL(t *testing.T) {
+	var probes atomic.Int32
+	c := newProbeTestClient(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("red")
+	})
+	c.probeTTL = 60 * time.Millisecond
+
+	// Two consecutive failing calls inside the TTL share one conclusion.
+	// The conclusion value itself is irrelevant here — only the probe
+	// count distinguishes cache hits from fresh dials.
+	_ = c.probeCloudThrottled()
+	_ = c.probeCloudThrottled()
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probe ran %d times inside TTL, want 1", got)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	_ = c.probeCloudThrottled()
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("probe ran %d times after TTL expiry, want 2", got)
+	}
+}
+
+func TestProbeSingleflightMergesConcurrentFailures(t *testing.T) {
+	release := make(chan struct{})
+	var probes atomic.Int32
+	c := newProbeTestClient(func(context.Context) error {
+		probes.Add(1)
+		<-release
+		return errors.New("red")
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Conclusion value ignored: this test counts dials, not outcomes.
+			_ = c.probeCloudThrottled()
+		}()
+	}
+	// Let every caller arrive while the first probe is still in flight.
+	time.Sleep(200 * time.Millisecond)
+	if got := probes.Load(); got != 1 {
+		close(release)
+		t.Fatalf("concurrent callers spawned %d probes, want 1", got)
+	}
+	close(release)
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

After a successful registration, the edge heartbeat watchdog treats **every** heartbeat / re-register failure as evidence of a stuck tunnel. During a public-DNS outage (or any network path failure to the cloud), that misclassification makes the edge process exit(1) after 5 failed heartbeats — an unnecessary restart: restarting cannot fix a network outage, event logs gain noise, and in-process state is lost. After the restart, the initial dial keeps backing off (or registration keeps retrying at edge_id=0), so an outage is not necessarily a continuous restart loop — but every threshold crossing is still a pointless exit.

This contradicts the initial-dial path, which retries unreachable clouds with unlimited backoff and never exits. The same process held two opposite policies for the same failure.

## Root cause

`heartbeatLoop` counted *all* heartbeat RPC failures toward `tunnelStuckThreshold` without distinguishing "cannot reach the cloud" from "cloud reachable but tunnel unresponsive" (the watchdog's original target). Classifying raw `net` error shapes at the biz layer also misses the blackholed-connection case (`context deadline exceeded`), and stale stuck counts survived across unreachable gaps.

## Fix

Two layers, so the tunnel `Call` exit is the single classification point.

**tunnel layer — error response ladder** (`internal/pkg/tunnel/probe.go`):

- Dial/DNS-stage failures map directly to the new sentinel `ErrCloudUnreachable` (fast path kept, `%w` chain preserved).
- Timeout-shaped failures (context deadline, including retry-abort wraps; an actively cancelled context is excluded even when a deadline error is embedded in the same chain) trigger one throttled reachability probe that uses the same transport semantics as the tunnel dialer: same resolved address, shared 10s dial budget, shared CA material and certificate verification, and an explicit handshake deadline so a SYN-answering middlebox cannot fake a green conclusion. The probe deliberately bypasses `trackConnection` so it cannot disturb the connection/generation state machine.
  - Probe red → `ErrCloudUnreachable` (whether to stay alive is the caller's decision).
  - Probe green → the transport is half-open rather than down: recycle it (generation-guarded) so the underlying RetryEnd redial recovers on the next tick, then return `ErrRPCTimeout` so the caller's accounting stays in charge.
- Concurrent probes are merged (singleflight) and a fresh conclusion is reused for 30s, preventing a probe storm during a partition.

**biz layer — watchdog classification switch** (`internal/edgeagent/biz/agent.go`):

- `isUnreachableError` now matches `errors.Is(tunnel.ErrCloudUnreachable)` instead of inspecting raw `net` error shapes — the biz layer no longer depends on the transport library's error forms.
- All three failure points (register retry, heartbeat, re-register) treat unreachable the same way: reset the stuck streak, log a WARN including the cloud address, stay alive, retry next tick. Stale counts no longer survive an unreachable gap (no more "4 stuck → outage → 1 stuck → exit").
- Stuck class (cloud reachable but the tunnel keeps failing) is unchanged: 5 consecutive failures + failed re-register → `errTunnelStuck` → exit(1).
- Accepted trade-off, documented in code: a flapping network can postpone the exit indefinitely; manager-side `device_offline` alerting covers that residual.

`Config.CloudAddr` is added purely for the unreachable WARN log, so operators can tell "network down, process alive" from "process dead" without digging through config files.

## Testing

- Table-driven classification tests pin the full ladder: context cancel wins over embedded deadlines, dial-stage vs write-stage `OpError`, retry-abort wraps, DNS errors.
- Probe unit tests via an injection seam cover every classification row, throttle behavior (singleflight + TTL), and recycle-on-green with stale-generation rejection.
- Integration tests against a real three-layer geminio server: healthy round-trip; blackholed handler (RPC goes silent → probe green → transport recycled → redial recovers); port refused (direct unreachable, no probe).
- Watchdog tests: unreachable-gap streak reset sequence, fresh counting after recovery, unreachable register-retry staying alive.
- `-race`, `-count=2` clean on both packages (matches CI).

## Behavior summary

| Failure | Before | After |
|---|---|---|
| DNS resolution failure | counted → exit(1) | WARN, stay alive, retry |
| TCP dial failure | counted → exit(1) | WARN, stay alive, retry |
| Blackholed connection (RPC timeout) | counted → exit(1) | probe red: stay alive; probe green: recycle transport + count as RPC timeout |
| Cloud reachable, heartbeat + re-register failing | exit(1) after 5 | unchanged: exit(1) after 5 |
| Auth-type remote errors | exit path preserved | unchanged |

## Notes

- `GOOS=windows go build ./...` currently fails in `internal/edgeagent/cmdpolicy` (`syscall.SysProcAttr.Setpgid` is Unix-only). The same failure exists on `upstream/main` (pre-existing) and is unrelated to the files touched here.
- Runtime fault-injection evidence for the review's acceptance scenarios will be attached in a follow-up comment.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
