### PR TITLE
fix(grafana): sync runtime Loki datasource settings

### DIFF
--- a/deploy/grafana/provisioning/datasources/loki.yml
+++ b/deploy/grafana/provisioning/datasources/loki.yml
@@ -12,7 +12,8 @@ datasources:
     # (v0.7.40 fix). Default lives in the grafana service compose env.
     url: ${ONGRID_LOG_URL}
     isDefault: false
-    editable: false
+    # The manager updates this datasource after runtime Loki settings change.
+    editable: true
     jsonData:
       timeout: 60
       maxLines: 5000

--- a/deploy/install/grafana/provisioning/datasources/loki.yml
+++ b/deploy/install/grafana/provisioning/datasources/loki.yml
@@ -14,7 +14,8 @@ datasources:
     # the grafana service compose env now; keep this a plain ${VAR}.
     url: ${ONGRID_LOG_URL}
     isDefault: false
-    editable: false
+    # The manager updates this datasource after runtime Loki settings change.
+    editable: true
     jsonData:
       timeout: 60
       maxLines: 5000

--- a/internal/manager/biz/grafana/datasource_test.go
+++ b/internal/manager/biz/grafana/datasource_test.go
@@ -1,0 +1,134 @@
+package grafana
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	settingbiz "github.com/ongridio/ongrid/internal/manager/biz/setting"
+	settingmodel "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+type fakeSettingRepo struct {
+	mu   sync.Mutex
+	rows map[string]*settingmodel.Setting
+}
+
+func newFakeSettingRepo() *fakeSettingRepo {
+	return &fakeSettingRepo{rows: map[string]*settingmodel.Setting{}}
+}
+
+func (r *fakeSettingRepo) key(category, key string) string { return category + "|" + key }
+
+func (r *fakeSettingRepo) Get(_ context.Context, category, key string) (*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row, ok := r.rows[r.key(category, key)]
+	if !ok {
+		return nil, errs.ErrNotFound
+	}
+	cp := *row
+	return &cp, nil
+}
+
+func (r *fakeSettingRepo) Set(_ context.Context, category, key, value string, sensitive bool) (*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row := &settingmodel.Setting{
+		Category:  category,
+		Key:       key,
+		Value:     value,
+		Sensitive: sensitive,
+		UpdatedAt: time.Now(),
+	}
+	r.rows[r.key(category, key)] = row
+	return row, nil
+}
+
+func (r *fakeSettingRepo) SetBatch(_ context.Context, settings []settingmodel.Setting) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	next := make(map[string]*settingmodel.Setting, len(r.rows)+len(settings))
+	for key, row := range r.rows {
+		cp := *row
+		next[key] = &cp
+	}
+	for i := range settings {
+		row := settings[i]
+		row.UpdatedAt = time.Now()
+		next[r.key(row.Category, row.Key)] = &row
+	}
+	r.rows = next
+	return nil
+}
+
+func (r *fakeSettingRepo) List(_ context.Context, category string) ([]*settingmodel.Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*settingmodel.Setting, 0, len(r.rows))
+	for _, row := range r.rows {
+		if category != "" && row.Category != category {
+			continue
+		}
+		cp := *row
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (r *fakeSettingRepo) Delete(_ context.Context, category, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.rows, r.key(category, key))
+	return nil
+}
+
+func TestLokiDatasourceFromSettings(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	for _, row := range []struct {
+		key       string
+		value     string
+		sensitive bool
+	}{
+		{settingmodel.KeyLokiURL, "https://loki.example.com/", false},
+		{settingmodel.KeyLokiBasicUser, "alice", false},
+		{settingmodel.KeyLokiBasicPassword, "secret", true},
+		{settingmodel.KeyLokiTLSInsecure, "true", false},
+	} {
+		if err := settings.Set(ctx, settingmodel.CategoryLoki, row.key, row.value, row.sensitive); err != nil {
+			t.Fatalf("set %s: %v", row.key, err)
+		}
+	}
+
+	ds := New(settings, false, nil).lokiDatasource(ctx)
+	if ds == nil {
+		t.Fatal("loki datasource = nil")
+	}
+	if ds.UID != lokiDatasourceUID || ds.Name != lokiDatasourceName || ds.Type != "loki" {
+		t.Fatalf("identity = (%s,%s,%s)", ds.UID, ds.Name, ds.Type)
+	}
+	if ds.URL != "https://loki.example.com" {
+		t.Fatalf("url = %q", ds.URL)
+	}
+	if !ds.BasicAuth || ds.BasicAuthUser != "alice" {
+		t.Fatalf("basic auth = %v user=%q", ds.BasicAuth, ds.BasicAuthUser)
+	}
+	if got := ds.SecureJSONData["basicAuthPassword"]; got != "secret" {
+		t.Fatalf("basic password = %q", got)
+	}
+	if got, ok := ds.JSONData["tlsSkipVerify"].(bool); !ok || !got {
+		t.Fatalf("tlsSkipVerify = %v", ds.JSONData["tlsSkipVerify"])
+	}
+}
+
+func TestLokiDatasourceEmptyURLSkipsSync(t *testing.T) {
+	t.Parallel()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	if ds := New(settings, false, nil).lokiDatasource(context.Background()); ds != nil {
+		t.Fatalf("loki datasource = %#v, want nil", ds)
+	}
+}

