### PR TITLE
feat: configure Agent output language and relax alert notes

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1791,7 +1791,8 @@ func main() {
 				// MaxStep cap, read its partial trail back from
 				// chat_messages and synthesise a low-confidence
 				// report instead of an empty failure.
-				WithMessageReader(aiopsRepo)
+				WithMessageReader(aiopsRepo).
+				WithLocaleResolver(settingSvc)
 			rcaInv = rcaInvConcrete
 			log.Info("alert: structured RCA investigator wired",
 				slog.String("summarizer_provider", firstNonEmpty(sumProvider, "llm_default")),

--- a/db/migrations/20260820170000_alter_alert_silence_name.down.sql
+++ b/db/migrations/20260820170000_alter_alert_silence_name.down.sql
@@ -1,0 +1,6 @@
+UPDATE alert_silences
+SET name = LEFT(name, 128)
+WHERE CHAR_LENGTH(name) > 128;
+
+ALTER TABLE alert_silences
+    MODIFY COLUMN name VARCHAR(128) NOT NULL DEFAULT '';

--- a/db/migrations/20260820170000_alter_alert_silence_name.up.sql
+++ b/db/migrations/20260820170000_alter_alert_silence_name.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE alert_silences
+    MODIFY COLUMN name VARCHAR(256) NOT NULL DEFAULT '';

--- a/internal/manager/biz/alert/investigator/usecase.go
+++ b/internal/manager/biz/alert/investigator/usecase.go
@@ -92,6 +92,13 @@ type MessageReader interface {
 	ListMessages(ctx context.Context, sessionID string, limit int) ([]*aiopsmodel.Message, error)
 }
 
+// LocaleResolver supplies the live system-wide Agent output language. It is
+// defined by the consumer so the alert domain does not depend on the settings
+// implementation. Empty/not-found preserves the request/deployment fallback.
+type LocaleResolver interface {
+	AgentOutputLocale(ctx context.Context) (locale string, found bool, err error)
+}
+
 // RelatedAlertQuerier finds incidents that fired close in time to the
 // target incident — used to populate the report's related_alerts
 // section so operators see co-occurring symptoms (e.g. swap_high +
@@ -168,6 +175,7 @@ type Usecase struct {
 	summarizer LLMSummarizer
 	related    RelatedAlertQuerier
 	messages   MessageReader
+	locales    LocaleResolver
 	cfg        Config
 	log        *slog.Logger
 
@@ -249,6 +257,13 @@ func (uc *Usecase) WithMessageReader(m MessageReader) *Usecase {
 	return uc
 }
 
+// WithLocaleResolver wires runtime Agent language settings. Resolution happens
+// for every newly enqueued investigation, so admin changes require no restart.
+func (uc *Usecase) WithLocaleResolver(r LocaleResolver) *Usecase {
+	uc.locales = r
+	return uc
+}
+
 // tryAcquireSem is the non-blocking permit grab. Returns true when a
 // slot was taken (caller MUST releaseSem on completion), false when
 // the cap is full. Nil sem (uncapped) always returns true.
@@ -311,11 +326,10 @@ func (uc *Usecase) InvestigateAsync(incident *alertmodel.Incident) {
 // back to Config defaults. Right now only Locale is plumbed, but the type
 // is here so callers grow it without breaking existing call sites.
 type EnqueueOpts struct {
-	// Locale overrides Config.DefaultLocale for this run only ("en", "zh").
-	// Empty → use Config.DefaultLocale. HTTP handler sets it from
-	// Accept-Language so a manual trigger's report comes back in the
-	// operator's current UI language; auto-fire / backfill leaves it
-	// empty and gets the site default.
+	// Locale is the request-context fallback for this run ("en", "zh").
+	// A configured Agent output locale takes precedence. When the Agent
+	// setting is absent, HTTP manual triggers use Accept-Language while
+	// auto-fire / backfill falls back to Config.DefaultLocale.
 	Locale string
 }
 
@@ -327,8 +341,8 @@ func (uc *Usecase) Enqueue(ctx context.Context, incident *alertmodel.Incident) {
 	uc.EnqueueWith(ctx, incident, EnqueueOpts{})
 }
 
-// EnqueueWith is Enqueue with per-call overrides. Today only Locale flows
-// through to the worker + extractor prompts. Empty opts ↔ Enqueue exactly.
+// EnqueueWith is Enqueue with request context. Locale resolution is:
+// live Agent setting → request locale → deployment default.
 func (uc *Usecase) EnqueueWith(ctx context.Context, incident *alertmodel.Incident, opts EnqueueOpts) {
 	if uc == nil || !uc.cfg.Enabled {
 		return
@@ -420,11 +434,23 @@ func (uc *Usecase) EnqueueWith(ctx context.Context, incident *alertmodel.Inciden
 	// is minutes-scale. Spawn the goroutine and return immediately.
 	// run() defers releaseSem so the slot frees on any termination
 	// path (success / error / panic / timeout).
-	locale := opts.Locale
-	if locale == "" {
-		locale = uc.cfg.DefaultLocale
-	}
+	locale := uc.resolveLocale(ctx, opts.Locale)
 	go uc.run(rep.ID, *incident, key, locale)
+}
+
+func (uc *Usecase) resolveLocale(ctx context.Context, requested string) string {
+	if uc.locales != nil {
+		locale, found, err := uc.locales.AgentOutputLocale(ctx)
+		if err != nil {
+			uc.logger().Warn("resolve Agent output locale failed; using fallback", slog.Any("err", err))
+		} else if found && strings.TrimSpace(locale) != "" {
+			return locale
+		}
+	}
+	if strings.TrimSpace(requested) != "" {
+		return requested
+	}
+	return uc.cfg.DefaultLocale
 }
 
 // ForceEnqueue is the manual-trigger path called from POST

--- a/internal/manager/biz/alert/investigator/usecase_test.go
+++ b/internal/manager/biz/alert/investigator/usecase_test.go
@@ -79,11 +79,21 @@ func (r *fakeRepo) ListIncidentsWithoutReport(_ context.Context, _ time.Time, _ 
 }
 
 type fakeSpawner struct {
-	mu      sync.Mutex
-	calls   []chatruntime.SpawnRequest
-	worker  *chatruntime.Worker
-	err     error
-	wait    time.Duration
+	mu     sync.Mutex
+	calls  []chatruntime.SpawnRequest
+	worker *chatruntime.Worker
+	err    error
+	wait   time.Duration
+}
+
+type fakeLocaleResolver struct {
+	locale string
+	found  bool
+	err    error
+}
+
+func (r fakeLocaleResolver) AgentOutputLocale(context.Context) (string, bool, error) {
+	return r.locale, r.found, r.err
 }
 
 func (s *fakeSpawner) SpawnWorker(ctx context.Context, req chatruntime.SpawnRequest) (*chatruntime.Worker, error) {
@@ -112,6 +122,25 @@ func TestEnqueue_DisabledByDefault(t *testing.T) {
 	uc.Enqueue(context.Background(), &alertmodel.Incident{ID: 1, Severity: "critical"})
 	if len(repo.created) != 0 {
 		t.Errorf("disabled UC created %d rows, want 0", len(repo.created))
+	}
+}
+
+func TestResolveLocalePrefersAgentSetting(t *testing.T) {
+	uc := NewUsecase(&fakeRepo{}, &fakeSpawner{}, nil, Config{DefaultLocale: "en"}, nil).
+		WithLocaleResolver(fakeLocaleResolver{locale: "zh", found: true})
+	if got := uc.resolveLocale(context.Background(), "en"); got != "zh" {
+		t.Fatalf("resolveLocale() = %q, want zh", got)
+	}
+}
+
+func TestResolveLocaleFallsBackToRequestThenDeploymentDefault(t *testing.T) {
+	uc := NewUsecase(&fakeRepo{}, &fakeSpawner{}, nil, Config{DefaultLocale: "en"}, nil).
+		WithLocaleResolver(fakeLocaleResolver{})
+	if got := uc.resolveLocale(context.Background(), "zh"); got != "zh" {
+		t.Fatalf("request fallback = %q, want zh", got)
+	}
+	if got := uc.resolveLocale(context.Background(), ""); got != "en" {
+		t.Fatalf("deployment fallback = %q, want en", got)
 	}
 }
 

--- a/internal/manager/biz/alert/silence_test.go
+++ b/internal/manager/biz/alert/silence_test.go
@@ -1,0 +1,101 @@
+package alert
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/alert"
+)
+
+type silenceTestClock struct {
+	now time.Time
+}
+
+func (c silenceTestClock) Now() time.Time { return c.now }
+
+func TestSilenceIncidentBoundsLongUnicodeName(t *testing.T) {
+	repo := newFakeRepo()
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	title := "cpu_high: " + strings.Repeat("节点负载过高", 60)
+	repo.incidents[39] = &model.Incident{
+		ID:        39,
+		Title:     title,
+		Rule:      "cpu_high",
+		RuleName:  "CPU high",
+		ScopeType: model.RuleScopeGlobal,
+		Severity:  "critical",
+		Status:    model.IncidentStatusOpen,
+	}
+
+	uc := NewUsecase(repo, nil)
+	uc.clock = silenceTestClock{now: now}
+	if err := uc.SilenceIncident(context.Background(), 39, 7, "30m", "investigating"); err != nil {
+		t.Fatalf("SilenceIncident() error = %v", err)
+	}
+	if len(repo.silences) != 1 {
+		t.Fatalf("silences = %d, want 1", len(repo.silences))
+	}
+	got := repo.silences[0].Name
+	if n := len([]rune(got)); n != maxSilenceNameRunes {
+		t.Fatalf("silence name runes = %d, want %d", n, maxSilenceNameRunes)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("silence name %q does not end with ellipsis", got)
+	}
+	if repo.incidents[39].Status != model.IncidentStatusSilenced {
+		t.Fatalf("incident status = %q, want %q", repo.incidents[39].Status, model.IncidentStatusSilenced)
+	}
+}
+
+func TestBuildSilenceNameFallsBackToRuleIdentity(t *testing.T) {
+	incident := &model.Incident{RuleName: "  CPU high  ", Rule: "cpu_high"}
+	if got := buildSilenceName(incident); got != "CPU high" {
+		t.Fatalf("buildSilenceName() = %q, want %q", got, "CPU high")
+	}
+}
+
+func TestIncidentMutationsAllowEmptyAndLongNotes(t *testing.T) {
+	mutations := []struct {
+		name   string
+		status string
+		apply  func(*Usecase, context.Context, uint64, uint64, string) error
+	}{
+		{name: "acknowledge", status: model.IncidentStatusAcknowledged, apply: (*Usecase).AckIncident},
+		{name: "resolve", status: model.IncidentStatusResolved, apply: (*Usecase).ResolveIncident},
+	}
+	notes := []struct {
+		name string
+		note string
+	}{
+		{name: "empty"},
+		{name: "long unicode", note: strings.Repeat("处理记录", 2000)},
+	}
+
+	for _, mutation := range mutations {
+		for _, note := range notes {
+			t.Run(mutation.name+"/"+note.name, func(t *testing.T) {
+				repo := newFakeRepo()
+				repo.incidents[1] = &model.Incident{ID: 1, Title: "CPU high", Rule: "cpu_high", Status: model.IncidentStatusOpen}
+				uc := NewUsecase(repo, nil)
+				if err := mutation.apply(uc, context.Background(), 1, 7, note.note); err != nil {
+					t.Fatalf("%s incident: %v", mutation.name, err)
+				}
+				if len(repo.events) != 1 {
+					t.Fatalf("events = %d, want 1", len(repo.events))
+				}
+				if repo.incidents[1].Status != mutation.status {
+					t.Fatalf("incident status = %q, want %q", repo.incidents[1].Status, mutation.status)
+				}
+				if note.note == "" {
+					if repo.events[0].Message != nil {
+						t.Fatalf("empty note message = %q, want nil", *repo.events[0].Message)
+					}
+				} else if repo.events[0].Message == nil || *repo.events[0].Message != note.note {
+					t.Fatal("long note was not preserved in the incident event")
+				}
+			})
+		}
+	}
+}

--- a/internal/manager/biz/alert/usecase.go
+++ b/internal/manager/biz/alert/usecase.go
@@ -82,6 +82,8 @@ type Usecase struct {
 	workflowDispatcher WorkflowDispatcher
 }
 
+const maxSilenceNameRunes = 256
+
 func NewUsecase(repo Repo, log *slog.Logger) *Usecase {
 	if log == nil {
 		log = slog.Default()
@@ -186,7 +188,7 @@ func (u *Usecase) SilenceIncident(ctx context.Context, id, operatorUserID uint64
 	}
 	reasonCopy := reason
 	if err := u.repo.CreateSilence(ctx, &model.Silence{
-		Name:         incident.Title,
+		Name:         buildSilenceName(incident),
 		ScopeType:    incident.ScopeType,
 		Status:       model.SilenceStatusActive,
 		MatchersJSON: matchers,
@@ -208,6 +210,24 @@ func (u *Usecase) SilenceIncident(ctx context.Context, id, operatorUserID uint64
 		ActorID:     &operatorUserID,
 		OccurredAt:  now,
 	}, incident.Rule)
+}
+
+func buildSilenceName(incident *model.Incident) string {
+	if incident == nil {
+		return ""
+	}
+	name := strings.TrimSpace(incident.Title)
+	if name == "" {
+		name = strings.TrimSpace(incident.RuleName)
+	}
+	if name == "" {
+		name = strings.TrimSpace(incident.Rule)
+	}
+	runes := []rune(name)
+	if len(runes) <= maxSilenceNameRunes {
+		return name
+	}
+	return string(runes[:maxSilenceNameRunes-1]) + "…"
 }
 
 func (u *Usecase) ListEvents(ctx context.Context, incidentID uint64, limit int) ([]*model.Event, error) {

--- a/internal/manager/biz/setting/agent.go
+++ b/internal/manager/biz/setting/agent.go
@@ -52,16 +52,40 @@ func (s *Service) AgentLLMTimeout(ctx context.Context) time.Duration {
 	return d
 }
 
+// AgentOutputLocale returns the live system-wide Agent output language.
+// Missing/empty means the caller should keep its contextual fallback (for
+// example, a manual RCA follows Accept-Language while an automatic RCA uses
+// the deployment default). Values are validated on write.
+func (s *Service) AgentOutputLocale(ctx context.Context) (string, bool, error) {
+	v, found, err := s.Get(ctx, model.CategoryAgent, model.KeyAgentOutputLocale)
+	if err != nil || !found {
+		return "", false, err
+	}
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return "", false, nil
+	}
+	return v, true, nil
+}
+
 // validateAgentSetting validates typed settings before persistence. Other
 // agent keys remain backwards-compatible with the generic setting store.
 func validateAgentSetting(key, value string) error {
-	if key != model.KeyAgentLLMTimeoutSeconds {
+	switch key {
+	case model.KeyAgentOutputLocale:
+		locale := strings.ToLower(strings.TrimSpace(value))
+		if locale != "" && locale != "zh" && locale != "en" {
+			return fmt.Errorf("%w: Agent output locale must be empty, zh, or en", errs.ErrInvalid)
+		}
+		return nil
+	case model.KeyAgentLLMTimeoutSeconds:
+		if _, err := parseAgentLLMTimeout(value); err != nil {
+			return fmt.Errorf("%w: %v", errs.ErrInvalid, err)
+		}
+		return nil
+	default:
 		return nil
 	}
-	if _, err := parseAgentLLMTimeout(value); err != nil {
-		return fmt.Errorf("%w: %v", errs.ErrInvalid, err)
-	}
-	return nil
 }
 
 func parseAgentLLMTimeout(raw string) (time.Duration, error) {

--- a/internal/manager/biz/setting/service_test.go
+++ b/internal/manager/biz/setting/service_test.go
@@ -215,6 +215,24 @@ func TestServiceSetBatchValidatesAgentLLMTimeout(t *testing.T) {
 	}
 }
 
+func TestAgentOutputLocale(t *testing.T) {
+	ctx := context.Background()
+	svc := New(newFakeRepo(), nil)
+
+	if got, found, err := svc.AgentOutputLocale(ctx); err != nil || found || got != "" {
+		t.Fatalf("unset AgentOutputLocale() = (%q, %v, %v), want empty, false, nil", got, found, err)
+	}
+	if err := svc.Set(ctx, model.CategoryAgent, model.KeyAgentOutputLocale, "ZH", false); err != nil {
+		t.Fatalf("Set(zh): %v", err)
+	}
+	if got, found, err := svc.AgentOutputLocale(ctx); err != nil || !found || got != "zh" {
+		t.Fatalf("AgentOutputLocale() = (%q, %v, %v), want zh, true, nil", got, found, err)
+	}
+	if err := svc.Set(ctx, model.CategoryAgent, model.KeyAgentOutputLocale, "ja", false); !errors.Is(err, errs.ErrInvalid) {
+		t.Fatalf("Set(ja) error = %v, want errs.ErrInvalid", err)
+	}
+}
+
 func TestServiceSetInvalidatesCache(t *testing.T) {
 	repo := newFakeRepo()
 	if _, err := repo.Set(context.Background(), "llm", "openai_model", "gpt-4o", false); err != nil {

--- a/internal/manager/model/alert/model.go
+++ b/internal/manager/model/alert/model.go
@@ -268,7 +268,7 @@ func (Event) TableName() string { return "alert_events" }
 
 type Silence struct {
 	ID           uint64         `gorm:"column:id;primaryKey;autoIncrement"`
-	Name         string         `gorm:"column:name;size:128;not null;default:''"`
+	Name         string         `gorm:"column:name;size:256;not null;default:''"`
 	Scope        string         `gorm:"column:scope;size:32;not null;default:''"`
 	ScopeType    string         `gorm:"column:scope_type;size:32;not null;default:''"`
 	// DeviceID renamed from EdgeID in May 2026 (entity split).

--- a/internal/manager/model/setting/model.go
+++ b/internal/manager/model/setting/model.go
@@ -63,6 +63,11 @@ const (
 	// generation in seconds. The typed setting accessor owns its default and
 	// range validation so callers cannot accidentally accept an unbounded value.
 	KeyAgentLLMTimeoutSeconds = "llm_timeout_seconds"
+	// KeyAgentOutputLocale controls the language used by headless Agent work
+	// that has no browser locale, starting with automatic RCA investigations.
+	// Empty/unset keeps the caller-specific fallback; supported values are
+	// "zh" and "en".
+	KeyAgentOutputLocale = "output_locale"
 )
 
 // (CategoryGit + KeyGitGitHubToken removed HTTPS git

--- a/internal/manager/service/alert/service.go
+++ b/internal/manager/service/alert/service.go
@@ -323,13 +323,11 @@ func (s *Service) AcknowledgeIncident(ctx context.Context, caller Caller, id uin
 	return toServiceIncident(row), nil
 }
 
-// ResolveIncident transitions an incident to resolved.
+// ResolveIncident transitions an incident to resolved. Note is optional and,
+// when present, is stored in the TEXT-backed incident timeline event.
 func (s *Service) ResolveIncident(ctx context.Context, caller Caller, id uint64, in IncidentMutationInput) (*Incident, error) {
 	if id == 0 {
 		return nil, fmt.Errorf("%w: incident id required", errs.ErrInvalid)
-	}
-	if strings.TrimSpace(in.Note) == "" {
-		return nil, fmt.Errorf("%w: resolve note required", errs.ErrInvalid)
 	}
 	if s.uc == nil {
 		return nil, errs.ErrNotWiredYet

--- a/internal/manager/service/alert/service_test.go
+++ b/internal/manager/service/alert/service_test.go
@@ -51,6 +51,16 @@ func TestServiceAcknowledgeIncidentAllowsEmptyNote(t *testing.T) {
 	}
 }
 
+func TestServiceResolveIncidentAllowsEmptyNote(t *testing.T) {
+	t.Parallel()
+
+	svc := NewStub()
+	_, err := svc.ResolveIncident(context.Background(), Caller{}, 9, IncidentMutationInput{})
+	if !errors.Is(err, errs.ErrNotWiredYet) {
+		t.Fatalf("ResolveIncident(empty note) err = %v, want not-wired-yet", err)
+	}
+}
+
 func TestServiceCreateChannelValidatesInput(t *testing.T) {
 	t.Parallel()
 

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/cn';
 //   - ghost:   border border-zinc-700 bg-zinc-900, used for refresh / secondary
 //   - danger:  red destructive (delete confirm dialogs)
 // Size is fixed (text-xs / px-2.5 py-1.5) so adjacent buttons don't drift.
-type Variant = 'primary' | 'ghost' | 'danger' | 'subtle';
+type Variant = 'primary' | 'ghost' | 'danger';
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: Variant;
@@ -19,8 +19,6 @@ const VARIANT_CLASS: Record<Variant, string> = {
     'border border-zinc-700 bg-zinc-900 text-zinc-300 hover:bg-zinc-800 disabled:opacity-40',
   danger:
     'bg-red-500 text-white hover:bg-red-600 disabled:opacity-50',
-  subtle:
-    'bg-zinc-100 text-zinc-900 hover:bg-white disabled:opacity-50',
 };
 
 export const Button = forwardRef<HTMLButtonElement, Props>(function Button(

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -470,7 +470,7 @@ function AgentDetailModal({
             type="button"
             onClick={() => void onUse()}
             disabled={busy}
-            className="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             <MessageSquarePlus size={11} /> {busy ? tr('创建中…', 'Creating…') : tr('使用此助理', 'Use this')}
           </button>
@@ -703,7 +703,7 @@ function AgentEditor({
               description.trim() === '' ||
               systemPrompt.trim() === ''
             }
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
           </button>

--- a/web/src/pages/AlertRules.tsx
+++ b/web/src/pages/AlertRules.tsx
@@ -799,7 +799,7 @@ function RuleEditorModalInner({
             type="button"
             onClick={submit}
             disabled={submitting}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
           </button>

--- a/web/src/pages/Alerts.tsx
+++ b/web/src/pages/Alerts.tsx
@@ -406,10 +406,6 @@ function ResolveDialog({
   const [err, setErr] = useState<string | null>(null);
 
   const submit = async () => {
-    if (!note.trim()) {
-      setErr(tr('请填写备注', 'Please add a note'));
-      return;
-    }
     setSubmitting(true);
     setErr(null);
     try {
@@ -440,7 +436,7 @@ function ResolveDialog({
             type="button"
             onClick={submit}
             disabled={submitting}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('提交中…', 'Submitting…') : tr('解决', 'Resolve')}
           </button>
@@ -453,7 +449,7 @@ function ResolveDialog({
           <div className="mt-1 text-[11px] text-zinc-500">incident #{incident.id}</div>
         </div>
         <label className="block text-xs text-zinc-400">
-          <span className="mb-1 block">{tr('备注（必填，进入 incident 时间线）', 'Note (required, recorded in the incident timeline)')}</span>
+          <span className="mb-1 block">{tr('备注（可选，进入 incident 时间线）', 'Note (optional; recorded in the incident timeline)')}</span>
           <textarea
             value={note}
             onChange={(e) => setNote(e.target.value)}

--- a/web/src/pages/DailyTools.tsx
+++ b/web/src/pages/DailyTools.tsx
@@ -616,7 +616,7 @@ export default function DailyToolsPage() {
               <button
                 type="submit"
                 disabled={!canRun}
-                className="ml-auto inline-flex h-9 shrink-0 items-center gap-1.5 self-end rounded-md bg-zinc-100 px-3 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+                className="ml-auto inline-flex h-9 shrink-0 items-center gap-1.5 self-end rounded-md bg-accent px-3 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
               >
                 <Play size={12} fill="currentColor" />
                 {active === 'capture' ? tr('开始', 'Start') : tr('执行', 'Run')}

--- a/web/src/pages/DeviceShell.tsx
+++ b/web/src/pages/DeviceShell.tsx
@@ -552,7 +552,7 @@ function ConnectModal({
           <Button variant="ghost" onClick={onCancel}>
             {tr('取消', 'Cancel')}
           </Button>
-          <Button variant="subtle" onClick={submit}>
+          <Button variant="primary" onClick={submit}>
             {tr('连接', 'Connect')}
           </Button>
         </>
@@ -704,4 +704,3 @@ function safeParse(s: string): Record<string, unknown> | null {
     return null;
   }
 }
-

--- a/web/src/pages/EdgeDetail.tsx
+++ b/web/src/pages/EdgeDetail.tsx
@@ -2036,7 +2036,7 @@ function PluginSpecEditor({
           type="button"
           onClick={() => void submit()}
           disabled={saving}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
         >
           {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}</span>

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -2208,7 +2208,7 @@ function RolesEditorModal({
             type="button"
             onClick={submit}
             disabled={submitting}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr("保存中…", "Saving…") : tr("保存", "Save")}
           </button>
@@ -2681,7 +2681,7 @@ function CreateEdgeModal({
             type="button"
             onClick={() => void go()}
             disabled={pending}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {pending ? tr("创建中…", "Creating…") : tr("创建", "Create")}
           </button>
@@ -2745,7 +2745,7 @@ function SecretRevealModal({
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white"
+          className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90"
         >
           {tr("我已保存", "I've saved it")}
         </button>
@@ -3006,7 +3006,7 @@ function BatchEnrollmentModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90"
           >
             {tr("我已保存命令", "I've saved the command")}
           </button>
@@ -3023,7 +3023,7 @@ function BatchEnrollmentModal({
               type="button"
               onClick={() => void createProfile()}
               disabled={pending}
-              className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
             >
               {pending
                 ? tr("生成中…", "Generating…")

--- a/web/src/pages/IncidentDetail.tsx
+++ b/web/src/pages/IncidentDetail.tsx
@@ -1079,8 +1079,8 @@ function ActionDialog({
   const cta = kind === 'ack' ? tr('确认', 'Acknowledge') : kind === 'resolve' ? tr('解决', 'Resolve') : tr('静默', 'Silence');
 
   const submit = async () => {
-    if (kind !== 'ack' && !note.trim()) {
-      setErr(kind === 'silence' ? tr('请填写静默原因', 'Please add a silence reason') : tr('请填写备注', 'Please add a note'));
+    if (kind === 'silence' && !note.trim()) {
+      setErr(tr('请填写静默原因', 'Please add a silence reason'));
       return;
     }
     if (kind === 'silence' && !until.trim()) {
@@ -1119,7 +1119,7 @@ function ActionDialog({
             type="button"
             onClick={submit}
             disabled={submitting}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('提交中…', 'Submitting…') : cta}
           </button>
@@ -1150,9 +1150,7 @@ function ActionDialog({
           <span className="mb-1 block">
             {kind === 'silence'
               ? tr('原因（必填）', 'Reason (required)')
-              : kind === 'ack'
-              ? tr('备注（可选，进入 incident 时间线）', 'Note (optional; recorded in the incident timeline)')
-              : tr('备注（必填，进入 incident 时间线）', 'Note (required; recorded in the incident timeline)')}
+              : tr('备注（可选，进入 incident 时间线）', 'Note (optional; recorded in the incident timeline)')}
           </span>
           <textarea
             value={note}

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -360,7 +360,7 @@ export default function KnowledgePage() {
             type="button"
             onClick={() => void runSearch()}
             disabled={searching || !query.trim()}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {searching ? tr('检索中…', 'Searching…') : tr('检索', 'Search')}
           </button>
@@ -1030,7 +1030,7 @@ function DocEditor({
                   ? tr('内置文档随同步更新、不可直接修改；复制一份到组织知识库后即可编辑', 'Built-in docs are refreshed on sync and not directly editable; copy into the org knowledge base to edit')
                   : tr('repo 文档随同步更新、不可直接修改；复制一份到组织知识库后即可编辑', 'Repo docs are refreshed on sync and not directly editable; copy into the org knowledge base to edit')
               }
-              className="flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
             >
               <Copy size={11} />
               {tr('复制为组织文档', 'Copy as org doc')}
@@ -1112,7 +1112,7 @@ function DocEditor({
             type="button"
             onClick={() => void submit()}
             disabled={submitting || title.trim() === '' || content.trim() === ''}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
           </button>

--- a/web/src/pages/KnowledgeRepos.tsx
+++ b/web/src/pages/KnowledgeRepos.tsx
@@ -353,7 +353,7 @@ function RepoCreator({ onClose, onCreated }: { onClose: () => void; onCreated: (
             type="button"
             onClick={() => void submit()}
             disabled={submitting || url.trim() === ''}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {submitting ? tr('保存中…', 'Saving…') : tr('保存（保存后再点同步）', 'Save (then click Sync)')}
           </button>
@@ -678,7 +678,7 @@ function AddSSHIdentityModal({
           <button
             type="button"
             onClick={closeAndRefresh}
-            className="inline-flex items-center rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white"
+            className="inline-flex items-center rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90"
           >
             {tr('我已复制', 'Copied — done')}
           </button>
@@ -732,7 +732,7 @@ function AddSSHIdentityModal({
             type="button"
             disabled={!canSubmit}
             onClick={() => void submit()}
-            className="inline-flex items-center gap-1 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-40"
+            className="inline-flex items-center gap-1 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-40"
           >
             {busy
               ? tr('处理中…', 'Working…')

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -667,7 +667,7 @@ export default function LogsPage() {
           <button
             type="submit"
             disabled={loading}
-            className="ml-auto inline-flex h-[34px] shrink-0 items-center gap-1.5 self-end rounded-md bg-zinc-100 px-3 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="ml-auto inline-flex h-[34px] shrink-0 items-center gap-1.5 self-end rounded-md bg-accent px-3 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {loading ? <Loader2 size={12} className="animate-spin" /> : <SearchIcon size={12} />}
             {tr('查询', 'Search')}

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -49,7 +49,7 @@ const RAIL_ITEMS: RailItem[] = [
   // the previous /communications and /bots paths live in App.tsx.
   { to: 'notifications', icon: Bell, labelZh: '通知', labelEn: 'Notifications', hintZh: '飞书 / 钉钉 / 企业微信 / Slack / Telegram / Webhook（告警推送）', hintEn: 'Slack / Telegram / Larksuite / DingTalk / WeCom / Webhook (alert delivery)' },
   { to: 'channels', icon: MessagesSquare, labelZh: 'IM', labelEn: 'Channels', hintZh: '飞书 / 钉钉 / Telegram / Slack 双向多轮', hintEn: 'Slack / Telegram / Larksuite / DingTalk — two-way multi-turn' },
-  { to: 'agent', icon: Bot, labelZh: '助理', labelEn: 'Agent', hintZh: 'AI 助理行为 — 写操作与超时', hintEn: 'AI assistant behaviour — writes and timeouts' },
+  { to: 'agent', icon: Bot, labelZh: '助理', labelEn: 'Agent', hintZh: '输出语言、写操作与超时', hintEn: 'Output language, writes, and timeouts' },
   { to: 'preferences', icon: Gauge, labelZh: '偏好', labelEn: 'Preferences', hintZh: '默认时间窗 / 自动刷新', hintEn: 'Default time window / auto-refresh' },
   { to: 'about', icon: Info, labelZh: '关于', labelEn: 'About', hintZh: '版本 / GitHub / 许可证', hintEn: 'Version / GitHub / license' },
 ];

--- a/web/src/pages/Skills.tsx
+++ b/web/src/pages/Skills.tsx
@@ -641,7 +641,7 @@ function SkillDetailModal({ skill, onClose }: { skill: SkillSummary; onClose(): 
           ) : (
             <Link
               to={`/skills/${encodeURIComponent(skill.key)}`}
-              className="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white"
+              className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90"
             >
               <Play size={11} /> {tr('执行', 'Run')}
             </Link>

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -115,13 +115,12 @@ function TaskList() {
           </div>
           {canMutate && (
             <div className="relative">
-              <button
-                type="button"
+              <Button
+                variant="primary"
                 onClick={() => setMenuOpen((v) => !v)}
-                className="inline-flex items-center gap-1.5 rounded-md border border-indigo-600 bg-indigo-600/20 px-2.5 py-1.5 text-xs text-indigo-200 hover:bg-indigo-600/30"
               >
                 <Plus size={12} /> {tr('新建任务', 'New task')} <ChevronDown size={12} className="opacity-70" />
-              </button>
+              </Button>
               {menuOpen && (
                 <>
                   <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} aria-hidden />

--- a/web/src/pages/Traces.tsx
+++ b/web/src/pages/Traces.tsx
@@ -454,7 +454,7 @@ export default function TracesPage() {
           <button
             type="submit"
             disabled={loading}
-            className="ml-auto inline-flex h-[34px] shrink-0 items-center gap-1.5 self-end rounded-md bg-zinc-100 px-3 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="ml-auto inline-flex h-[34px] shrink-0 items-center gap-1.5 self-end rounded-md bg-accent px-3 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {loading ? <Loader2 size={12} className="animate-spin" /> : <SearchIcon size={12} />}
             {tr('查询', 'Search')}

--- a/web/src/pages/clusters/ClusterEnrollmentModal.tsx
+++ b/web/src/pages/clusters/ClusterEnrollmentModal.tsx
@@ -94,7 +94,7 @@ export function ClusterEnrollmentModal({
       size="lg"
       footer={
         created ? (
-          <Button variant="subtle" onClick={onClose}>
+          <Button variant="primary" onClick={onClose}>
             {tr("我已保存命令", "I've saved the command")}
           </Button>
         ) : (

--- a/web/src/pages/settings/Agent.test.tsx
+++ b/web/src/pages/settings/Agent.test.tsx
@@ -79,3 +79,50 @@ describe('SettingsAgent LLM timeout', () => {
     expect(calls).toBe(0);
   });
 });
+
+describe('SettingsAgent output language', () => {
+  it('loads and persists the Agent output locale', async () => {
+    let saved: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/v1/system-settings', () => HttpResponse.json({
+        items: [{
+          category: 'agent',
+          key: 'output_locale',
+          value: 'en',
+          sensitive: false,
+          updated_at: '2026-08-19T00:00:00Z',
+        }],
+        total: 1,
+      })),
+      http.put('/api/v1/system-settings/agent/output_locale', async ({ request }) => {
+        saved = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({
+          category: 'agent',
+          key: 'output_locale',
+          value: 'zh',
+          sensitive: false,
+          updated_at: '2026-08-19T00:00:00Z',
+        });
+      }),
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <SettingsAgent />
+        </MemoryRouter>,
+      );
+    });
+
+    const select = await screen.findByRole('combobox', { name: 'Output language' });
+    expect(select).toHaveValue('en');
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.selectOptions(select, 'zh');
+      await user.click(screen.getByRole('button', { name: 'Save language' }));
+    });
+
+    await waitFor(() => expect(saved).toEqual({ value: 'zh', sensitive: false }));
+  });
+});

--- a/web/src/pages/settings/Agent.tsx
+++ b/web/src/pages/settings/Agent.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Bot, Clock3, Loader2, Save, ShieldCheck } from 'lucide-react';
+import { Bot, Clock3, Languages, Loader2, Save, ShieldCheck } from 'lucide-react';
 import { listSettings, setSetting } from '@/api/settings';
 import { Button } from '@/components/ui';
 import { useI18n } from '@/i18n/locale';
@@ -16,6 +16,7 @@ import { cn } from '@/lib/cn';
 const CATEGORY = 'agent';
 const KEY = 'write_enabled';
 const LLM_TIMEOUT_KEY = 'llm_timeout_seconds';
+const OUTPUT_LOCALE_KEY = 'output_locale';
 const DEFAULT_LLM_TIMEOUT_SECONDS = 120;
 const MIN_LLM_TIMEOUT_SECONDS = 30;
 const MAX_LLM_TIMEOUT_SECONDS = 900;
@@ -24,9 +25,11 @@ export default function SettingsAgent() {
   const { tr } = useI18n();
   const [writeEnabled, setWriteEnabled] = useState(false);
   const [llmTimeoutSeconds, setLLMTimeoutSeconds] = useState(String(DEFAULT_LLM_TIMEOUT_SECONDS));
+  const [outputLocale, setOutputLocale] = useState<'' | 'zh' | 'en'>('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savingTimeout, setSavingTimeout] = useState(false);
+  const [savingLocale, setSavingLocale] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -34,10 +37,12 @@ export default function SettingsAgent() {
       const res = await listSettings(CATEGORY);
       const row = res.items.find((i) => i.key === KEY);
       const timeoutRow = res.items.find((i) => i.key === LLM_TIMEOUT_KEY);
+      const localeRow = res.items.find((i) => i.key === OUTPUT_LOCALE_KEY);
       // Missing row → server default is DISABLED (fail-safe).
       setWriteEnabled(row ? row.value === 'true' : false);
       // Missing timeout row → server and UI both use the stable 120s default.
       setLLMTimeoutSeconds(timeoutRow?.value || String(DEFAULT_LLM_TIMEOUT_SECONDS));
+      setOutputLocale(localeRow?.value === 'zh' || localeRow?.value === 'en' ? localeRow.value : '');
       setErr(null);
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -90,6 +95,18 @@ export default function SettingsAgent() {
       setSavingTimeout(false);
     }
   }, [llmTimeoutSeconds, tr]);
+
+  const onSaveLocale = useCallback(async () => {
+    setSavingLocale(true);
+    setErr(null);
+    try {
+      await setSetting(CATEGORY, OUTPUT_LOCALE_KEY, outputLocale, false);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingLocale(false);
+    }
+  }, [outputLocale]);
 
   return (
     <div className="space-y-4">
@@ -155,6 +172,52 @@ export default function SettingsAgent() {
           {tr(
             '提示：改动立即生效，对所有用户的新对话轮次生效，无需重启。已在进行中的工具调用不受影响。',
             'Note: takes effect immediately on the next chat turn for every user, no restart needed. Tool calls already in flight are unaffected.',
+          )}
+        </p>
+      </section>
+
+      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="mb-3 flex items-center gap-2">
+          <Languages size={14} className="text-zinc-400" />
+          <h2 className="text-sm font-medium text-zinc-100">{tr('Agent 输出语言', 'Agent output language')}</h2>
+        </div>
+        <p className="mb-4 text-xs leading-relaxed text-zinc-500">
+          {tr(
+            '设置无浏览器上下文的 Agent 后台任务输出语言，当前包括自动根因分析。显式选择后，手动重新分析也使用同一语言。',
+            'Sets the output language for background Agent work without browser context, currently including automatic root-cause analysis. Once selected, manual reruns use the same language.',
+          )}
+        </p>
+        {loading ? (
+          <div className="flex h-10 items-center text-xs text-zinc-500">
+            <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-end gap-3">
+            <div>
+              <label htmlFor="agent-output-locale" className="mb-1.5 block text-sm text-zinc-300">
+                {tr('输出语言', 'Output language')}
+              </label>
+              <select
+                id="agent-output-locale"
+                value={outputLocale}
+                onChange={(event) => setOutputLocale(event.target.value as '' | 'zh' | 'en')}
+                className="h-10 w-64 rounded-md border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition focus:border-zinc-600"
+              >
+                <option value="">{tr('按任务上下文', 'Use task context')}</option>
+                <option value="zh">中文</option>
+                <option value="en">English</option>
+              </select>
+            </div>
+            <Button variant="subtle" disabled={savingLocale} onClick={() => void onSaveLocale()}>
+              <Save size={14} />
+              {savingLocale ? tr('保存中…', 'Saving…') : tr('保存语言', 'Save language')}
+            </Button>
+          </div>
+        )}
+        <p className="mt-3 text-[11px] text-zinc-600">
+          {tr(
+            '未配置时，交互任务跟随用户界面语言，自动任务使用部署默认语言。配置保存后对新任务立即生效。',
+            'When unset, interactive work follows the UI language and automatic work uses the deployment default. Saved changes apply to new work immediately.',
           )}
         </p>
       </section>

--- a/web/src/pages/settings/Agent.tsx
+++ b/web/src/pages/settings/Agent.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Bot, Clock3, Languages, Loader2, Save, ShieldCheck } from 'lucide-react';
 import { listSettings, setSetting } from '@/api/settings';
-import { Button } from '@/components/ui';
+import { Button, Card } from '@/components/ui';
 import { useI18n } from '@/i18n/locale';
 import { cn } from '@/lib/cn';
 
@@ -111,7 +111,7 @@ export default function SettingsAgent() {
   return (
     <div className="space-y-4">
       {err && <div className="text-xs text-red-400">{err}</div>}
-      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <Card className="p-5">
         <div className="mb-3 flex items-center gap-2">
           <ShieldCheck size={14} className="text-zinc-400" />
           <h2 className="text-sm font-medium text-zinc-100">{tr('写操作权限', 'Write actions')}</h2>
@@ -174,9 +174,9 @@ export default function SettingsAgent() {
             'Note: takes effect immediately on the next chat turn for every user, no restart needed. Tool calls already in flight are unaffected.',
           )}
         </p>
-      </section>
+      </Card>
 
-      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <Card className="p-5">
         <div className="mb-3 flex items-center gap-2">
           <Languages size={14} className="text-zinc-400" />
           <h2 className="text-sm font-medium text-zinc-100">{tr('Agent 输出语言', 'Agent output language')}</h2>
@@ -192,37 +192,42 @@ export default function SettingsAgent() {
             <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
           </div>
         ) : (
-          <div className="flex flex-wrap items-end gap-3">
-            <div>
-              <label htmlFor="agent-output-locale" className="mb-1.5 block text-sm text-zinc-300">
+          <>
+            <label className="block max-w-sm" htmlFor="agent-output-locale">
+              <span className="mb-1 block text-xs text-zinc-400">
                 {tr('输出语言', 'Output language')}
-              </label>
+              </span>
               <select
                 id="agent-output-locale"
                 value={outputLocale}
                 onChange={(event) => setOutputLocale(event.target.value as '' | 'zh' | 'en')}
-                className="h-10 w-64 rounded-md border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition focus:border-zinc-600"
+                className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 outline-none transition focus:border-zinc-600"
               >
                 <option value="">{tr('按任务上下文', 'Use task context')}</option>
                 <option value="zh">中文</option>
                 <option value="en">English</option>
               </select>
+            </label>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Button variant="primary" disabled={savingLocale} onClick={() => void onSaveLocale()}>
+                <Save size={14} />
+                {savingLocale ? tr('保存中…', 'Saving…') : tr('保存语言', 'Save language')}
+              </Button>
+              <span className="text-xs text-zinc-500">
+                {tr('保存后对新任务立即生效', 'Applies to new work immediately after saving')}
+              </span>
             </div>
-            <Button variant="subtle" disabled={savingLocale} onClick={() => void onSaveLocale()}>
-              <Save size={14} />
-              {savingLocale ? tr('保存中…', 'Saving…') : tr('保存语言', 'Save language')}
-            </Button>
-          </div>
+          </>
         )}
-        <p className="mt-3 text-[11px] text-zinc-600">
+        <p className="mt-4 text-[11px] leading-relaxed text-zinc-600">
           {tr(
             '未配置时，交互任务跟随用户界面语言，自动任务使用部署默认语言。配置保存后对新任务立即生效。',
             'When unset, interactive work follows the UI language and automatic work uses the deployment default. Saved changes apply to new work immediately.',
           )}
         </p>
-      </section>
+      </Card>
 
-      <section className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <Card className="p-5">
         <div className="mb-3 flex items-center gap-2">
           <Clock3 size={14} className="text-zinc-400" />
           <h2 className="text-sm font-medium text-zinc-100">{tr('LLM 请求超时', 'LLM request timeout')}</h2>
@@ -239,25 +244,27 @@ export default function SettingsAgent() {
           </div>
         ) : (
           <>
-            <label htmlFor="agent-llm-timeout-seconds" className="mb-1.5 block text-sm text-zinc-300">
-              {tr('超时秒数', 'Timeout seconds')}
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                id="agent-llm-timeout-seconds"
-                type="number"
-                min={MIN_LLM_TIMEOUT_SECONDS}
-                max={MAX_LLM_TIMEOUT_SECONDS}
-                step={1}
-                value={llmTimeoutSeconds}
-                onChange={(event) => setLLMTimeoutSeconds(event.target.value)}
-                className="h-10 w-48 rounded-md border border-zinc-700 bg-zinc-950 px-3 font-mono text-sm text-zinc-100 outline-none transition focus:border-zinc-600"
-              />
-              <span className="text-sm text-zinc-500">{tr('秒', 'seconds')}</span>
+            <div className="max-w-sm">
+              <label className="mb-1 block text-xs text-zinc-400" htmlFor="agent-llm-timeout-seconds">
+                {tr('超时秒数', 'Timeout seconds')}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="agent-llm-timeout-seconds"
+                  type="number"
+                  min={MIN_LLM_TIMEOUT_SECONDS}
+                  max={MAX_LLM_TIMEOUT_SECONDS}
+                  step={1}
+                  value={llmTimeoutSeconds}
+                  onChange={(event) => setLLMTimeoutSeconds(event.target.value)}
+                  className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 font-mono text-xs text-zinc-100 outline-none transition focus:border-zinc-600"
+                />
+                <span className="shrink-0 text-xs text-zinc-500">{tr('秒', 'seconds')}</span>
+              </div>
             </div>
             <div className="mt-4 flex items-center gap-3">
               <Button
-                variant="subtle"
+                variant="primary"
                 disabled={savingTimeout}
                 onClick={() => void onSaveTimeout()}
               >
@@ -270,13 +277,13 @@ export default function SettingsAgent() {
             </div>
           </>
         )}
-        <p className="mt-3 text-[11px] text-zinc-600">
+        <p className="mt-4 text-[11px] leading-relaxed text-zinc-600">
           {tr(
             `允许范围 ${MIN_LLM_TIMEOUT_SECONDS}–${MAX_LLM_TIMEOUT_SECONDS} 秒；保存后对新任务立即生效。`,
             `Allowed range: ${MIN_LLM_TIMEOUT_SECONDS}–${MAX_LLM_TIMEOUT_SECONDS} seconds; applies to new work immediately after saving.`,
           )}
         </p>
-      </section>
+      </Card>
     </div>
   );
 }

--- a/web/src/pages/settings/Channels.tsx
+++ b/web/src/pages/settings/Channels.tsx
@@ -347,7 +347,7 @@ function IMAppEditor({
             type="button"
             onClick={save}
             disabled={busy}
-            className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-white disabled:opacity-50"
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
           >
             {busy ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
           </button>

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -277,7 +277,7 @@ function PrometheusCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="subtle">
+        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
@@ -565,7 +565,7 @@ function GrafanaCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={save} disabled={!dirty || saving} variant="subtle">
+        <Button onClick={save} disabled={!dirty || saving} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
@@ -989,7 +989,7 @@ function LokiCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="subtle">
+        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
@@ -1184,7 +1184,7 @@ function TempoCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="subtle">
+        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
@@ -1515,7 +1515,7 @@ function WebSearchCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="subtle">
+        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>

--- a/web/src/pages/settings/LLM.tsx
+++ b/web/src/pages/settings/LLM.tsx
@@ -564,7 +564,7 @@ function LLMProviderCard({ meta }: { meta: LLMProviderMeta }) {
           {probe.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{probe.kind === 'testing' ? tr('检测中…', 'Testing…') : tr('测试配置', 'Test configuration')}</span>
         </Button>
-        <Button onClick={submit} disabled={!dirty || saving || probe.kind === 'testing'} variant="subtle">
+        <Button onClick={submit} disabled={!dirty || saving || probe.kind === 'testing'} variant="primary">
           {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
           <span>{saving
             ? probe.kind === 'testing' ? tr('校验中…', 'Validating…') : tr('保存中…', 'Saving…')

--- a/web/src/pages/settings/Marketplace.tsx
+++ b/web/src/pages/settings/Marketplace.tsx
@@ -625,7 +625,7 @@ function InstallCard({
             onClick={submit}
             disabled={!canSubmit || !isAdmin}
             title={!isAdmin ? tr('需要 admin 权限', 'Admin permission required') : undefined}
-            variant="subtle"
+            variant="primary"
           >
             {installing ? (
               <Loader2 size={13} className="animate-spin" />
@@ -702,7 +702,7 @@ function ConfirmModal({
               <Trash2 size={12} />
               {tr('回滚卸载', 'Roll back')}
             </Button>
-            <Button onClick={onClose} variant="subtle">
+            <Button onClick={onClose} variant="primary">
               {tr('完成', 'Done')}
             </Button>
           </>

--- a/web/src/pages/settings/Notifications.tsx
+++ b/web/src/pages/settings/Notifications.tsx
@@ -480,7 +480,7 @@ function ChannelEditorModal({
           <Button onClick={onClose} variant="ghost">
             {tr('取消', 'Cancel')}
           </Button>
-          <Button onClick={submit} disabled={submitting} variant="subtle">
+          <Button onClick={submit} disabled={submitting} variant="primary">
             {submitting ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
           </Button>
         </>

--- a/web/src/pages/settings/Upgrade.tsx
+++ b/web/src/pages/settings/Upgrade.tsx
@@ -247,7 +247,7 @@ function CommandList({
                 <div className="mt-1 font-mono text-[11px] text-zinc-500">{item.arch}</div>
               </div>
               <Button
-                variant={copied === item.id ? 'subtle' : 'ghost'}
+                variant="ghost"
                 onClick={() => onCopy(item)}
                 className="w-full justify-center sm:w-auto"
               >


### PR DESCRIPTION
## Summary

- add a live system-wide Agent output language setting for background and manual RCA runs
- allow empty and long acknowledgement/resolution notes while keeping silence reasons required
- expand generated silence names safely to 256 Unicode characters
- align primary command buttons and Agent settings controls with the shared UI pattern

## Validation

- `make build`
- `make test-race`
- `make test-e2e`
- `go vet ./...`
- `pnpm --dir web test` (159 tests)
- targeted ESLint: 0 errors
- real MySQL/API checks for empty and 6000-character Ack/Resolve notes
- dark/light Playwright screenshots on the deployed test environment

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

Related to #224.
Related to #283.