### PR TITLE
fix(edge): skip missing upgrade hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -802,6 +802,7 @@ test-release-package: ## [test] 校验安装 URL 与 Compose 发布包内容
 	bash scripts/test-public-url.sh
 	bash scripts/test-upgrade-data-permissions.sh
 	bash scripts/test-install-asset-modes.sh
+	bash scripts/test-edge-upgrade-hook-guard.sh
 	$(MAKE) --no-print-directory test-edge-attachments
 	bash scripts/test-compose-release-package.sh
 	bash scripts/test-apply-pending-upgrade.sh

--- a/deploy/install/edge/install.sh
+++ b/deploy/install/edge/install.sh
@@ -344,6 +344,10 @@ cat > "$UPGRADE_SERVICE_FILE" <<'EOF'
 [Unit]
 Description=ongrid edge pending-upgrade apply (root, pre-start)
 Documentation=file:///usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+# The online installer can continue when this optional script cannot be
+# downloaded. Skip this unit in that case so the agent does not leave a
+# persistent failed unit on every start.
+ConditionPathIsExecutable=/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
 Before=ongrid-edge.service
 After=local-fs.target
 

--- a/deploy/install/edge/ongrid-edge-upgrade.service
+++ b/deploy/install/edge/ongrid-edge-upgrade.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=ongrid edge pending-upgrade apply (root, pre-start)
 Documentation=file:///usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+# The online installer can continue when this optional script cannot be
+# downloaded. Skip this unit in that case so the agent does not leave a
+# persistent failed unit on every start.
+ConditionPathIsExecutable=/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
 # Ordered before the agent so a staged whole-bundle upgrade is swapped in
 # (and the previous boot's health / auto-rollback check runs) BEFORE
 # ongrid-edge starts. ongrid-edge.service pulls this in via Wants=, which

--- a/scripts/test-edge-upgrade-hook-guard.sh
+++ b/scripts/test-edge-upgrade-hook-guard.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+hook=/usr/local/lib/ongrid-edge/apply-pending-upgrade.sh
+condition="=${hook}"
+sources=(
+    "$repo_root/deploy/install/edge/ongrid-edge-upgrade.service"
+    "$repo_root/deploy/install/edge/install.sh"
+)
+
+for source in "${sources[@]}"; do
+    rg -Fqx "$condition" "$source" >/dev/null \
+        || { echo "missing upgrade-hook condition: $source" >&2; exit 1; }
+done
+
+echo "edge upgrade hook guard: ok"


### PR DESCRIPTION
Fixes #334

## Summary

- skip the upgrade oneshot when `apply-pending-upgrade.sh` is unavailable
- apply the guard to both online and packaged edge installers
- add the guard to the release-package test target

## Validation

- `make test-release-package`

`go test ./... -race` and `go vet ./...` were not run because the local terminal does not have the Go toolchain installed.