--- a/internal/manager/biz/grafana/service.go
+++ b/internal/manager/biz/grafana/service.go
@@ -1,16 +1,17 @@
 // Package grafana orchestrates the manager-side Grafana auto-config flow
 // (PR-2). The biz layer bridges three things:
 //
-//   1. system_settings.{category=grafana} for the operator-supplied root
-//      URL + service-account token
-//   2. system_settings.{category=prom}.query_url so the auto-created
-//      datasource points at the same TSDB the manager is writing to
-//   3. embedded dashboard JSON shipped inside the manager binary
+//  1. system_settings.{category=grafana} for the operator-supplied root
+//     URL + service-account token
+//  2. system_settings.{category=prom}.query_url so the auto-created
+//     datasource points at the same TSDB the manager is writing to
+//  3. embedded dashboard JSON shipped inside the manager binary
 //
-// Two ops are exposed:
+// Three ops are exposed:
 //   - Test: build a Client from settings, hit /api/health
 //   - Sync: ensure the ongrid folder, upsert the prom datasource, push
 //     every embedded dashboard with overwrite=true
+//   - SyncLoki: update only the managed Loki datasource after settings change
 package grafana
 
 import (
@@ -37,10 +38,15 @@ import (
 // them as keys for "is this already there?". Renaming them would create
 // duplicates instead of replacing.
 const (
-	folderUID    = "ongrid"
-	folderTitle  = "ongrid"
-	datasourceUID  = "ongrid-prometheus"
-	datasourceName = "ongrid-prometheus"
+	folderUID      = "ongrid"
+	folderTitle    = "ongrid"
+	datasourceUID  = promDatasourceUID
+	datasourceName = promDatasourceName
+
+	promDatasourceUID  = "ongrid-prometheus"
+	promDatasourceName = "ongrid-prometheus"
+	lokiDatasourceUID  = "ongrid-loki"
+	lokiDatasourceName = "ongrid-loki"
 )
 
 //go:embed dashboards/*.json
@@ -172,6 +178,7 @@ func (s *Service) BootstrapEmbedded(ctx context.Context, adminUser, adminPasswor
 type SyncResult struct {
 	Folder      string   `json:"folder"`
 	Datasource  string   `json:"datasource"`
+	Datasources []string `json:"datasources,omitempty"`
 	Dashboards  []string `json:"dashboards"` // titles synced
 }
 
@@ -216,8 +223,8 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicPassword)
 
 	ds := pkggrafana.Datasource{
-		UID:    datasourceUID,
-		Name:   datasourceName,
+		UID:    promDatasourceUID,
+		Name:   promDatasourceName,
 		Type:   "prometheus",
 		URL:    promURL,
 		Access: "proxy",
@@ -235,7 +242,15 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
 	}
 	if err := c.UpsertDatasource(ctx, ds); err != nil {
-		return nil, fmt.Errorf("upsert datasource: %w", err)
+		return nil, fmt.Errorf("upsert prometheus datasource: %w", err)
+	}
+
+	datasources := []string{promDatasourceName}
+	if lokiDS := s.lokiDatasource(ctx); lokiDS != nil {
+		if err := s.syncLokiDatasource(ctx, c); err != nil {
+			return nil, fmt.Errorf("upsert loki datasource: %w", err)
+		}
+		datasources = append(datasources, lokiDatasourceName)
 	}
 
 	titles, err := s.pushDashboards(ctx, c)
@@ -244,16 +259,65 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 	}
 
 	res := &SyncResult{
-		Folder:     folderTitle,
-		Datasource: datasourceName,
-		Dashboards: titles,
+		Folder:      folderTitle,
+		Datasource:  promDatasourceName,
+		Datasources: datasources,
+		Dashboards:  titles,
 	}
 	s.log.Info("grafana sync done",
 		slog.String("folder", res.Folder),
-		slog.String("datasource", res.Datasource),
+		slog.Any("datasources", res.Datasources),
 		slog.Int("dashboards", len(res.Dashboards)),
 	)
 	return res, nil
+}
+
+// SyncLoki updates only the managed Loki datasource. It is intentionally
+// separate from Sync so changing Loki settings does not rewrite dashboards.
+func (s *Service) SyncLoki(ctx context.Context) error {
+	c, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	return s.syncLokiDatasource(ctx, c)
+}
+
+func (s *Service) syncLokiDatasource(ctx context.Context, c *pkggrafana.Client) error {
+	lokiDS := s.lokiDatasource(ctx)
+	if lokiDS == nil {
+		return errors.New("grafana: cannot sync Loki datasource: loki.url is empty")
+	}
+	return c.UpsertDatasource(ctx, *lokiDS)
+}
+
+func (s *Service) lokiDatasource(ctx context.Context) *pkggrafana.Datasource {
+	lokiURL, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiURL)
+	lokiURL = strings.TrimRight(strings.TrimSpace(lokiURL), "/")
+	if lokiURL == "" {
+		return nil
+	}
+	ds := &pkggrafana.Datasource{
+		UID:    lokiDatasourceUID,
+		Name:   lokiDatasourceName,
+		Type:   "loki",
+		URL:    lokiURL,
+		Access: "proxy",
+		JSONData: map[string]any{
+			"timeout":  60,
+			"maxLines": 5000,
+		},
+	}
+	if tlsInsecure, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiTLSInsecure); strings.EqualFold(strings.TrimSpace(tlsInsecure), "true") {
+		ds.JSONData["tlsSkipVerify"] = true
+	}
+	basicUser, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiBasicUser)
+	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryLoki, settingmodel.KeyLokiBasicPassword)
+	if basicUser = strings.TrimSpace(basicUser); basicUser != "" {
+		ds.BasicAuth = true
+		ds.BasicAuthUser = basicUser
+		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
+	}
+	return ds
 }
 
 // client builds a pkg/grafana.Client from settings; returns a friendly
