### PR TITLE
fix(logs): preserve legacy edge ingestion compatibility

### DIFF
--- a/cmd/ongrid/k8s_telemetry_target_test.go
+++ b/cmd/ongrid/k8s_telemetry_target_test.go
@@ -45,6 +45,9 @@ func TestPluginEndpointResolverPublishesExternalSignalSettings(t *testing.T) {
 	if logs.Endpoint != "https://loki.example/otlp/v1/logs" || logs.BasicUser != "loki-user" || logs.BasicPassword != "loki-pass" || !logs.TLSInsecure || logs.UseTelemetryCredential {
 		t.Fatalf("logs target = %#v", logs)
 	}
+	if got := resolver.Endpoint(context.Background(), "logs"); got != "https://loki.example/loki/api/v1/push" {
+		t.Fatalf("ordinary Edge logs endpoint = %q", got)
+	}
 	edgeLogs, err := (logsLokiTargetResolver{resolver: resolver}).ResolveLokiTarget(context.Background())
 	if err != nil {
 		t.Fatalf("resolve ordinary Edge logs: %v", err)
@@ -79,6 +82,9 @@ func TestPluginEndpointResolverFallsBackToManagerForInternalSeeds(t *testing.T) 
 	}
 	if logs.Endpoint != "https://manager.example/loki/otlp/v1/logs" || !logs.UseTelemetryCredential {
 		t.Fatalf("logs target = %#v", logs)
+	}
+	if got := resolver.Endpoint(context.Background(), "logs"); got != "https://manager.example/loki/api/v1/push" {
+		t.Fatalf("ordinary Edge logs endpoint = %q", got)
 	}
 	if traces.Endpoint != "https://manager.example/v1/traces" || !traces.UseTelemetryCredential {
 		t.Fatalf("traces target = %#v", traces)

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -2995,6 +2995,20 @@ func (r lokiQueryEndpointResolver) ResolveLokiEndpoint(ctx context.Context) (pkg
 }
 
 func (r pluginEndpointResolver) Endpoint(ctx context.Context, plugin string) string {
+	// Keep the Edge wire contract on Loki's legacy push URL. Pre-OTel Edge
+	// releases pass it directly to Promtail, while current releases translate
+	// it to OTLP locally. Sending OTLP here would break every old Edge as soon
+	// as Manager reloads its plugin config.
+	if plugin == "logs" {
+		if r.loki != nil {
+			if u := edgeReachableLokiURL(r.loki.URL(ctx)); u != "" {
+				return u + "/loki/api/v1/push"
+			}
+		}
+		if r.publicURL != "" {
+			return strings.TrimRight(r.publicURL, "/") + "/loki/api/v1/push"
+		}
+	}
 	target, err := r.ResolveTelemetryTarget(ctx, plugin)
 	if err != nil {
 		return ""

--- a/deploy/install/nginx.conf
+++ b/deploy/install/nginx.conf
@@ -208,6 +208,12 @@ http {
             proxy_read_timeout    60s;
         }
 
+        # Standard Loki OTLP path used by current Edge releases. Keep the
+        # /loki/otlp alias above for already-published RC clients.
+        location = /otlp/v1/logs {
+            rewrite ^ /loki/otlp/v1/logs last;
+        }
+
         location = /__auth_dataplane {
             internal;
             proxy_pass http://ongrid_backend/internal/auth/dataplane-verify;

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -217,6 +217,12 @@ http {
             proxy_read_timeout    60s;
         }
 
+        # Standard Loki OTLP path used by current Edge releases. Keep the
+        # /loki/otlp alias above for already-published RC clients.
+        location = /otlp/v1/logs {
+            rewrite ^ /loki/otlp/v1/logs last;
+        }
+
         location = /__auth_dataplane {
             internal;
             proxy_pass http://ongrid_backend/internal/auth/dataplane-verify;

--- a/internal/edgeagent/plugins/logs/render.go
+++ b/internal/edgeagent/plugins/logs/render.go
@@ -607,7 +607,7 @@ func lokiOTLPLogsEndpoint(raw string) (string, error) {
 	path := strings.TrimRight(parsed.Path, "/")
 	switch {
 	case strings.HasSuffix(path, "/loki/api/v1/push"):
-		path = strings.TrimSuffix(path, "/loki/api/v1/push") + "/loki/otlp/v1/logs"
+		path = strings.TrimSuffix(path, "/loki/api/v1/push") + "/otlp/v1/logs"
 	case strings.HasSuffix(path, "/otlp/v1/logs"):
 	case strings.HasSuffix(path, "/otlp"):
 		path += "/v1/logs"

--- a/internal/edgeagent/plugins/logs/render_test.go
+++ b/internal/edgeagent/plugins/logs/render_test.go
@@ -80,6 +80,8 @@ func TestDeployNginxRoutesLokiOTLPToNativeEndpoint(t *testing.T) {
 		}
 		config := string(body)
 		if !strings.Contains(config, "location = /loki/otlp/v1/logs") ||
+			!strings.Contains(config, "location = /otlp/v1/logs") ||
+			!strings.Contains(config, "rewrite ^ /loki/otlp/v1/logs last;") ||
 			!strings.Contains(config, "proxy_pass http://loki_backend/otlp/v1/logs;") {
 			t.Fatalf("%s does not route authenticated OTLP logs to Loki's native endpoint", relativePath)
 		}
@@ -114,7 +116,7 @@ func TestRenderBuiltInLokiPipeline(t *testing.T) {
 
 	exporters := object(t, root, "exporters")
 	loki := object(t, exporters, "otlphttp/builtin_loki")
-	if got := scalar(t, loki, "logs_endpoint"); got != "https://manager.example.com/loki/otlp/v1/logs" {
+	if got := scalar(t, loki, "logs_endpoint"); got != "https://manager.example.com/otlp/v1/logs" {
 		t.Fatalf("logs_endpoint = %q", got)
 	}
 	headers := object(t, loki, "headers")
@@ -474,7 +476,7 @@ func TestRenderRejectsUnsafeOrDuplicateFileSources(t *testing.T) {
 
 func TestLokiOTLPLogsEndpoint(t *testing.T) {
 	tests := map[string]string{
-		"https://manager.example.com/loki/api/v1/push":  "https://manager.example.com/loki/otlp/v1/logs",
+		"https://manager.example.com/loki/api/v1/push":  "https://manager.example.com/otlp/v1/logs",
 		"https://manager.example.com/loki/otlp":         "https://manager.example.com/loki/otlp/v1/logs",
 		"https://manager.example.com/loki/otlp/v1/logs": "https://manager.example.com/loki/otlp/v1/logs",
 		"https://loki.example.com/otlp":                 "https://loki.example.com/otlp/v1/logs",


### PR DESCRIPTION
## Summary

- Keep the Manager wire endpoint compatible with legacy Edge releases.
- Translate new Edge log export to the standard OTLP path.
- Accept both OTLP paths in nginx during the RC upgrade window.

## Tests

- `go test ./cmd/ongrid ./internal/edgeagent/plugins/logs`
- `go test -race ./cmd/ongrid ./internal/edgeagent/plugins/logs`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md