### PR TITLE
fix(data): suppress expected record not found logs

### DIFF
--- a/internal/pkg/dbx/dbx.go
+++ b/internal/pkg/dbx/dbx.go
@@ -17,11 +17,14 @@ package dbx
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	gormmysql "gorm.io/driver/mysql"
@@ -56,7 +59,7 @@ func openMySQL(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	}
 
 	gdb, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Warn),
+		Logger: newGORMLogger(os.Stdout),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dbx: mysql open: %w", err)
@@ -99,7 +102,7 @@ func openSQLite(path string, log *slog.Logger) (*gorm.DB, error) {
 	dsn := buildSQLiteDSN(path)
 
 	gdb, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Warn),
+		Logger: newGORMLogger(os.Stdout),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dbx: sqlite open %q: %w", path, err)
@@ -109,6 +112,15 @@ func openSQLite(path string, log *slog.Logger) (*gorm.DB, error) {
 		log.Info("sqlite opened", "path", path, "journal_mode", "WAL", "foreign_keys", "on")
 	}
 	return gdb, nil
+}
+
+func newGORMLogger(w io.Writer) logger.Interface {
+	return logger.New(log.New(w, "\r\n", log.LstdFlags), logger.Config{
+		SlowThreshold:             200 * time.Millisecond,
+		LogLevel:                  logger.Warn,
+		IgnoreRecordNotFoundError: true,
+		Colorful:                  true,
+	})
 }
 
 // buildSQLiteDSN appends pragma query params expected by modernc/glebarez sqlite.

--- a/internal/pkg/dbx/dbx_test.go
+++ b/internal/pkg/dbx/dbx_test.go
@@ -1,7 +1,11 @@
 package dbx
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/ongridio/ongrid/internal/pkg/config"
 	"gorm.io/gorm"
@@ -26,6 +30,26 @@ func TestOpen_SQLiteInMemory(t *testing.T) {
 	}
 	if one != 1 {
 		t.Errorf("SELECT 1 = %d, want 1", one)
+	}
+}
+
+func TestGORMLoggerIgnoresRecordNotFound(t *testing.T) {
+	var out bytes.Buffer
+	gormLog := newGORMLogger(&out)
+	trace := func(err error) {
+		gormLog.Trace(context.Background(), time.Now(), func() (string, int64) {
+			return "SELECT 1", 0
+		}, err)
+	}
+
+	trace(gorm.ErrRecordNotFound)
+	if out.Len() != 0 {
+		t.Fatalf("record not found was logged: %q", out.String())
+	}
+
+	trace(errors.New("query failed"))
+	if !contains(out.String(), "query failed") {
+		t.Fatalf("real database error was not logged: %q", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- configure the shared GORM logger to ignore expected `ErrRecordNotFound` traces
- preserve real database errors and slow-query warnings for MySQL and SQLite
- add a regression test covering both suppressed not-found traces and retained real errors

## Testing

- `go build ./cmd/ongrid`
- `go test -race ./internal/pkg/dbx`
- `go vet ./internal/pkg/dbx`
- local `ongrid:dev`: `/healthz` returned 200; post-restart counts were `record_not_found=0`, `sql_errors=0`

`go build ./...` on macOS remains blocked by existing `cmd/ongrid-edge` Linux/Windows-only platform symbols; Linux CI provides the full repository build check.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md