### PR TITLE
fix(upgrade): wait for MySQL recovery

### DIFF
--- a/deploy/install/data-permissions.sh
+++ b/deploy/install/data-permissions.sh
@@ -171,6 +171,23 @@ ongrid_repair_data_permissions_if_enabled() {
     esac
 }
 
+ongrid_wait_for_container_healthy() {
+    local container="$1" attempts="${2:-150}" interval="${3:-2}"
+    local status="" i
+
+    for ((i = 1; i <= attempts; i++)); do
+        status=$(docker inspect --format \
+            '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+            "$container" 2>/dev/null || true)
+        [[ "$status" == healthy ]] && return 0
+        (( i < attempts )) && sleep "$interval"
+    done
+
+    printf '[ERROR] container %s did not become healthy (last status: %s)\n' \
+        "$container" "${status:-unknown}" >&2
+    return 1
+}
+
 ongrid_restore_existing_stack() {
     local install_dir="$1"
 

--- a/deploy/install/upgrade.sh
+++ b/deploy/install/upgrade.sh
@@ -690,8 +690,18 @@ chmod 600 "$ENV_FILE"
 # config files created under a restrictive umask stay 0640 until chmod'd here.
 ongrid_normalize_shared_asset_modes "$INSTALL_DIR"
 
-# Bring stack back up; gorm AutoMigrate handles schema diff.
-log_info "starting stack with new version"
+# MySQL can restart once while InnoDB resizes redo logs after an image upgrade.
+# Start it separately so Compose does not treat that recovery as a failed stack.
+log_info "starting MySQL with new version"
+(
+    cd "$INSTALL_DIR"
+    docker compose --env-file .env up -d mysql
+)
+log_info "waiting for MySQL to become healthy (up to 5m)"
+ongrid_wait_for_container_healthy ongrid-mysql 150 2
+
+# Bring the remaining stack up; gorm AutoMigrate handles schema diff.
+log_info "starting remaining stack with new version"
 (
     cd "$INSTALL_DIR"
     docker compose --env-file .env up -d

--- a/scripts/test-upgrade-data-permissions.sh
+++ b/scripts/test-upgrade-data-permissions.sh
@@ -230,6 +230,26 @@ grep -Fqx "$install_dir|docker compose --env-file .env up -d" "$docker_log" \
 chown_should_fail=0
 stat_owner_state=expected
 
+health_statuses="$tmp_dir/health-statuses"
+printf 'starting\nunhealthy\nhealthy\n' >"$health_statuses"
+docker() {
+    local status
+    status=$(sed -n '1p' "$health_statuses")
+    sed '1d' "$health_statuses" >"$health_statuses.next"
+    mv "$health_statuses.next" "$health_statuses"
+    printf '%s\n' "$status"
+}
+sleep() { :; }
+ongrid_wait_for_container_healthy ongrid-mysql 3 0 \
+    || fail "container recovery was rejected before the final healthy state"
+
+printf 'starting\nunhealthy\n' >"$health_statuses"
+if ongrid_wait_for_container_healthy ongrid-mysql 2 0 2>"$tmp_dir/health-error.log"; then
+    fail "container health wait accepted a permanently unhealthy container"
+fi
+grep -Fq 'last status: unhealthy' "$tmp_dir/health-error.log" \
+    || fail "container health timeout did not report the final state"
+
 grep -Fq -- '--repair-permissions' "$upgrade_script" \
     || fail "upgrade.sh does not expose the explicit repair flag"
 grep -Fq 'REPAIR_PERMISSIONS=$(ongrid_normalize_boolean "$REPAIR_PERMISSIONS_RAW")' "$upgrade_script" \
@@ -255,6 +275,10 @@ grep -Fq 'docker compose --env-file .env up -d --force-recreate ongrid nginx' "$
     || fail "manual Edge rollback does not recreate containers with Edge bind mounts"
 grep -Fq 'trap - ERR' "$upgrade_script" \
     || fail "upgrade.sh health failure can trigger a partial automatic Edge-only rollback"
+grep -Fq 'docker compose --env-file .env up -d mysql' "$upgrade_script" \
+    || fail "upgrade.sh does not start MySQL separately"
+grep -Fq 'ongrid_wait_for_container_healthy ongrid-mysql 150 2' "$upgrade_script" \
+    || fail "upgrade.sh does not wait for MySQL recovery"
 grep -Fq 'for d in /tmp/ongrid-v*-linux /tmp/ongrid-v*-linux-*; do' "$upgrade_script" \
     || fail "upgrade.sh does not prune both universal and legacy extracted release directories"
 grep -Fq '"$INSTALL_DIR"/ongrid-v*-linux.tar.xz' "$upgrade_script" \


### PR DESCRIPTION
## Summary

- start MySQL separately during Compose upgrades
- wait up to five minutes for MySQL to recover and become healthy before starting dependent services
- cover transient recovery and permanent unhealthy states with the existing upgrade helper test

## Testing

- `make test-release-package`
- `bash -n deploy/install/data-permissions.sh deploy/install/upgrade.sh scripts/test-upgrade-data-permissions.sh`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
