### PR TITLE
fix(ui): normalize K8s label casing

### DIFF
--- a/web/src/pages/Edges.test.tsx
+++ b/web/src/pages/Edges.test.tsx
@@ -198,7 +198,7 @@ describe("EdgesPage", () => {
     const k8sRow = k8sNameCells[0].closest("tr");
     expect(k8sRow).not.toBeNull();
     expect(
-      within(k8sRow as HTMLTableRowElement).getByText("K8S"),
+      within(k8sRow as HTMLTableRowElement).getByText("K8s"),
     ).toBeInTheDocument();
     const clusterLink = within(k8sRow as HTMLTableRowElement).getByRole(
       "link",

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -1505,7 +1505,7 @@ function EdgeAccessMeta({
   return (
     <div className="flex min-w-0 shrink-0 items-center gap-1">
       <EdgeAccessPill kind={attachments.length > 0 ? "k8s" : "host"}>
-        {attachments.length > 0 ? "K8S" : "Host"}
+        {attachments.length > 0 ? "K8s" : "Host"}
       </EdgeAccessPill>
       {clusters.map((item) => (
         <ClusterChipLink

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -295,7 +295,7 @@ describe('KubernetesPage', () => {
     expect(screen.getByText('online')).toBeInTheDocument();
     expect(screen.getByText('Controller 运行中')).toBeInTheDocument();
     expect(screen.getByText('ongrid-k8s-control-plane')).toBeInTheDocument();
-    expect(screen.getByText('K8S 版本')).toBeInTheDocument();
+    expect(screen.getByText('K8s 版本')).toBeInTheDocument();
     expect(screen.getByText('v1.30.0')).toBeInTheDocument();
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
     expect(screen.getByText('1 个待接入')).toBeInTheDocument();
@@ -839,7 +839,7 @@ describe('KubernetesPage', () => {
     });
   });
 
-  it('K8S 指标使用 Grafana 11 Explore 深链打开 Prometheus 查询', async () => {
+  it('K8s 指标使用 Grafana 11 Explore 深链打开 Prometheus 查询', async () => {
     let launchPayload: { expr?: string } | null = null;
     const replace = vi.fn();
     const open = vi.spyOn(window, 'open').mockReturnValue({
@@ -1840,7 +1840,7 @@ describe('KubernetesPage', () => {
     expect(screen.getByTestId('initial-prompt')).toHaveTextContent('回滚方案');
   });
 
-  it('渲染当前集群的 K8S 写动作审计记录', async () => {
+  it('渲染当前集群的 K8s 写动作审计记录', async () => {
     renderKubernetesDetail('/kubernetes/1?tab=actions');
 
     expect(await screen.findByText('写动作')).toBeInTheDocument();
@@ -1854,7 +1854,7 @@ describe('KubernetesPage', () => {
     expect(screen.getAllByText('restart rollout').length).toBeGreaterThan(0);
     expect(screen.getAllByText('delete pod').length).toBeGreaterThan(0);
     expect(screen.queryByText('apply patch')).not.toBeInTheDocument();
-    expect(await screen.findByText('K8S 写动作审计')).toBeInTheDocument();
+    expect(await screen.findByText('K8s 写动作审计')).toBeInTheDocument();
     expect(screen.getByText('rollout_restart · default · Deployment/api')).toBeInTheDocument();
     expect(screen.getAllByText('已执行').length).toBeGreaterThan(0);
     expect(screen.getAllByText('请求已记录').length).toBeGreaterThan(0);

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -177,7 +177,7 @@ export default function KubernetesPage() {
               <thead className="border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
                 <tr>
                   <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('集群', 'Cluster')}</th>
-                  <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('K8S 版本', 'K8S version')}</th>
+                  <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('K8s 版本', 'K8s version')}</th>
                   <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('模式', 'Mode')}</th>
                   <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('状态', 'Status')}</th>
                   <th className="whitespace-nowrap px-4 py-2.5 text-left">{tr('节点接入', 'Node access')}</th>
@@ -1945,7 +1945,7 @@ function K8sTelemetryDrilldowns({
       <div className="divide-y divide-zinc-800/60">
         <TelemetryLinkCell
           icon={BarChart3}
-          title={tr('K8S 指标', 'K8S metrics')}
+          title={tr('K8s 指标', 'K8s metrics')}
           source="Prometheus"
           statusLabel={clusterID ? tr('查询已就绪', 'query ready') : tr('等待 cluster_id', 'waiting for cluster_id')}
           statusTone={clusterID ? 'info' : 'default'}
@@ -1956,7 +1956,7 @@ function K8sTelemetryDrilldowns({
         />
         <TelemetryLinkCell
           icon={FileText}
-          title={tr('K8S 日志', 'K8S logs')}
+          title={tr('K8s 日志', 'K8s logs')}
           source="Loki"
           statusLabel={clusterID ? tr('查询已就绪', 'query ready') : tr('等待 cluster_id', 'waiting for cluster_id')}
           statusTone={clusterID ? 'info' : 'default'}
@@ -1967,7 +1967,7 @@ function K8sTelemetryDrilldowns({
         />
         <TelemetryLinkCell
           icon={Waypoints}
-          title={tr('K8S 链路', 'K8S traces')}
+          title={tr('K8s 链路', 'K8s traces')}
           source="Tempo"
           statusLabel={clusterID ? tr('查询已就绪', 'query ready') : tr('等待 cluster_id', 'waiting for cluster_id')}
           statusTone={clusterID ? 'info' : 'default'}
@@ -2275,7 +2275,7 @@ function K8sActionAudit({
         <div className="flex min-w-0 items-center gap-2">
           <ShieldCheck size={15} className="text-zinc-400" />
           <div className="min-w-0">
-            <div className="text-sm font-medium text-zinc-100">{tr('K8S 写动作审计', 'K8S action audit')}</div>
+            <div className="text-sm font-medium text-zinc-100">{tr('K8s 写动作审计', 'K8s action audit')}</div>
             <div className="mt-0.5 text-xs text-zinc-500">
               {loading && !hasRows
                 ? tr('加载中…', 'Loading…')
@@ -2357,7 +2357,7 @@ function K8sActionAudit({
         ) : (
           <FilteredResourceEmptyState
             icon={ShieldCheck}
-            title={filtered ? tr('暂无匹配写动作审计记录', 'No matching action audit record') : tr('暂无当前集群的 K8S 写动作审批记录。', 'No K8S write-action approval records for this cluster.')}
+            title={filtered ? tr('暂无匹配写动作审计记录', 'No matching action audit record') : tr('暂无当前集群的 K8s 写动作审批记录。', 'No K8s write-action approval records for this cluster.')}
             filtered={filtered}
             hint={emptyHint}
             onClear={onClearFilters}

--- a/web/src/pages/PacketCaptures.tsx
+++ b/web/src/pages/PacketCaptures.tsx
@@ -107,7 +107,7 @@ export default function PacketCapturesPage() {
     <main className="anim-fade flex min-w-0 flex-1 flex-col overflow-hidden">
       <PageHeader
         title={tr('抓包', 'Packet captures')}
-        subtitle={tr('从在线主机 Edge 发起有边界的非 K8S 抓包任务，用于故障证据留存和后续产物解析。', 'Start bounded non-Kubernetes captures from online host edges for incident evidence and later artifact parsing.')}
+        subtitle={tr('从在线主机 Edge 发起有边界的非 K8s 抓包任务，用于故障证据留存和后续产物解析。', 'Start bounded non-Kubernetes captures from online host edges for incident evidence and later artifact parsing.')}
         actions={
           <>
             <Button onClick={() => void load()}>


### PR DESCRIPTION
## Summary

- normalize user-visible `K8S` labels to the standard `K8s` casing
- update matching UI assertions while leaving code identifiers unchanged

## Validation

- `npm test -- --run src/pages/Kubernetes.test.tsx src/pages/Edges.test.tsx`
- targeted ESLint
- `npm run typecheck`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