@@ -473,14 +537,14 @@ func buildMonitorDashboardJSON(uid, title string, panels []*monitormodel.Panel) 
 		})
 	}
 	return map[string]any{
-		"uid":         uid,
-		"title":       title,
-		"description": "Auto-managed by ongrid. Edits in Grafana will be overwritten — change panels in the ongrid Monitor page.",
-		"tags":        []string{"ongrid", "managed"},
-		"editable":    true,
-		"timezone":    "",
+		"uid":           uid,
+		"title":         title,
+		"description":   "Auto-managed by ongrid. Edits in Grafana will be overwritten — change panels in the ongrid Monitor page.",
+		"tags":          []string{"ongrid", "managed"},
+		"editable":      true,
+		"timezone":      "",
 		"schemaVersion": 38,
-		"panels":      gPanels,
+		"panels":        gPanels,
 		"time": map[string]any{
 			"from": "now-1h",
 			"to":   "now",

--- a/internal/manager/server/integration/http.go
+++ b/internal/manager/server/integration/http.go
@@ -29,6 +29,7 @@ import (
 type GrafanaService interface {
 	Test(ctx context.Context) error
 	Sync(ctx context.Context) (*bizgrafana.SyncResult, error)
+	SyncLoki(ctx context.Context) error
 	FetchDashboardJSON(ctx context.Context, uid string) ([]byte, error)
 }
 
@@ -122,6 +123,7 @@ func (h *Handler) SetLLMProbe(p LLMConfigProbe) { h.llmProbe = p }
 //
 //	POST /v1/integrations/grafana/test           (admin)  — verify connectivity
 //	POST /v1/integrations/grafana/sync           (admin)  — push folder + datasource + dashboards
+//	POST /v1/integrations/grafana/sync-loki      (admin)  — push only the Loki datasource
 //	POST /v1/integrations/prom/test              (admin)  — run "up" PromQL probe
 //	POST /v1/integrations/llm/test               (admin)  — validate an unsaved provider tuple
 //	POST /v1/integrations/llm/validate-and-save  (admin)  — validate every model and atomically save
@@ -135,6 +137,7 @@ func (h *Handler) SetLLMProbe(p LLMConfigProbe) { h.llmProbe = p }
 func (h *Handler) Register(r chi.Router) {
 	r.Post("/v1/integrations/grafana/test", h.testGrafana)
 	r.Post("/v1/integrations/grafana/sync", h.syncGrafana)
+	r.Post("/v1/integrations/grafana/sync-loki", h.syncLoki)
 	r.Post("/v1/integrations/prom/test", h.testProm)
 	r.Post("/v1/integrations/loki/test", h.testLoki)
 	r.Post("/v1/integrations/tempo/test", h.testTempo)
@@ -325,6 +328,28 @@ func (h *Handler) syncGrafana(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, res)
+}
+
+// syncLoki updates the Grafana Loki datasource after loki.* settings are
+// saved, without rewriting dashboards or the Prometheus datasource.
+//
+// @Summary Sync Grafana Loki datasource
+// @Tags integrations
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} errorBody
+// @Failure 403 {object} errorBody
+// @Failure 502 {object} errorBody
+// @Router /api/v1/integrations/grafana/sync-loki [post]
+func (h *Handler) syncLoki(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+	if err := h.grafana.SyncLoki(r.Context()); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // testProm runs a tiny PromQL probe ("up") against the configured Prom

--- a/internal/manager/server/integration/http_test.go
+++ b/internal/manager/server/integration/http_test.go
@@ -23,6 +23,7 @@ import (
 type stubGrafana struct {
 	test           func(ctx context.Context) error
 	sync           func(ctx context.Context) (*bizgrafana.SyncResult, error)
+	syncLoki       func(ctx context.Context) error
 	fetchDashboard func(ctx context.Context, uid string) ([]byte, error)
 }
 
@@ -48,6 +49,12 @@ func (s *stubLLMRouterInvalidator) Invalidate() { s.calls++ }
 
 func (s stubGrafana) Test(ctx context.Context) error                           { return s.test(ctx) }
 func (s stubGrafana) Sync(ctx context.Context) (*bizgrafana.SyncResult, error) { return s.sync(ctx) }
+func (s stubGrafana) SyncLoki(ctx context.Context) error {
+	if s.syncLoki == nil {
+		return nil
+	}
+	return s.syncLoki(ctx)
+}
 func (s stubGrafana) FetchDashboardJSON(ctx context.Context, uid string) ([]byte, error) {
 	return s.fetchDashboard(ctx, uid)
 }
@@ -157,6 +164,45 @@ func TestFetchDashboardMapsTransportErrorTo502(t *testing.T) {
 
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSyncLokiRequiresAdminAndInvokesService(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		role       string
+		wantStatus int
+		wantCalled bool
+	}{
+		{name: "admin", role: "admin", wantStatus: http.StatusOK, wantCalled: true},
+		{name: "non-admin", role: "member", wantStatus: http.StatusForbidden, wantCalled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			g := stubGrafana{
+				test: func(_ context.Context) error { return nil },
+				sync: func(_ context.Context) (*bizgrafana.SyncResult, error) { return nil, nil },
+				syncLoki: func(_ context.Context) error {
+					called = true
+					return nil
+				},
+				fetchDashboard: func(_ context.Context, _ string) ([]byte, error) { return nil, nil },
+			}
+			router := newRouter(NewHandler(g, nil, nil, nil, nil))
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/integrations/grafana/sync-loki", nil)
+			req = req.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 7, Role: tc.role}))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), tc.wantStatus)
+			}
+			if called != tc.wantCalled {
+				t.Fatalf("SyncLoki called = %v, want %v", called, tc.wantCalled)
+			}
+		})
 	}
 }
 

