### PR TITLE
fix(report): 定时报告非 UTC 时区不触发，next_fire_at 统一存 UTC

### DIFF
--- a/internal/manager/biz/report/query.go
+++ b/internal/manager/biz/report/query.go
@@ -104,7 +104,9 @@ func (u *Usecase) UpdateSchedule(ctx context.Context, s *model.ReportSchedule, n
 	if err != nil {
 		return err
 	}
-	s.NextFireAt = &next
+	// UTC storage convention — see CreateSchedule.
+	utc := next.UTC()
+	s.NextFireAt = &utc
 	return u.repo.UpdateSchedule(ctx, s)
 }
 
@@ -127,7 +129,9 @@ func (u *Usecase) SetScheduleEnabled(ctx context.Context, id uint64, enabled boo
 		if err != nil {
 			return nil, err
 		}
-		s.NextFireAt = &next
+		// UTC storage convention — see CreateSchedule.
+		utc := next.UTC()
+		s.NextFireAt = &utc
 	}
 	if err := u.repo.UpdateSchedule(ctx, s); err != nil {
 		return nil, err

--- a/internal/manager/biz/report/query.go
+++ b/internal/manager/biz/report/query.go
@@ -96,7 +96,7 @@ func (u *Usecase) UpdateSchedule(ctx context.Context, s *model.ReportSchedule, n
 		}
 		s.CronSpec = spec
 	}
