### PR TITLE
fix(traces): force interoperable TLS curve

### DIFF
--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -141,14 +141,16 @@ exporters:
     headers:
       Authorization: "{{ .AuthHeader }}"
     {{- end }}
-    {{- if .TLSInsecureSkipVerify }}
     tls:
       # The standard install ships a self-signed manager cert
       # (deploy/install/upgrade.sh), so otelcol's default cert verification
       # fails the OTLP/HTTPS push. Skip verification by default; operators
       # who plug in a real cert can set spec.tls_insecure_skip_verify=false.
-      insecure_skip_verify: true
-    {{- end }}
+      insecure_skip_verify: {{ .TLSInsecureSkipVerify }}
+      # Collector 0.157 advertises X25519MLKEM768 by default. Some deployed
+      # TLS terminators black-hole that ClientHello instead of negotiating a
+      # supported curve, so keep the manager trace path on interoperable X25519.
+      curve_preferences: [X25519]
     compression: gzip
     timeout: 30s
     sending_queue:

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -203,6 +203,7 @@ func TestRenderTLSInsecureSkipVerify(t *testing.T) {
 	for _, want := range []string{
 		"tls:",
 		"insecure_skip_verify: true",
+		"curve_preferences: [X25519]",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("rendered config missing %q\n--- full body ---\n%s", want, body)
@@ -457,10 +458,15 @@ func TestRenderTLSInsecureSkipVerifyDisabled(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	body := string(out)
-	// With a real cert the operator opts out; the tls block must be absent
-	// so otelcol verifies the cert chain.
-	if strings.Contains(body, "insecure_skip_verify") {
-		t.Errorf("tls block must be absent when disabled, got:\n%s", body)
+	// With a real cert the operator opts out while retaining the interoperable
+	// key exchange used by the trace exporter.
+	for _, want := range []string{
+		"insecure_skip_verify: false",
+		"curve_preferences: [X25519]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered config missing %q\n--- full body ---\n%s", want, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- constrain the manager Trace OTLP/HTTP exporter to X25519
- preserve the existing certificate verification toggle
- cover both skip-verify modes with rendered-config regression tests

## Reproduction and validation

- reproduced `Client.Timeout exceeded while awaiting headers` with the official `otelcol-contrib v0.157.0` against a local TLS terminator that black-holes ClientHello messages containing X25519MLKEM768
- verified the fixed exporter offers only X25519 and successfully delivers `POST /v1/traces` to the same endpoint
- validated the rendered configuration with the official `otelcol-contrib v0.157.0` binary
- passed `go test -race ./internal/edgeagent/plugins/...`
- passed `go vet ./internal/edgeagent/plugins/traces`
- passed `make build-edge-linux-amd64`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
