### PR TITLE
fix(logs): improve Loki ingestion and query responsiveness

### DIFF
--- a/deploy/install/loki-config.yaml
+++ b/deploy/install/loki-config.yaml
@@ -51,8 +51,8 @@ limits_config:
             - unit
   retention_period: "${LOKI_RETENTION_PERIOD:-720h}"
   max_global_streams_per_user: 10000  # cardinality 守门 (ADR-012 §决策第 10 条)
-  ingestion_rate_mb: 8
-  ingestion_burst_size_mb: 16
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   max_query_series: 10000

--- a/scripts/test-compose-release-package.sh
+++ b/scripts/test-compose-release-package.sh
@@ -136,6 +136,10 @@ for arch in amd64 arm64; do
     "$extract_dir/$package_root/docker-compose.yml"
   grep -Fq 'retention_period: "${LOKI_RETENTION_PERIOD:-720h}"' \
     "$extract_dir/$package_root/loki-config.yaml"
+  grep -Fqx '  ingestion_rate_mb: 16' \
+    "$extract_dir/$package_root/loki-config.yaml"
+  grep -Fqx '  ingestion_burst_size_mb: 32' \
+    "$extract_dir/$package_root/loki-config.yaml"
   grep -Fq 'block_retention: "${TEMPO_BLOCK_RETENTION:-168h}"' \
     "$extract_dir/$package_root/tempo-config.yaml"
   grep -Fxq 'ONGRID_EDGE_DEPS_TAG=edge-deps-test' \

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -256,6 +256,27 @@ describe('LogsPage', () => {
     await waitFor(() => expect(closedCursor).toBe('origin-es-cursor'));
   });
 
+  it('renders log results without waiting for the histogram', async () => {
+    let releaseHistogram!: () => void;
+    const histogramGate = new Promise<void>((resolve) => { releaseHistogram = resolve; });
+    server.use(http.post('/api/v1/logs/histogram', async () => {
+      await histogramGate;
+      return HttpResponse.json({
+        code: 0,
+        message: '',
+        data: [{ start: '2026-08-19T01:00:00.000Z', count: 5 }],
+      });
+    }));
+
+    render(<MemoryRouter><LogsPage /></MemoryRouter>);
+
+    await screen.findByText('payment request completed');
+    expect(screen.getByText('日志总数', { exact: false })).toHaveTextContent('0');
+
+    await act(async () => { releaseHistogram(); });
+    await waitFor(() => expect(screen.getByText('日志总数', { exact: false })).toHaveTextContent('5'));
+  });
+
   it('resolves a cluster name from topology when logs contain only cluster_id', async () => {
     const recordsWithoutClusterName = records.map((record) => ({
       ...record,

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -342,6 +342,7 @@ export default function LogsPage() {
   const nextCursorRef = useRef('');
   const pageRequestRef = useRef<LogSearchRequest | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
+  const histogramAbortRef = useRef<AbortController | null>(null);
   const pageAbortRef = useRef<AbortController | null>(null);
   const facetAbortRef = useRef<AbortController | null>(null);
   const resultScrollRef = useRef<HTMLElement>(null);
@@ -464,33 +465,37 @@ export default function LogsPage() {
     const seq = ++requestSeq.current;
     ++paginationGeneration.current;
     searchAbortRef.current?.abort();
+    histogramAbortRef.current?.abort();
     pageAbortRef.current?.abort();
     pageAbortRef.current = null;
     pageRequestRef.current = null;
     abandonPagination();
     setLoadingMore(false);
-    const controller = new AbortController();
-    searchAbortRef.current = controller;
+    const searchController = new AbortController();
+    const histogramController = new AbortController();
+    searchAbortRef.current = searchController;
+    histogramAbortRef.current = histogramController;
     if (!quiet) setLoading(true);
     setError(null);
+    setHistogram([]);
+    void getLogHistogram(
+      { ...input, limit: 1, cursor: undefined },
+      histogramInterval(timeWindow.duration),
+      histogramController.signal,
+    ).then((buckets) => {
+      if (seq === requestSeq.current) setHistogram(buckets ?? []);
+    }).catch((err) => {
+      if ((err as Error).name !== 'AbortError') {
+        console.warn('log histogram request failed', err);
+      }
+    }).finally(() => {
+      if (histogramAbortRef.current === histogramController) histogramAbortRef.current = null;
+    });
     try {
-      const [searchOutcome, histogramOutcome] = await Promise.allSettled([
-        searchLogs(input, controller.signal),
-        getLogHistogram({ ...input, limit: 1, cursor: undefined }, histogramInterval(timeWindow.duration), controller.signal),
-      ]);
-      if (searchOutcome.status === 'rejected') throw searchOutcome.reason;
-      const result = searchOutcome.value;
+      const result = await searchLogs(input, searchController.signal);
       if (seq !== requestSeq.current) {
         closeCursorQuietly(result.next_cursor ?? '');
         return;
-      }
-      if (histogramOutcome.status === 'rejected' && (histogramOutcome.reason as Error).name === 'AbortError') {
-        closeCursorQuietly(result.next_cursor ?? '');
-        return;
-      }
-      const buckets = histogramOutcome.status === 'fulfilled' ? histogramOutcome.value : [];
-      if (histogramOutcome.status === 'rejected') {
-        console.warn('log histogram request failed', histogramOutcome.reason);
       }
       pageRequestRef.current = input;
       setHasCompletedSearch(true);
@@ -498,10 +503,10 @@ export default function LogsPage() {
       replaceNextCursor(result.next_cursor ?? '');
       setBackends(result.backends ?? []);
       setTookMS(result.took_ms ?? 0);
-      setHistogram(buckets ?? []);
       if (!quiet) resultScrollRef.current?.scrollTo?.({ top: 0 });
     } catch (err) {
       if (seq !== requestSeq.current || (err as Error).name === 'AbortError') return;
+      histogramController.abort();
       pageRequestRef.current = null;
       setHasCompletedSearch(true);
       setError(errorMessage(err));
@@ -511,7 +516,7 @@ export default function LogsPage() {
         replaceNextCursor('');
       }
     } finally {
-      if (searchAbortRef.current === controller) searchAbortRef.current = null;
+      if (searchAbortRef.current === searchController) searchAbortRef.current = null;
       if (seq === requestSeq.current) setLoading(false);
     }
   }, [abandonPagination, buildRequest, closeCursorQuietly, replaceNextCursor, resolveWindow, tr]);
@@ -574,6 +579,7 @@ export default function LogsPage() {
 
   useEffect(() => () => {
     searchAbortRef.current?.abort();
+    histogramAbortRef.current?.abort();
     pageAbortRef.current?.abort();
     facetAbortRef.current?.abort();
     abandonPagination();


### PR DESCRIPTION
## Summary

- raise the default Loki ingestion rate and burst limits from 8/16 MB to 16/32 MB
- render log search results without waiting for the histogram request
- verify the Loki limits are included in release packages and cover asynchronous histogram behavior

## Validation

- `npm test -- --run src/pages/Logs.test.tsx --testTimeout=20000`
- `npm run typecheck`
- `npx eslint src/pages/Logs.tsx src/pages/Logs.test.tsx --max-warnings 0`
- `npm run build`
- `bash scripts/test-compose-release-package.sh`

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