--- a/tests/e2e/grafana_loki_datasource_test.go
+++ b/tests/e2e/grafana_loki_datasource_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+// Catalog: O4 — Loki settings update syncs Grafana datasource. Flow:
+//   - start manager with fake external services
+//   - save Grafana root/token settings and Loki URL/auth settings
+//   - POST /v1/integrations/grafana/sync-loki
+//   - fake Grafana observes a Loki datasource upsert with the configured URL
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ongridio/ongrid/tests/e2e/testenv"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGrafana_LokiProvisioningAllowsRuntimeUpdates_O4(t *testing.T) {
+	t.Parallel()
+	type provisioning struct {
+		Datasources []struct {
+			UID      string `yaml:"uid"`
+			Editable bool   `yaml:"editable"`
+		} `yaml:"datasources"`
+	}
+
+	paths := []string{
+		filepath.Join("..", "..", "deploy", "grafana", "provisioning", "datasources", "loki.yml"),
+		filepath.Join("..", "..", "deploy", "install", "grafana", "provisioning", "datasources", "loki.yml"),
+	}
+	for _, path := range paths {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read provisioning: %v", err)
+			}
+			var cfg provisioning
+			if err := yaml.Unmarshal(raw, &cfg); err != nil {
+				t.Fatalf("decode provisioning: %v", err)
+			}
+			for _, ds := range cfg.Datasources {
+				if ds.UID == "ongrid-loki" {
+					if !ds.Editable {
+						t.Fatal("ongrid-loki must be editable for runtime settings sync")
+					}
+					return
+				}
+			}
+			t.Fatal("ongrid-loki datasource is missing")
+		})
+	}
+}
+
+func TestGrafana_LokiDatasourceSync_O4(t *testing.T) {
+	type datasourceReq struct {
+		UID            string         `json:"uid"`
+		Name           string         `json:"name"`
+		Type           string         `json:"type"`
+		URL            string         `json:"url"`
+		Access         string         `json:"access"`
+		BasicAuth      bool           `json:"basicAuth"`
+		BasicAuthUser  string         `json:"basicAuthUser"`
+		JSONData       map[string]any `json:"jsonData"`
+		SecureJSONData map[string]any `json:"secureJsonData"`
+	}
+
+	updated := make(chan datasourceReq, 1)
+	grafana := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources/uid/ongrid-loki":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":42,"uid":"ongrid-loki","readOnly":false,"url":"http://loki:3100"}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/datasources/42":
+			var got datasourceReq
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				http.Error(w, "invalid datasource payload", http.StatusBadRequest)
+				return
+			}
+			updated <- got
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":42}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer grafana.Close()
+
+	env := testenv.Start(t)
+	pair := env.LoginAdmin()
+
+	settings := []struct {
+		category  string
+		key       string
+		value     string
+		sensitive bool
+	}{
+		{"grafana", "root_url", grafana.URL, false},
+		{"grafana", "sa_token", "fake-grafana-token", true},
+		{"loki", "url", "https://loki.customer.example/", false},
+		{"loki", "basic_user", "alice", false},
+		{"loki", "basic_password", "secret-password", true},
+		{"loki", "tls_insecure", "true", false},
+	}
+	for _, setting := range settings {
+		status, body, err := env.DoJSON("PUT",
+			"/api/v1/system-settings/"+setting.category+"/"+setting.key,
+			map[string]any{"value": setting.value, "sensitive": setting.sensitive},
+			pair.AccessToken,
+		)
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("PUT %s/%s: status=%d body=%v err=%v", setting.category, setting.key, status, body, err)
+		}
+	}
+
+	status, body, err := env.DoJSON("POST", "/api/v1/integrations/grafana/sync-loki", nil, pair.AccessToken)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("sync loki datasource: status=%d body=%v err=%v", status, body, err)
+	}
+	var got datasourceReq
+	select {
+	case got = <-updated:
+	default:
+		t.Fatal("existing ongrid-loki datasource was not updated")
+	}
+
+	if got.UID != "ongrid-loki" || got.Name != "ongrid-loki" || got.Type != "loki" {
+		t.Fatalf("datasource identity = %+v", got)
+	}
+	if got.URL != "https://loki.customer.example" {
+		t.Fatalf("datasource url = %q", got.URL)
+	}
+	if got.Access != "proxy" {
+		t.Fatalf("datasource access = %q", got.Access)
+	}
+	if !got.BasicAuth || got.BasicAuthUser != "alice" {
+		t.Fatalf("basic auth = %v user=%q", got.BasicAuth, got.BasicAuthUser)
+	}
+	if got.SecureJSONData["basicAuthPassword"] != "secret-password" {
+		t.Fatalf("secure basic password missing: %+v", got.SecureJSONData)
+	}
+	if got.JSONData["tlsSkipVerify"] != true {
+		t.Fatalf("tlsSkipVerify = %v", got.JSONData["tlsSkipVerify"])
+	}
+}

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -70,6 +70,10 @@ export function syncGrafana(): Promise<GrafanaSyncResult> {
   return request<GrafanaSyncResult>('POST', '/integrations/grafana/sync');
 }
 
