### PR TITLE
fix(k8s): make node metrics listener configurable

### DIFF
--- a/cmd/ongrid-edge/k8s_data_plane.go
+++ b/cmd/ongrid-edge/k8s_data_plane.go
@@ -148,7 +148,7 @@ func runDataPlaneDiagnostics(ctx context.Context, registry *prometheus.Registry,
 			log.Debug("write data-plane readiness response", slog.Any("err", err))
 		}
 	})
-	addr := envOr("ONGRID_EDGE_METRICS_ADDR", edgeMetricsAddr)
+	addr := edgeMetricsListenAddr()
 	return httpserver.New(addr, router, log.With(slog.String("listener", "data-plane-diagnostics"))).Start(ctx)
 }
 

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -59,9 +59,13 @@ import (
 // version is overwritten at build time via -ldflags.
 var version = "dev"
 
-// edgeMetricsAddr is the local debug /metrics port for edge. Kept separate
-// from cloud metrics (:9100) so both can run on the same dev host.
+// edgeMetricsAddr is the default local debug /metrics listener for edge. Kept
+// separate from cloud metrics (:9100) so both can run on the same dev host.
 const edgeMetricsAddr = ":9101"
+
+func edgeMetricsListenAddr() string {
+	return envOr("ONGRID_EDGE_METRICS_ADDR", edgeMetricsAddr)
+}
 
 func main() {
 	if handled, err := runK8sHostCommand(context.Background(), os.Args[1:]); handled {
@@ -285,7 +289,7 @@ func main() {
 	metricsMux.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})
-	metricsServer := httpserver.New(edgeMetricsAddr, metricsMux, log.With(slog.String("listener", "metrics")))
+	metricsServer := httpserver.New(edgeMetricsListenAddr(), metricsMux, log.With(slog.String("listener", "metrics")))
 
 	eg.Go(func() error { return metricsServer.Start(egCtx) })
 	// When agent.Run returns (clean ctx cancel OR upgrade

--- a/cmd/ongrid-edge/metrics_addr_test.go
+++ b/cmd/ongrid-edge/metrics_addr_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestEdgeMetricsListenAddr_UsesDefaultAndEnvironmentOverride(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("ONGRID_EDGE_METRICS_ADDR", "")
+		if got := edgeMetricsListenAddr(); got != edgeMetricsAddr {
+			t.Fatalf("edgeMetricsListenAddr() = %q, want %q", got, edgeMetricsAddr)
+		}
+	})
+
+	t.Run("environment override", func(t *testing.T) {
+		t.Setenv("ONGRID_EDGE_METRICS_ADDR", ":19101")
+		if got := edgeMetricsListenAddr(); got != ":19101" {
+			t.Fatalf("edgeMetricsListenAddr() = %q, want %q", got, ":19101")
+		}
+	})
+}

