### PR TITLE
fix(build): remove redundant runtime apt update

### DIFF
--- a/deploy/Dockerfile.ongrid
+++ b/deploy/Dockerfile.ongrid
@@ -93,7 +93,6 @@ RUN set -eux; \
 ARG ONNXRUNTIME_VERSION=1.20.1
 ARG TARGETARCH
 RUN set -eux; \
-    apt-get update && apt-get install -y --no-install-recommends unzip; \
     arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
     case "${arch}" in \
         amd64|x86_64) ORT_ARCH=x64; NUGET_RID=linux-x64 ;; \
@@ -107,13 +106,12 @@ RUN set -eux; \
     else \
         curl -fsSL -o /tmp/ort.nupkg \
             "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime/${ONNXRUNTIME_VERSION}"; \
-        unzip -q /tmp/ort.nupkg "runtimes/${NUGET_RID}/native/libonnxruntime.so" -d /tmp/ort-nuget; \
+        python3 -c 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extract(sys.argv[2], sys.argv[3])' \
+            /tmp/ort.nupkg "runtimes/${NUGET_RID}/native/libonnxruntime.so" /tmp/ort-nuget; \
         install -m 0755 /tmp/ort-nuget/runtimes/${NUGET_RID}/native/libonnxruntime.so /usr/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION}; \
     fi; \
     ln -sf /usr/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} /usr/lib/libonnxruntime.so; \
     rm -rf /tmp/ort.tgz /tmp/ort.nupkg /tmp/ort-nuget /tmp/onnxruntime-linux-${ORT_ARCH}-${ONNXRUNTIME_VERSION}; \
-    apt-get purge -y --auto-remove unzip; \
-    rm -rf /var/lib/apt/lists/*; \
     ldconfig
 ENV ONNX_PATH=/usr/lib/libonnxruntime.so
 


### PR DESCRIPTION
Reuse the existing Python runtime for the ONNX Runtime NuGet fallback. This removes a redundant Debian index refresh from the runtime image build while preserving the primary verified archive path and fallback behavior.

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md