### PR TITLE
docs(readme): update download links to v0.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ Choose the command for your server architecture:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Product Tour

--- a/README_DE.md
+++ b/README_DE.md
@@ -63,15 +63,15 @@ Wählen Sie den Befehl für Ihre Serverarchitektur:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Produkttour

--- a/README_ES.md
+++ b/README_ES.md
@@ -63,15 +63,15 @@ Elige el comando para la arquitectura de tu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Recorrido del producto

--- a/README_FR.md
+++ b/README_FR.md
@@ -63,15 +63,15 @@ Choisissez la commande adaptée à l’architecture de votre serveur :
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Tour du produit

--- a/README_JA.md
+++ b/README_JA.md
@@ -63,15 +63,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## 製品ツアー

--- a/README_KO.md
+++ b/README_KO.md
@@ -63,15 +63,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## 제품 둘러보기

--- a/README_PT.md
+++ b/README_PT.md
@@ -63,15 +63,15 @@ Escolha o comando para a arquitetura do seu servidor:
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Tour do produto

--- a/README_RU.md
+++ b/README_RU.md
@@ -63,15 +63,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## Обзор продукта

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -63,15 +63,15 @@
 
 **AMD64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-amd64.tar.xz
-tar -xf ongrid-v0.14.0-linux-amd64.tar.xz && cd ongrid-v0.14.0-linux-amd64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-amd64.tar.xz
+tar -xf ongrid-v0.14.1-linux-amd64.tar.xz && cd ongrid-v0.14.1-linux-amd64
 sudo ./install.sh
 ```
 
 **ARM64**
 ```bash
-wget https://github.com/ongridio/ongrid/releases/download/v0.14.0/ongrid-v0.14.0-linux-arm64.tar.xz
-tar -xf ongrid-v0.14.0-linux-arm64.tar.xz && cd ongrid-v0.14.0-linux-arm64
+wget https://github.com/ongridio/ongrid/releases/download/v0.14.1/ongrid-v0.14.1-linux-arm64.tar.xz
+tar -xf ongrid-v0.14.1-linux-arm64.tar.xz && cd ongrid-v0.14.1-linux-arm64
 sudo ./install.sh
 ```
 
@@ -79,10 +79,10 @@ sudo ./install.sh
 
 ```bash
 # AMD64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-amd64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-amd64.tar.xz
 
 # ARM64
-wget https://ongrid.cloud/dl/ongrid-v0.14.0-linux-arm64.tar.xz
+wget https://ongrid.cloud/dl/ongrid-v0.14.1-linux-arm64.tar.xz
 ```
 
 ## 产品导览


### PR DESCRIPTION
## Summary

- Update all localized README download commands from v0.14.0 to v0.14.1.
- Keep GitHub Release and ongrid.cloud mirror examples aligned for amd64 and arm64.
- Verify the referenced v0.14.1 GitHub Release assets are uploaded.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md