--- a/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- $nodeConfigChecksum := printf "%s\n%s\n%s" .Values.mode .Values.manager.publicURL .Values.manager.tunnelAddr | sha256sum -}}
+{{- $nodeConfigChecksum := printf "%s\n%s\n%s\n%s" .Values.mode .Values.manager.publicURL .Values.manager.tunnelAddr .Values.node.metricsAddr | sha256sum -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -135,6 +135,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: ONGRID_EDGE_COLLECTOR_MODE
               value: {{ .Values.node.collectorMode | quote }}
+            - name: ONGRID_EDGE_METRICS_ADDR
+              value: {{ .Values.node.metricsAddr | quote }}
             - name: HOST_PROC
               value: /proc
             - name: HOST_SYS

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -20,6 +20,9 @@ image:
 
 node:
   serviceAccountName: ""
+  # The Node DaemonSet uses hostNetwork. Set a different listener when the
+  # host already has another ongrid-edge process using the default :9101.
+  metricsAddr: ":9101"
   # hostmetrics exposes node_exporter and the metrics plugin forwards it.
   # Keep the legacy embedded periodic push off to avoid duplicate node_* series.
   collectorMode: "off"

--- a/internal/manager/service/alert/service_test.go
+++ b/internal/manager/service/alert/service_test.go
@@ -395,9 +395,10 @@ func (f *fakeNotifier) Send(_ context.Context, msg notify.Message, channels ...s
 	return f.err
 }
 
+// These tests use the default HTTP client because BuildSenderFromChannel is
+// intentionally exercised as wired; httptest.Server.Close closes the shared
+// default transport, so running them in parallel can interrupt the other test.
 func TestServiceTestChannelHappyPath(t *testing.T) {
-	t.Parallel()
-
 	// TestChannel now builds a typed sender from the channel + POSTs directly
 	// (bypassing the global notify master switch), so point the endpoint at a
 	// real test server; a 200 means the delivery link works.
@@ -420,8 +421,6 @@ func TestServiceTestChannelHappyPath(t *testing.T) {
 }
 
 func TestServiceTestChannelReportsFailure(t *testing.T) {
-	t.Parallel()
-
 	// Real upstream failure (503) must surface as accepted=false with detail —
 	// not a silent no-op and not "channel not configured".
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -102,6 +102,7 @@ grep -q 'expirationSeconds: 3600' "$tmp_dir/default-node.yaml"
 grep -q 'defaultMode: 0444' "$tmp_dir/default-node.yaml"
 grep -A1 'name: ONGRID_EDGE_SECRET_DIR' "$tmp_dir/default-node.yaml" | grep -q 'value: /var/lib/ongrid-edge/k8s-state/secrets'
 grep -A1 'name: ONGRID_EDGE_COLLECTOR_MODE' "$tmp_dir/default.yaml" | grep -q 'value: "off"'
+grep -A1 'name: ONGRID_EDGE_METRICS_ADDR' "$tmp_dir/default-node.yaml" | grep -q 'value: ":9101"'
 grep -q 'add: \["CHOWN", "DAC_OVERRIDE", "FOWNER"\]' "$tmp_dir/default.yaml"
 grep -q 'add: \["DAC_READ_SEARCH", "NET_ADMIN", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"\]' "$tmp_dir/default.yaml"
 ! grep -q 'SYS_ADMIN\|SYS_PTRACE' "$tmp_dir/default.yaml"
@@ -190,6 +191,15 @@ extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir
 test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-controller.yaml")" = "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-controller.yaml")"
 test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-node.yaml")" = "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-node.yaml")"
 test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-scraper.yaml")" != "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/metrics-config-scraper.yaml")"
+
+# The node agent shares the host network, so operators must be able to move
+# its diagnostics listener away from an existing host-level edge agent.
+helm template node-metrics-address "$chart_package" "${common_args[@]}" \
+  --set-string node.metricsAddr=:19101 \
+  >"$tmp_dir/node-metrics-address.yaml"
+extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/node-metrics-address.yaml" "$tmp_dir/node-metrics-address-node.yaml"
+grep -A1 'name: ONGRID_EDGE_METRICS_ADDR' "$tmp_dir/node-metrics-address-node.yaml" | grep -q 'value: ":19101"'
+test "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/default-node.yaml")" != "$(awk '/checksum\/config:/ {print $2}' "$tmp_dir/node-metrics-address-node.yaml")"
 
 helm template upgrade "$chart_package" "${common_args[@]}" --is-upgrade >"$tmp_dir/upgrade.yaml"
 grep -q '# Source: ongrid-edge/templates/upgrade-preflight.yaml' "$tmp_dir/upgrade.yaml"


### PR DESCRIPTION
## Problem

The Kubernetes Node DaemonSet runs with `hostNetwork: true`, while the Edge diagnostics/metrics listener was hard-coded to `:9101`. If the target node already has a host-level `ongrid-edge` process or another exporter using that port, the Node Edge fails to start and enters `CrashLoopBackOff`.

Reproduced in production: the host-level Edge was already listening on `:9101`, preventing the Kubernetes Node Edge from starting.

Fixes #261

## Changes

- Added the `ONGRID_EDGE_METRICS_ADDR` environment variable. The default remains `:9101` for backward compatibility.
- Controller, standalone Edge, and Kubernetes data-plane diagnostics now use the same configurable address.
- Added the Helm value `node.metricsAddr` and injected it into the Node DaemonSet.
- Included the metrics address in the DaemonSet configuration checksum so changing the value triggers a rolling update.
- Added tests covering the default value, environment variable override, and checksum changes.

## Verification

- `git diff --check`
- `go test ./cmd/ongrid-edge`
- Full `make test-k8s-chart`
- Kubernetes verification: after setting `node.metricsAddr=:19101`, the Node reached `1/1 Running`; `:19101` and the existing `:9101` listener operated simultaneously.

The local environment did not have Go or Helm installed. Unit tests and chart validation were completed on the target server with Go 1.25 and Helm.

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md

## Port Configuration

The Node DaemonSet uses `hostNetwork: true` and listens on `:9101` by default. If another service is using that port on a node, specify an unused port:

```bash
--set-string node.metricsAddr=:19101
```

The value can also be set in `values.yaml`:

```yaml
node:
  metricsAddr: ":19101"
```

The selected port must be available on the host of every Kubernetes node.