+export function syncLokiDatasource(): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/grafana/sync-loki');
+}
+
 // testPromConnection runs a tiny "up" PromQL probe via the manager. Used
 // by the Prom integration card to validate URL + Bearer/Basic before the
 // user trusts that the wiring is good.

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -33,6 +33,7 @@ import {
   revealSetting,
   testGrafanaConnection,
   syncGrafana,
+  syncLokiDatasource,
   testPromConnection,
   testLokiConnection,
   testTempoConnection,
@@ -839,6 +840,7 @@ function LokiCard() {
   const [saving, setSaving] = useState(false);
   const [savedOk, setSavedOk] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [grafanaSyncWarning, setGrafanaSyncWarning] = useState<string | null>(null);
   const [probe, setProbe] = useState<
     | { kind: 'idle' }
     | { kind: 'testing' }
@@ -889,11 +891,13 @@ function LokiCard() {
   const dirty = LOKI_KEYS.some((k) => draft[k] !== server[k]);
   const update = (k: keyof LokiForm, v: string) => {
     setSavedOk(false);
+    setGrafanaSyncWarning(null);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
   const submit = async () => {
     setSaving(true);
     setErr(null);
+    setGrafanaSyncWarning(null);
     try {
       for (const k of LOKI_KEYS) {
         if (draft[k] === server[k]) continue;
@@ -901,6 +905,17 @@ function LokiCard() {
       }
       await refresh();
       setSavedOk(true);
+      try {
+        await syncLokiDatasource();
+      } catch (e) {
+        const msg = e instanceof ApiError ? e.message : (e as Error).message;
+        setGrafanaSyncWarning(
+          tr(
+            `Loki 已保存，但 Grafana 数据源同步失败：${msg}`,
+            `Loki was saved, but the Grafana datasource sync failed: ${msg}`
+          )
+        );
+      }
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : (e as Error).message);
     } finally {
@@ -1001,6 +1016,7 @@ function LokiCard() {
           <span>{tr('在 Grafana 中查看日志', 'Open logs in Grafana')}</span>
         </button>
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
+        {grafanaSyncWarning && <span className="break-all text-xs text-amber-400">{grafanaSyncWarning}</span>}
       </div>
       <ProbeLine probe={probe} okLabel={tr('✓ Loki 可达，/ready 返回成功', '✓ Loki reachable, /ready returned success')} />
     </Card>


### PR DESCRIPTION
## Summary
- sync the managed Loki datasource when runtime Loki settings are saved
- keep provisioning editable so Grafana accepts API updates
- add admin API, unit coverage, and real manager E2E coverage

## Validation
- `go test -count=1 ./internal/manager/biz/grafana ./internal/manager/server/integration`
- `go test -race -count=1 ./internal/manager/biz/grafana ./internal/manager/server/integration`
- `go test -tags=e2e -run "TestGrafana_Loki" -count=1 ./tests/e2e`
- `npm --prefix web run typecheck`
- `go vet ./internal/manager/biz/grafana ./internal/manager/server/integration`
- verified update against Grafana 11.1.4 using the project image

## Rollback
Revert this PR. Provisioned Loki remains available with its compose-time URL.

## Checklist
- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

Addresses #122