### PR TITLE
feat(observability): configure built-in storage limits

### DIFF
--- a/api/manager/setting/v1/setting.proto
+++ b/api/manager/setting/v1/setting.proto
@@ -6,6 +6,11 @@ option go_package = "github.com/ongridio/ongrid/api/gen/manager/setting/v1;setti
 
 // SettingService 管理管理员可编辑的运行时配置。
 service SettingService {
+    // ApplyBuiltInObservabilityLimits saves storage limits and recreates only
+    // the selected built-in Compose service in explicitly enabled test setups.
+    // HTTP implementation:
+    // POST /api/v1/system-settings/observability/{service}/apply.
+    rpc ApplyBuiltInObservabilityLimits(ApplyBuiltInObservabilityLimitsRequest) returns (ApplyBuiltInObservabilityLimitsResponse);
     // ValidateLLMConfiguration 使用未落库的草稿配置发起最小模型请求，
     // 返回可机器识别的失败原因。HTTP 实现：
     // POST /api/v1/integrations/llm/test。
@@ -14,6 +19,17 @@ service SettingService {
     // 全部通过后原子保存；空 api_key 表示显式禁用该提供商。
     // HTTP 实现：POST /api/v1/integrations/llm/validate-and-save。
     rpc ValidateAndSaveLLMConfiguration(ValidateAndSaveLLMConfigurationRequest) returns (ValidateAndSaveLLMConfigurationResponse);
+}
+
+message ApplyBuiltInObservabilityLimitsRequest {
+    // service is one of prometheus, loki, or tempo.
+    string service = 1 [json_name = "service"];
+    // values accepts only the documented retention keys for service.
+    map<string, string> values = 2 [json_name = "values"];
+}
+
+message ApplyBuiltInObservabilityLimitsResponse {
+    string status = 1 [json_name = "status"];
 }
 
 message ValidateLLMConfigurationRequest {

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -515,7 +515,7 @@ func main() {
 	// take effect on the edge's next reload (push or 60s safety-net poll).
 	lokiResolver := managerbizsetting.NewLokiResolver(settingSvc, cfg.Logs.URL)
 	tempoResolver := managerbizsetting.NewTempoResolver(settingSvc, cfg.Traces.URL)
-	settingHandler := managerserversetting.NewHandler(settingSvc)
+	settingHandler := managerserversetting.NewHandler(settingSvc, managerbizsetting.NewObservabilityApplierFromEnv(settingSvc, log))
 
 	// Grafana integration biz layer (PR-2). Wraps the pkg/grafana HTTP
 	// client and reads creds from system_settings on every Test/Sync call.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -43,3 +43,15 @@ ONGRID_EMBEDDING_MODEL=bge-small-zh-v1.5
 ONGRID_EMBEDDING_DIM=512
 ONGRID_EMBEDDING_API_KEY=
 ONGRID_EMBEDDING_BASE_URL=
+
+# --- Embedded observability retention (test environments can lower these) ---
+ONGRID_PROM_RETENTION_TIME=2160h
+ONGRID_PROM_RETENTION_SIZE=20GB
+ONGRID_LOKI_RETENTION_PERIOD=720h
+ONGRID_TEMPO_BLOCK_RETENTION=168h
+
+# Test-only direct apply. Enable only when Manager runs on the Compose host.
+# ONGRID_OBSERVABILITY_COMPOSE_DIR=/absolute/path/to/ongrid
+# ONGRID_OBSERVABILITY_ENV_FILE=/absolute/path/to/ongrid/deploy/.env
+# ONGRID_OBSERVABILITY_COMPOSE_FILES=deploy/docker-compose.yml
+# ONGRID_OBSERVABILITY_COMPOSE_PROJECT=ongrid

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -238,8 +238,8 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=90d
-      - --storage.tsdb.retention.size=20GB
+      - --storage.tsdb.retention.time=${ONGRID_PROM_RETENTION_TIME:-2160h}
+      - --storage.tsdb.retention.size=${ONGRID_PROM_RETENTION_SIZE:-20GB}
       - --web.enable-remote-write-receiver
       - --web.enable-lifecycle
       - --web.external-url=/prometheus/
@@ -266,8 +266,11 @@ services:
     image: docker.cnb.cool/ongridio/ongrid/loki:3.4.0
     container_name: ongrid-loki
     restart: unless-stopped
+    environment:
+      LOKI_RETENTION_PERIOD: ${ONGRID_LOKI_RETENTION_PERIOD:-720h}
     command:
       - -config.file=/etc/loki/local-config.yaml
+      - -config.expand-env=true
     volumes:
       - loki_data:/loki
       - ./install/loki-config.yaml:/etc/loki/local-config.yaml:ro
@@ -282,8 +285,11 @@ services:
     image: docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
     container_name: ongrid-tempo
     restart: unless-stopped
+    environment:
+      TEMPO_BLOCK_RETENTION: ${ONGRID_TEMPO_BLOCK_RETENTION:-168h}
     command:
       - -config.file=/etc/tempo/tempo.yaml
+      - -config.expand-env=true
     volumes:
       - tempo_data:/var/tempo
       - ./install/tempo-config.yaml:/etc/tempo/tempo.yaml:ro

--- a/deploy/install/.env.example
+++ b/deploy/install/.env.example
@@ -128,6 +128,12 @@ ONGRID_EMBEDDING_DIM=512
 ONGRID_HTTP_ADDR=:8080
 ONGRID_METRICS_ADDR=:9100
 
+# Embedded observability retention defaults consumed by docker compose.
+ONGRID_PROM_RETENTION_TIME=2160h
+ONGRID_PROM_RETENTION_SIZE=20GB
+ONGRID_LOKI_RETENTION_PERIOD=720h
+ONGRID_TEMPO_BLOCK_RETENTION=168h
+
 # --- Frontier broker (upstream singchia/frontier; ADR-007) ---
 # Manager dials the broker's service-bound port over the docker compose
 # network. Container-internal only; never published to host. The broker's

--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -379,7 +379,7 @@ ADR-009 之后 Prometheus 升级为**核心服务**。默认随 `install.sh` / `
 1. **被动接收 manager remote_write**：edge 通过 `push_prom_samples` 把开集 series 推到 manager，manager 自动加 `edge_id` + `ongrid_source` label 后转发到 prometheus 的 remote_write 接收口（CLI flag `--web.enable-remote-write-receiver` 已开）。
 2. **服务 AI agent 的 `query_promql` 工具**：aiops tool registry 在 `cfg.Prom.Enabled=true` 时注册该工具，让 LLM 通过 `/api/v1/query_range` 跑任意 PromQL（30s 超时硬约束）。
 
-数据保留：默认 90 天 / 20GB cap，由 docker-compose 中的 `--storage.tsdb.retention.time=90d` 和 `--storage.tsdb.retention.size=20GB` flag 控制。要调整，编辑 `/opt/ongrid/docker-compose.yml` 后 `docker compose up -d` 重起 prometheus 服务。
+数据保留：Prometheus 默认 90 天 / 20GB，Loki 默认 30 天，Tempo 默认 7 天。在显式启用受控 Compose applicator 的测试环境中，可在「设置 → 集成」展开对应组件的「高级配置：内置存储限制」，点击一次「保存并应用」；接口只允许更新这四个保留参数并重建选中的内置组件，不接受任意命令。启用时需给宿主机上的 Manager 设置 `ONGRID_OBSERVABILITY_COMPOSE_DIR`、`ONGRID_OBSERVABILITY_ENV_FILE`、`ONGRID_OBSERVABILITY_COMPOSE_FILES`（逗号分隔）以及可选的 `ONGRID_OBSERVABILITY_COMPOSE_PROJECT`。默认生产部署不授予 Manager Docker 控制权，仍由运维侧管理 `/opt/ongrid/.env` 中的 `ONGRID_PROM_RETENTION_TIME`、`ONGRID_PROM_RETENTION_SIZE`、`ONGRID_LOKI_RETENTION_PERIOD`、`ONGRID_TEMPO_BLOCK_RETENTION`。这些限制不影响外部数据源。
 
 **关闭** AI PromQL 链路（保留容器但 manager 不转发）：
 

--- a/deploy/install/docker-compose.yml
+++ b/deploy/install/docker-compose.yml
@@ -340,7 +340,7 @@ services:
   # Receives remote_write pushes from the manager (open-set edge samples
   # via push_prom_samples) and serves PromQL to the aiops query_promql
   # tool. Not published to host — manager reaches it on the docker network
-  # at http://prometheus:9090/prometheus. Retention: 90d / 20GB cap.
+  # at http://prometheus:9090/prometheus. Retention defaults: 90d / 20GB cap.
   prometheus:
     image: docker.cnb.cool/ongridio/ongrid/prometheus:v2.54.0
     container_name: ongrid-prometheus
@@ -348,8 +348,8 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=90d
-      - --storage.tsdb.retention.size=20GB
+      - --storage.tsdb.retention.time=${ONGRID_PROM_RETENTION_TIME:-2160h}
+      - --storage.tsdb.retention.size=${ONGRID_PROM_RETENTION_SIZE:-20GB}
       - --web.enable-remote-write-receiver
       - --web.enable-lifecycle
       - --web.external-url=/prometheus/
@@ -387,8 +387,11 @@ services:
     image: docker.cnb.cool/ongridio/ongrid/loki:3.4.0
     container_name: ongrid-loki
     restart: unless-stopped
+    environment:
+      LOKI_RETENTION_PERIOD: ${ONGRID_LOKI_RETENTION_PERIOD:-720h}
     command:
       - -config.file=/etc/loki/local-config.yaml
+      - -config.expand-env=true
     volumes:
       # Loki TSDB / chunks on host. Loki runs as uid 10001; chowned by
       # install.sh. For production externalisation, point ONGRID_LOG_URL
@@ -409,8 +412,11 @@ services:
     image: docker.cnb.cool/ongridio/ongrid/tempo:2.10.0
     container_name: ongrid-tempo
     restart: unless-stopped
+    environment:
+      TEMPO_BLOCK_RETENTION: ${ONGRID_TEMPO_BLOCK_RETENTION:-168h}
     command:
       - -config.file=/etc/tempo/tempo.yaml
+      - -config.expand-env=true
     volumes:
       # Tempo blocks on host. Tempo runs as uid 10001 (same as Loki);
       # chowned by install.sh. For production externalisation, point

--- a/deploy/install/loki-config.yaml
+++ b/deploy/install/loki-config.yaml
@@ -49,14 +49,14 @@ limits_config:
             - node
             - filename
             - unit
-  retention_period: 720h            # 30 天
+  retention_period: "${LOKI_RETENTION_PERIOD:-720h}"
   max_global_streams_per_user: 10000  # cardinality 守门 (ADR-012 §决策第 10 条)
   ingestion_rate_mb: 8
   ingestion_burst_size_mb: 16
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   max_query_series: 10000
-  max_query_lookback: 720h
+  max_query_lookback: "${LOKI_RETENTION_PERIOD:-720h}"
 
 compactor:
   working_directory: /loki/compactor

--- a/deploy/install/tempo-config.yaml
+++ b/deploy/install/tempo-config.yaml
@@ -22,7 +22,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 168h            # 7 days (ADR-013 §决策第 4 条)
+    block_retention: "${TEMPO_BLOCK_RETENTION:-168h}"
     compacted_block_retention: 1h
     compaction_window: 1h
     max_block_bytes: 100_000_000     # ~100 MB blocks

--- a/internal/manager/biz/setting/observability_apply.go
+++ b/internal/manager/biz/setting/observability_apply.go
@@ -1,0 +1,245 @@
+package setting
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	settingmodel "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/runner"
+)
+
+// observabilityApplyConfig enables the deliberately opt-in Compose applicator.
+// It is intended for test installations where the manager runs on the Compose
+// host; normal deployments keep it disabled and never grant Docker access.
+type observabilityApplyConfig struct {
+	Workdir      string
+	EnvFile      string
+	ComposeFiles []string
+	Project      string
+}
+
+type ObservabilityApplier struct {
+	settings *Service
+	cfg      observabilityApplyConfig
+	runner   runner.Runner
+	log      *slog.Logger
+	applying atomic.Bool
+}
+
+func NewObservabilityApplierFromEnv(settings *Service, log *slog.Logger) *ObservabilityApplier {
+	var files []string
+	for _, file := range strings.Split(os.Getenv("ONGRID_OBSERVABILITY_COMPOSE_FILES"), ",") {
+		if file = strings.TrimSpace(file); file != "" {
+			files = append(files, file)
+		}
+	}
+	return newObservabilityApplier(settings, observabilityApplyConfig{
+		Workdir:      strings.TrimSpace(os.Getenv("ONGRID_OBSERVABILITY_COMPOSE_DIR")),
+		EnvFile:      strings.TrimSpace(os.Getenv("ONGRID_OBSERVABILITY_ENV_FILE")),
+		ComposeFiles: files,
+		Project:      strings.TrimSpace(os.Getenv("ONGRID_OBSERVABILITY_COMPOSE_PROJECT")),
+	}, runner.NewShellRunner(), log)
+}
+
+func newObservabilityApplier(settings *Service, cfg observabilityApplyConfig, commandRunner runner.Runner, log *slog.Logger) *ObservabilityApplier {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ObservabilityApplier{settings: settings, cfg: cfg, runner: commandRunner, log: log.With(slog.String("component", "observability-apply"))}
+}
+
+func (a *ObservabilityApplier) Enabled() bool {
+	return a != nil && a.settings != nil && a.runner != nil && a.cfg.Workdir != "" && a.cfg.EnvFile != "" && len(a.cfg.ComposeFiles) > 0
+}
+
+func (a *ObservabilityApplier) SaveAndApply(ctx context.Context, service string, values map[string]string) (err error) {
+	if !a.Enabled() {
+		return fmt.Errorf("%w: direct observability apply is disabled", errs.ErrNotWiredYet)
+	}
+	envValues, err := observabilityEnvValues(service, values)
+	if err != nil {
+		return err
+	}
+	// ponytail: process-local gating fits single-Manager test stacks; use a
+	// file lock only if multi-process host-side apply is ever supported.
+	if !a.applying.CompareAndSwap(false, true) {
+		return fmt.Errorf("%w: another observability apply is in progress", errs.ErrConflict)
+	}
+	defer func() {
+		a.applying.Store(false)
+		if err != nil {
+			a.log.Error("apply built-in observability storage limits", slog.String("service", service), slog.Any("err", err))
+		}
+	}()
+
+	settings := make([]settingmodel.Setting, 0, len(values))
+	for key, value := range values {
+		settings = append(settings, settingmodel.Setting{
+			Category: settingmodel.CategoryObservability,
+			Key:      key,
+			Value:    value,
+		})
+	}
+	if err := a.settings.SetBatch(ctx, settings); err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(a.cfg.EnvFile)
+	if err != nil {
+		return fmt.Errorf("read observability env file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: observability env file must be a regular file", errs.ErrInvalid)
+	}
+	before, err := os.ReadFile(a.cfg.EnvFile)
+	if err != nil {
+		return fmt.Errorf("read observability env file: %w", err)
+	}
+	if err := writeFileAtomic(a.cfg.EnvFile, updateEnv(before, envValues), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("update observability env file: %w", err)
+	}
+
+	applyErr := a.runCompose(ctx, service)
+	if applyErr == nil {
+		a.log.Info("built-in observability storage limits applied", slog.String("service", service))
+		return nil
+	}
+
+	restoreErr := writeFileAtomic(a.cfg.EnvFile, before, info.Mode().Perm())
+	if restoreErr != nil {
+		return errors.Join(applyErr, fmt.Errorf("restore observability env file: %w", restoreErr))
+	}
+	if rollbackErr := a.runCompose(context.WithoutCancel(ctx), service); rollbackErr != nil {
+		return errors.Join(applyErr, fmt.Errorf("restore built-in %s: %w", service, rollbackErr))
+	}
+	return applyErr
+}
+
+func (a *ObservabilityApplier) runCompose(ctx context.Context, service string) error {
+	args := []string{"docker", "compose", "--env-file", a.cfg.EnvFile}
+	if a.cfg.Project != "" {
+		args = append(args, "-p", a.cfg.Project)
+	}
+	for _, file := range a.cfg.ComposeFiles {
+		args = append(args, "-f", file)
+	}
+	args = append(args, "up", "-d", "--no-deps", "--force-recreate", service)
+	env := map[string]string{"PATH": os.Getenv("PATH")}
+	if home, err := os.UserHomeDir(); err == nil {
+		env["HOME"] = home
+	}
+	for _, key := range []string{"DOCKER_CONFIG", "DOCKER_CONTEXT", "DOCKER_HOST"} {
+		if value := os.Getenv(key); value != "" {
+			env[key] = value
+		}
+	}
+	result, err := a.runner.Run(ctx, runner.Spec{
+		Argv:           args,
+		Env:            env,
+		Workdir:        a.cfg.Workdir,
+		Timeout:        2 * time.Minute,
+		MaxOutputBytes: 32 << 10,
+	})
+	if err != nil {
+		return fmt.Errorf("apply built-in %s limits: %w", service, err)
+	}
+	if result.ExitCode != 0 {
+		message := strings.TrimSpace(result.Stderr)
+		if message == "" {
+			message = strings.TrimSpace(result.Stdout)
+		}
+		return fmt.Errorf("apply built-in %s limits: docker compose exited %d: %s", service, result.ExitCode, message)
+	}
+	return nil
+}
+
+func observabilityEnvValues(service string, values map[string]string) (map[string]string, error) {
+	keys := map[string]map[string]string{
+		"prometheus": {
+			settingmodel.KeyPrometheusRetentionTime: "ONGRID_PROM_RETENTION_TIME",
+			settingmodel.KeyPrometheusRetentionSize: "ONGRID_PROM_RETENTION_SIZE",
+		},
+		"loki": {
+			settingmodel.KeyLokiRetentionPeriod: "ONGRID_LOKI_RETENTION_PERIOD",
+		},
+		"tempo": {
+			settingmodel.KeyTempoBlockRetention: "ONGRID_TEMPO_BLOCK_RETENTION",
+		},
+	}
+	allowed, ok := keys[service]
+	if !ok {
+		return nil, fmt.Errorf("%w: unsupported observability service %q", errs.ErrInvalid, service)
+	}
+	if len(values) != len(allowed) {
+		return nil, fmt.Errorf("%w: incomplete observability settings for %s", errs.ErrInvalid, service)
+	}
+	out := make(map[string]string, len(allowed))
+	for key, envKey := range allowed {
+		value, ok := values[key]
+		if !ok {
+			return nil, fmt.Errorf("%w: missing observability setting %q", errs.ErrInvalid, key)
+		}
+		out[envKey] = value
+	}
+	return out, nil
+}
+
+func updateEnv(before []byte, values map[string]string) []byte {
+	lines := strings.Split(strings.TrimSuffix(string(before), "\n"), "\n")
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	filtered := lines[:0]
+	for _, line := range lines {
+		key, _, found := strings.Cut(line, "=")
+		if found {
+			if _, replaced := values[key]; replaced {
+				continue
+			}
+		}
+		filtered = append(filtered, line)
+	}
+	for len(filtered) > 0 && filtered[len(filtered)-1] == "" {
+		filtered = filtered[:len(filtered)-1]
+	}
+	for _, key := range keys {
+		filtered = append(filtered, key+"="+values[key])
+	}
+	return []byte(strings.Join(filtered, "\n") + "\n")
+}
+
+func writeFileAtomic(path string, content []byte, mode os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".observability-env-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/manager/biz/setting/observability_apply_test.go
+++ b/internal/manager/biz/setting/observability_apply_test.go
@@ -1,0 +1,107 @@
+package setting
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	settingmodel "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/runner"
+)
+
+type recordingRunner struct {
+	spec runner.Spec
+}
+
+func (r *recordingRunner) Isolation() runner.Isolation { return runner.IsolationNone }
+func (r *recordingRunner) Run(_ context.Context, spec runner.Spec) (runner.Result, error) {
+	r.spec = spec
+	return runner.Result{}, nil
+}
+
+func TestObservabilityApplierUpdatesOnlyAllowedEnvAndRunsFixedCompose(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("KEEP=yes\nONGRID_PROM_RETENTION_TIME=2160h\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	commandRunner := &recordingRunner{}
+	applier := newObservabilityApplier(New(newFakeRepo(), nil), observabilityApplyConfig{
+		Workdir: dir, EnvFile: envFile, ComposeFiles: []string{"compose.yml"}, Project: "test",
+	}, commandRunner, nil)
+	err := applier.SaveAndApply(context.Background(), "prometheus", map[string]string{
+		settingmodel.KeyPrometheusRetentionTime: "120h",
+		settingmodel.KeyPrometheusRetentionSize: "2GB",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "KEEP=yes\nONGRID_PROM_RETENTION_SIZE=2GB\nONGRID_PROM_RETENTION_TIME=120h\n"
+	if string(got) != want {
+		t.Fatalf("env = %q, want %q", got, want)
+	}
+	wantArgv := []string{"docker", "compose", "--env-file", envFile, "-p", "test", "-f", "compose.yml", "up", "-d", "--no-deps", "--force-recreate", "prometheus"}
+	if !reflect.DeepEqual(commandRunner.spec.Argv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", commandRunner.spec.Argv, wantArgv)
+	}
+}
+
+type blockingRunner struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingRunner) Isolation() runner.Isolation { return runner.IsolationNone }
+func (r *blockingRunner) Run(ctx context.Context, _ runner.Spec) (runner.Result, error) {
+	close(r.started)
+	select {
+	case <-r.release:
+		return runner.Result{}, nil
+	case <-ctx.Done():
+		return runner.Result{}, ctx.Err()
+	}
+}
+
+func TestObservabilityApplierRejectsConcurrentSaveBeforePersistence(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("KEEP=yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repo := newFakeRepo()
+	commandRunner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+	applier := newObservabilityApplier(New(repo, nil), observabilityApplyConfig{
+		Workdir: dir, EnvFile: envFile, ComposeFiles: []string{"compose.yml"},
+	}, commandRunner, nil)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- applier.SaveAndApply(context.Background(), "loki", map[string]string{
+			settingmodel.KeyLokiRetentionPeriod: "720h",
+		})
+	}()
+	<-commandRunner.started
+
+	err := applier.SaveAndApply(context.Background(), "loki", map[string]string{
+		settingmodel.KeyLokiRetentionPeriod: "48h",
+	})
+	if !errors.Is(err, errs.ErrConflict) {
+		t.Fatalf("concurrent SaveAndApply() error = %v, want errs.ErrConflict", err)
+	}
+	if value, found, err := applier.settings.Get(context.Background(), settingmodel.CategoryObservability, settingmodel.KeyLokiRetentionPeriod); err != nil || !found || value != "720h" {
+		t.Fatalf("persisted value = %q, found=%v, err=%v", value, found, err)
+	}
+
+	close(commandRunner.release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/manager/biz/setting/service.go
+++ b/internal/manager/biz/setting/service.go
@@ -111,10 +111,8 @@ func (s *Service) Set(ctx context.Context, category, key, value string, sensitiv
 	if category == "" || key == "" {
 		return fmt.Errorf("%w: category/key required", errs.ErrInvalid)
 	}
-	if category == model.CategoryAgent {
-		if err := validateAgentSetting(key, value); err != nil {
-			return err
-		}
+	if err := validateSetting(category, key, value); err != nil {
+		return err
 	}
 	if _, err := s.repo.Set(ctx, category, key, value, sensitive); err != nil {
 		return err
@@ -142,10 +140,8 @@ func (s *Service) SetBatch(ctx context.Context, settings []model.Setting) error 
 		if settings[i].Category == "" || settings[i].Key == "" {
 			return fmt.Errorf("%w: category/key required", errs.ErrInvalid)
 		}
-		if settings[i].Category == model.CategoryAgent {
-			if err := validateAgentSetting(settings[i].Key, settings[i].Value); err != nil {
-				return err
-			}
+		if err := validateSetting(settings[i].Category, settings[i].Key, settings[i].Value); err != nil {
+			return err
 		}
 	}
 	if err := s.repo.SetBatch(ctx, settings); err != nil {
@@ -161,6 +157,39 @@ func (s *Service) SetBatch(ctx context.Context, settings []model.Setting) error 
 		slog.Int("count", len(settings)),
 		slog.String("category", settings[0].Category),
 	)
+	return nil
+}
+
+func validateSetting(category, key, value string) error {
+	switch category {
+	case model.CategoryAgent:
+		return validateAgentSetting(key, value)
+	case model.CategoryObservability:
+		return validateObservabilitySetting(key, value)
+	default:
+		return nil
+	}
+}
+
+func validateObservabilitySetting(key, value string) error {
+	switch key {
+	case model.KeyPrometheusRetentionTime, model.KeyLokiRetentionPeriod, model.KeyTempoBlockRetention:
+		return validateBoundedUnit(key, value, "h", 24, 24*3650)
+	case model.KeyPrometheusRetentionSize:
+		return validateBoundedUnit(key, value, "GB", 1, 10240)
+	default:
+		return fmt.Errorf("%w: unsupported observability setting %q", errs.ErrInvalid, key)
+	}
+}
+
+func validateBoundedUnit(key, value, unit string, min, max int) error {
+	if !strings.HasSuffix(value, unit) {
+		return fmt.Errorf("%w: %s must use %s", errs.ErrInvalid, key, unit)
+	}
+	n, err := strconv.Atoi(strings.TrimSuffix(value, unit))
+	if err != nil || n < min || n > max {
+		return fmt.Errorf("%w: %s must be between %d%s and %d%s", errs.ErrInvalid, key, min, unit, max, unit)
+	}
 	return nil
 }
 

--- a/internal/manager/biz/setting/service_test.go
+++ b/internal/manager/biz/setting/service_test.go
@@ -215,6 +215,38 @@ func TestServiceSetBatchValidatesAgentLLMTimeout(t *testing.T) {
 	}
 }
 
+func TestServiceSetValidatesObservabilityLimits(t *testing.T) {
+	svc := New(newFakeRepo(), nil)
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		valid bool
+	}{
+		{name: "minimum duration", key: model.KeyLokiRetentionPeriod, value: "24h", valid: true},
+		{name: "maximum duration", key: model.KeyTempoBlockRetention, value: "87600h", valid: true},
+		{name: "duration too short", key: model.KeyPrometheusRetentionTime, value: "23h"},
+		{name: "duration wrong unit", key: model.KeyLokiRetentionPeriod, value: "7d"},
+		{name: "duration with whitespace", key: model.KeyLokiRetentionPeriod, value: " 24h"},
+		{name: "minimum size", key: model.KeyPrometheusRetentionSize, value: "1GB", valid: true},
+		{name: "size too large", key: model.KeyPrometheusRetentionSize, value: "10241GB"},
+		{name: "size wrong unit", key: model.KeyPrometheusRetentionSize, value: "1GiB"},
+		{name: "unknown key", key: "mysql_retention", value: "24h"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := svc.Set(ctx, model.CategoryObservability, test.key, test.value, false)
+			if test.valid && err != nil {
+				t.Fatalf("Set() error = %v", err)
+			}
+			if !test.valid && !errors.Is(err, errs.ErrInvalid) {
+				t.Fatalf("Set() error = %v, want errs.ErrInvalid", err)
+			}
+		})
+	}
+}
+
 func TestAgentOutputLocale(t *testing.T) {
 	ctx := context.Background()
 	svc := New(newFakeRepo(), nil)

--- a/internal/manager/model/setting/model.go
+++ b/internal/manager/model/setting/model.go
@@ -45,6 +45,18 @@ const (
 	CategoryPlatform  = "platform"  // platform-wide infrastructure behaviour toggles
 )
 
+const CategoryObservability = "observability"
+
+// Well-known keys under CategoryObservability. The integration cards persist
+// these values before an explicitly enabled test-environment applicator updates
+// the matching ONGRID_* variables and recreates the selected built-in service.
+const (
+	KeyPrometheusRetentionTime = "prometheus_retention_time"
+	KeyPrometheusRetentionSize = "prometheus_retention_size"
+	KeyLokiRetentionPeriod     = "loki_retention_period"
+	KeyTempoBlockRetention     = "tempo_block_retention"
+)
+
 // Well-known keys under CategoryPlatform.
 const (
 	// KeyNetworkDiscoveryEnabled controls whether the manager accepts passive

--- a/internal/manager/server/setting/http.go
+++ b/internal/manager/server/setting/http.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -19,6 +20,7 @@ import (
 	bizaudit "github.com/ongridio/ongrid/internal/manager/biz/audit"
 	bizsetting "github.com/ongridio/ongrid/internal/manager/biz/setting"
 	auditmodel "github.com/ongridio/ongrid/internal/manager/model/audit"
+	settingmodel "github.com/ongridio/ongrid/internal/manager/model/setting"
 	auditmw "github.com/ongridio/ongrid/internal/manager/server/middleware"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
@@ -34,11 +36,14 @@ type SettingService interface {
 }
 
 type Handler struct {
-	svc SettingService
+	svc     SettingService
+	applier *bizsetting.ObservabilityApplier
 }
 
 // NewHandler builds a handler serving the /v1/system-settings surface.
-func NewHandler(svc SettingService) *Handler { return &Handler{svc: svc} }
+func NewHandler(svc SettingService, applier *bizsetting.ObservabilityApplier) *Handler {
+	return &Handler{svc: svc, applier: applier}
+}
 
 // Register attaches the routes under a chi.Router that already has the
 // auth middleware in front of it (see cmd/ongrid).
@@ -47,6 +52,61 @@ func (h *Handler) Register(r chi.Router) {
 	r.Put("/v1/system-settings/{category}/{key}", h.put)
 	r.Delete("/v1/system-settings/{category}/{key}", h.delete)
 	r.Get("/v1/system-settings/{category}/{key}/reveal", h.reveal)
+	r.Post("/v1/system-settings/observability/{service}/apply", h.applyObservability)
+}
+
+type applyObservabilityReq struct {
+	Values map[string]string `json:"values"`
+}
+
+// @Summary Save and apply built-in observability storage limits
+// @Tags settings
+// @Accept json
+// @Produce json
+// @Param service path string true "Built-in service: prometheus, loki, or tempo"
+// @Param body body applyObservabilityReq true "Storage limits"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} errorBody
+// @Failure 401 {object} errorBody
+// @Failure 403 {object} errorBody
+// @Failure 409 {object} errorBody
+// @Failure 500 {object} errorBody
+// @Failure 501 {object} errorBody
+// @Router /api/v1/system-settings/observability/{service}/apply [post]
+func (h *Handler) applyObservability(w http.ResponseWriter, r *http.Request) {
+	if _, ok := requireAdmin(w, r); !ok {
+		return
+	}
+	if h.applier == nil || !h.applier.Enabled() {
+		writeErr(w, fmt.Errorf("%w: direct apply is not enabled for this deployment", errs.ErrNotWiredYet))
+		return
+	}
+	service := chi.URLParam(r, "service")
+	var req applyObservabilityReq
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	auditmw.SetAuditEvent(r, bizaudit.Event{
+		Action:       auditmodel.ActionSettingUpdate,
+		ResourceType: auditmodel.ResourceSetting,
+		ResourceID:   settingmodel.CategoryObservability + "/" + service,
+		Payload:      map[string]any{"category": settingmodel.CategoryObservability, "service": service},
+	})
+	if err := h.applier.SaveAndApply(r.Context(), service, req.Values); err != nil {
+		if errors.Is(err, errs.ErrInvalid) || errors.Is(err, errs.ErrConflict) || errors.Is(err, errs.ErrNotWiredYet) {
+			writeErr(w, err)
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, errorBody{
+			Error: "could not save and apply the built-in component limits",
+			Code:  "apply-failed",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "applied"})
 }
 
 type listResp struct {
@@ -259,6 +319,10 @@ func errCode(err error) int {
 		return http.StatusNotFound
 	case errors.Is(err, errs.ErrInvalid):
 		return http.StatusBadRequest
+	case errors.Is(err, errs.ErrConflict):
+		return http.StatusConflict
+	case errors.Is(err, errs.ErrNotWiredYet):
+		return http.StatusNotImplemented
 	default:
 		return http.StatusInternalServerError
 	}
@@ -274,6 +338,10 @@ func errSlug(err error) string {
 		return "not-found"
 	case errors.Is(err, errs.ErrInvalid):
 		return "invalid-argument"
+	case errors.Is(err, errs.ErrConflict):
+		return "conflict"
+	case errors.Is(err, errs.ErrNotWiredYet):
+		return "not-wired"
 	default:
 		return "internal"
 	}

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -111,6 +111,8 @@ for arch in amd64 arm64; do
     "$package_root/pcap-parser-auth.sh" \
     "$package_root/docker-compose.yml" \
     "$package_root/prometheus.yml" \
+    "$package_root/loki-config.yaml" \
+    "$package_root/tempo-config.yaml" \
     "$package_root/edge/fetch-edge-assets.sh" \
     "$package_root/edge/verify-edge-deps-archive.sh" \
     "$package_root/edge/edge-assets-lib.sh" \
@@ -124,6 +126,18 @@ for arch in amd64 arm64; do
   tar -xf "$archive" -C "$extract_dir"
   grep -Fqx 'vtest' "$extract_dir/$package_root/VERSION"
   grep -Fqx 'ONGRID_VERSION=vtest' "$extract_dir/$package_root/.env.example"
+  grep -Fqx 'ONGRID_PROM_RETENTION_TIME=2160h' "$extract_dir/$package_root/.env.example"
+  grep -Fqx 'ONGRID_PROM_RETENTION_SIZE=20GB' "$extract_dir/$package_root/.env.example"
+  grep -Fqx 'ONGRID_LOKI_RETENTION_PERIOD=720h' "$extract_dir/$package_root/.env.example"
+  grep -Fqx 'ONGRID_TEMPO_BLOCK_RETENTION=168h' "$extract_dir/$package_root/.env.example"
+  grep -Fq -- '--storage.tsdb.retention.time=${ONGRID_PROM_RETENTION_TIME:-2160h}' \
+    "$extract_dir/$package_root/docker-compose.yml"
+  grep -Fq -- '--storage.tsdb.retention.size=${ONGRID_PROM_RETENTION_SIZE:-20GB}' \
+    "$extract_dir/$package_root/docker-compose.yml"
+  grep -Fq 'retention_period: "${LOKI_RETENTION_PERIOD:-720h}"' \
+    "$extract_dir/$package_root/loki-config.yaml"
+  grep -Fq 'block_retention: "${TEMPO_BLOCK_RETENTION:-168h}"' \
+    "$extract_dir/$package_root/tempo-config.yaml"
   grep -Fxq 'ONGRID_EDGE_DEPS_TAG=edge-deps-test' \
     "$extract_dir/$package_root/edge/edge-artifacts.env"
   grep -Fxq 'ONGRID_EDGE_TARGETS=linux-amd64 linux-arm64' \

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -43,6 +43,17 @@ export function deleteSetting(category: string, key: string): Promise<void> {
   );
 }
 
+export function applyObservabilityLimits(
+  service: 'prometheus' | 'loki' | 'tempo',
+  values: Record<string, string>,
+): Promise<{ status: string }> {
+  return request<{ status: string }>(
+    'POST',
+    `/system-settings/observability/${service}/apply`,
+    { values },
+  );
+}
+
 // revealSetting returns the cleartext value for a sensitive row. Admin-only.
 // The UI uses this to populate sensitive inputs as ●●●●●● by default
 // while still allowing an eye-toggle reveal of the actual chars.

--- a/web/src/pages/settings/Advanced.test.tsx
+++ b/web/src/pages/settings/Advanced.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BuiltInStorageAdvanced from './Advanced';
+import { applyObservabilityLimits, listSettings } from '@/api/settings';
+
+vi.mock('@/api/settings', () => ({
+  listSettings: vi.fn(),
+  applyObservabilityLimits: vi.fn(async () => ({ status: 'applied' })),
+}));
+
+describe('BuiltInStorageAdvanced', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    vi.mocked(listSettings).mockResolvedValue({
+      items: [
+        { category: 'observability', key: 'prometheus_retention_time', value: '168h', sensitive: false, updated_at: '' },
+        { category: 'observability', key: 'prometheus_retention_size', value: '2GB', sensitive: false, updated_at: '' },
+      ],
+      total: 2,
+    });
+  });
+
+  it('keeps Prometheus limits collapsed, scoped to built-in, and saves its fields only', async () => {
+    render(<BuiltInStorageAdvanced service="prometheus" />);
+    expect(screen.queryByLabelText('Prometheus 保留天数')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '高级配置：内置存储限制' }));
+    const retention = await screen.findByLabelText('Prometheus 保留天数');
+    expect(retention).toHaveValue(7);
+    expect(screen.getByText('仅对 Ongrid 内置 Prometheus 生效。')).toBeVisible();
+
+    fireEvent.change(retention, { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存并应用' }));
+
+    await waitFor(() => expect(applyObservabilityLimits).toHaveBeenCalledTimes(1));
+    expect(applyObservabilityLimits).toHaveBeenCalledWith('prometheus', {
+      prometheus_retention_time: '120h',
+      prometheus_retention_size: '2GB',
+    });
+    expect(screen.getByText('已保存并应用到内置 Prometheus。')).toBeVisible();
+  });
+});

--- a/web/src/pages/settings/Advanced.tsx
+++ b/web/src/pages/settings/Advanced.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import { Check, ChevronDown, ChevronRight, Loader2, Save } from 'lucide-react';
+import { applyObservabilityLimits, listSettings } from '@/api/settings';
+import { Button } from '@/components/ui';
+import { useI18n } from '@/i18n/locale';
+
+const CATEGORY = 'observability';
+const MAX_RETENTION_DAYS = 3650;
+const MAX_PROMETHEUS_SIZE_GB = 10240;
+
+const CONFIG = {
+  prometheus: {
+    title: 'Prometheus',
+    externalZh: '外部 Prometheus / VictoriaMetrics / Mimir / Cortex / Thanos',
+    externalEn: 'External Prometheus / VictoriaMetrics / Mimir / Cortex / Thanos backends',
+    fields: [
+      { key: 'prometheus_retention_time', kind: 'days', labelZh: '保留天数', labelEn: 'Retention days', defaultValue: '90', max: MAX_RETENTION_DAYS },
+      { key: 'prometheus_retention_size', kind: 'gb', labelZh: '最大数据量', labelEn: 'Maximum data', defaultValue: '20', max: MAX_PROMETHEUS_SIZE_GB },
+    ],
+  },
+  loki: {
+    title: 'Loki',
+    externalZh: '外部 Loki / VictoriaLogs',
+    externalEn: 'External Loki / VictoriaLogs backends',
+    fields: [
+      { key: 'loki_retention_period', kind: 'days', labelZh: '保留天数', labelEn: 'Retention days', defaultValue: '30', max: MAX_RETENTION_DAYS },
+    ],
+  },
+  tempo: {
+    title: 'Tempo',
+    externalZh: '外部 Tempo / VictoriaTraces',
+    externalEn: 'External Tempo / VictoriaTraces backends',
+    fields: [
+      { key: 'tempo_block_retention', kind: 'days', labelZh: '保留天数', labelEn: 'Retention days', defaultValue: '7', max: MAX_RETENTION_DAYS },
+    ],
+  },
+} as const;
+
+type Service = keyof typeof CONFIG;
+type Field = (typeof CONFIG)[Service]['fields'][number];
+type Form = Record<string, string>;
+
+export default function BuiltInStorageAdvanced({ service }: { service: Service }) {
+  const { tr } = useI18n();
+  const config = CONFIG[service];
+  const defaults = Object.fromEntries(config.fields.map((field) => [field.key, field.defaultValue]));
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [draft, setDraft] = useState<Form>(defaults);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    if (loading || loaded) return;
+    setLoading(true);
+    try {
+      const response = await listSettings(CATEGORY);
+      const values = new Map(response.items.map((item) => [item.key, item.value]));
+      const next = Object.fromEntries(config.fields.map((field) => [
+        field.key,
+        displayValue(field, values.get(field.key)) ?? field.defaultValue,
+      ]));
+      setDraft(next);
+      setLoaded(true);
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next) void load();
+  };
+  const validationError = validate(config.fields, draft, tr);
+  const save = async () => {
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await applyObservabilityLimits(service, Object.fromEntries(config.fields.map((field) => [
+        field.key,
+        persistedValue(field, draft[field.key]),
+      ])));
+      setSaved(true);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-5 border-t border-zinc-800 pt-4">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={toggle}
+        className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-300"
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <span>{tr('高级配置：内置存储限制', 'Advanced: built-in storage limits')}</span>
+      </button>
+
+      {open && (
+        <div className="mt-3 border-l border-zinc-800 pl-4">
+          <p className="mb-4 text-[11px] leading-relaxed text-zinc-500">
+            <b className="font-medium text-amber-400">{tr(`仅对 Ongrid 内置 ${config.title} 生效。`, `Only affects Ongrid's built-in ${config.title}.`)}</b>{' '}
+            {tr(`${config.externalZh} 不受这里的配置影响。`, `${config.externalEn} are unaffected.`)}
+          </p>
+
+          {loading || (!loaded && !error) ? (
+            <div className="flex h-16 items-center text-xs text-zinc-500">
+              <Loader2 size={13} className="mr-2 animate-spin" /> {tr('加载中…', 'Loading…')}
+            </div>
+          ) : loaded ? (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {config.fields.map((field) => (
+                <NumberField
+                  key={field.key}
+                  label={tr(field.labelZh, field.labelEn)}
+                  ariaLabel={`${config.title} ${tr(field.labelZh, field.labelEn)}`}
+                  value={draft[field.key]}
+                  max={field.max}
+                  suffix={field.kind === 'days' ? tr('天', 'days') : 'GB'}
+                  onChange={(value) => {
+                    setDraft((current) => ({ ...current, [field.key]: value }));
+                    setSaved(false);
+                    setError(null);
+                  }}
+                />
+              ))}
+            </div>
+          ) : null}
+
+          {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+          {saved && <p className="mt-3 text-xs text-emerald-400">{tr(`已保存并应用到内置 ${config.title}。`, `Saved and applied to the built-in ${config.title}.`)}</p>}
+
+          {loaded && (
+            <div className="mt-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <Button variant="primary" disabled={saving || Boolean(validationError)} onClick={() => void save()}>
+                  {saving ? <Loader2 size={13} className="animate-spin" /> : saved ? <Check size={13} /> : <Save size={13} />}
+                  {saving ? tr('应用中…', 'Applying…') : saved ? tr('已应用', 'Applied') : tr('保存并应用', 'Save and apply')}
+                </Button>
+              </div>
+
+              <p className="mt-3 text-[11px] leading-relaxed text-zinc-500">
+                {tr(
+                  `应用时会短暂重建内置 ${config.title} 容器，已持久化的数据不会被清空。`,
+                  `Applying briefly recreates the built-in ${config.title} container without clearing persisted data.`,
+                )}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  ariaLabel,
+  value,
+  max,
+  suffix,
+  onChange,
+}: {
+  label: string;
+  ariaLabel: string;
+  value: string;
+  max: number;
+  suffix: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block text-xs text-zinc-400">
+      <span className="mb-1.5 block">{label}</span>
+      <div className="flex items-center rounded-md border border-zinc-700 bg-zinc-950 focus-within:border-indigo-500/70">
+        <input
+          type="number"
+          aria-label={ariaLabel}
+          min={1}
+          max={max}
+          step={1}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-zinc-100 outline-none"
+        />
+        <span className="border-l border-zinc-800 px-3 text-[11px] text-zinc-500">{suffix}</span>
+      </div>
+    </label>
+  );
+}
+
+function validate(fields: readonly Field[], form: Form, tr: (zh: string, en: string) => string): string | null {
+  for (const field of fields) {
+    const value = Number(form[field.key]);
+    if (!Number.isInteger(value) || value < 1 || value > field.max) {
+      return field.kind === 'days'
+        ? tr(`保留天数必须是 1 到 ${field.max} 的整数。`, `Retention days must be a whole number from 1 to ${field.max}.`)
+        : tr(`容量必须是 1 到 ${field.max} GB 的整数。`, `Size must be a whole number from 1 to ${field.max} GB.`);
+    }
+  }
+  return null;
+}
+
+function displayValue(field: Field, value: string | undefined): string | null {
+  if (!value) return null;
+  const unit = field.kind === 'days' ? 'h' : 'GB';
+  if (!value.endsWith(unit)) return null;
+  const parsed = Number(value.slice(0, -unit.length));
+  if (!Number.isInteger(parsed) || parsed < 1) return null;
+  return field.kind === 'days' && parsed % 24 === 0 ? String(parsed / 24) : field.kind === 'gb' ? String(parsed) : null;
+}
+
+function persistedValue(field: Field, value: string): string {
+  return field.kind === 'days' ? `${Number(value) * 24}h` : `${Number(value)}GB`;
+}

--- a/web/src/pages/settings/Integrations.test.tsx
+++ b/web/src/pages/settings/Integrations.test.tsx
@@ -101,6 +101,28 @@ describe('SettingsIntegrations log backend presentation', () => {
     vi.restoreAllMocks();
   });
 
+  it('places built-in storage limits under each integration advanced section', async () => {
+    vi.mocked(getLogBackend).mockResolvedValue(backend('unselected', 'loki'));
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <SettingsIntegrations />
+      </MemoryRouter>,
+    );
+
+    const prometheus = (await screen.findByRole('heading', { name: 'Prometheus 集成' })).closest('section');
+    const loki = await screen.findByRole('region', { name: 'Loki 日志后端配置' });
+    const tempo = (await screen.findByRole('heading', { name: 'Tempo 集成（链路）' })).closest('section');
+    expect(prometheus).not.toBeNull();
+    expect(tempo).not.toBeNull();
+    expect(within(prometheus!).getByRole('button', { name: '高级配置：内置存储限制' })).toBeVisible();
+    expect(within(loki).getByRole('button', { name: '高级配置：内置存储限制' })).toBeVisible();
+    expect(within(tempo!).getByRole('button', { name: '高级配置：内置存储限制' })).toBeVisible();
+
+    fireEvent.click(within(prometheus!).getByRole('button', { name: '高级配置：内置存储限制' }));
+    expect(await within(prometheus!).findByText('仅对 Ongrid 内置 Prometheus 生效。')).toBeVisible();
+  });
+
   it('selects Loki immediately and leaves device verification to the separate action', async () => {
     let currentBackend = backend('selected');
     const activeLoki = {

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -58,6 +58,7 @@ import { ApiError } from '@/api/client';
 import { Button, Card } from '@/components/ui';
 import { cn } from '@/lib/cn';
 import { useI18n } from '@/i18n/locale';
+import BuiltInStorageAdvanced from './Advanced';
 
 // Settings → 集成. Four cards, all backend-driven, parallel naming:
 //   - Prometheus 集成   → system_settings.prom; manager reads on every
@@ -318,6 +319,7 @@ function PrometheusCard() {
         {err && <span className="text-xs text-red-400">{err}</span>}
       </div>
       <PromProbeLine probe={probe} />
+      <BuiltInStorageAdvanced service="prometheus" />
     </Card>
   );
 }
@@ -1564,6 +1566,7 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
       {switchMessage && <p className="mt-3 text-xs text-emerald-400">✓ {switchMessage}</p>}
       <ConnectionCheckProgress value={connectionCheck} error={connectionCheckError} />
       <ProbeLine probe={probe} okLabel={tr('✓ Loki 可达，/ready 返回成功', '✓ Loki reachable, /ready returned success')} />
+      <BuiltInStorageAdvanced service="loki" />
     </section>
   );
 }
@@ -1758,6 +1761,7 @@ function TempoCard() {
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
       </div>
       <ProbeLine probe={probe} okLabel={tr('✓ Tempo 连接测试成功', '✓ Tempo connection test succeeded')} />
+      <BuiltInStorageAdvanced service="tempo" />
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

- add per-integration advanced controls for built-in Prometheus, Loki, and Tempo retention limits
- save and directly apply validated limits through an opt-in, test-environment Compose applicator with atomic env updates and rollback
- wire Compose retention defaults, document the test-only applicator, and cover backend, UI, and release-package behavior

## Validation

- `go test -race ./...`
- `go vet ./...`
- `make build-ongrid`
- `npm test -- --run src/pages/settings/Advanced.test.tsx src/pages/settings/Integrations.test.tsx`
- `npm run typecheck`
- targeted ESLint and `npm run build`
- proto descriptor compilation and `scripts/test-compose-release-package.sh`
- local end-to-end apply verified for Prometheus, Loki, and Tempo; Prometheus reports 80d / 18GiB after the latest update

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
