### PR TITLE
fix(web): handle empty organization role update response

### DIFF
--- a/web/src/api/orgs.ts
+++ b/web/src/api/orgs.ts
@@ -84,8 +84,10 @@ export function setOrgMemberRole(
   orgId: number,
   userId: number,
   role: OrgRole
-): Promise<OrgMember> {
-  return request<OrgMember>('PATCH', `/orgs/${orgId}/members/${userId}`, { role });
+): Promise<void> {
+  // The manager intentionally returns 204 after a successful role update;
+  // there is no response body to decode into an OrgMember.
+  return request<void>('PATCH', `/orgs/${orgId}/members/${userId}`, { role });
 }
 
 export function removeOrgMember(orgId: number, userId: number): Promise<void> {

--- a/web/src/pages/settings/Orgs.test.tsx
+++ b/web/src/pages/settings/Orgs.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import SettingsOrgs from './Orgs';
+import { server } from '@/test/msw-server';
+
+describe('SettingsOrgs', () => {
+  beforeEach(() => {
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    server.use(
+      http.get('/api/v1/orgs', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 1,
+              name: '默认组织',
+              description: '',
+              parent_id: null,
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+          total: 1,
+        }),
+      ),
+      http.get('/api/v1/orgs/1/members', () =>
+        HttpResponse.json({
+          items: [
+            {
+              user_id: 2,
+              email: 'ws@example.com',
+              display_name: 'ws',
+              role: 'member',
+            },
+          ],
+          total: 1,
+        }),
+      ),
+      // The real handler returns 204 with no response body.
+      http.patch('/api/v1/orgs/1/members/2', () => new HttpResponse(null, { status: 204 })),
+    );
+  });
+
+  it('keeps the member row rendered when role update returns 204', async () => {
+    render(<SettingsOrgs />);
+
+    const roleSelect = await screen.findByRole('combobox');
+    await userEvent.selectOptions(roleSelect, 'viewer');
+
+    expect(screen.getByDisplayValue('只读')).toBeInTheDocument();
+    expect(screen.getByText('ws@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('ws@example.com');
+  });
+});

--- a/web/src/pages/settings/Orgs.tsx
+++ b/web/src/pages/settings/Orgs.tsx
@@ -249,8 +249,10 @@ export default function SettingsOrgs() {
   const changeRole = async (m: OrgMember, role: OrgRole) => {
     if (selectedId == null || m.role === role) return;
     try {
-      const next = await setOrgMemberRole(selectedId, m.user_id, role);
-      setMembers((cur) => cur.map((x) => (x.user_id === m.user_id ? next : x)));
+      await setOrgMemberRole(selectedId, m.user_id, role);
+      // PATCH returns 204, so retain the row's identity/email fields and
+      // update only the role after the server confirms the mutation.
+      setMembers((cur) => cur.map((x) => (x.user_id === m.user_id ? { ...x, role } : x)));
       setToast({ kind: 'ok', text: `${m.email} → ${ROLE_LABEL[role]}` });
     } catch (e) {
       setToast({ kind: 'err', text: errMsg(e) });


### PR DESCRIPTION
## Summary

Fix the blank settings page that occurs after changing an organization member role. The manager endpoint returns `204 No Content`; the frontend now keeps the existing member row and updates only its role.

## Root Cause

`setOrgMemberRole` was typed as returning an `OrgMember`. The empty 204 response decoded to `null`, and the page replaced the member row with that value before rendering `m.role`.

## Changes

- Treat the role update API as `Promise<void>`.
- Preserve member identity and contact fields after a successful role update.
- Add a regression test covering the 204 response.

## Validation

- `npm test -- --run src/pages/settings/Orgs.test.tsx`
- `npm run build`
- `git diff --check`

## Screenshots

### Before: role selector interaction

![Role selector before the fix](https://github.com/user-attachments/assets/ebaad4c9-baf3-4337-bb2d-75febbc3adba)

### After: blank page reproduced

![Blank page after the role update](https://github.com/user-attachments/assets/efd25c96-74e6-4ab8-99c1-96fa7f3fe4a5)

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

Fixes #350