### PR TITLE
fix(kubernetes): keep resource views aligned with live state

### DIFF
--- a/internal/manager/biz/k8s/usecase.go
+++ b/internal/manager/biz/k8s/usecase.go
@@ -816,7 +816,7 @@ func (u *Usecase) ListPods(ctx context.Context, f ListPodsFilter) ([]*model.Pod,
 	if _, err := u.repo.GetCluster(ctx, f.ClusterID); err != nil {
 		return nil, err
 	}
-	return u.repo.ListPods(ctx, f)
+	return u.listCurrentPods(ctx, f)
 }
 
 func (u *Usecase) CountPods(ctx context.Context, f ListPodsFilter) (int64, error) {
@@ -829,7 +829,83 @@ func (u *Usecase) CountPods(ctx context.Context, f ListPodsFilter) (int64, error
 	if _, err := u.repo.GetCluster(ctx, f.ClusterID); err != nil {
 		return 0, err
 	}
-	return u.repo.CountPods(ctx, f)
+	f.Limit = 0
+	f.Offset = 0
+	items, err := u.listCurrentPods(ctx, f)
+	return int64(len(items)), err
+}
+
+func (u *Usecase) listCurrentPods(ctx context.Context, f ListPodsFilter) ([]*model.Pod, error) {
+	query := f
+	query.Limit = 0
+	query.Offset = 0
+	pods, err := u.repo.ListPods(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	workloads, err := u.repo.ListWorkloads(ctx, ListWorkloadsFilter{ClusterID: f.ClusterID})
+	if err != nil {
+		return nil, err
+	}
+	workloadsByKey := make(map[string]*model.Workload, len(workloads))
+	for _, workload := range workloads {
+		if workload != nil {
+			workloadsByKey[workloadResourceKey(workload.Kind, workload.Namespace, workload.Name)] = workload
+		}
+	}
+	current := make([]*model.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if currentPod(pod, workloadsByKey) && (!f.IssueOnly || actionablePodIssue(pod, workloadsByKey)) {
+			current = append(current, pod)
+		}
+	}
+	if f.Offset >= len(current) {
+		return []*model.Pod{}, nil
+	}
+	end := len(current)
+	if f.Limit > 0 && f.Offset+f.Limit < end {
+		end = f.Offset + f.Limit
+	}
+	return current[f.Offset:end], nil
+}
+
+func currentPod(pod *model.Pod, workloads map[string]*model.Workload) bool {
+	if pod == nil {
+		return false
+	}
+	owner := workloads[workloadResourceKey(pod.OwnerKind, pod.Namespace, pod.OwnerName)]
+	if owner == nil {
+		switch strings.ToLower(strings.TrimSpace(pod.OwnerKind)) {
+		case "deployment", "replicaset", "statefulset", "daemonset", "job", "cronjob":
+			return false
+		default:
+			return true
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(owner.Kind), "Job") {
+		return true
+	}
+	if owner.DesiredReplicas <= 0 {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(pod.Phase), "Failed") || owner.ReadyReplicas < owner.DesiredReplicas
+}
+
+func actionablePodIssue(pod *model.Pod, workloads map[string]*model.Workload) bool {
+	if pod == nil {
+		return false
+	}
+	owner := workloads[workloadResourceKey(pod.OwnerKind, pod.Namespace, pod.OwnerName)]
+	if owner == nil {
+		return true
+	}
+	if !strings.EqualFold(strings.TrimSpace(pod.Phase), "Failed") {
+		return owner.DesiredReplicas > 0 || strings.EqualFold(strings.TrimSpace(owner.Kind), "Job")
+	}
+	if strings.EqualFold(strings.TrimSpace(owner.Kind), "Job") {
+		return owner.IsTerminalFailure
+	}
+	return owner.DesiredReplicas > 0 && owner.ReadyReplicas < owner.DesiredReplicas
 }
 
 func (u *Usecase) ListEvents(ctx context.Context, f ListEventsFilter) ([]*model.Event, error) {
@@ -883,7 +959,7 @@ func (u *Usecase) listActionableWarningEvents(ctx context.Context, f ListEventsF
 	if err != nil {
 		return nil, err
 	}
-	pods, err := u.repo.ListPods(ctx, ListPodsFilter{ClusterID: f.ClusterID, IssueOnly: true})
+	pods, err := u.listCurrentPods(ctx, ListPodsFilter{ClusterID: f.ClusterID, IssueOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1033,24 +1109,23 @@ func (u *Usecase) GetClusterHealth(ctx context.Context, clusterID uint64) (Clust
 	if out.DegradedWorkloads, err = u.repo.CountWorkloads(ctx, ListWorkloadsFilter{ClusterID: clusterID, IssueOnly: true, GroupReplicaSets: true}); err != nil {
 		return out, err
 	}
-	if out.PendingPods, err = u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Phase: "Pending"}); err != nil {
-		return out, err
-	}
-	if out.CrashLoopBackOffPods, err = u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Reason: "CrashLoopBackOff"}); err != nil {
-		return out, err
-	}
-	if out.OOMKilledPods, err = u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Reason: "OOMKilled"}); err != nil {
-		return out, err
-	}
-	imagePullBackOff, err := u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Reason: "ImagePullBackOff"})
+	actionablePods, err := u.listCurrentPods(ctx, ListPodsFilter{ClusterID: clusterID, IssueOnly: true})
 	if err != nil {
 		return out, err
 	}