-	loc, err := loadLocation(s.Timezone)
+	loc, err := LoadLocation(s.Timezone)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (u *Usecase) SetScheduleEnabled(ctx context.Context, id uint64, enabled boo
 	if !enabled {
 		s.NextFireAt = nil
 	} else {
-		loc, err := loadLocation(s.Timezone)
+		loc, err := LoadLocation(s.Timezone)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func (u *Usecase) RunNow(ctx context.Context, scheduleID uint64, locale string, 
 	if err != nil {
 		return nil, err
 	}
-	loc, err := loadLocation(s.Timezone)
+	loc, err := LoadLocation(s.Timezone)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manager/biz/report/scheduler.go
+++ b/internal/manager/biz/report/scheduler.go
@@ -80,7 +80,7 @@ func (s *Scheduler) fireOne(ctx context.Context, sched *model.ReportSchedule, no
 		}
 	}()
 
-	loc, err := loadLocation(sched.Timezone)
+	loc, err := LoadLocation(sched.Timezone)
 	if err != nil {
 		s.log.Warn("bad schedule timezone — disabling",
 			slog.Uint64("schedule_id", sched.ID), slog.String("tz", sched.Timezone))

--- a/internal/manager/biz/report/scheduler_test.go
+++ b/internal/manager/biz/report/scheduler_test.go
@@ -41,6 +41,39 @@ func TestCreateSchedule_ArmsNextFire(t *testing.T) {
 	}
 }
 
+// TestCreateSchedule_StoresNextFireAsUTC pins the storage convention that
+// makes DueSchedules correct for non-UTC timezones. A schedule whose
+// timezone is Asia/Shanghai must persist its armed next_fire_at as a UTC
+// instant, not a +08:00 wall-clock string — otherwise the SQLite string
+// comparison `next_fire_at <= now` (now in UTC) never selects it.
+func TestCreateSchedule_StoresNextFireAsUTC(t *testing.T) {
+	repo := newFakeRepo()
+	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())
+	loc := mustLoc(t, "Asia/Shanghai")
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, loc)
+
+	s := &model.ReportSchedule{
+		ID:        1,
+		CreatedBy: 42,
+		Kind:      model.KindWeekly,
+		Timezone:  "Asia/Shanghai",
+	}
+	if err := uc.CreateSchedule(context.Background(), s, now); err != nil {
+		t.Fatal(err)
+	}
+	if s.NextFireAt == nil {
+		t.Fatal("next_fire_at not armed")
+	}
+	// The armed instant is the same, but must be represented in UTC.
+	if s.NextFireAt.Location() != time.UTC {
+		t.Errorf("next_fire_at location = %v, want UTC", s.NextFireAt.Location())
+	}
+	want := time.Date(2026, 6, 15, 1, 0, 0, 0, time.UTC) // next Mon 09:00 Shanghai == 01:00 UTC
+	if !s.NextFireAt.Equal(want) {
+		t.Errorf("next_fire_at = %s, want %s", s.NextFireAt, want)
+	}
+}
+
 func TestCreateSchedule_CustomRequiresSpec(t *testing.T) {
 	repo := newFakeRepo()
 	uc := NewUsecase(repo, nopGenerator{}, seqIDGen())

--- a/internal/manager/biz/report/task.go
+++ b/internal/manager/biz/report/task.go
@@ -23,7 +23,7 @@ func (u *Usecase) CreateOneoffTaskAndRun(ctx context.Context, createdBy uint64, 
 	if strings.TrimSpace(tz) == "" {
 		tz = "UTC"
 	}
-	loc, err := loadLocation(tz)
+	loc, err := LoadLocation(tz)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (u *Usecase) RerunOneoffTask(ctx context.Context, taskID, locale string, no
 	if err != nil {
 		return nil, err
 	}
-	loc, err := loadLocation("UTC")
+	loc, err := LoadLocation("UTC")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manager/biz/report/usecase.go
+++ b/internal/manager/biz/report/usecase.go
@@ -152,7 +152,14 @@ func (u *Usecase) CreateSchedule(ctx context.Context, s *model.ReportSchedule, n
 	if s.AgentPersona == "" {
 		s.AgentPersona = model.DefaultReporterPersona
 	}
-	s.NextFireAt = &next
+	// Store next_fire_at in UTC (see CronNext): the scheduler evaluates
+	// against a UTC clock, so persisting a schedule-timezone value would
+	// break the `next_fire_at <= now` string comparison in DueSchedules
+	// for any non-UTC timezone (the +08:00 > +00:00 text sort makes a
+	// due schedule look not-due). Display layers localize from the UTC
+	// instant on read.
+	utc := next.UTC()
+	s.NextFireAt = &utc
 	return u.repo.CreateSchedule(ctx, s)
 }
 
@@ -190,7 +197,12 @@ func (u *Usecase) FireSchedule(ctx context.Context, s *model.ReportSchedule, fir
 	// re-select this row forever.
 	now := fireAt
 	s.LastFireAt = &now
-	s.NextFireAt = &nextFireAt
+	// Normalize to UTC for the same reason as CreateSchedule — the
+	// scheduler computes nextFireAt in the schedule timezone, but the
+	// DueSchedules comparison (next_fire_at <= now, both UTC) requires a
+	// UTC representation.
+	utcNext := nextFireAt.UTC()
+	s.NextFireAt = &utcNext
 	if rpt.Status == model.StatusPending {
 		s.LastReportID = &rpt.ID
 	}

--- a/internal/manager/biz/report/usecase.go
+++ b/internal/manager/biz/report/usecase.go
@@ -135,7 +135,7 @@ func (u *Usecase) CreateSchedule(ctx context.Context, s *model.ReportSchedule, n
 		}
 		s.CronSpec = spec
 	}
-	loc, err := loadLocation(s.Timezone)
+	loc, err := LoadLocation(s.Timezone)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (u *Usecase) FireSchedule(ctx context.Context, s *model.ReportSchedule, fir
 	if err := u.ensureGeneratorReady(ctx); err != nil {
 		return nil, err
 	}
-	loc, err := loadLocation(s.Timezone)
+	loc, err := LoadLocation(s.Timezone)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (u *Usecase) FireSchedule(ctx context.Context, s *model.ReportSchedule, fir
 // taskRef is the owning-task back-ref (HLD-022), e.g. "report-schedule:42" when
 // invoked via a schedule's run-now; "" for a truly ad-hoc generate.
 func (u *Usecase) GenerateNow(ctx context.Context, createdBy uint64, kind, tz, scopeJSON, locale, taskRef string, period Period) (*model.Report, error) {
-	if _, err := loadLocation(tz); err != nil {
+	if _, err := LoadLocation(tz); err != nil {
 		return nil, err
 	}
 	if err := u.ensureGeneratorReady(ctx); err != nil {
@@ -294,9 +294,10 @@ func (u *Usecase) ensureGeneratorReady(ctx context.Context) error {
 	return nil
 }
 
-// loadLocation resolves a schedule timezone, defaulting to UTC on empty.
-// An unparseable tz is a config error surfaced as ErrInvalid.
-func loadLocation(tz string) (*time.Location, error) {
+// LoadLocation resolves a schedule timezone, defaulting to UTC on empty.
+// An unparseable tz is a config error surfaced as ErrInvalid. Exported so
+// the data-layer next_fire_at backfill resolves timezones identically.
+func LoadLocation(tz string) (*time.Location, error) {
 	if tz == "" {
 		return time.UTC, nil
 	}

--- a/internal/manager/data/report/store/migrate.go
+++ b/internal/manager/data/report/store/migrate.go
@@ -3,8 +3,12 @@
 package store
 
 import (
+	"log/slog"
+	"time"
+
 	"gorm.io/gorm"
 
+	biz "github.com/ongridio/ongrid/internal/manager/biz/report"
 	model "github.com/ongridio/ongrid/internal/manager/model/report"
 	"github.com/ongridio/ongrid/internal/pkg/dbx"
 )
@@ -37,7 +41,63 @@ func Migrate(db *gorm.DB) error {
 	// HLD-022 backfill: stamp the owning-task back-ref on existing scheduled
 	// reports. Idempotent (only fills empty task_id), additive (a new column),
 	// safe to re-run every boot.
-	return db.Exec(
+	if err := db.Exec(
 		"UPDATE reports SET task_id = CONCAT('report-schedule:', schedule_id) WHERE schedule_id IS NOT NULL AND (task_id IS NULL OR task_id = '')",
-	).Error
+	).Error; err != nil {
+		return err
+	}
+	return backfillNextFireUTC(db, time.Now().UTC())
+}
+
+// backfillNextFireUTC re-arms next_fire_at for schedules written before the
+// column carried a UTC convention.
+//
+// Under SQLite a time.Time is stored as ISO-8601 text *including its
+// offset*, and DueSchedules' `next_fire_at <= now` degrades to a lexical
+// compare: a row persisted as '…17:40:00+08:00' never sorts below a UTC
+// now, so the schedule is never selected, never reaches FireSchedule, and
+// so can never re-arm itself out of the broken state. (MySQL stores
+// DATETIME(3) and compares numerically, so rows there were never stuck —
+// re-arming them is a no-op that keeps the two backends on one path.)
+//
+// next_fire_at is recomputed from cron_spec and the schedule's IANA
+// timezone rather than converted from the stored value, so the result
+// does not depend on which of the two on-disk formats a row happens to
+// carry. Rows the database already sees as due are skipped: those fire on
+// the next tick and FireSchedule normalizes them, whereas re-arming would
+// push them past a pending fire. That skip is also what makes this cheap
+// to re-run on every boot — a healthy future row recomputes to the value
+// it already holds.
+func backfillNextFireUTC(db *gorm.DB, now time.Time) error {
+	var rows []*model.ReportSchedule
+	if err := db.
+		Where("enabled = ? AND (next_fire_at IS NULL OR next_fire_at > ?)", true, now).
+		Find(&rows).Error; err != nil {
+		return err
+	}
+	for _, s := range rows {
+		loc, err := biz.LoadLocation(s.Timezone)
+		if err != nil {
+			// Unresolvable tz (no system tzdata, or a bad value): leave the
+			// row untouched rather than re-arm it against the wrong zone.
+			slog.Warn("report schedule next_fire_at backfill skipped: bad timezone",
+				"schedule_id", s.ID, "timezone", s.Timezone, "err", err)
+			continue
+		}
+		next, err := biz.CronNext(s.CronSpec, loc, now)
+		if err != nil {
+			slog.Warn("report schedule next_fire_at backfill skipped: bad cron spec",
+				"schedule_id", s.ID, "cron_spec", s.CronSpec, "err", err)
+			continue
+		}
+		// UpdateColumn, not Update: re-arming is migration bookkeeping and
+		// must not bump updated_at as though an operator had edited the
+		// schedule.
+		if err := db.Model(&model.ReportSchedule{}).
+			Where("id = ?", s.ID).
+			UpdateColumn("next_fire_at", next.UTC()).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/manager/data/report/store/migrate_test.go
+++ b/internal/manager/data/report/store/migrate_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+)
+
+// legacySchedule mimics a row written before next_fire_at carried a UTC
+// convention: the store persists whatever zone the caller hands it, so a
+// non-UTC time.Time lands in SQLite as '…+08:00' text.
+func legacySchedule(t *testing.T, id uint64, name string, enabled bool, nextFire time.Time) *model.ReportSchedule {
+	t.Helper()
+	return &model.ReportSchedule{
+		ID:         id,
+		CreatedBy:  1,
+		Name:       name,
+		Kind:       model.KindCustom,
+		CronSpec:   "40 17 * * *",
+		Timezone:   "Asia/Shanghai",
+		ScopeJSON:  `{}`,
+		Enabled:    enabled,
+		NextFireAt: &nextFire,
+	}
+}
+
+// TestBackfillNextFireUTC_UnsticksLegacyOffsetRow covers the upgrade path
+// the UTC convention alone does not fix: a schedule created before the
+// change still holds a schedule-timezone next_fire_at, which DueSchedules'
+// lexical compare never selects, so the row cannot re-arm itself.
+func TestBackfillNextFireUTC_UnsticksLegacyOffsetRow(t *testing.T) {
+	repo := newReportTestRepo(t)
+	ctx := context.Background()
+
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("LoadLocation Asia/Shanghai: %v", err)
+	}
+	// 17:40 CST == 09:40 UTC. Stored in the schedule timezone, as the
+	// pre-fix write path did.
+	legacy := time.Date(2026, 6, 8, 17, 40, 0, 0, shanghai)
+	if err := repo.CreateSchedule(ctx, legacySchedule(t, 1, "legacy-cst", true, legacy)); err != nil {
+		t.Fatalf("create legacy schedule: %v", err)
+	}
+
+	// The instant has passed, yet the row is invisible to the scheduler —
+	// '2026-06-08 17:40:00+08:00' does not sort below a UTC now.
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	stuck, err := repo.DueSchedules(ctx, now)
+	if err != nil {
+		t.Fatalf("DueSchedules before backfill: %v", err)
+	}
+	if len(stuck) != 0 {
+		t.Fatalf("DueSchedules before backfill returned %d rows, want 0 (stuck row precondition)", len(stuck))
+	}
+
+	if err := backfillNextFireUTC(repo.db, now); err != nil {
+		t.Fatalf("backfillNextFireUTC: %v", err)
+	}
+
+	// Re-armed from cron_spec + Asia/Shanghai: the next 17:40 CST after
+	// 10:00 UTC is 2026-06-09 17:40 CST == 09:40 UTC.
+	want := time.Date(2026, 6, 9, 9, 40, 0, 0, time.UTC)
+	got, err := repo.GetSchedule(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetSchedule: %v", err)
+	}
+	if got.NextFireAt == nil || !got.NextFireAt.Equal(want) {
+		t.Fatalf("next_fire_at = %v, want %v", got.NextFireAt, want)
+	}
+
+	// The point of the re-arm: the database can now select the row.
+	due, err := repo.DueSchedules(ctx, want.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("DueSchedules after backfill: %v", err)
+	}
+	if len(due) != 1 || due[0].ID != 1 {
+		t.Fatalf("DueSchedules after backfill returned %v, want the re-armed schedule 1", due)
+	}
+}
+
+// TestBackfillNextFireUTC_SkipsDueAndDisabled guards the every-boot cost of
+// the backfill: a schedule the database already sees as due must keep its
+// pending fire, and a disabled schedule must not be re-armed behind the
+// operator's back.
+func TestBackfillNextFireUTC_SkipsDueAndDisabled(t *testing.T) {
+	repo := newReportTestRepo(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	pendingFire := now.Add(-30 * time.Second)
+	disabledFire := now.Add(72 * time.Hour)
+
+	if err := repo.CreateSchedule(ctx, legacySchedule(t, 1, "due-now", true, pendingFire)); err != nil {
+		t.Fatalf("create due schedule: %v", err)
+	}
+	if err := repo.CreateSchedule(ctx, legacySchedule(t, 2, "disabled", false, disabledFire)); err != nil {
+		t.Fatalf("create disabled schedule: %v", err)
+	}
+	// The Enabled column carries a `default:true` tag, so GORM substitutes
+	// the default for a zero-value bool on insert — disable it explicitly.
+	if err := repo.db.Model(&model.ReportSchedule{}).
+		Where("id = ?", 2).
+		Update("enabled", false).Error; err != nil {
+		t.Fatalf("disable schedule 2: %v", err)
+	}
+
+	if err := backfillNextFireUTC(repo.db, now); err != nil {
+		t.Fatalf("backfillNextFireUTC: %v", err)
+	}
+
+	due, err := repo.GetSchedule(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetSchedule 1: %v", err)
+	}
+	if due.NextFireAt == nil || !due.NextFireAt.Equal(pendingFire) {
+		t.Errorf("due schedule next_fire_at = %v, want %v (pending fire must survive)", due.NextFireAt, pendingFire)
+	}
+
+	disabled, err := repo.GetSchedule(ctx, 2)
+	if err != nil {
+		t.Fatalf("GetSchedule 2: %v", err)
+	}
+	if disabled.NextFireAt == nil || !disabled.NextFireAt.Equal(disabledFire) {
+		t.Errorf("disabled schedule next_fire_at = %v, want %v (untouched)", disabled.NextFireAt, disabledFire)
+	}
+}
+
+// TestBackfillNextFireUTC_Idempotent — the backfill runs on every boot, so
+// a second pass over an already-normalized row must be a no-op.
+func TestBackfillNextFireUTC_Idempotent(t *testing.T) {
+	repo := newReportTestRepo(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	future := time.Date(2026, 6, 9, 9, 40, 0, 0, time.UTC)
+	if err := repo.CreateSchedule(ctx, legacySchedule(t, 1, "healthy-utc", true, future)); err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+
+	for i := range 2 {
+		if err := backfillNextFireUTC(repo.db, now); err != nil {
+			t.Fatalf("backfillNextFireUTC pass %d: %v", i+1, err)
+		}
+		got, err := repo.GetSchedule(ctx, 1)
+		if err != nil {
+			t.Fatalf("GetSchedule pass %d: %v", i+1, err)
+		}
+		if got.NextFireAt == nil || !got.NextFireAt.Equal(future) {
+			t.Fatalf("pass %d: next_fire_at = %v, want %v", i+1, got.NextFireAt, future)
+		}
+	}
+}

--- a/internal/manager/data/report/store/repo_test.go
+++ b/internal/manager/data/report/store/repo_test.go
@@ -47,6 +47,62 @@ func sampleReport(id string, scheduleID uint64, periodStart time.Time) *model.Re
 	}
 }
 
+// TestDueSchedules_UTCStoredIsDue is the regression for the non-UTC
+// timezone firing bug. next_fire_at is persisted in UTC (the schedule
+// timezone is Asia/Shanghai here, so 17:40 CST = 09:40 UTC). DueSchedules
+// compares next_fire_at <= now against a UTC clock, so only a UTC-stored
+// value sorts correctly; a +08:00-stored value would compare as
+// "17:40..." > "09:4x..." and never be selected.
+func TestDueSchedules_UTCStoredIsDue(t *testing.T) {
+	repo := newReportTestRepo(t)
+	ctx := context.Background()
+
+	// 2026-06-08 17:40 Asia/Shanghai == 09:40 UTC. Store the UTC instant.
+	due := time.Date(2026, 6, 8, 9, 40, 0, 0, time.UTC)
+	future := due.Add(24 * time.Hour)
+
+	if err := repo.CreateSchedule(ctx, &model.ReportSchedule{
+		ID:         1,
+		CreatedBy:  1,
+		Name:       "due-utc",
+		Kind:       model.KindCustom,
+		CronSpec:   "40 17 * * 3",
+		Timezone:   "Asia/Shanghai",
+		ScopeJSON:  `{}`,
+		Enabled:    true,
+		NextFireAt: &due,
+	}); err != nil {
+		t.Fatalf("create due schedule: %v", err)
+	}
+	if err := repo.CreateSchedule(ctx, &model.ReportSchedule{
+		ID:         2,
+		CreatedBy:  1,
+		Name:       "future",
+		Kind:       model.KindCustom,
+		CronSpec:   "40 17 * * 3",
+		Timezone:   "Asia/Shanghai",
+		ScopeJSON:  `{}`,
+		Enabled:    true,
+		NextFireAt: &future,
+	}); err != nil {
+		t.Fatalf("create future schedule: %v", err)
+	}
+
+	// Scheduler clock runs UTC; at 10:00 UTC the 09:40 UTC (17:40 CST)
+	// schedule is due, the next-day one is not.
+	now := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	rows, err := repo.DueSchedules(ctx, now)
+	if err != nil {
+		t.Fatalf("DueSchedules: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("DueSchedules returned %d rows, want 1", len(rows))
+	}
+	if rows[0].ID != 1 {
+		t.Errorf("due schedule id = %d, want 1", rows[0].ID)
+	}
+}
+
 func TestReportSoftDeleteAllowsSchedulePeriodReuse(t *testing.T) {
 	repo := newReportTestRepo(t)
 	ctx := context.Background()

--- a/internal/manager/model/report/model.go
+++ b/internal/manager/model/report/model.go
@@ -81,7 +81,13 @@ type ReportSchedule struct {
 	AgentPersona   string  `gorm:"column:agent_persona;size:64;not null;default:'reporter'"`
 	PromptOverride *string `gorm:"column:prompt_override;type:text"` // NULL = use persona default
 
-	// Scheduling state
+	// Scheduling state. NextFireAt / LastFireAt are always persisted as UTC
+	// instants: the evaluator's `next_fire_at <= now` runs against a UTC
+	// clock, and under SQLite that comparison is lexical over offset-bearing
+	// text, so a schedule-timezone value would never be selected. Display
+	// layers localize from the UTC instant (rendering it in Timezone, not
+	// the viewer's zone). See dbx.openMySQL for the per-backend storage
+	// contract.
 	Enabled      bool       `gorm:"column:enabled;not null;default:true;index:idx_rsched_enabled_next,priority:1"`
 	NextFireAt   *time.Time `gorm:"column:next_fire_at;index:idx_rsched_enabled_next,priority:2"`
 	LastFireAt   *time.Time `gorm:"column:last_fire_at"`

--- a/internal/pkg/dbx/dbx.go
+++ b/internal/pkg/dbx/dbx.go
@@ -50,6 +50,25 @@ func Open(cfg config.DBConfig, log *slog.Logger) (*gorm.DB, error) {
 
 // openMySQL opens a MySQL connection via gorm and verifies reachability
 // with Ping(). The DSN password is never logged.
+//
+// Time storage contract. A Go time.Time is the source of truth for every
+// timestamp column; the on-disk representation differs per backend and is
+// not itself a UTC timestamp:
+//
+//   - MySQL DATETIME carries no offset. go-sql-driver/mysql converts a
+//     time.Time to the DSN's `loc` (ONGRID_DB_DSN defaults to loc=Local)
+//     before writing, and parses back through the same `loc` on read, so
+//     the instant round-trips regardless of the zone the value carried in
+//     Go — but the stored wall clock is driver-local, not UTC.
+//   - SQLite stores ISO-8601 text *including* the offset, which makes
+//     `WHERE ts <= ?` a lexical compare. Values written in a non-UTC zone
+//     therefore sort wrongly against a UTC bind; see the next_fire_at
+//     backfill in internal/manager/data/report/store.
+//
+// Consequences: normalize to UTC in Go before persisting anything that is
+// range-queried, and treat any consumer that reads these columns outside
+// this driver (ops scripts, BI, a raw SELECT) as responsible for
+// converting from the driver's `loc` itself.
 func openMySQL(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	if dsn == "" {
 		return nil, fmt.Errorf("dbx: empty mysql DSN")

--- a/tests/e2e/report_schedule_mysql_test.go
+++ b/tests/e2e/report_schedule_mysql_test.go
@@ -1,0 +1,107 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	store "github.com/ongridio/ongrid/internal/manager/data/report/store"
+	model "github.com/ongridio/ongrid/internal/manager/model/report"
+	"github.com/ongridio/ongrid/tests/e2e/testenv"
+)
+
+// TestReportScheduleNextFireMySQLRoundTrip pins the MySQL half of the
+// next_fire_at storage contract (see dbx.openMySQL).
+//
+// The SQLite regressions in internal/manager/data/report/store cannot speak
+// for MySQL: DATETIME carries no offset and compares numerically, while
+// go-sql-driver converts every time.Time through the DSN's `loc` on the way
+// in and back out. This test therefore runs the whole thing with the
+// process pinned to Asia/Shanghai — the case a UTC-only test suite would
+// never catch — and asserts that instants survive the round trip and that
+// DueSchedules still selects on the right side of the boundary.
+func TestReportScheduleNextFireMySQLRoundTrip(t *testing.T) {
+	// The DSN's loc=Local is resolved against time.Local when the driver
+	// parses it, so this must be set before the connection is opened.
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("LoadLocation Asia/Shanghai: %v", err)
+	}
+	original := time.Local
+	time.Local = shanghai
+	t.Cleanup(func() { time.Local = original })
+
+	db, err := gorm.Open(gormmysql.Open(testenv.SharedMySQLDSN(t)), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open mysql: %v", err)
+	}
+	if err := store.Migrate(db); err != nil {
+		t.Fatalf("store.Migrate: %v", err)
+	}
+	// The container's schema is shared across e2e tests.
+	if err := db.Exec("DELETE FROM report_schedules").Error; err != nil {
+		t.Fatalf("clear report_schedules: %v", err)
+	}
+
+	repo := store.NewRepo(db)
+	ctx := context.Background()
+
+	// 17:40 Asia/Shanghai == 09:40 UTC, written as the fixed write path
+	// writes it: a UTC instant, from a process that is not in UTC.
+	due := time.Date(2026, 6, 8, 9, 40, 0, 0, time.UTC)
+	future := due.Add(24 * time.Hour)
+	for id, next := range map[uint64]time.Time{1: due, 2: future} {
+		if err := repo.CreateSchedule(ctx, &model.ReportSchedule{
+			ID:         id,
+			CreatedBy:  1,
+			Name:       "mysql-roundtrip",
+			Kind:       model.KindCustom,
+			CronSpec:   "40 17 * * *",
+			Timezone:   "Asia/Shanghai",
+			ScopeJSON:  `{}`,
+			Enabled:    true,
+			NextFireAt: &next,
+		}); err != nil {
+			t.Fatalf("create schedule %d: %v", id, err)
+		}
+	}
+
+	// MySQL DATETIME stores driver-local wall clock, so the value read back
+	// is tagged Asia/Shanghai rather than UTC — the contract is that the
+	// *instant* is preserved, not the zone.
+	got, err := repo.GetSchedule(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetSchedule: %v", err)
+	}
+	if got.NextFireAt == nil || !got.NextFireAt.Equal(due) {
+		t.Fatalf("next_fire_at round-tripped as %v, want the instant %v", got.NextFireAt, due)
+	}
+
+	// The scheduler ticks on a UTC clock while the driver binds through
+	// Local; the 09:40 UTC schedule is due at 10:00 UTC, the next day's is
+	// not.
+	rows, err := repo.DueSchedules(ctx, time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("DueSchedules: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != 1 {
+		t.Fatalf("DueSchedules returned %v, want only schedule 1", rows)
+	}
+
+	// Nothing is due an hour before that.
+	none, err := repo.DueSchedules(ctx, time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("DueSchedules (before): %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("DueSchedules before the fire time returned %v, want none", none)
+	}
+}

--- a/tests/e2e/testenv/env.go
+++ b/tests/e2e/testenv/env.go
@@ -444,6 +444,13 @@ func TerminateSharedMySQL() {
 	mysqlContainer = nil
 }
 
+// SharedMySQLDSN exposes the shared container's DSN to tests that exercise
+// a store against real MySQL without spawning a manager process. The DSN
+// carries the production `loc=Local` setting, so a test that reassigns
+// time.Local before calling this observes the driver's timezone conversion
+// exactly as a deployment in that zone would.
+func SharedMySQLDSN(t *testing.T) string { return sharedMySQL(t) }
+
 // sharedMySQL brings up one MySQL container per `go test` process and
 // returns a DSN pointing at the `ongrid` schema. Tests share the schema
 // but each Start truncates the cross-test-leaky tables (system_settings,


### PR DESCRIPTION
## 问题

`DueSchedules` 用 SQLite **字符串比较** `next_fire_at <= now`（`now` 由调度器以 UTC 传入），但 `next_fire_at` 之前按 **schedule 时区**（如 `Asia/Shanghai` 的 `+08:00`）落库。字符串比较时 `'2026-08-19 17:40:00+08:00' <= '2026-08-19 09:44:58+00:00'` 因 `'17' > '09'` 永远为 false，导致**非 UTC 时区的定时报告从不触发**（本机实测 `test` 定时 17:40 Asia/Shanghai 一直 `next_fire_at` 到期却不执行）。

## 修复

按 `CronNext` 既有设计意图（"caller store as UTC / render local"），将四个写点统一归一化为 **UTC** 存储 `next_fire_at`：
- `CreateSchedule`
- `UpdateSchedule`
- `SetScheduleEnabled`
- `FireSchedule`

`last_fire_at` 本就来自调度器的 UTC 时钟，不变。展示侧由前端从 UTC instant 本地化。

## 测试

- `TestCreateSchedule_StoresNextFireAsUTC`：验证写点把 `next_fire_at` 存成 UTC。
- `TestDueSchedules_UTCStoredIsDue`：验证 UTC 存储下 `DueSchedules` 能命中"到期"的 Asia/Shanghai 定时。
- 全量 `go build ./...`、`go vet`、`go test -race` 通过。

## 变更

- `internal/manager/biz/report/usecase.go`
- `internal/manager/biz/report/query.go`
- `internal/manager/biz/report/scheduler_test.go`
- `internal/manager/data/report/store/repo_test.go`

## PR Checklist

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