-	errImagePull, err := u.repo.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, Reason: "ErrImagePull"})
-	if err != nil {
-		return out, err
+	for _, pod := range actionablePods {
+		if pod.Phase == "Pending" {
+			out.PendingPods++
+		}
+		switch pod.Reason {
+		case "CrashLoopBackOff":
+			out.CrashLoopBackOffPods++
+		case "OOMKilled":
+			out.OOMKilledPods++
+		case "ImagePullBackOff", "ErrImagePull":
+			out.ImagePullBackOffPods++
+		}
 	}
-	out.ImagePullBackOffPods = imagePullBackOff + errImagePull
 	nodes, err := u.repo.ListNodes(ctx, clusterID)
 	if err != nil {
 		return out, err
@@ -1080,7 +1155,24 @@ func (u *Usecase) namespaceSummaries(ctx context.Context, clusterID uint64) ([]N
 		}
 		current.Namespace = namespace
 		summary := current
+		summary.Pods = 0
 		byNamespace[namespace] = &summary
+	}
+	pods, err := u.listCurrentPods(ctx, ListPodsFilter{ClusterID: clusterID})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods {
+		namespace := strings.TrimSpace(pod.Namespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		summary := byNamespace[namespace]
+		if summary == nil {
+			summary = &NamespaceSummary{Namespace: namespace}
+			byNamespace[namespace] = summary
+		}
+		summary.Pods++
 	}
 	warnings, err := u.listActionableWarningEvents(ctx, ListEventsFilter{ClusterID: clusterID})
 	if err != nil {
@@ -1106,7 +1198,11 @@ func (u *Usecase) namespaceSummaries(ctx context.Context, clusterID uint64) ([]N
 		}
 	}
 	summaries = summaries[:0]
-	for _, summary := range byNamespace {
+	for namespace, summary := range byNamespace {
+		if summary.Workloads == 0 && summary.Pods == 0 && summary.Events == 0 && summary.Warnings == 0 {
+			delete(byNamespace, namespace)
+			continue
+		}
 		summaries = append(summaries, *summary)
 	}
 	sort.Slice(summaries, func(i, j int) bool { return summaries[i].Namespace < summaries[j].Namespace })

--- a/internal/manager/biz/k8s/usecase_test.go
+++ b/internal/manager/biz/k8s/usecase_test.go
@@ -1059,6 +1059,56 @@ func TestUsecaseListWorkloadsAttachesDeploymentReplicaSetVersions(t *testing.T) 
 	}
 }
 
+func TestUsecasePodsExcludeRecoveredControllerHistory(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeRepo()
+	reg, err := NewUsecase(base, newFakeIssuer(), Config{}).CreateCluster(ctx, CreateClusterInput{Name: "prod"})
+	if err != nil {
+		t.Fatalf("CreateCluster() error = %v", err)
+	}
+	clusterID := reg.Cluster.ID
+	base.pods[podKey(clusterID, "apps", "api-old-evicted", "pod-old")] = &model.Pod{ClusterID: clusterID, Namespace: "apps", Name: "api-old-evicted", UID: "pod-old", Phase: "Failed", Reason: "Evicted", OwnerKind: "ReplicaSet", OwnerName: "api-old"}
+	base.pods[podKey(clusterID, "apps", "api-current-evicted", "pod-current")] = &model.Pod{ClusterID: clusterID, Namespace: "apps", Name: "api-current-evicted", UID: "pod-current", Phase: "Failed", Reason: "Evicted", OwnerKind: "ReplicaSet", OwnerName: "api-current"}
+	base.pods[podKey(clusterID, "apps", "standalone-failed", "pod-standalone")] = &model.Pod{ClusterID: clusterID, Namespace: "apps", Name: "standalone-failed", UID: "pod-standalone", Phase: "Failed", Reason: "Unknown"}
+	base.pods[podKey(clusterID, "apps", "deleted-job-complete", "pod-deleted-job")] = &model.Pod{ClusterID: clusterID, Namespace: "apps", Name: "deleted-job-complete", UID: "pod-deleted-job", Phase: "Succeeded", Reason: "Completed", OwnerKind: "Job", OwnerName: "deleted-job"}
+	base.events = []*model.Event{
+		{ClusterID: clusterID, UID: "old-event", Type: "Warning", InvolvedKind: "Pod", InvolvedNamespace: "apps", InvolvedName: "api-old-evicted", InvolvedUID: "pod-old"},
+		{ClusterID: clusterID, UID: "current-event", Type: "Warning", InvolvedKind: "Pod", InvolvedNamespace: "apps", InvolvedName: "api-current-evicted", InvolvedUID: "pod-current"},
+	}
+	repo := &groupingWorkloadRepo{
+		fakeRepo: base,
+		topLevel: []*model.Workload{
+			{ClusterID: clusterID, Namespace: "apps", Kind: "ReplicaSet", Name: "api-old", DesiredReplicas: 0, ReadyReplicas: 0},
+			{ClusterID: clusterID, Namespace: "apps", Kind: "ReplicaSet", Name: "api-current", DesiredReplicas: 1, ReadyReplicas: 0},
+		},
+	}
+	uc := NewUsecase(repo, newFakeIssuer(), Config{})
+
+	visible, err := uc.ListPods(ctx, ListPodsFilter{ClusterID: clusterID, Limit: 100})
+	if err != nil || len(visible) != 2 {
+		t.Fatalf("ListPods() = %+v, err = %v, want only current and standalone pods", visible, err)
+	}
+	visibleTotal, err := uc.CountPods(ctx, ListPodsFilter{ClusterID: clusterID})
+	if err != nil || visibleTotal != 2 {
+		t.Fatalf("CountPods() = %d, err = %v, want 2", visibleTotal, err)
+	}
+	pods, err := uc.ListPods(ctx, ListPodsFilter{ClusterID: clusterID, IssueOnly: true, Limit: 100})
+	if err != nil {
+		t.Fatalf("ListPods(issue) error = %v", err)
+	}
+	if len(pods) != 2 || pods[0].Name == "api-old-evicted" || pods[1].Name == "api-old-evicted" {
+		t.Fatalf("issue pods = %+v, want current and standalone failures", pods)
+	}
+	total, err := uc.CountPods(ctx, ListPodsFilter{ClusterID: clusterID, IssueOnly: true})
+	if err != nil || total != 2 {
+		t.Fatalf("CountPods(issue) = %d, err = %v, want 2", total, err)
+	}
+	events, err := uc.ListEvents(ctx, ListEventsFilter{ClusterID: clusterID, IssueOnly: true, Limit: 100})
+	if err != nil || len(events) != 1 || events[0].UID != "current-event" {
+		t.Fatalf("issue events = %+v, err = %v, want current-event", events, err)
+	}
+}
+
 func TestUsecaseInventoryReplacesSameNameNodeWithDifferentRealUID(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeRepo()

--- a/internal/manager/biz/topology/usecase.go
+++ b/internal/manager/biz/topology/usecase.go
@@ -128,7 +128,13 @@ func (u *Usecase) DeleteNode(ctx context.Context, id uint64) error {
 	if err != nil {
 		return err
 	}
+	if node.Type == string(model.NodeTypeDevice) {
+		return fmt.Errorf("%w: device topology nodes must be deleted from Devices", errs.ErrConflict)
+	}
 	if node.Type == string(model.NodeTypeCluster) {
+		if _, owned, _ := topologyKubernetesClusterProps(node.PropsJSON); owned {
+			return fmt.Errorf("%w: kubernetes-owned topology clusters must be deleted from Kubernetes", errs.ErrConflict)
+		}
 		for _, guard := range u.clusterDeleteGuards {
 			if err := guard.ValidateClusterDelete(ctx, id); err != nil {
 				return err

--- a/internal/manager/biz/topology/usecase_test.go
+++ b/internal/manager/biz/topology/usecase_test.go
@@ -205,6 +205,10 @@ func (g clusterDeleteGuardStub) ValidateClusterDelete(_ context.Context, cluster
 func TestDeleteClusterEnforcesRelationsAndDependentGuards(t *testing.T) {
 	uc := newUC(t)
 	ctx := context.Background()
+	managed, _ := uc.CreateNode(ctx, string(model.NodeTypeCluster), "k8s", `{"source":"kubernetes","k8s_cluster_id":48}`)
+	if err := uc.DeleteNode(ctx, managed.ID); !errors.Is(err, errs.ErrConflict) {
+		t.Fatalf("DeleteNode(kubernetes-owned) error = %v, want ErrConflict", err)
+	}
 	cluster, _ := uc.CreateNode(ctx, string(model.NodeTypeCluster), "bare-metal", `{"source":"manual"}`)
 	device, _ := uc.CreateNode(ctx, string(model.NodeTypeDevice), "host", "")
 	relation, err := uc.CreateRelation(ctx, device.ID, cluster.ID, model.RelMemberOf, `{"source":"manual"}`)
@@ -524,6 +528,9 @@ func TestDeleteNodeForDeviceRemovesRelationsAndNode(t *testing.T) {
 	dev, err := uc.CreateNode(ctx, string(model.NodeTypeDevice), "node-a", "")
 	if err != nil {
 		t.Fatalf("CreateNode(device) error = %v", err)
+	}
+	if err := uc.DeleteNode(ctx, dev.ID); !errors.Is(err, errs.ErrConflict) {
+		t.Fatalf("DeleteNode(device) error = %v, want ErrConflict", err)
 	}
 	svc, err := uc.CreateNode(ctx, string(model.NodeTypeService), "svc-a", "")
 	if err != nil {

--- a/web/src/pages/Kubernetes.test.tsx
+++ b/web/src/pages/Kubernetes.test.tsx
@@ -44,6 +44,11 @@ function ChatStateProbe() {
   return <div data-testid="initial-prompt">{state?.initialPrompt || ''}</div>;
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="current-location">{`${location.pathname}${location.search}`}</div>;
+}
+
 function renderKubernetesList() {
   return render(
     <MemoryRouter>
@@ -99,6 +104,13 @@ describe('KubernetesPage', () => {
           total: 2,
         }),
       ),
+      http.get('/api/v1/topology/nodes', () => HttpResponse.json({
+        items: [
+          { id: 1, type: 'cluster', name: 'kind-local', props: { source: 'kubernetes', k8s_cluster_id: 1 }, created_at: '', updated_at: '' },
+          { id: 95, type: 'cluster', name: 'vm-kubeadm-fresh-pull', props: { source: 'kubernetes', k8s_cluster_id: 48 }, created_at: '', updated_at: '' },
+        ],
+        total: 2,
+      })),
       http.get('/api/v1/k8s/clusters/:id', () => HttpResponse.json(cluster)),
       http.get('/api/v1/k8s/clusters/:id/health', () => HttpResponse.json({
         degraded_workloads: 0,
@@ -891,6 +903,46 @@ describe('KubernetesPage', () => {
     open.mockRestore();
   });
 
+  it('K8s 日志只进入平台日志中心', async () => {
+    render(
+      <MemoryRouter initialEntries={['/kubernetes/48']}>
+        <Routes>
+          <Route path="/kubernetes/:clusterId" element={<KubernetesClusterDetailPage />} />
+          <Route path="/logs" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const logsEntry = await screen.findByRole('group', { name: 'K8s 日志' });
+    expect(within(logsEntry).getByRole('button', { name: '查看日志' })).toBeInTheDocument();
+    expect(within(logsEntry).queryByRole('button', { name: '在 Grafana 中打开' })).not.toBeInTheDocument();
+
+    fireEvent.click(within(logsEntry).getByRole('button', { name: '查看日志' }));
+
+    expect(screen.getByTestId('current-location')).toHaveTextContent('/logs?cluster_id=95&range=1h');
+  });
+
+  it('Workload 资源日志进入平台日志中心并携带资源筛选', async () => {
+    render(
+      <MemoryRouter initialEntries={['/kubernetes/48?tab=workloads']}>
+        <Routes>
+          <Route path="/kubernetes/:clusterId" element={<KubernetesClusterDetailPage />} />
+          <Route path="/logs" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const workloadCells = await screen.findAllByText('ongrid-edge-controller');
+    const row = workloadCells.map((cell) => cell.closest('tr')).find(Boolean);
+    expect(row).toBeTruthy();
+    fireEvent.click(within(row as HTMLElement).getByRole('button', { name: '排障' }));
+    fireEvent.click(within(screen.getByRole('menu', { name: '资源排障' })).getByRole('button', { name: '日志' }));
+
+    expect(screen.getByTestId('current-location')).toHaveTextContent(
+      '/logs?cluster_id=95&range=1h&namespace=ongrid-system&workload=ongrid-edge-controller',
+    );
+  });
+
   it('集群详情提供 Helm 升级命令', async () => {
     renderKubernetesDetail('/kubernetes/1');
 
@@ -1373,11 +1425,12 @@ describe('KubernetesPage', () => {
     expect(row).not.toBeNull();
     fireEvent.click(within(row as HTMLElement).getByRole('button', { name: '排障' }));
 
-    expect(within(row as HTMLElement).getByRole('button', { name: '日志' })).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByRole('button', { name: 'describe' })).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByRole('button', { name: '链路' })).toBeInTheDocument();
+    const menu = screen.getByRole('menu', { name: '资源排障' });
+    expect(within(menu).getByRole('button', { name: '日志' })).toBeInTheDocument();
+    expect(within(menu).getByRole('button', { name: 'describe' })).toBeInTheDocument();
+    expect(within(menu).getByRole('button', { name: '链路' })).toBeInTheDocument();
 
-    fireEvent.click(within(row as HTMLElement).getByRole('button', { name: 'AI 分析' }));
+    fireEvent.click(within(menu).getByRole('button', { name: 'AI 分析' }));
 
     await waitFor(() => {
       expect(sessionPayload).toEqual({ title: 'analyze ongrid-edge-controller-abc', agent_id: 'default' });
@@ -1447,16 +1500,17 @@ describe('KubernetesPage', () => {
     expect(warningRow).not.toBeNull();
     fireEvent.click(within(warningRow as HTMLElement).getByRole('button', { name: '排障' }));
 
-    expect(within(warningRow as HTMLElement).getByRole('button', { name: '日志' })).toBeInTheDocument();
-    expect(within(warningRow as HTMLElement).getByRole('button', { name: 'describe' })).toBeInTheDocument();
-    expect(within(warningRow as HTMLElement).getByRole('button', { name: '链路' })).toBeInTheDocument();
+    const menu = screen.getByRole('menu', { name: '资源排障' });
+    expect(within(menu).getByRole('button', { name: '日志' })).toBeInTheDocument();
+    expect(within(menu).getByRole('button', { name: 'describe' })).toBeInTheDocument();
+    expect(within(menu).getByRole('button', { name: '链路' })).toBeInTheDocument();
 
     const normalObject = await screen.findByText('Pod/ongrid-edge-controller-abc');
     const normalRow = normalObject.closest('tr');
     expect(normalRow).not.toBeNull();
     expect(within(normalRow as HTMLElement).queryByRole('button', { name: '排障' })).not.toBeInTheDocument();
 
-    fireEvent.click(within(warningRow as HTMLElement).getByRole('button', { name: 'AI 分析' }));
+    fireEvent.click(within(menu).getByRole('button', { name: 'AI 分析' }));
 
     await waitFor(() => {
       expect(sessionPayload).toEqual({ title: 'analyze BackOff', agent_id: 'default' });
@@ -1746,11 +1800,14 @@ describe('KubernetesPage', () => {
     expect(row).toBeTruthy();
     fireEvent.click(within(row as HTMLElement).getByRole('button', { name: '排障' }));
 
-    expect(within(row as HTMLElement).getByRole('button', { name: '日志' })).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByRole('button', { name: 'describe' })).toBeInTheDocument();
-    expect(within(row as HTMLElement).queryByRole('button', { name: '链路' })).not.toBeInTheDocument();
+    const menu = screen.getByRole('menu', { name: '资源排障' });
+    expect(row).not.toContainElement(menu);
+    expect(menu).toHaveClass('fixed');
+    expect(within(menu).getByRole('button', { name: '日志' })).toBeInTheDocument();
+    expect(within(menu).getByRole('button', { name: 'describe' })).toBeInTheDocument();
+    expect(within(menu).queryByRole('button', { name: '链路' })).not.toBeInTheDocument();
 
-    fireEvent.click(within(row as HTMLElement).getByRole('button', { name: 'AI 分析' }));
+    fireEvent.click(within(menu).getByRole('button', { name: 'AI 分析' }));
 
     await waitFor(() => {
       expect(sessionPayload).toEqual({ title: 'analyze ongrid-k8s-control-plane', agent_id: 'default' });
@@ -1805,6 +1862,41 @@ describe('KubernetesPage', () => {
 
     expect(screen.getByRole('textbox', { name: '搜索资源' })).toHaveValue('');
     expect(screen.getByRole('button', { name: '只看异常' })).not.toHaveClass('border-amber-500/50');
+  });
+
+  it('异常线索只保留一个更多菜单并可点击外部关闭', async () => {
+    server.use(
+      http.get('/api/v1/k8s/clusters/:id/nodes', () => HttpResponse.json({
+        items: [{
+          id: 12,
+          cluster_id: 1,
+          node_name: 'worker-not-ready',
+          node_uid: 'node-not-ready',
+          edge_id: 6,
+          device_id: 18,
+          conditions: [{ type: 'Ready', status: 'False' }],
+          kubelet_version: 'v1.30.0',
+          last_seen_at: '2026-06-29T10:00:00Z',
+        }],
+        total: 1,
+      })),
+    );
+    renderKubernetesDetail('/kubernetes/1?tab=pods');
+
+    const moreButtons = await screen.findAllByText('更多');
+    expect(moreButtons.length).toBeGreaterThan(1);
+    const firstMenu = moreButtons[0].closest('details');
+    const secondMenu = moreButtons[1].closest('details');
+
+    fireEvent.click(moreButtons[0]);
+    expect(firstMenu).toHaveAttribute('open');
+
+    fireEvent.click(moreButtons[1]);
+    expect(firstMenu).not.toHaveAttribute('open');
+    expect(secondMenu).toHaveAttribute('open');
+
+    fireEvent.click(screen.getByText('异常线索'));
+    expect(secondMenu).not.toHaveAttribute('open');
   });
 
   it('异常线索内联展示并发起匹配的写动作建议', async () => {

--- a/web/src/pages/Kubernetes.tsx
+++ b/web/src/pages/Kubernetes.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   Activity,
@@ -61,6 +62,7 @@ import { formatNumber, fullDateTime, relativeTime } from '@/lib/format';
 import { usePoll } from '@/lib/usePoll';
 import { useObservability } from '@/store/observability';
 import { usePermissions } from '@/store/me';
+import { listNodes as listTopologyNodes } from '@/api/topology';
 import {
   POLL_INTERVAL_MS,
   RESOURCE_PAGE_SIZE,
@@ -333,6 +335,8 @@ export function KubernetesClusterDetailPage() {
   const navigate = useNavigate();
   const grafanaOrgId = useObservability((s) => s.grafanaOrgId);
   const { clusterId = '' } = useParams();
+  const routeClusterID = clusterId.trim();
+  const [logClusterID, setLogClusterID] = useState('');
   const [searchParams, setSearchParams] = useSearchParams();
   const rawActiveTab = normalizeTab(searchParams.get('tab'));
   const [cluster, setCluster] = useState<KubernetesCluster | null>(null);
@@ -376,6 +380,26 @@ export function KubernetesClusterDetailPage() {
   const [resourceFilterError, setResourceFilterError] = useState<string | null>(null);
   const [resourceFilterRetryNonce, setResourceFilterRetryNonce] = useState(0);
   const [resourceFilterRefreshNonce, setResourceFilterRefreshNonce] = useState(0);
+
+  useEffect(() => {
+    if (!routeClusterID) {
+      setLogClusterID('');
+      return;
+    }
+    let cancelled = false;
+    setLogClusterID('');
+    void listTopologyNodes({ type: 'cluster', limit: 500 }).then((result) => {
+      if (cancelled) return;
+      const match = (result.items ?? []).find((node) => (
+        node.props?.source === 'kubernetes'
+        && String(node.props.k8s_cluster_id ?? '') === routeClusterID
+      ));
+      setLogClusterID(match ? String(match.id) : routeClusterID);
+    }).catch(() => {
+      if (!cancelled) setLogClusterID(routeClusterID);
+    });
+    return () => { cancelled = true; };
+  }, [routeClusterID]);
 
   const refresh = useCallback(async (opts?: { silent?: boolean }) => {
     if (!clusterId) return;
@@ -748,35 +772,24 @@ export function KubernetesClusterDetailPage() {
     setResourceActionType('all');
     openResourceTab(tab, { scroll: true });
   }, [openResourceTab]);
-  const openResourceLogs = useCallback(async (issue: K8sTriageIssue) => {
-    if (!cluster?.id) return;
-    const query = issueLogsQuery(String(cluster.id), issue);
-    const base = await fetchGrafanaRootURL();
-    const now = Date.now();
-    await openObservabilityUrl(buildExploreUrl({
-      base,
-      dsType: 'loki',
-      dsUid: 'ongrid-loki',
-      query: { expr: query, queryType: 'range' },
-      fromMs: now - 60 * 60 * 1000,
-      toMs: now,
-      orgId: grafanaOrgId,
-    }));
-  }, [cluster?.id, grafanaOrgId]);
+  const openResourceLogs = useCallback((issue: K8sTriageIssue) => {
+    if (!logClusterID) return;
+    navigate(k8sLogsPath(logClusterID, issue));
+  }, [logClusterID, navigate]);
   const openResourceTraces = useCallback(async (issue: K8sTriageIssue) => {
-    if (!cluster?.id) return;
+    if (!routeClusterID) return;
     const base = await fetchGrafanaRootURL();
     const now = Date.now();
     await openObservabilityUrl(buildExploreUrl({
       base,
       dsType: 'tempo',
       dsUid: 'ongrid-tempo',
-      query: { query: issueTraceQuery(String(cluster.id), issue), queryType: 'traceql' },
+      query: { query: issueTraceQuery(routeClusterID, issue), queryType: 'traceql' },
       fromMs: now - 60 * 60 * 1000,
       toMs: now,
       orgId: grafanaOrgId,
     }));
-  }, [cluster?.id, grafanaOrgId]);
+  }, [grafanaOrgId, routeClusterID]);
   const startResourceChat = useCallback(async (issue: K8sTriageIssue, mode: 'describe' | 'analyze') => {
     if (!cluster) return;
     const prompt = mode === 'describe'
@@ -937,6 +950,8 @@ export function KubernetesClusterDetailPage() {
             <>
               <K8sHealthQueue
                 cluster={cluster}
+                clusterID={routeClusterID}
+                logClusterID={logClusterID}
                 crashLoopTotal={crashLoopTotal}
                 warningEventTotal={warningEventTotal}
                 triageIssues={triageIssues}
@@ -1118,7 +1133,8 @@ export function KubernetesClusterDetailPage() {
               </div>
 
               <K8sTelemetryDrilldowns
-                cluster={cluster}
+                clusterID={routeClusterID}
+                logClusterID={logClusterID}
                 namespaces={namespaces}
               />
             </>
@@ -1454,6 +1470,8 @@ function clusterVisibleIssueChips(
 
 function K8sHealthQueue({
   cluster,
+  clusterID,
+  logClusterID,
   crashLoopTotal,
   warningEventTotal,
   triageIssues,
@@ -1463,6 +1481,8 @@ function K8sHealthQueue({
   onOpenIssueResource,
 }: {
   cluster: KubernetesCluster | null;
+  clusterID: string;
+  logClusterID: string;
   crashLoopTotal: number;
   warningEventTotal: number;
   triageIssues: K8sTriageIssue[];
@@ -1475,6 +1495,15 @@ function K8sHealthQueue({
   const navigate = useNavigate();
   const grafanaOrgId = useObservability((s) => s.grafanaOrgId);
   const [writeBusy, setWriteBusy] = useState<string | null>(null);
+  useEffect(() => {
+    const closeOtherMenus = (event: MouseEvent) => {
+      document.querySelectorAll<HTMLDetailsElement>('details[data-k8s-triage-menu][open]').forEach((menu) => {
+        if (!menu.contains(event.target as Node)) menu.open = false;
+      });
+    };
+    document.addEventListener('click', closeOtherMenus);
+    return () => document.removeEventListener('click', closeOtherMenus);
+  }, []);
   const writeEnabled = cluster?.mode === 'full-node';
   const queueWriteActionRecommendations = writeEnabled ? writeActionRecommendations : [];
   const hasOpenIssues = triageIssues.length > 0;
@@ -1485,31 +1514,20 @@ function K8sHealthQueue({
       : 'success';
   const queueIssues = triageIssues.slice(0, 8);
 
-  async function openIssueLogs(issue: K8sTriageIssue) {
-    if (!cluster?.id) return;
-    const query = issueLogsQuery(String(cluster.id), issue);
-    const base = await fetchGrafanaRootURL();
-    const now = Date.now();
-    await openObservabilityUrl(buildExploreUrl({
-      base,
-      dsType: 'loki',
-      dsUid: 'ongrid-loki',
-      query: { expr: query, queryType: 'range' },
-      fromMs: now - 60 * 60 * 1000,
-      toMs: now,
-      orgId: grafanaOrgId,
-    }));
+  function openIssueLogs(issue: K8sTriageIssue) {
+    if (!logClusterID) return;
+    navigate(k8sLogsPath(logClusterID, issue));
   }
 
   async function openIssueTraces(issue: K8sTriageIssue) {
-    if (!cluster?.id) return;
+    if (!clusterID) return;
     const base = await fetchGrafanaRootURL();
     const now = Date.now();
     await openObservabilityUrl(buildExploreUrl({
       base,
       dsType: 'tempo',
       dsUid: 'ongrid-tempo',
-      query: { query: issueTraceQuery(String(cluster.id), issue), queryType: 'traceql' },
+      query: { query: issueTraceQuery(clusterID, issue), queryType: 'traceql' },
       fromMs: now - 60 * 60 * 1000,
       toMs: now,
       orgId: grafanaOrgId,
@@ -1599,7 +1617,7 @@ function K8sHealthQueue({
                 recommendationBusy={writeBusy}
                 recommendationDisabled={!isAdmin}
                 onOpenResource={() => onOpenIssueResource(issue)}
-                onOpenLogs={() => void openIssueLogs(issue)}
+                onOpenLogs={() => openIssueLogs(issue)}
                 onDescribe={() => void startIssueChat(issue, 'describe')}
                 onTrace={() => void openIssueTraces(issue)}
                 onAnalyze={() => void startIssueChat(issue, 'analyze')}
@@ -1763,7 +1781,7 @@ function TriageQueueRow({
           {issueResourceActionLabel(issue, tr)}
         </Button>
         {hasMoreActions && (
-          <details className="group relative">
+          <details data-k8s-triage-menu className="group relative">
             <summary className="inline-flex cursor-pointer list-none items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-[11px] font-medium text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 [&::-webkit-details-marker]:hidden">
               <MoreHorizontal size={11} />
               {tr('更多', 'More')}
@@ -1828,18 +1846,19 @@ function issueResourceActionLabel(issue: K8sTriageIssue, tr: (zh: string, en: st
 }
 
 function K8sTelemetryDrilldowns({
-  cluster,
+  clusterID,
+  logClusterID,
   namespaces,
 }: {
-  cluster: KubernetesCluster | null;
+  clusterID: string;
+  logClusterID: string;
   namespaces: string[];
 }) {
   const { tr } = useI18n();
+  const navigate = useNavigate();
   const grafanaOrgId = useObservability((s) => s.grafanaOrgId);
-  const [opening, setOpening] = useState<'metrics' | 'logs' | 'traces' | null>(null);
+  const [opening, setOpening] = useState<'metrics' | 'traces' | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const clusterID = cluster?.id ? String(cluster.id) : '';
-
   const namespaceMatcher = useMemo(() => {
     const cleaned = namespaces.map((ns) => ns.trim()).filter(Boolean);
     if (cleaned.length === 0) return '.+';
@@ -1851,9 +1870,9 @@ function K8sTelemetryDrilldowns({
     return `sum by (namespace, phase) (kube_pod_status_phase{cluster_id="${clusterID}",ongrid_source=~"k8s:.*"} == 1)`;
   }, [clusterID]);
   const logsQuery = useMemo(() => {
-    if (!clusterID) return '';
-    return `{cluster_id="${clusterID}",namespace=~"${namespaceMatcher}"}`;
-  }, [clusterID, namespaceMatcher]);
+    if (!logClusterID) return '';
+    return `{cluster_id="${logClusterID}",namespace=~"${namespaceMatcher}"}`;
+  }, [logClusterID, namespaceMatcher]);
   const traceQL = useMemo(() => {
     if (!clusterID) return '';
     return `{resource.cluster_id="${clusterID}"}`;
@@ -1883,28 +1902,9 @@ function K8sTelemetryDrilldowns({
     }
   }
 
-  async function openLogs() {
-    if (!logsQuery) return;
-    setOpening('logs');
-    setError(null);
-    try {
-      const base = await fetchGrafanaRootURL();
-      const now = Date.now();
-      const url = buildExploreUrl({
-        base,
-        dsType: 'loki',
-        dsUid: 'ongrid-loki',
-        query: { expr: logsQuery, queryType: 'range' },
-        fromMs: now - 60 * 60 * 1000,
-        toMs: now,
-        orgId: grafanaOrgId,
-      });
-      await openObservabilityUrl(url);
-    } catch (e) {
-      setError(e instanceof ApiError ? e.message : (e as Error).message);
-    } finally {
-      setOpening(null);
-    }
+  function openLogs() {
+    if (!logClusterID) return;
+    navigate(k8sLogsPath(logClusterID));
   }
 
   async function openTraces() {
@@ -1937,7 +1937,7 @@ function K8sTelemetryDrilldowns({
         <div className="min-w-0">
           <div className="text-sm font-medium text-zinc-100">{tr('可观测入口', 'Observability')}</div>
           <div className="mt-0.5 truncate font-mono text-[11px] text-zinc-500">
-            cluster_id={clusterID || '—'}
+            k8s_cluster_id={clusterID || '—'} · log_cluster_id={logClusterID || '—'}
           </div>
         </div>
         <Chip tone="info">{tr('3 个数据源', '3 data sources')}</Chip>
@@ -1958,12 +1958,14 @@ function K8sTelemetryDrilldowns({
           icon={FileText}
           title={tr('K8s 日志', 'K8s logs')}
           source="Loki"
-          statusLabel={clusterID ? tr('查询已就绪', 'query ready') : tr('等待 cluster_id', 'waiting for cluster_id')}
-          statusTone={clusterID ? 'info' : 'default'}
+          statusLabel={logClusterID ? tr('查询已就绪', 'query ready') : tr('等待 cluster_id', 'waiting for cluster_id')}
+          statusTone={logClusterID ? 'info' : 'default'}
           query={logsQuery || '—'}
-          loading={opening === 'logs'}
-          disabled={!clusterID}
-          onOpen={() => void openLogs()}
+          loading={false}
+          disabled={!logClusterID}
+          actionLabel={tr('查看日志', 'View logs')}
+          actionIcon={Search}
+          onOpen={openLogs}
         />
         <TelemetryLinkCell
           icon={Waypoints}
@@ -1996,6 +1998,8 @@ function TelemetryLinkCell({
   query,
   loading,
   disabled,
+  actionLabel,
+  actionIcon: ActionIcon = ExternalLink,
   onOpen,
 }: {
   icon: LucideIcon;
@@ -2006,11 +2010,13 @@ function TelemetryLinkCell({
   query: string;
   loading: boolean;
   disabled: boolean;
+  actionLabel?: string;
+  actionIcon?: LucideIcon;
   onOpen(): void;
 }) {
   const { tr } = useI18n();
   return (
-    <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+    <div role="group" aria-label={title} className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
           <Icon size={15} className="shrink-0 text-zinc-400" />
@@ -2033,8 +2039,8 @@ function TelemetryLinkCell({
         </details>
       </div>
       <Button className="justify-center md:min-w-24" onClick={onOpen} disabled={disabled || loading}>
-        <ExternalLink size={12} />
-        {loading ? tr('打开中…', 'Opening…') : tr('打开图表', 'Open chart')}
+        <ActionIcon size={12} />
+        {loading ? tr('打开中…', 'Opening…') : actionLabel || tr('打开图表', 'Open chart')}
       </Button>
     </div>
   );
@@ -2914,6 +2920,24 @@ type ResourceRowActionHandlers = {
 function ResourceRowActions({ issue, actions }: { issue: K8sTriageIssue; actions: ResourceRowActionHandlers }) {
   const { tr } = useI18n();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
+  const syncPosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    setPosition({ top: rect.bottom + 4, right: Math.max(8, window.innerWidth - rect.right) });
+  }, []);
+  useEffect(() => {
+    if (!open) return;
+    syncPosition();
+    window.addEventListener('resize', syncPosition);
+    window.addEventListener('scroll', syncPosition, true);
+    return () => {
+      window.removeEventListener('resize', syncPosition);
+      window.removeEventListener('scroll', syncPosition, true);
+    };
+  }, [open, syncPosition]);
   const run = (fn: (issue: K8sTriageIssue) => void) => {
     setOpen(false);
     fn(issue);
@@ -2921,54 +2945,65 @@ function ResourceRowActions({ issue, actions }: { issue: K8sTriageIssue; actions
   return (
     <div className="relative inline-flex justify-end">
       <Button
+        ref={triggerRef}
         className="h-7 px-2 text-[11px]"
         onClick={() => setOpen((value) => !value)}
+        aria-haspopup="menu"
         aria-expanded={open}
       >
         <MoreHorizontal size={11} />
         {tr('排障', 'Triage')}
       </Button>
-      {open && (
-        <div className="absolute right-0 top-full z-20 mt-1 w-32 rounded-lg border border-zinc-800 bg-zinc-950 p-1 text-left shadow-xl">
-          <button
-            type="button"
-            className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
-            onClick={() => run(actions.onAnalyze)}
+      {open && position && createPortal(
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} aria-hidden />
+          <div
+            role="menu"
+            aria-label={tr('资源排障', 'Resource triage')}
+            className="fixed z-50 w-32 rounded-lg border border-zinc-800 bg-zinc-950 p-1 text-left shadow-xl"
+            style={position}
           >
-            <Activity size={11} />
-            {tr('AI 分析', 'AI analyze')}
-          </button>
-          {issueSupportsLogs(issue) && (
             <button
               type="button"
               className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
-              onClick={() => run(actions.onOpenLogs)}
+              onClick={() => run(actions.onAnalyze)}
             >
-              <FileText size={11} />
-              {tr('日志', 'Logs')}
+              <Activity size={11} />
+              {tr('AI 分析', 'AI analyze')}
             </button>
-          )}
-          {issueSupportsDescribe(issue) && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
-              onClick={() => run(actions.onDescribe)}
-            >
-              <Search size={11} />
-              describe
-            </button>
-          )}
-          {issueSupportsTrace(issue) && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
-              onClick={() => run(actions.onTrace)}
-            >
-              <Network size={11} />
-              {tr('链路', 'Trace')}
-            </button>
-          )}
-        </div>
+            {issueSupportsLogs(issue) && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
+                onClick={() => run(actions.onOpenLogs)}
+              >
+                <FileText size={11} />
+                {tr('日志', 'Logs')}
+              </button>
+            )}
+            {issueSupportsDescribe(issue) && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
+                onClick={() => run(actions.onDescribe)}
+              >
+                <Search size={11} />
+                describe
+              </button>
+            )}
+            {issueSupportsTrace(issue) && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] text-zinc-300 hover:bg-zinc-900 hover:text-zinc-100"
+                onClick={() => run(actions.onTrace)}
+              >
+                <Network size={11} />
+                {tr('链路', 'Trace')}
+              </button>
+            )}
+          </div>
+        </>,
+        document.body,
       )}
     </div>
   );
@@ -4817,15 +4852,15 @@ function buildNamespaceRows(
   return [...rows.values()].sort((a, b) => a.namespace.localeCompare(b.namespace));
 }
 
-function issueLogsQuery(clusterID: string, issue: K8sTriageIssue) {
-  const namespace = issue.namespace ? `,namespace="${escapeLabelValue(issue.namespace)}"` : '';
-  if ((issue.kind === 'pod' || issue.resourceKind === 'Pod') && issue.name) {
-    return `{cluster_id="${clusterID}"${namespace},pod="${escapeLabelValue(issue.name)}"}`;
-  }
-  if (issue.kind === 'node' && issue.nodeName) {
-    return `{cluster_id="${clusterID}",node_name="${escapeLabelValue(issue.nodeName)}"}`;
-  }
-  return `{cluster_id="${clusterID}"${namespace}}`;
+function k8sLogsPath(clusterID: string, issue?: K8sTriageIssue) {
+  const params = new URLSearchParams({ cluster_id: clusterID, range: '1h' });
+  if (!issue) return `/logs?${params.toString()}`;
+  if (issue.namespace) params.set('namespace', issue.namespace);
+  const resourceKind = (issue.resourceKind || issue.kind).trim().toLowerCase();
+  if (resourceKind === 'pod' && issue.name) params.set('pod', issue.name);
+  else if (resourceKind === 'node' && (issue.nodeName || issue.name)) params.set('node', issue.nodeName || issue.name || '');
+  else if (isWorkloadKind(resourceKind) && issue.name) params.set('workload', issue.name);
+  return `/logs?${params.toString()}`;
 }
 
 function issueTraceQuery(clusterID: string, issue: K8sTriageIssue) {

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -81,7 +81,15 @@ type CapturedSearchRequest = {
   start: string;
   end: string;
   cursor?: string;
-  scope?: { cluster_ids?: string[]; levels?: string[] };
+  scope?: {
+    cluster_ids?: string[];
+    namespaces?: string[];
+    workloads?: string[];
+    pods?: string[];
+    containers?: string[];
+    nodes?: string[];
+    levels?: string[];
+  };
 };
 
 const searchRequests: CapturedSearchRequest[] = [];
@@ -195,6 +203,28 @@ describe('LogsPage', () => {
     expect(screen.getByRole('link', { name: /采集与后端配置/ })).toHaveAttribute('href', '/settings/integrations?focus=logs');
     expect(screen.queryByText('日志检索')).not.toBeInTheDocument();
     expect(screen.queryByText('采集配置')).not.toBeInTheDocument();
+  });
+
+  it('applies the cluster and time range from a Kubernetes log deep link', async () => {
+    render(
+      <MemoryRouter initialEntries={['/logs?cluster_id=7&range=6h&namespace=production&workload=payments&pod=payments-7d4&container=payments&node=worker-1']}>
+        <LogsPage />
+      </MemoryRouter>,
+    );
+
+    await waitForInitialLogs();
+
+    expect(screen.getByRole('combobox', { name: '集群' })).toHaveValue('7');
+    expect(screen.getByRole('combobox', { name: '时间范围' })).toHaveValue('6h');
+    expect(searchRequests[0]?.scope).toMatchObject({
+      cluster_ids: ['7'],
+      namespaces: ['production'],
+      workloads: ['payments'],
+      pods: ['payments-7d4'],
+      containers: ['payments'],
+      nodes: ['worker-1'],
+    });
+    expect(new Date(searchRequests[0].end).getTime() - new Date(searchRequests[0].start).getTime()).toBe(6 * 60 * 60 * 1000);
   });
 
   it('keeps successful logs and closes their cursor when the histogram fails', async () => {

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   AlertTriangle,
   BarChart3,
@@ -72,6 +72,7 @@ const INPUT = 'h-9 w-full rounded-md border border-zinc-800 bg-zinc-950 px-2.5 t
 
 type ScopeKey =
   | 'cluster_ids'
+  | 'namespaces'
   | 'workloads'
   | 'pods'
   | 'containers'
@@ -129,6 +130,7 @@ function buildDisplayFields(fields: LogField[], records: LogRecord[]): DisplayFi
 
 const EMPTY_SCOPE: ScopeDraft = {
   cluster_ids: '',
+  namespaces: '',
   workloads: '',
   pods: '',
   containers: '',
@@ -283,7 +285,21 @@ function topologyNodeLabel(node: TopologyNode): string {
 
 export default function LogsPage() {
   const { tr } = useI18n();
-  const [range, setRange] = useState('1h');
+  const [searchParams] = useSearchParams();
+  const requestedRange = searchParams.get('range') || '';
+  const initialRange = RANGE_PRESETS.some((item) => item.value === requestedRange && item.value !== 'custom')
+    ? requestedRange
+    : '1h';
+  const initialScope: ScopeDraft = {
+    ...EMPTY_SCOPE,
+    cluster_ids: searchParams.get('cluster_id')?.trim() || '',
+    namespaces: searchParams.get('namespace')?.trim() || '',
+    workloads: searchParams.get('workload')?.trim() || '',
+    pods: searchParams.get('pod')?.trim() || '',
+    containers: searchParams.get('container')?.trim() || '',
+    nodes: searchParams.get('node')?.trim() || '',
+  };
+  const [range, setRange] = useState(initialRange);
   const [customStart, setCustomStart] = useState('');
   const [customEnd, setCustomEnd] = useState('');
   const [query, setQuery] = useState('');
@@ -294,8 +310,8 @@ export default function LogsPage() {
   const [committedMode, setCommittedMode] = useState<LogMatchMode>('any');
   const [deviceID, setDeviceID] = useState('');
   const [role, setRole] = useState<'' | EdgeRole>('');
-  const [scopeDraft, setScopeDraft] = useState<ScopeDraft>(EMPTY_SCOPE);
-  const [committedScope, setCommittedScope] = useState<ScopeDraft>(EMPTY_SCOPE);
+  const [scopeDraft, setScopeDraft] = useState<ScopeDraft>(() => initialScope);
+  const [committedScope, setCommittedScope] = useState<ScopeDraft>(() => initialScope);
   const [advanced, setAdvanced] = useState(false);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [clusters, setClusters] = useState<TopologyNode[]>([]);
@@ -669,7 +685,7 @@ export default function LogsPage() {
     if (role) items.push({ label: tr('角色', 'Role'), value: role });
     if (deviceID) items.push({ label: 'device_id', value: deviceID });
     const labels: Record<ScopeKey, string> = {
-      cluster_ids: 'cluster_id', workloads: 'workload', pods: 'pod',
+      cluster_ids: 'cluster_id', namespaces: 'namespace', workloads: 'workload', pods: 'pod',
       containers: 'container', nodes: 'node', source_ids: 'source_id',
       levels: 'level', files: 'file', units: 'unit',
     };
@@ -827,6 +843,7 @@ export default function LogsPage() {
               <FilterInput label={tr('排除关键词', 'Exclude keywords')} value={exclude} onChange={setExclude} wide />
               <FilterInput label={tr('级别', 'Level')} value={scopeDraft.levels} onChange={(value) => setScopeDraft((current) => ({ ...current, levels: value }))} suggestions={fieldValues.level} />
               <FilterInput label={tr('文件', 'File')} value={scopeDraft.files} onChange={(value) => setScopeDraft((current) => ({ ...current, files: value }))} suggestions={fieldValues.file} wide />
+              <FilterInput label="Namespace" value={scopeDraft.namespaces} onChange={(value) => setScopeDraft((current) => ({ ...current, namespaces: value }))} />
               <FilterInput label="Workload" value={scopeDraft.workloads} onChange={(value) => setScopeDraft((current) => ({ ...current, workloads: value }))} />
               <FilterInput label="Pod" value={scopeDraft.pods} onChange={(value) => setScopeDraft((current) => ({ ...current, pods: value }))} />
               <FilterInput label="Container" value={scopeDraft.containers} onChange={(value) => setScopeDraft((current) => ({ ...current, containers: value }))} />

--- a/web/src/pages/Topology.tsx
+++ b/web/src/pages/Topology.tsx
@@ -38,6 +38,8 @@ import {
 
 type Tab = 'graph' | 'nodes' | 'relation-types';
 
+const isDomainManagedNodeType = (type: string) => type === 'device' || type === 'cluster';
+
 export default function TopologyPage() {
   const role = useAuth((s) => s.role);
   const isAdmin = role === 'admin';
@@ -187,6 +189,7 @@ function NodesTab({ isAdmin }: { isAdmin: boolean }) {
   // creatingType doubles as visible flag (truthy = open) + type pre-fill
   // for the modal. null = closed.
   const [creatingType, setCreatingType] = useState<string | null>(null);
+  const canCreateSelectedType = !isDomainManagedNodeType(typeFilter);
 
   const [nodeTypes, setNodeTypes] = useState<NodeType[]>([]);
   const typeChips = useMemo(
@@ -244,7 +247,7 @@ function NodesTab({ isAdmin }: { isAdmin: boolean }) {
               <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
               {tr('刷新', 'Refresh')}
             </Button>
-            {isAdmin && (
+            {isAdmin && canCreateSelectedType && (
               <Button
                 variant="primary"
                 onClick={() => setCreatingType(typeFilter || 'service')}
@@ -269,7 +272,7 @@ function NodesTab({ isAdmin }: { isAdmin: boolean }) {
               hint={isAdmin
                 ? tr('录入第一个开始', 'Add your first node to get started')
                 : tr('联系管理员录入节点', 'Ask an admin to add nodes')}
-              action={isAdmin ? (
+              action={isAdmin && canCreateSelectedType ? (
                 <Button variant="primary" onClick={() => setCreatingType(typeFilter || 'service')}>
                   <Plus size={12} /> {creatingTypeLabel(typeFilter, tr)}
                 </Button>
@@ -366,6 +369,7 @@ function NodeDetailDrawer({
   const [err, setErr] = useState<string | null>(null);
   const [addingRelation, setAddingRelation] = useState(false);
   const [busy, setBusy] = useState(false);
+  const domainManaged = isDomainManagedNodeType(node.type);
 
   const fetchNeighbors = useCallback(async () => {
     setLoading(true);
@@ -487,12 +491,21 @@ function NodeDetailDrawer({
           </ul>
         )}
       </div>
-      {isAdmin && (
+      {isAdmin && !domainManaged && (
         <div className="border-t border-zinc-800/60 px-4 py-3">
           <Button variant="danger" onClick={handleDeleteNode} disabled={busy} className="w-full justify-center">
             <Trash2 size={12} />
             {tr('删除节点', 'Delete node')}
           </Button>
+        </div>
+      )}
+      {isAdmin && domainManaged && (
+        <div className="border-t border-zinc-800/60 px-4 py-3 text-[11px] text-zinc-500">
+          {node.type === 'device'
+            ? tr('此节点由设备管理同步，请从设备页面删除。', 'This node is synced from Devices. Delete it from the Devices page.')
+            : node.props?.source === 'kubernetes'
+              ? tr('此节点由 Kubernetes 托管，请从 Kubernetes 集群页面删除。', 'This node is managed by Kubernetes. Delete it from the Kubernetes cluster page.')
+              : tr('此节点由集群管理同步，请从集群页面删除。', 'This node is synced from Clusters. Delete it from the Clusters page.')}
         </div>
       )}
       {addingRelation && (
@@ -571,7 +584,7 @@ function CreateNodeModal({
   defaultType?: string;
 }) {
   const { tr, locale } = useI18n();
-  const [type, setType] = useState(defaultType);
+  const [type, setType] = useState(isDomainManagedNodeType(defaultType) ? 'service' : defaultType);
   const [name, setName] = useState('');
   const [propsText, setPropsText] = useState('');
   const [busy, setBusy] = useState(false);
@@ -674,7 +687,7 @@ function CreateNodeModal({
             }}
             className="w-full rounded-md border border-zinc-800 bg-zinc-900/60 px-2 py-1.5 text-zinc-100 focus:border-zinc-600 focus:outline-none"
           >
-            {nodeTypes.map((nt) => (
+            {nodeTypes.filter((nt) => !isDomainManagedNodeType(nt.name)).map((nt) => (
               <option key={nt.name} value={nt.name}>
                 {localizedTypeLabel(nt, locale)}（{nt.name}）
               </option>
@@ -1480,6 +1493,7 @@ function GraphTab({ isAdmin }: { isAdmin: boolean }) {
   // pre-fill hint for the modal's type field — if you're looking at
   // 服务, clicking 新建 should propose creating a service.
   const [creatingType, setCreatingType] = useState<string | null>(null);
+  const canCreateSelectedType = !isDomainManagedNodeType(typeFilter);
   // Show ALL nodes by default — including orphans (no relations yet) —
   // so a freshly-registered fleet doesn't look empty. Orphans only get
   // pruned when the operator focuses an app (appFocus): the BFS reachable
@@ -1656,7 +1670,7 @@ function GraphTab({ isAdmin }: { isAdmin: boolean }) {
               <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
               {tr('刷新', 'Refresh')}
             </Button>
-            {isAdmin && (
+            {isAdmin && canCreateSelectedType && (
               <Button
                 variant="primary"
                 onClick={() => setCreatingType(typeFilter || 'service')}
@@ -1681,7 +1695,7 @@ function GraphTab({ isAdmin }: { isAdmin: boolean }) {
               hint={isAdmin
                 ? tr('录入第一个开始', 'Add your first node to get started')
                 : tr('联系管理员录入节点', 'Ask an admin to add nodes')}
-              action={isAdmin ? (
+              action={isAdmin && canCreateSelectedType ? (
                 <Button variant="primary" onClick={() => setCreatingType(typeFilter || 'service')}>
                   <Plus size={12} /> {creatingTypeLabel(typeFilter, tr)}
                 </Button>


### PR DESCRIPTION
## Summary

- keep Kubernetes issue and pod views limited to resources that exist in the current snapshot while retaining workload revision history
- route Kubernetes resource logs to the internal Logs page with the topology log cluster ID, while metrics and traces continue using the Kubernetes cluster ID
- fix action menu positioning and single-open behavior, and prevent device or cluster lifecycle operations from the generic Topology page

## Testing

- env GOCACHE=/private/tmp/ongrid-go-cache go test ./internal/manager/biz/topology
- npm run typecheck
- npx eslint src/pages/Topology.tsx --max-warnings 0
- npm test -- --run src/pages/Clusters.test.tsx
- targeted Kubernetes and Logs tests (53 passed)
- local manager and web images rebuilt; https://localhost:8443/topology returned HTTP 200

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md