### PR TITLE
feat(observability): improve trace exploration and correlation

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -2527,9 +2527,7 @@ func main() {
 	// provider (otel global stays as the default no-op).
 	otelhttpmw := func(next http.Handler) http.Handler {
 		return otelhttp.NewHandler(next, "ongrid-manager",
-			otelhttp.WithFilter(func(r *http.Request) bool {
-				return r.URL.Path != "/healthz" && r.URL.Path != "/readyz"
-			}),
+			otelhttp.WithFilter(shouldTraceHTTPRequest),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 				if route := chi.RouteContext(r.Context()).RoutePattern(); route != "" {
 					return r.Method + " " + route
@@ -2941,6 +2939,15 @@ func main() {
 		os.Exit(1)
 	}
 	log.Info("ongrid shutdown complete")
+}
+
+func shouldTraceHTTPRequest(r *http.Request) bool {
+	path := r.URL.Path
+	return path != "/healthz" &&
+		path != "/readyz" &&
+		path != "/api/v1/prometheus/auth" &&
+		path != "/api/v1/traces" &&
+		!strings.HasPrefix(path, "/api/v1/traces/")
 }
 
 // llmResolverFunc is a tiny adapter from biz/setting.Service to the

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -238,11 +238,19 @@ func main() {
 	if otelEndpoint == "" {
 		otelEndpoint = "tempo:4318"
 	}
+	otelSamplingRatio := 1.0
+	if raw := strings.TrimSpace(os.Getenv("ONGRID_OTEL_SAMPLING_RATIO")); raw != "" {
+		if ratio, parseErr := strconv.ParseFloat(raw, 64); parseErr != nil || ratio <= 0 || ratio > 1 {
+			log.Warn("tracing: invalid sampling ratio, using 1.0", slog.String("value", raw))
+		} else {
+			otelSamplingRatio = ratio
+		}
+	}
 	otelShutdown, err := tracing.Init(rootCtx, tracing.Config{
 		ServiceName:   "ongrid-manager",
 		Endpoint:      otelEndpoint,
 		Insecure:      true,
-		SamplingRatio: 1.0,
+		SamplingRatio: otelSamplingRatio,
 	})
 	if err != nil {
 		log.Warn("tracing: init failed (continuing without OTel)", slog.Any("err", err))
@@ -2518,6 +2526,9 @@ func main() {
 	// provider (otel global stays as the default no-op).
 	otelhttpmw := func(next http.Handler) http.Handler {
 		return otelhttp.NewHandler(next, "ongrid-manager",
+			otelhttp.WithFilter(func(r *http.Request) bool {
+				return r.URL.Path != "/healthz" && r.URL.Path != "/readyz"
+			}),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 				if route := chi.RouteContext(r.Context()).RoutePattern(); route != "" {
 					return r.Method + " " + route
@@ -2532,10 +2543,8 @@ func main() {
 	// OTel HTTP middleware — wraps every request in a span named
 	// "{METHOD} {ROUTE_PATTERN}" so Tempo's spanmetrics generator can
 	// derive traces_spanmetrics_latency_bucket per route. Routes added
-	// after this middleware get traced; the bare /healthz / /readyz
-	// endpoints below are also wrapped (cheap; they get filtered later
-	// by service_name=ongrid-manager,span_name=GET /healthz if you
-	// want to exclude them).
+	// after this middleware get traced. Health probes are excluded by the
+	// filter above so they cannot crowd useful traces out of Tempo search.
 	mux.Use(otelhttpmw)
 	// ADR-026 self-obs HTTP metrics — runs after OTel so chi has populated
 	// RouteContext before we read RoutePattern for the histogram label.

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -240,7 +241,7 @@ func main() {
 	}
 	otelSamplingRatio := 1.0
 	if raw := strings.TrimSpace(os.Getenv("ONGRID_OTEL_SAMPLING_RATIO")); raw != "" {
-		if ratio, parseErr := strconv.ParseFloat(raw, 64); parseErr != nil || ratio <= 0 || ratio > 1 {
+		if ratio, parseErr := strconv.ParseFloat(raw, 64); parseErr != nil || math.IsNaN(ratio) || ratio < 0 || ratio > 1 {
 			log.Warn("tracing: invalid sampling ratio, using 1.0", slog.String("value", raw))
 		} else {
 			otelSamplingRatio = ratio

--- a/cmd/ongrid/tracing_filter_test.go
+++ b/cmd/ongrid/tracing_filter_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestShouldTraceHTTPRequest(t *testing.T) {
+	tests := map[string]bool{
+		"/healthz":                        false,
+		"/readyz":                         false,
+		"/api/v1/prometheus/auth":         false,
+		"/api/v1/traces":                  false,
+		"/api/v1/traces/search":           false,
+		"/internal/auth/dataPlane-verify": true,
+		"/api/v1/aiops/sessions":          true,
+	}
+	for path, want := range tests {
+		if got := shouldTraceHTTPRequest(httptest.NewRequest("GET", path, nil)); got != want {
+			t.Errorf("shouldTraceHTTPRequest(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -88,6 +88,9 @@ services:
       ONGRID_PROM_URL: ${ONGRID_PROM_URL:-http://prometheus:9090/prometheus}
       ONGRID_PROM_REMOTE_WRITE_URL: ${ONGRID_PROM_REMOTE_WRITE_URL:-}
       ONGRID_PROM_QUERY_URL: ${ONGRID_PROM_QUERY_URL:-http://prometheus:9090/prometheus}
+      # Root-span head sampling. Keep local development at 100%; production
+      # can lower this without rebuilding the manager image.
+      ONGRID_OTEL_SAMPLING_RATIO: ${ONGRID_OTEL_SAMPLING_RATIO:-1}
       # Knowledge base / RAG: local BGE embedding + qdrant. This mirrors
       # the install package default so the dev stack has KB search without
       # an external embedding API key.

--- a/deploy/install/docker-compose.yml
+++ b/deploy/install/docker-compose.yml
@@ -147,6 +147,7 @@ services:
       # OTel tracing — Tempo OTLP HTTP receiver (HLD-004 Phase-B trace
       # evaluators need real spans for traces_spanmetrics_* to populate).
       ONGRID_OTEL_ENDPOINT: ${ONGRID_OTEL_ENDPOINT:-tempo:4318}
+      ONGRID_OTEL_SAMPLING_RATIO: ${ONGRID_OTEL_SAMPLING_RATIO:-1}
       # ADR-009: cloud-side Prometheus. Manager remote_writes open-set
       # samples here and the aiops query_promql tool reads from it.
       ONGRID_PROM_ENABLED: ${ONGRID_PROM_ENABLED:-true}

--- a/internal/manager/biz/aiops/agent/agent.go
+++ b/internal/manager/biz/aiops/agent/agent.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+
 	biz "github.com/ongridio/ongrid/internal/manager/biz/aiops"
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/toolreplay"
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
@@ -31,11 +33,14 @@ import (
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/llm"
 	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // ErrMaxIterationsReached is returned from Run when cfg.MaxIterations elapse
 // without the assistant producing a final (no-tool-calls) reply.
 var ErrMaxIterationsReached = errors.New("agent: max iterations reached")
+
+var agentTracer = otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/aiops/agent")
 
 // Config tunes the agent loop.
 type Config struct {
@@ -328,7 +333,9 @@ func (a *Agent) RunStream(ctx context.Context, sessionID string, userID uint64, 
 	return a.runInternal(ctx, sessionID, userID, userContent, emit, RunOptions{})
 }
 
-func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64, userContent string, emit Emit, opts RunOptions) (*Reply, error) {
+func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64, userContent string, emit Emit, opts RunOptions) (reply *Reply, retErr error) {
+	ctx, span := agentTracer.Start(ctx, "aiops.Agent.Run")
+	defer func() { tracing.EndSpan(span, retErr) }()
 	if a.sessions == nil || a.llm == nil || a.tools == nil {
 		return nil, errs.ErrNotWiredYet
 	}

--- a/internal/manager/biz/aiops/graph/tool_adapter.go
+++ b/internal/manager/biz/aiops/graph/tool_adapter.go
@@ -10,8 +10,12 @@ import (
 	einotool "github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 	"github.com/eino-contrib/jsonschema"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // toolMemo is a per-run cache of identical (read-tool, args) calls. The
@@ -440,8 +444,14 @@ func (a *einoToolAdapter) InvokableRun(ctx context.Context, argumentsInJSON stri
 			}
 		}
 	}
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/aiops/graph").Start(ctx, "aiops.Tool."+a.cacheName,
+		trace.WithAttributes(attribute.String("aiops.tool.name", a.cacheName)),
+	)
+	var spanErr error
+	defer func() { tracing.EndSpan(span, spanErr) }()
 	out, err = a.inner.InvokableRun(ctx, argumentsInJSON, resolved.opts...)
 	if err != nil {
+		spanErr = err
 		// Count most failures toward the cap so a failing tool cannot be
 		// hammered. draft_config_change is the exception: validation failures
 		// are common while the model corrects structured config args, and only

--- a/internal/manager/biz/aiops/tools/registry.go
+++ b/internal/manager/biz/aiops/tools/registry.go
@@ -20,11 +20,16 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	devicebiz "github.com/ongridio/ongrid/internal/manager/biz/device"
 	edgebiz "github.com/ongridio/ongrid/internal/manager/biz/edge"
 	topologybiz "github.com/ongridio/ongrid/internal/manager/biz/topology"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/llm"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // Caller is the narrow seam this package needs from the frontierbound SDK
@@ -471,11 +476,15 @@ func (r *Registry) Schemas() []llm.ToolSchema {
 // Nil args are replaced by an empty object `{}` for tools that take no
 // arguments (matches OpenAI's tool_call shape when the model decides to call
 // a zero-arg tool).
-func (r *Registry) Invoke(ctx context.Context, name string, args json.RawMessage) (ExecuteResult, error) {
+func (r *Registry) Invoke(ctx context.Context, name string, args json.RawMessage) (result ExecuteResult, retErr error) {
 	t, ok := r.tools[name]
 	if !ok {
 		return ExecuteResult{}, fmt.Errorf("%w: tool %q", errs.ErrNotFound, name)
 	}
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/aiops/tools").Start(ctx, "aiops.Tool."+name,
+		trace.WithAttributes(attribute.String("aiops.tool.name", name)),
+	)
+	defer func() { tracing.EndSpan(span, retErr) }()
 	if len(args) == 0 {
 		args = json.RawMessage(`{}`)
 	}

--- a/internal/manager/biz/alert/pipeline.go
+++ b/internal/manager/biz/alert/pipeline.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+
 	edgebiz "github.com/ongridio/ongrid/internal/manager/biz/edge"
 	model "github.com/ongridio/ongrid/internal/manager/model/alert"
 	edgemodel "github.com/ongridio/ongrid/internal/manager/model/edge"
@@ -193,6 +195,8 @@ func (e *PipelineEvaluator) EvaluateOnce(ctx context.Context) {
 }
 
 func (e *PipelineEvaluator) evaluate(ctx context.Context) {
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/alert").Start(ctx, "alert.Evaluate")
+	defer span.End()
 	now := e.now()
 	if e.edges != nil {
 		// Refresh the device_last_seen_seconds_ago gauge first so any

--- a/internal/manager/biz/flow/engine.go
+++ b/internal/manager/biz/flow/engine.go
@@ -24,12 +24,19 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	model "github.com/ongridio/ongrid/internal/manager/model/flow"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // maxConcurrentNodes caps fan-out so a wide graph can't spawn an
 // unbounded number of agent workers at once.
 const maxConcurrentNodes = 4
+
+var flowTracer = otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/flow")
 
 // Engine executes a parsed graph against a run row.
 type Engine struct {
@@ -65,6 +72,13 @@ type runState struct {
 // a manual and an alert trigger doesn't double-fire the manual branch on
 // an alert.
 func (e *Engine) Execute(ctx context.Context, run *model.FlowRun, g *Graph, entryType string) (status string, runErr error) {
+	ctx, span := flowTracer.Start(ctx, "flow.Engine.Execute",
+		trace.WithAttributes(attribute.String("flow.entry_type", entryTypeLabel(entryType))),
+	)
+	defer func() {
+		span.SetAttributes(attribute.String("flow.status", status))
+		tracing.EndSpan(span, runErr)
+	}()
 	defer func() {
 		if r := recover(); r != nil {
 			status = model.RunStatusFailed
@@ -161,6 +175,11 @@ func (e *Engine) activate(ctx context.Context, run *model.FlowRun, g *Graph, byI
 // runNode resolves config, executes, persists the FlowRunNode row, and
 // fires the resulting control port.
 func (e *Engine) runNode(ctx context.Context, run *model.FlowRun, g *Graph, byID map[string]GraphNode, st *runState, node GraphNode) {
+	ctx, span := flowTracer.Start(ctx, "flow.Node."+node.Type,
+		trace.WithAttributes(attribute.String("flow.node.type", node.Type)),
+	)
+	var execErr error
+	defer func() { tracing.EndSpan(span, execErr) }()
 	started := time.Now().UTC()
 	row := &model.FlowRunNode{
 		RunID:    run.ID,
@@ -202,7 +221,6 @@ func (e *Engine) runNode(ctx context.Context, run *model.FlowRun, g *Graph, byID
 	}
 
 	var res NodeResult
-	var execErr error
 	if resolveErr != nil {
 		execErr = resolveErr
 	} else {
@@ -278,7 +296,11 @@ func entryTypeLabel(t string) string {
 // editor uses to surface a node's real output before it's wired into the
 // flow). It resolves the node's config against rc, runs the executor, and
 // returns the result — no persistence, no edge traversal.
-func (e *Engine) RunSingle(ctx context.Context, node GraphNode, rc *RunContext) (NodeResult, error) {
+func (e *Engine) RunSingle(ctx context.Context, node GraphNode, rc *RunContext) (result NodeResult, retErr error) {
+	ctx, span := flowTracer.Start(ctx, "flow.Node."+node.Type,
+		trace.WithAttributes(attribute.String("flow.node.type", node.Type)),
+	)
+	defer func() { tracing.EndSpan(span, retErr) }()
 	var cfg map[string]any
 	if len(node.Config) > 0 {
 		var raw map[string]any

--- a/internal/manager/biz/logs/search.go
+++ b/internal/manager/biz/logs/search.go
@@ -8,9 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	model "github.com/ongridio/ongrid/internal/manager/model/logs"
 	apperrs "github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/logquery"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 const maxHistogramBuckets = 500
@@ -24,7 +28,9 @@ type searchCursorEnvelope struct {
 	Cursor            string `json:"cursor"`
 }
 
-func (s *Service) Search(ctx context.Context, req logquery.SearchRequest) (*logquery.SearchResult, error) {
+func (s *Service) Search(ctx context.Context, req logquery.SearchRequest) (result *logquery.SearchResult, retErr error) {
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/logs").Start(ctx, "logs.Search")
+	defer func() { tracing.EndSpan(span, retErr) }()
 	if err := req.NormalizeAndValidate(); err != nil {
 		return nil, err
 	}
@@ -33,7 +39,9 @@ func (s *Service) Search(ctx context.Context, req logquery.SearchRequest) (*logq
 		return nil, err
 	}
 	searcher := s.loki
+	backendName := "loki"
 	if backend != nil {
+		backendName = "elasticsearch"
 		searcher, err = s.elasticsearchClient(ctx, backend)
 		if err != nil {
 			return nil, err
@@ -52,10 +60,11 @@ func (s *Service) Search(ctx context.Context, req logquery.SearchRequest) (*logq
 	} else if searcher == nil {
 		return nil, errors.New("current Loki backend is unavailable")
 	}
+	span.SetAttributes(attribute.String("logs.backend", backendName))
 	// Product search windows own (start, end]. Backend search APIs use an
 	// inclusive lower bound, so exclude the start boundary explicitly.
 	req.Start = req.Start.Add(time.Nanosecond)
-	result, err := searcher.Search(ctx, req)
+	result, err = searcher.Search(ctx, req)
 	if err != nil || backend == nil || result.NextCursor == "" {
 		return result, err
 	}
@@ -170,15 +179,17 @@ func (s *Service) FieldValues(ctx context.Context, req logquery.FieldValuesReque
 	return searcher.FieldValues(ctx, req)
 }
 
-func (s *Service) Histogram(ctx context.Context, req logquery.SearchRequest, interval time.Duration) ([]logquery.HistogramBucket, error) {
+func (s *Service) Histogram(ctx context.Context, req logquery.SearchRequest, interval time.Duration) (result []logquery.HistogramBucket, retErr error) {
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/logs").Start(ctx, "logs.Histogram")
+	defer func() { tracing.EndSpan(span, retErr) }()
 	if err := req.NormalizeAndValidate(); err != nil {
 		return nil, err
 	}
 	if interval <= 0 || interval > logquery.MaxSearchWindow {
 		return nil, errors.New("logquery: histogram interval is invalid")
 	}
-	span := req.End.Sub(req.Start)
-	bucketCount := int((span-1)/interval) + 1
+	window := req.End.Sub(req.Start)
+	bucketCount := int((window-1)/interval) + 1
 	if bucketCount > maxHistogramBuckets {
 		return nil, fmt.Errorf("logquery: histogram exceeds %d buckets; increase interval", maxHistogramBuckets)
 	}

--- a/internal/manager/biz/promwrite/ingester.go
+++ b/internal/manager/biz/promwrite/ingester.go
@@ -24,8 +24,12 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/ongridio/ongrid/internal/pkg/prom"
 	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
@@ -189,14 +193,21 @@ func buildPromSamples(samples []tunnel.PromSample, fixedLabels map[string]string
 	return out
 }
 
-func (i *Ingester) write(ctx context.Context, entityLabel string, entityID uint64, source string, out []pkgpromwrite.Sample) error {
+func (i *Ingester) write(ctx context.Context, entityLabel string, entityID uint64, source string, out []pkgpromwrite.Sample) (retErr error) {
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/biz/promwrite").Start(ctx, "metrics.RemoteWrite")
+	span.SetAttributes(
+		attribute.Int("metrics.sample_count", len(out)),
+		attribute.String("metrics.entity_type", entityLabel),
+	)
+	defer func() { tracing.EndSpan(span, retErr) }()
+
 	if err := i.w.Write(ctx, out); err != nil {
 		i.recordFailure()
 		// Self-observability: prom_write_total{result=fail} agrees with the
 		// health snapshot (Failures++ / LastFailureAt) the health_ingest
 		// evaluator reads, so both surfaces report the same failure events.
 		prom.IncPromWrite(err)
-		i.log.Warn("promwrite: write failed",
+		i.log.WarnContext(ctx, "promwrite: write failed",
 			slog.String("entity_label", entityLabel),
 			slog.Uint64("entity_id", entityID),
 			slog.String("source", source),

--- a/internal/manager/biz/promwrite/ingester_test.go
+++ b/internal/manager/biz/promwrite/ingester_test.go
@@ -8,6 +8,10 @@ import (
 	"sync"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	pkgpromwrite "github.com/ongridio/ongrid/internal/pkg/promwrite"
 	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
@@ -231,6 +235,35 @@ func TestIngester_Push_WriterErrPropagates(t *testing.T) {
 	if err := ing.Push(context.Background(), 1, "src", in); err == nil {
 		t.Errorf("expected writer error to propagate")
 	}
+}
+
+func TestIngester_Push_CreatesRemoteWriteParentSpan(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	ing := NewIngester(&fakeWriter{}, slog.Default())
+	ctx, parent := provider.Tracer("test").Start(context.Background(), "ingest")
+	if err := ing.Push(ctx, 1, "embedded", []tunnel.PromSample{{Name: "up", Value: 1}}); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	parent.End()
+
+	for _, span := range recorder.Ended() {
+		if span.Name() != "metrics.RemoteWrite" {
+			continue
+		}
+		if span.Parent().SpanID() != parent.SpanContext().SpanID() {
+			t.Fatalf("remote write parent = %s, want %s", span.Parent().SpanID(), parent.SpanContext().SpanID())
+		}
+		return
+	}
+	t.Fatal("metrics.RemoteWrite span missing")
 }
 
 func TestIngester_Push_NilWriterDegrades(t *testing.T) {

--- a/internal/manager/server/traces/http.go
+++ b/internal/manager/server/traces/http.go
@@ -21,9 +21,11 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/otel"
 
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tracequery"
+	"github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // Querier is the narrow surface this handler needs. *tracequery.Client
@@ -138,7 +140,9 @@ func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.Search")
 	out, err := h.q.SearchTraces(ctx, opts)
+	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
@@ -163,7 +167,9 @@ func (h *Handler) getTrace(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.Get")
 	out, err := h.q.GetTrace(ctx, id)
+	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
@@ -187,7 +193,9 @@ func (h *Handler) tagValues(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
+	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.TagValues")
 	out, err := h.q.TagValues(ctx, tag)
+	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return

--- a/internal/manager/server/traces/http.go
+++ b/internal/manager/server/traces/http.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"go.opentelemetry.io/otel"
 
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tracequery"
@@ -138,11 +137,9 @@ func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(tracing.WithoutHTTPClientTracing(r.Context()), 30*time.Second)
 	defer cancel()
-	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.Search")
 	out, err := h.q.SearchTraces(ctx, opts)
-	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
@@ -165,11 +162,9 @@ func (h *Handler) getTrace(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "trace_id required")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(tracing.WithoutHTTPClientTracing(r.Context()), 30*time.Second)
 	defer cancel()
-	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.Get")
 	out, err := h.q.GetTrace(ctx, id)
-	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
@@ -191,11 +186,9 @@ func (h *Handler) tagValues(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "tag required")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(tracing.WithoutHTTPClientTracing(r.Context()), 15*time.Second)
 	defer cancel()
-	ctx, span := otel.Tracer("github.com/ongridio/ongrid/internal/manager/server/traces").Start(ctx, "traces.TagValues")
 	out, err := h.q.TagValues(ctx, tag)
-	tracing.EndSpan(span, err)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return

--- a/internal/pkg/dbx/dbx.go
+++ b/internal/pkg/dbx/dbx.go
@@ -16,6 +16,8 @@
 package dbx
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -27,6 +29,10 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	gormmysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -59,7 +65,7 @@ func openMySQL(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	}
 
 	gdb, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
-		Logger: newGORMLogger(os.Stdout),
+		Logger: instrumentGORMLogger(newGORMLogger(os.Stdout), "mysql"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dbx: mysql open: %w", err)
@@ -102,7 +108,7 @@ func openSQLite(path string, log *slog.Logger) (*gorm.DB, error) {
 	dsn := buildSQLiteDSN(path)
 
 	gdb, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: newGORMLogger(os.Stdout),
+		Logger: instrumentGORMLogger(newGORMLogger(os.Stdout), "sqlite"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dbx: sqlite open %q: %w", path, err)
@@ -121,6 +127,116 @@ func newGORMLogger(w io.Writer) logger.Interface {
 		IgnoreRecordNotFoundError: true,
 		Colorful:                  true,
 	})
+}
+
+type otelGORMLogger struct {
+	logger.Interface
+	dialect string
+	tracer  trace.Tracer
+}
+
+func instrumentGORMLogger(base logger.Interface, dialect string) logger.Interface {
+	return otelGORMLogger{
+		Interface: base,
+		dialect:   dialect,
+		tracer:    otel.Tracer("github.com/ongridio/ongrid/internal/pkg/dbx"),
+	}
+}
+
+func (l otelGORMLogger) LogMode(level logger.LogLevel) logger.Interface {
+	return otelGORMLogger{
+		Interface: l.Interface.LogMode(level),
+		dialect:   l.dialect,
+		tracer:    l.tracer,
+	}
+}
+
+func (l otelGORMLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		l.Interface.Trace(ctx, begin, fc, err)
+		return
+	}
+
+	_, span := l.tracer.Start(ctx, "DB QUERY",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithTimestamp(begin),
+	)
+	if !span.IsRecording() {
+		span.End()
+		l.Interface.Trace(ctx, begin, fc, err)
+		return
+	}
+
+	query, rows := fc()
+	operation := databaseOperation(query)
+	collection := databaseCollection(query, operation)
+	spanName := "DB " + operation
+	if collection != "" {
+		spanName += " " + collection
+	}
+	span.SetName(spanName)
+	span.SetAttributes(
+		attribute.String("db.system.name", l.dialect),
+		attribute.String("db.operation.name", operation),
+		attribute.String("peer.service", l.dialect),
+	)
+	if collection != "" {
+		span.SetAttributes(attribute.String("db.collection.name", collection))
+	}
+	if rows >= 0 {
+		span.SetAttributes(attribute.Int64("db.response.returned_rows", rows))
+	}
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End(trace.WithTimestamp(time.Now()))
+
+	l.Interface.Trace(ctx, begin, func() (string, int64) { return query, rows }, err)
+}
+
+func databaseOperation(query string) string {
+	fields := strings.Fields(query)
+	if len(fields) == 0 {
+		return "QUERY"
+	}
+	return strings.ToUpper(strings.Trim(fields[0], "`\""))
+}
+
+func databaseCollection(query, operation string) string {
+	fields := strings.Fields(query)
+	if len(fields) < 2 {
+		return ""
+	}
+	index := -1
+	switch operation {
+	case "SELECT", "DELETE":
+		for i := 1; i+1 < len(fields); i++ {
+			if strings.EqualFold(fields[i], "FROM") {
+				index = i + 1
+				break
+			}
+		}
+	case "INSERT", "REPLACE":
+		if strings.EqualFold(fields[1], "INTO") && len(fields) > 2 {
+			index = 2
+		}
+	case "UPDATE":
+		index = 1
+	}
+	if index < 0 || index >= len(fields) {
+		return ""
+	}
+	name := strings.Trim(fields[index], "`\"[](),;")
+	if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+		name = strings.Trim(name[dot+1:], "`\"[]")
+	}
+	for _, r := range name {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' {
+			return ""
+		}
+	}
+	return name
 }
 
 // buildSQLiteDSN appends pragma query params expected by modernc/glebarez sqlite.

--- a/internal/pkg/dbx/dbx_test.go
+++ b/internal/pkg/dbx/dbx_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/ongridio/ongrid/internal/pkg/config"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gorm.io/gorm"
 )
 
@@ -50,6 +54,71 @@ func TestGORMLoggerIgnoresRecordNotFound(t *testing.T) {
 	trace(errors.New("query failed"))
 	if !contains(out.String(), "query failed") {
 		t.Fatalf("real database error was not logged: %q", out.String())
+	}
+}
+
+func TestInstrumentGORMLogger_CreatesDatabaseChildSpanWithoutQueryValues(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	gormLog := instrumentGORMLogger(newGORMLogger(io.Discard), "mysql")
+	ctx, parent := provider.Tracer("test").Start(context.Background(), "request")
+	gormLog.Trace(ctx, time.Now().Add(-time.Millisecond), func() (string, int64) {
+		return "SELECT * FROM users WHERE password = 'super-secret'", 1
+	}, nil)
+	parent.End()
+
+	var databaseSpan sdktrace.ReadOnlySpan
+	for _, span := range recorder.Ended() {
+		if span.Name() == "DB SELECT users" {
+			databaseSpan = span
+			break
+		}
+	}
+	if databaseSpan == nil {
+		t.Fatalf("database span missing; ended spans = %d", len(recorder.Ended()))
+	}
+	if databaseSpan.Parent().SpanID() != parent.SpanContext().SpanID() {
+		t.Fatalf("database parent span = %s, want %s", databaseSpan.Parent().SpanID(), parent.SpanContext().SpanID())
+	}
+
+	attrs := map[string]string{}
+	for _, attr := range databaseSpan.Attributes() {
+		attrs[string(attr.Key)] = attr.Value.Emit()
+	}
+	if attrs["db.system.name"] != "mysql" || attrs["db.operation.name"] != "SELECT" || attrs["db.collection.name"] != "users" {
+		t.Fatalf("database attributes = %#v", attrs)
+	}
+	for _, value := range attrs {
+		if contains(value, "super-secret") {
+			t.Fatalf("query value leaked into span attributes: %#v", attrs)
+		}
+	}
+}
+
+func TestDatabaseCollection_ExtractsSafeTableNames(t *testing.T) {
+	tests := []struct {
+		query     string
+		operation string
+		want      string
+	}{
+		{"SELECT * FROM `users` WHERE id = 1", "SELECT", "users"},
+		{"INSERT INTO audit_events (id) VALUES (1)", "INSERT", "audit_events"},
+		{"UPDATE `ongrid`.`devices` SET name = 'x'", "UPDATE", "devices"},
+		{"DELETE FROM sessions WHERE id = 1", "DELETE", "sessions"},
+		{"SELECT 1", "SELECT", ""},
+		{"SELECT * FROM users;DROP", "SELECT", ""},
+	}
+	for _, test := range tests {
+		if got := databaseCollection(test.query, test.operation); got != test.want {
+			t.Errorf("databaseCollection(%q, %q) = %q, want %q", test.query, test.operation, got, test.want)
+		}
 	}
 }
 

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -1,13 +1,16 @@
 // Package logger wraps log/slog with ongrid conventions.
 //
 // gospec red line: structured logs only, JSON handler, never log raw user
-// content (chat messages, request bodies, secrets). Injecting trace_id /
-// org_id is handled at call sites via slog attributes.
+// content (chat messages, request bodies, secrets). Context-aware log calls
+// automatically include the active OpenTelemetry trace and span IDs.
 package logger
 
 import (
+	"context"
 	"log/slog"
 	"os"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // New returns a *slog.Logger that writes JSON lines to stderr at the given
@@ -16,11 +19,34 @@ func New(level slog.Level) *slog.Logger {
 	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: level,
 	})
-	return slog.New(h)
+	return slog.New(traceHandler{Handler: h})
 }
 
 // WithService returns a logger decorated with a "service" attribute.
 // Used by cmd/ongrid and cmd/ongrid-edge at startup.
 func WithService(l *slog.Logger, name string) *slog.Logger {
 	return l.With(slog.String("service", name))
+}
+
+type traceHandler struct {
+	slog.Handler
+}
+
+func (h traceHandler) Handle(ctx context.Context, record slog.Record) error {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if spanContext.IsValid() {
+		record.AddAttrs(
+			slog.String("trace_id", spanContext.TraceID().String()),
+			slog.String("span_id", spanContext.SpanID().String()),
+		)
+	}
+	return h.Handler.Handle(ctx, record)
+}
+
+func (h traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return traceHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h traceHandler) WithGroup(name string) slog.Handler {
+	return traceHandler{Handler: h.Handler.WithGroup(name)}
 }

--- a/internal/pkg/logger/logger_test.go
+++ b/internal/pkg/logger/logger_test.go
@@ -1,0 +1,41 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceHandler_ContextLogIncludesTraceAndSpanIDs(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex: %v", err)
+	}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	var output bytes.Buffer
+	log := slog.New(traceHandler{Handler: slog.NewJSONHandler(&output, nil)}).With("component", "test")
+	log.InfoContext(ctx, "request failed")
+
+	var record map[string]any
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatalf("decode log record: %v", err)
+	}
+	if got := record["trace_id"]; got != traceID.String() {
+		t.Fatalf("trace_id = %v, want %s", got, traceID)
+	}
+	if got := record["span_id"]; got != spanID.String() {
+		t.Fatalf("span_id = %v, want %s", got, spanID)
+	}
+}

--- a/internal/pkg/logquery/client.go
+++ b/internal/pkg/logquery/client.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // QueryRangeResult is the unmarshalled `data` field from
@@ -96,6 +98,7 @@ func newClient(r BaseURLResolver, hc *http.Client, log *slog.Logger) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
+	hc = oteltracing.InstrumentHTTPClient(hc, "loki")
 	return &Client{base: r, httpClient: hc, log: log}
 }
 
@@ -262,7 +265,7 @@ func (c *Client) do(ctx context.Context, path string, q url.Values) ([]byte, err
 		return nil, fmt.Errorf("logquery: read body: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		c.log.Warn("logquery: non-200",
+		c.log.WarnContext(ctx, "logquery: non-200",
 			slog.Int("status", resp.StatusCode),
 			slog.String("path", path),
 		)

--- a/internal/pkg/logquery/elasticsearch.go
+++ b/internal/pkg/logquery/elasticsearch.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 const (
@@ -73,6 +75,7 @@ func NewElasticsearchClient(cfg ElasticsearchConfig, hc *http.Client, log *slog.
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
+	hc = oteltracing.InstrumentHTTPClient(hc, elasticsearchBackendName)
 	if log == nil {
 		log = slog.Default()
 	}
@@ -803,7 +806,7 @@ func (c *ElasticsearchClient) doJSONWithLimit(ctx context.Context, method, path 
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			c.log.Warn("close Elasticsearch response", slog.Any("err", closeErr))
+			c.log.WarnContext(ctx, "close Elasticsearch response", slog.Any("err", closeErr))
 		}
 	}()
 	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))

--- a/internal/pkg/promquery/client.go
+++ b/internal/pkg/promquery/client.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // InstantResult is the unmarshalled `data` field from a Prom query response,
@@ -78,6 +80,7 @@ func newClient(r BaseURLResolver, hc *http.Client, log *slog.Logger) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
+	hc = oteltracing.InstrumentHTTPClient(hc, "prometheus")
 	return &Client{base: r, httpClient: hc, log: log}
 }
 
@@ -144,7 +147,7 @@ func (c *Client) do(ctx context.Context, path string, q url.Values) (*InstantRes
 		// Prom uses 400 for query parse errors; we want to decode that JSON
 		// so the caller can see the errorType. Anything else is an outright
 		// transport / server failure.
-		c.log.Warn("promquery: non-200",
+		c.log.WarnContext(ctx, "promquery: non-200",
 			slog.Int("status", resp.StatusCode),
 			slog.String("path", path),
 		)

--- a/internal/pkg/promwrite/client.go
+++ b/internal/pkg/promwrite/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
+	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // Label is one (name, value) pair attached to a Sample. The Prometheus
@@ -113,6 +114,7 @@ func newClient(r EndpointResolver, hc *http.Client, log *slog.Logger) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
+	hc = oteltracing.InstrumentHTTPClient(hc, "prometheus")
 	return &Client{endpoint: r, httpClient: hc, log: log}
 }
 
@@ -167,11 +169,10 @@ func (c *Client) Write(ctx context.Context, samples []Sample) error {
 	// Pull a bounded portion of the body into the error so callers can log
 	// it without unbounded memory exposure.
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-	c.log.Warn("promwrite: non-2xx",
+	c.log.WarnContext(ctx, "promwrite: non-2xx",
 		slog.Int("status", resp.StatusCode),
 		slog.Int("samples", len(samples)),
 		slog.String("body", string(body)),
 	)
 	return fmt.Errorf("promwrite: %s returned %d: %s", url, resp.StatusCode, string(body))
 }
-

--- a/internal/pkg/tracequery/client.go
+++ b/internal/pkg/tracequery/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
 
 // SearchResult is the unmarshalled `data` field from a Tempo /api/search
@@ -83,6 +85,7 @@ func newClient(r BaseURLResolver, hc *http.Client, log *slog.Logger) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
+	hc = oteltracing.InstrumentHTTPClient(hc, "tempo")
 	return &Client{base: r, httpClient: hc, log: log}
 }
 
@@ -233,7 +236,7 @@ func (c *Client) do(ctx context.Context, path string, q url.Values) ([]byte, err
 		return nil, fmt.Errorf("tracequery: %s: not found", path)
 	}
 	if resp.StatusCode != http.StatusOK {
-		c.log.Warn("tracequery: non-200",
+		c.log.WarnContext(ctx, "tracequery: non-200",
 			slog.Int("status", resp.StatusCode),
 			slog.String("path", path),
 		)

--- a/internal/pkg/tracing/tracing.go
+++ b/internal/pkg/tracing/tracing.go
@@ -60,6 +60,14 @@ type Config struct {
 // Shutdown gracefully drains the span buffer to the collector.
 type Shutdown func(context.Context) error
 
+type suppressHTTPClientTracingKey struct{}
+
+// WithoutHTTPClientTracing prevents InstrumentHTTPClient from creating a
+// client span for requests derived from ctx.
+func WithoutHTTPClientTracing(ctx context.Context) context.Context {
+	return context.WithValue(ctx, suppressHTTPClientTracingKey{}, true)
+}
+
 // EndSpan records an operation error before ending span. Keeping this in one
 // place prevents business spans from silently disagreeing on error status.
 func EndSpan(span trace.Span, err error) {
@@ -84,6 +92,10 @@ func InstrumentHTTPClient(client *http.Client, peerService string) *http.Client 
 	}
 	peerService = strings.TrimSpace(peerService)
 	opts := []otelhttp.Option{
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			suppressed, _ := r.Context().Value(suppressHTTPClientTracingKey{}).(bool)
+			return !suppressed
+		}),
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			if peerService == "" {
 				return "HTTP " + r.Method

--- a/internal/pkg/tracing/tracing.go
+++ b/internal/pkg/tracing/tracing.go
@@ -21,6 +21,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -106,7 +107,7 @@ func Init(ctx context.Context, cfg Config) (Shutdown, error) {
 	if strings.TrimSpace(cfg.Endpoint) == "" {
 		return func(context.Context) error { return nil }, nil
 	}
-	if cfg.SamplingRatio <= 0 || cfg.SamplingRatio > 1 {
+	if math.IsNaN(cfg.SamplingRatio) || cfg.SamplingRatio < 0 || cfg.SamplingRatio > 1 {
 		cfg.SamplingRatio = 1.0
 	}
 

--- a/internal/pkg/tracing/tracing.go
+++ b/internal/pkg/tracing/tracing.go
@@ -21,15 +21,20 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Config bundles what Init needs.
@@ -53,6 +58,46 @@ type Config struct {
 
 // Shutdown gracefully drains the span buffer to the collector.
 type Shutdown func(context.Context) error
+
+// EndSpan records an operation error before ending span. Keeping this in one
+// place prevents business spans from silently disagreeing on error status.
+func EndSpan(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}
+
+// InstrumentHTTPClient returns a shallow copy of client whose transport
+// creates CLIENT spans and propagates W3C trace context to the backend.
+// The caller-owned client and transport are left untouched.
+func InstrumentHTTPClient(client *http.Client, peerService string) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	clone := *client
+	base := clone.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	peerService = strings.TrimSpace(peerService)
+	opts := []otelhttp.Option{
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			if peerService == "" {
+				return "HTTP " + r.Method
+			}
+			return "HTTP " + r.Method + " " + peerService
+		}),
+	}
+	if peerService != "" {
+		opts = append(opts, otelhttp.WithSpanOptions(
+			trace.WithAttributes(attribute.String("peer.service", peerService)),
+		))
+	}
+	clone.Transport = otelhttp.NewTransport(base, opts...)
+	return &clone
+}
 
 // Init builds and registers the global TracerProvider. When endpoint
 // is empty, returns a no-op shutdown so boot logic can defer

--- a/internal/pkg/tracing/tracing_test.go
+++ b/internal/pkg/tracing/tracing_test.go
@@ -27,7 +27,7 @@ func TestInstrumentHTTPClient_CreatesChildSpanAndPropagatesContext(t *testing.T)
 		_ = provider.Shutdown(context.Background())
 	})
 
-	traceparent := make(chan string, 1)
+	traceparent := make(chan string, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		traceparent <- r.Header.Get("traceparent")
 		w.WriteHeader(http.StatusNoContent)
@@ -54,11 +54,27 @@ func TestInstrumentHTTPClient_CreatesChildSpanAndPropagatesContext(t *testing.T)
 		t.Fatal("traceparent header was not propagated")
 	}
 
+	suppressedReq, err := http.NewRequestWithContext(WithoutHTTPClientTracing(ctx), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext suppressed: %v", err)
+	}
+	suppressedResp, err := client.Do(suppressedReq)
+	if err != nil {
+		t.Fatalf("Do suppressed: %v", err)
+	}
+	if err := suppressedResp.Body.Close(); err != nil {
+		t.Fatalf("close suppressed response body: %v", err)
+	}
+	if got := <-traceparent; got != "" {
+		t.Fatalf("suppressed traceparent = %q, want empty", got)
+	}
+
 	var clientSpan sdktrace.ReadOnlySpan
+	clientSpans := 0
 	for _, span := range recorder.Ended() {
 		if span.Name() == "HTTP GET tempo" {
 			clientSpan = span
-			break
+			clientSpans++
 		}
 	}
 	if clientSpan == nil {
@@ -69,6 +85,9 @@ func TestInstrumentHTTPClient_CreatesChildSpanAndPropagatesContext(t *testing.T)
 	}
 	if got := spanAttribute(clientSpan, "peer.service"); got != "tempo" {
 		t.Fatalf("peer.service = %q, want tempo", got)
+	}
+	if clientSpans != 1 {
+		t.Fatalf("client spans = %d, want 1", clientSpans)
 	}
 }
 

--- a/internal/pkg/tracing/tracing_test.go
+++ b/internal/pkg/tracing/tracing_test.go
@@ -1,0 +1,100 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestInstrumentHTTPClient_CreatesChildSpanAndPropagatesContext(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	traceparent := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceparent <- r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client := InstrumentHTTPClient(server.Client(), "tempo")
+	ctx, parent := provider.Tracer("test").Start(context.Background(), "parent")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close response body: %v", err)
+	}
+	parent.End()
+
+	if got := <-traceparent; got == "" {
+		t.Fatal("traceparent header was not propagated")
+	}
+
+	var clientSpan sdktrace.ReadOnlySpan
+	for _, span := range recorder.Ended() {
+		if span.Name() == "HTTP GET tempo" {
+			clientSpan = span
+			break
+		}
+	}
+	if clientSpan == nil {
+		t.Fatalf("client span missing; ended spans = %d", len(recorder.Ended()))
+	}
+	if clientSpan.Parent().SpanID() != parent.SpanContext().SpanID() {
+		t.Fatalf("client parent span = %s, want %s", clientSpan.Parent().SpanID(), parent.SpanContext().SpanID())
+	}
+	if got := spanAttribute(clientSpan, "peer.service"); got != "tempo" {
+		t.Fatalf("peer.service = %q, want tempo", got)
+	}
+}
+
+func TestEndSpan_RecordsErrorStatus(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	_, span := provider.Tracer("test").Start(context.Background(), "operation")
+	EndSpan(span, errors.New("failed"))
+	if err := provider.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	ended := recorder.Ended()
+	if len(ended) != 1 || ended[0].Status().Code.String() != "Error" {
+		t.Fatalf("ended spans = %#v, want one error span", ended)
+	}
+	if len(ended[0].Events()) == 0 || ended[0].Events()[0].Name != "exception" {
+		t.Fatalf("error event missing: %#v", ended[0].Events())
+	}
+}
+
+func spanAttribute(span sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,6 +117,7 @@ export default function App() {
         <Route path="/monitor" element={<MonitorPage />} />
         <Route path="/logs" element={<LogsPage />} />
         <Route path="/traces" element={<TracesPage />} />
+        <Route path="/traces/:traceId" element={<TracesPage />} />
         <Route path="/kubernetes" element={<KubernetesPage />} />
         <Route path="/kubernetes/:clusterId" element={<KubernetesClusterDetailPage />} />
         <Route path="/alerts" element={<AlertsPage />} />

--- a/web/src/api/traces.ts
+++ b/web/src/api/traces.ts
@@ -36,14 +36,25 @@ export type TraceSearchResponse = {
 // {"batches":[{"resource":{...},"scopeSpans":[{"spans":[...]}]}]} —
 // older versions used `instrumentationLibrarySpans` instead of
 // `scopeSpans`. The page walks both shapes.
+export type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string | number;
+  doubleValue?: number;
+  boolValue?: boolean;
+  bytesValue?: string;
+  arrayValue?: { values?: OtlpAnyValue[] };
+  kvlistValue?: { values?: OtlpAttribute[] };
+};
+
 export type OtlpAttribute = {
   key: string;
-  value?: {
-    stringValue?: string;
-    intValue?: string | number;
-    doubleValue?: number;
-    boolValue?: boolean;
-  };
+  value?: OtlpAnyValue;
+};
+
+export type OtlpSpanEvent = {
+  timeUnixNano?: string;
+  name: string;
+  attributes?: OtlpAttribute[];
 };
 
 export type OtlpSpan = {
@@ -56,6 +67,7 @@ export type OtlpSpan = {
   endTimeUnixNano?: string;
   status?: { code?: number | string; message?: string };
   attributes?: OtlpAttribute[];
+  events?: OtlpSpanEvent[];
 };
 
 export type OtlpScopeSpans = {

--- a/web/src/components/traces/TraceWaterfall.test.ts
+++ b/web/src/components/traces/TraceWaterfall.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TraceGetResponse } from '@/api/traces';
+import { buildTraceWaterfallModel } from './TraceWaterfall';
+
+describe('buildTraceWaterfallModel', () => {
+  it('builds an ordered span tree and keeps orphan spans visible', () => {
+    const trace: TraceGetResponse = {
+      resourceSpans: [
+        {
+          resource: { attributes: [{ key: 'service.name', value: { stringValue: 'api' } }] },
+          scopeSpans: [{
+            spans: [
+              { spanId: 'root', name: 'GET /orders', startTimeUnixNano: '1000000000', endTimeUnixNano: '5000000000' },
+              { spanId: 'late', parentSpanId: 'root', name: 'publish', startTimeUnixNano: '3000000000', endTimeUnixNano: '4500000000', status: { code: 2 } },
+              {
+                spanId: 'early',
+                parentSpanId: 'root',
+                name: 'DB SELECT',
+                startTimeUnixNano: '1200000000',
+                endTimeUnixNano: '1800000000',
+                attributes: [{ key: 'peer.service', value: { stringValue: 'mysql' } }],
+              },
+              { spanId: 'orphan', parentSpanId: 'missing', name: 'detached', startTimeUnixNano: '2000000000', endTimeUnixNano: '2100000000' },
+            ],
+          }],
+        },
+      ],
+    };
+
+    const model = buildTraceWaterfallModel(trace);
+
+    expect(model.durationMs).toBe(4000);
+    expect(model.errorCount).toBe(1);
+    expect(model.services).toEqual(['api', 'mysql']);
+    expect(model.roots.map((span) => span.spanId)).toEqual(['root', 'orphan']);
+    expect(model.byKey.get('root')?.children.map((span) => span.spanId)).toEqual(['early', 'late']);
+    expect(model.byKey.get('early')?.peerService).toBe('mysql');
+  });
+});

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -1,0 +1,597 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  ListTree,
+  Maximize2,
+  Minimize2,
+  Search,
+} from 'lucide-react';
+import {
+  type OtlpAttribute,
+  type OtlpResourceSpans,
+  type OtlpSpanEvent,
+  type TraceGetResponse,
+} from '@/api/traces';
+import { Button, Card, Chip } from '@/components/ui';
+import { useI18n } from '@/i18n/locale';
+import { cn } from '@/lib/cn';
+
+export type TraceSpanNode = {
+  key: string;
+  spanId?: string;
+  parentSpanId?: string;
+  parentKey?: string;
+  name: string;
+  service: string;
+  peerService?: string;
+  kind?: number | string;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  statusCode?: number | string;
+  statusMessage?: string;
+  attributes: OtlpAttribute[];
+  resourceAttributes: OtlpAttribute[];
+  events: OtlpSpanEvent[];
+  children: TraceSpanNode[];
+};
+
+export type TraceWaterfallModel = {
+  spans: TraceSpanNode[];
+  roots: TraceSpanNode[];
+  byKey: Map<string, TraceSpanNode>;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  errorCount: number;
+  services: string[];
+};
+
+type VisibleSpan = { node: TraceSpanNode; depth: number };
+
+type Props = {
+  trace: TraceGetResponse;
+  traceId: string;
+  fallbackService?: string;
+  fallbackName?: string;
+};
+
+export function TraceWaterfall({ trace, traceId, fallbackService, fallbackName }: Props) {
+  const { tr } = useI18n();
+  const model = useMemo(() => buildTraceWaterfallModel(trace), [trace]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
+  const [filterText, setFilterText] = useState('');
+  const [errorsOnly, setErrorsOnly] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const workspaceRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSelectedKey(model.roots[0]?.key ?? model.spans[0]?.key ?? null);
+    setCollapsedKeys(new Set());
+    setFilterText('');
+    setErrorsOnly(false);
+  }, [model]);
+
+  useEffect(() => {
+    const syncFullscreen = () => setIsFullscreen(document.fullscreenElement === workspaceRef.current);
+    document.addEventListener('fullscreenchange', syncFullscreen);
+    return () => document.removeEventListener('fullscreenchange', syncFullscreen);
+  }, []);
+
+  const visible = useMemo(
+    () => visibleSpans(model, collapsedKeys, filterText, errorsOnly),
+    [model, collapsedKeys, filterText, errorsOnly],
+  );
+  const selected = (selectedKey && model.byKey.get(selectedKey)) || visible[0]?.node || null;
+  const root = model.roots[0] ?? model.spans[0];
+  const service = root?.service || fallbackService || '-';
+  const name = root?.name || fallbackName || tr('未命名 trace', 'Unnamed trace');
+
+  if (model.spans.length === 0) {
+    return (
+      <Card className="text-xs text-zinc-500">
+        {tr('trace 详情为空（Tempo 可能尚未刷盘）。', 'No span detail (Tempo may not have flushed yet).')}
+      </Card>
+    );
+  }
+
+  const toggleCollapsed = (key: string) => {
+    setCollapsedKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleFullscreen = () => {
+    const action = document.fullscreenElement
+      ? document.exitFullscreen()
+      : workspaceRef.current?.requestFullscreen();
+    void action?.catch(() => undefined);
+  };
+
+  return (
+    <div
+      ref={workspaceRef}
+      className={cn('space-y-3', isFullscreen && 'h-screen overflow-auto bg-zinc-950 p-4')}
+      data-testid="trace-waterfall"
+    >
+      <Card className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className={cn('h-2 w-2 shrink-0 rounded-full', model.errorCount ? 'bg-red-500' : 'bg-zinc-500')} />
+            <h2 className="truncate font-mono text-sm font-medium text-zinc-100" title={name}>{name}</h2>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-zinc-500">
+            <span>{service}</span>
+            <span>·</span>
+            <span className="font-mono" title={traceId}>{shortId(traceId)}</span>
+            <CopyValueButton value={traceId} label={tr('复制 trace_id', 'Copy trace_id')} />
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-1.5">
+          <Chip>{formatDuration(model.durationMs)}</Chip>
+          <Chip>{tr(`${model.spans.length} 个 Span`, `${model.spans.length} spans`)}</Chip>
+          <Chip>{tr(`${model.services.length} 个服务`, `${model.services.length} services`)}</Chip>
+          {model.errorCount > 0 && (
+            <Chip tone="danger">{tr(`${model.errorCount} 个错误`, `${model.errorCount} errors`)}</Chip>
+          )}
+          <Button
+            onClick={toggleFullscreen}
+            aria-pressed={isFullscreen}
+            title={isFullscreen ? tr('退出全屏', 'Exit fullscreen') : tr('最大化链路工作区', 'Maximize trace workspace')}
+          >
+            {isFullscreen ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+            {isFullscreen ? tr('退出全屏', 'Exit fullscreen') : tr('最大化', 'Maximize')}
+          </Button>
+        </div>
+      </Card>
+
+      <section className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+        <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800/60 px-3 py-2.5">
+          <label className="relative min-w-56 flex-1">
+            <Search size={12} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500" />
+            <input
+              value={filterText}
+              onChange={(event) => setFilterText(event.target.value)}
+              aria-label={tr('搜索 Span', 'Search spans')}
+              placeholder={tr('搜索 Span、服务或 Span ID', 'Search span, service, or span ID')}
+              className="h-8 w-full rounded-md border border-zinc-800 bg-zinc-950 pl-8 pr-2 text-xs text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none"
+            />
+          </label>
+          <Button
+            aria-pressed={errorsOnly}
+            onClick={() => setErrorsOnly((value) => !value)}
+            className={cn(errorsOnly && 'border-red-500/40 bg-red-500/10 text-red-300')}
+          >
+            <AlertTriangle size={12} /> {tr('只看错误', 'Errors only')}
+          </Button>
+          <Button onClick={() => setCollapsedKeys(new Set())} title={tr('展开全部 Span', 'Expand all spans')}>
+            <ListTree size={12} /> {tr('展开全部', 'Expand all')}
+          </Button>
+          <Button
+            onClick={() => setCollapsedKeys(new Set(model.spans.filter((span) => span.children.length > 0).map((span) => span.key)))}
+            title={tr('折叠所有父 Span', 'Collapse all parent spans')}
+          >
+            {tr('折叠全部', 'Collapse all')}
+          </Button>
+          <span className="ml-auto text-[11px] text-zinc-500">
+            {tr(`显示 ${visible.length}/${model.spans.length}`, `${visible.length}/${model.spans.length} shown`)}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-[minmax(260px,36%)_minmax(420px,1fr)] border-b border-zinc-800/60 bg-zinc-950/40 text-[10px] uppercase tracking-wide text-zinc-500">
+          <div className="border-r border-zinc-800/60 px-3 py-2">{tr('调用树', 'Span tree')}</div>
+          <div className="relative px-3 py-2">
+            <div className="flex justify-between font-mono normal-case tracking-normal">
+              {[0, 0.25, 0.5, 0.75, 1].map((ratio) => (
+                <span key={ratio}>{formatDuration(model.durationMs * ratio)}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className={cn('overflow-auto', isFullscreen ? 'max-h-[calc(100vh-260px)]' : 'max-h-[430px]')}>
+          {visible.length === 0 ? (
+            <div className="px-4 py-10 text-center text-xs text-zinc-500">
+              {tr('没有匹配的 Span', 'No matching spans')}
+            </div>
+          ) : (
+            visible.map(({ node, depth }) => {
+              const active = selected?.key === node.key;
+              const collapsed = collapsedKeys.has(node.key);
+              return (
+                <div
+                  key={node.key}
+                  className={cn(
+                    'grid min-w-[760px] grid-cols-[minmax(260px,36%)_minmax(420px,1fr)] border-b border-zinc-800/40 text-[11px] last:border-b-0',
+                    active ? 'bg-zinc-800/60' : 'hover:bg-zinc-900/60',
+                  )}
+                >
+                  <div className="flex min-w-0 items-center border-r border-zinc-800/60 px-2 py-1.5">
+                    <span className="shrink-0" style={{ width: depth * 14 }} aria-hidden="true" />
+                    {node.children.length > 0 ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleCollapsed(node.key)}
+                        className="mr-1 rounded p-0.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+                        aria-label={collapsed ? tr('展开子 Span', 'Expand child spans') : tr('折叠子 Span', 'Collapse child spans')}
+                      >
+                        {collapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+                      </button>
+                    ) : (
+                      <span className="mr-1 w-[16px] shrink-0" />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setSelectedKey(node.key)}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left focus:outline-none"
+                    >
+                      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', isErrorStatus(node.statusCode) ? 'bg-red-500' : 'bg-zinc-500')} />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-mono text-zinc-200" title={node.name}>{node.name}</span>
+                        <span className="block truncate text-[10px] text-zinc-500" title={spanServiceLabel(node)}>{spanServiceLabel(node)}</span>
+                      </span>
+                      <span className="shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(node.durationMs)}</span>
+                    </button>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedKey(node.key)}
+                    className="relative min-h-8 px-3 text-left focus:outline-none"
+                    aria-label={tr(`选择 Span ${node.name}`, `Select span ${node.name}`)}
+                  >
+                    {[0.25, 0.5, 0.75].map((ratio) => (
+                      <span
+                        key={ratio}
+                        className="pointer-events-none absolute inset-y-0 border-l border-zinc-800/60"
+                        style={{ left: `${ratio * 100}%` }}
+                        aria-hidden="true"
+                      />
+                    ))}
+                    <span
+                      className={cn(
+                        'absolute top-1/2 h-3 -translate-y-1/2 rounded-sm',
+                        active ? 'bg-indigo-500' : isErrorStatus(node.statusCode) ? 'bg-red-500' : 'bg-sky-500/70',
+                      )}
+                      style={spanBarStyle(node, model)}
+                      title={`${node.name} · ${formatDuration(node.durationMs)}`}
+                    />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </section>
+
+      {selected && <SpanDetails span={selected} traceStartMs={model.startMs} />}
+    </div>
+  );
+}
+
+function SpanDetails({ span, traceStartMs }: { span: TraceSpanNode; traceStartMs: number }) {
+  const { tr } = useI18n();
+  const offsetMs = Math.max(0, span.startMs - traceStartMs);
+  return (
+    <Card className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className={cn('h-2 w-2 rounded-full', isErrorStatus(span.statusCode) ? 'bg-red-500' : 'bg-zinc-500')} />
+            <h3 className="truncate font-mono text-sm font-medium text-zinc-100" title={span.name}>{span.name}</h3>
+          </div>
+          <p className="mt-1 text-[11px] text-zinc-500">{spanServiceLabel(span)}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <Chip>{spanKindLabel(span.kind)}</Chip>
+          <Chip>{formatDuration(span.durationMs)}</Chip>
+          <Chip>{tr(`起点 +${formatDuration(offsetMs)}`, `Starts +${formatDuration(offsetMs)}`)}</Chip>
+          {isErrorStatus(span.statusCode) ? <Chip tone="danger">error</Chip> : <Chip>ok</Chip>}
+        </div>
+      </div>
+
+      {span.statusMessage && (
+        <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+          <span className="break-words">{span.statusMessage}</span>
+        </div>
+      )}
+
+      <div className="grid gap-3 xl:grid-cols-[280px_minmax(0,1fr)]">
+        <section>
+          <h4 className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">{tr('概览', 'Overview')}</h4>
+          <dl className="divide-y divide-zinc-800/60 overflow-hidden rounded-lg border border-zinc-800/60 text-[11px]">
+            <DetailRow label="span_id" value={span.spanId || '-'} copy={span.spanId} />
+            <DetailRow label="parent_span_id" value={span.parentSpanId || '-'} copy={span.parentSpanId} />
+            <DetailRow label={tr('开始', 'Start')} value={`+${formatDuration(offsetMs)}`} />
+            <DetailRow label={tr('耗时', 'Duration')} value={formatDuration(span.durationMs)} />
+          </dl>
+        </section>
+        <div className="grid min-w-0 gap-3 lg:grid-cols-2">
+          <AttributeList title={tr('Span 属性', 'Span attributes')} attributes={span.attributes} />
+          <AttributeList title={tr('资源属性', 'Resource attributes')} attributes={span.resourceAttributes} />
+        </div>
+      </div>
+
+      {span.events.length > 0 && (
+        <section>
+          <h4 className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">
+            {tr(`事件 (${span.events.length})`, `Events (${span.events.length})`)}
+          </h4>
+          <div className="divide-y divide-zinc-800/60 overflow-hidden rounded-lg border border-zinc-800/60">
+            {span.events.map((event, index) => (
+              <div key={`${event.name}-${event.timeUnixNano ?? index}`} className="px-3 py-2 text-[11px]">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-mono text-zinc-200">{event.name}</span>
+                  <span className="text-zinc-500">+{formatDuration(Math.max(0, nanosToMs(event.timeUnixNano) - traceStartMs))}</span>
+                </div>
+                {event.attributes && event.attributes.length > 0 && (
+                  <div className="mt-1 font-mono text-[10px] text-zinc-500">
+                    {event.attributes.map((attribute) => `${attribute.key}=${attributeValue(attribute)}`).join(' · ')}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </Card>
+  );
+}
+
+function DetailRow({ label, value, copy }: { label: string; value: string; copy?: string }) {
+  return (
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] gap-2 px-3 py-2">
+      <dt className="text-zinc-500">{label}</dt>
+      <dd className="flex min-w-0 items-center gap-1 font-mono text-zinc-300">
+        <span className="truncate" title={value}>{value}</span>
+        {copy && <CopyValueButton value={copy} label={`Copy ${label}`} />}
+      </dd>
+    </div>
+  );
+}
+
+function AttributeList({ title, attributes }: { title: string; attributes: OtlpAttribute[] }) {
+  return (
+    <section className="min-w-0">
+      <h4 className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">{title}</h4>
+      <dl className="max-h-52 divide-y divide-zinc-800/60 overflow-auto rounded-lg border border-zinc-800/60 text-[11px]">
+        {attributes.length === 0 ? (
+          <div className="px-3 py-5 text-center text-zinc-500">-</div>
+        ) : attributes.map((attribute) => (
+          <div key={attribute.key} className="grid grid-cols-[minmax(110px,34%)_minmax(0,1fr)] gap-2 px-3 py-1.5">
+            <dt className="truncate font-mono text-zinc-500" title={attribute.key}>{attribute.key}</dt>
+            <dd className="break-all font-mono text-zinc-300">{attributeValue(attribute)}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function CopyValueButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      className="shrink-0 rounded p-0.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+      title={label}
+      aria-label={label}
+    >
+      {copied ? <Check size={10} /> : <Copy size={10} />}
+    </button>
+  );
+}
+
+export function buildTraceWaterfallModel(trace: TraceGetResponse): TraceWaterfallModel {
+  const groups: OtlpResourceSpans[] = [];
+  if (Array.isArray(trace.batches)) groups.push(...trace.batches);
+  if (Array.isArray(trace.resourceSpans)) groups.push(...trace.resourceSpans);
+
+  const spans: TraceSpanNode[] = [];
+  const usedKeys = new Set<string>();
+  const bySpanId = new Map<string, TraceSpanNode>();
+
+  groups.forEach((group, groupIndex) => {
+    const resourceAttributes = group.resource?.attributes ?? [];
+    const service = readAttribute(resourceAttributes, 'service.name') ?? '';
+    const scopes = [...(group.scopeSpans ?? []), ...(group.instrumentationLibrarySpans ?? [])];
+    scopes.forEach((scope, scopeIndex) => {
+      (scope.spans ?? []).forEach((span, spanIndex) => {
+        const fallbackKey = `${groupIndex}:${scopeIndex}:${spanIndex}`;
+        const preferredKey = span.spanId || fallbackKey;
+        const key = usedKeys.has(preferredKey) ? fallbackKey : preferredKey;
+        usedKeys.add(key);
+        const startMs = nanosToMs(span.startTimeUnixNano);
+        const endMs = nanosToMs(span.endTimeUnixNano);
+        const node: TraceSpanNode = {
+          key,
+          spanId: span.spanId,
+          parentSpanId: span.parentSpanId,
+          name: span.name,
+          service,
+          peerService: readAttribute(span.attributes ?? [], 'peer.service'),
+          kind: span.kind,
+          startMs,
+          endMs,
+          durationMs: Math.max(0, endMs - startMs),
+          statusCode: span.status?.code,
+          statusMessage: span.status?.message,
+          attributes: span.attributes ?? [],
+          resourceAttributes,
+          events: span.events ?? [],
+          children: [],
+        };
+        spans.push(node);
+        if (span.spanId && !bySpanId.has(span.spanId)) bySpanId.set(span.spanId, node);
+      });
+    });
+  });
+
+  for (const node of spans) {
+    const parent = node.parentSpanId ? bySpanId.get(node.parentSpanId) : undefined;
+    if (parent && parent !== node) {
+      node.parentKey = parent.key;
+      parent.children.push(node);
+    }
+  }
+
+  const compare = (a: TraceSpanNode, b: TraceSpanNode) => a.startMs - b.startMs || b.durationMs - a.durationMs;
+  spans.sort(compare);
+  for (const node of spans) node.children.sort(compare);
+
+  const roots = spans.filter((span) => !span.parentKey);
+  const reachable = new Set<string>();
+  const markReachable = (node: TraceSpanNode) => {
+    if (reachable.has(node.key)) return;
+    reachable.add(node.key);
+    for (const child of node.children) markReachable(child);
+  };
+  roots.forEach(markReachable);
+  for (const node of spans) {
+    if (!reachable.has(node.key)) {
+      roots.push(node);
+      markReachable(node);
+    }
+  }
+  roots.sort(compare);
+
+  const starts = spans.map((span) => span.startMs).filter(Number.isFinite);
+  const ends = spans.map((span) => span.endMs).filter(Number.isFinite);
+  const startMs = starts.length ? Math.min(...starts) : 0;
+  const endMs = ends.length ? Math.max(...ends) : startMs;
+  const services = Array.from(new Set(
+    spans.flatMap((span) => [span.service, span.peerService]).filter((service): service is string => Boolean(service)),
+  )).sort();
+  return {
+    spans,
+    roots,
+    byKey: new Map(spans.map((span) => [span.key, span])),
+    startMs,
+    endMs,
+    durationMs: Math.max(0, endMs - startMs),
+    errorCount: spans.filter((span) => isErrorStatus(span.statusCode)).length,
+    services,
+  };
+}
+
+function visibleSpans(
+  model: TraceWaterfallModel,
+  collapsedKeys: Set<string>,
+  filterText: string,
+  errorsOnly: boolean,
+): VisibleSpan[] {
+  const query = filterText.trim().toLowerCase();
+  const filtering = Boolean(query || errorsOnly);
+  const allowed = new Set<string>();
+
+  if (filtering) {
+    for (const span of model.spans) {
+      const matchesQuery = !query || `${span.name} ${spanServiceLabel(span)} ${span.spanId ?? ''}`.toLowerCase().includes(query);
+      const matchesError = !errorsOnly || isErrorStatus(span.statusCode);
+      if (!matchesQuery || !matchesError) continue;
+      let current: TraceSpanNode | undefined = span;
+      const seenParents = new Set<string>();
+      while (current && !seenParents.has(current.key)) {
+        allowed.add(current.key);
+        seenParents.add(current.key);
+        current = current.parentKey ? model.byKey.get(current.parentKey) : undefined;
+      }
+    }
+  }
+
+  const out: VisibleSpan[] = [];
+  const visited = new Set<string>();
+  const visit = (node: TraceSpanNode, depth: number) => {
+    if (visited.has(node.key)) return;
+    visited.add(node.key);
+    if (!filtering || allowed.has(node.key)) out.push({ node, depth });
+    if (!filtering && collapsedKeys.has(node.key)) return;
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const root of model.roots) visit(root, 0);
+  return out;
+}
+
+function spanServiceLabel(span: TraceSpanNode): string {
+  if (span.peerService && span.peerService !== span.service) return `${span.service || '-'} → ${span.peerService}`;
+  return span.service || span.peerService || '-';
+}
+
+function spanBarStyle(node: TraceSpanNode, model: TraceWaterfallModel) {
+  const total = Math.max(model.durationMs, 0.001);
+  const left = clamp(((node.startMs - model.startMs) / total) * 100, 0, 100);
+  const maxWidth = Math.max(0.25, 100 - left);
+  const width = Math.min(maxWidth, Math.max(0.25, (Math.max(node.durationMs, 0.001) / total) * 100));
+  return { left: `${left}%`, width: `${width}%` };
+}
+
+function attributeValue(attribute: OtlpAttribute): string {
+  return valueText(attribute.value);
+}
+
+function valueText(value: OtlpAttribute['value']): string {
+  if (!value) return '';
+  if (value.stringValue !== undefined) return value.stringValue;
+  if (value.intValue !== undefined) return String(value.intValue);
+  if (value.doubleValue !== undefined) return String(value.doubleValue);
+  if (value.boolValue !== undefined) return String(value.boolValue);
+  if (value.bytesValue !== undefined) return value.bytesValue;
+  if (value.arrayValue?.values) return `[${value.arrayValue.values.map(valueText).join(', ')}]`;
+  if (value.kvlistValue?.values) {
+    return `{ ${value.kvlistValue.values.map((attribute) => `${attribute.key}: ${attributeValue(attribute)}`).join(', ')} }`;
+  }
+  return '';
+}
+
+function readAttribute(attributes: OtlpAttribute[], key: string): string | undefined {
+  const value = attributes.find((attribute) => attribute.key === key);
+  return value ? attributeValue(value) : undefined;
+}
+
+function nanosToMs(value?: string): number {
+  if (!value) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed / 1_000_000 : 0;
+}
+
+function isErrorStatus(code?: number | string): boolean {
+  return code === 2 || code === '2' || code === 'STATUS_CODE_ERROR';
+}
+
+function spanKindLabel(kind?: number | string): string {
+  if (kind === undefined || kind === null) return '-';
+  if (typeof kind === 'string' && /^[A-Z_]+$/.test(kind)) return kind.replace(/^SPAN_KIND_/, '').toLowerCase();
+  const numeric = typeof kind === 'number' ? kind : Number(kind);
+  return ['-', 'internal', 'server', 'client', 'producer', 'consumer'][numeric] ?? '-';
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '-';
+  if (ms === 0) return '0ms';
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`;
+  if (ms < 1000) return `${ms.toFixed(ms < 10 ? 2 : 1)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function shortId(id: string): string {
+  if (id.length <= 16) return id;
+  return `${id.slice(0, 8)}…${id.slice(-6)}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -362,7 +362,7 @@ function AttributeList({ title, attributes }: { title: string; attributes: OtlpA
   return (
     <section className="min-w-0">
       <h4 className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">{title}</h4>
-      <dl className="max-h-52 divide-y divide-zinc-800/60 overflow-auto rounded-lg border border-zinc-800/60 text-[11px]">
+      <dl className="divide-y divide-zinc-800/60 overflow-hidden rounded-lg border border-zinc-800/60 text-[11px]">
         {attributes.length === 0 ? (
           <div className="px-3 py-5 text-center text-zinc-500">-</div>
         ) : attributes.map((attribute) => (

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -293,7 +293,7 @@ function SpanDetails({ span, traceStartMs }: { span: TraceSpanNode; traceStartMs
           <Chip>{spanKindLabel(span.kind)}</Chip>
           <Chip>{formatDuration(span.durationMs)}</Chip>
           <Chip>{tr(`起点 +${formatDuration(offsetMs)}`, `Starts +${formatDuration(offsetMs)}`)}</Chip>
-          {isErrorStatus(span.statusCode) ? <Chip tone="danger">error</Chip> : <Chip>ok</Chip>}
+          {isErrorStatus(span.statusCode) ? <Chip tone="danger">error</Chip> : <Chip>{isOkStatus(span.statusCode) ? 'ok' : 'unset'}</Chip>}
         </div>
       </div>
 
@@ -570,6 +570,10 @@ function nanosToMs(value?: string): number {
 
 function isErrorStatus(code?: number | string): boolean {
   return code === 2 || code === '2' || code === 'STATUS_CODE_ERROR';
+}
+
+function isOkStatus(code?: number | string): boolean {
+  return code === 1 || code === '1' || code === 'STATUS_CODE_OK';
 }
 
 function spanKindLabel(kind?: number | string): string {

--- a/web/src/components/traces/traceSummary.test.ts
+++ b/web/src/components/traces/traceSummary.test.ts
@@ -48,7 +48,9 @@ describe('traceSearchQuery', () => {
   });
 
   it('defaults to business traces and can select internal traffic', () => {
-    expect(traceSearchQuery('', '', '')).toContain('trace:rootName !~');
+    const businessQuery = traceSearchQuery('', '', '');
+    expect(businessQuery).toContain('trace:rootName !~');
+    expect(businessQuery).toContain('/api/v1/prometheus/auth');
     expect(traceSearchQuery('', '', '', '', 'internal')).toContain('trace:rootName =~');
   });
 });

--- a/web/src/components/traces/traceSummary.test.ts
+++ b/web/src/components/traces/traceSummary.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatTraceSummaryDuration,
+  traceSearchQuery,
+  traceSummaryDurationMs,
+} from './traceSummary';
+
+describe('traceSummaryDurationMs', () => {
+  it('uses Tempo durationNanos when a sub-millisecond durationMs is omitted', () => {
+    expect(traceSummaryDurationMs({
+      traceID: 'sub-ms',
+      spanSet: { spans: [{ durationNanos: '245347' }] },
+    })).toBeCloseTo(0.245347);
+  });
+
+  it('prefers the trace duration and falls back to the longest returned span', () => {
+    expect(traceSummaryDurationMs({
+      traceID: 'milliseconds',
+      durationMs: 12,
+      spanSet: { spans: [{ durationNanos: '245347' }] },
+    })).toBe(12);
+    expect(traceSummaryDurationMs({
+      traceID: 'span-sets',
+      spanSets: [{ spans: [{ durationNanos: '65337' }, { durationNanos: '376854' }] }],
+    })).toBeCloseTo(0.376854);
+  });
+});
+
+describe('formatTraceSummaryDuration', () => {
+  it('keeps sub-millisecond values visible in milliseconds', () => {
+    expect(formatTraceSummaryDuration(0.245347)).toBe('0.245ms');
+    expect(formatTraceSummaryDuration(0.0004)).toBe('<0.001ms');
+    expect(formatTraceSummaryDuration(0)).toBe('-');
+  });
+});
+
+describe('traceSearchQuery', () => {
+  it('requests the latest traces for unfiltered, facet, and explicit searches', () => {
+    expect(traceSearchQuery('', '', '', '', 'all')).toBe('{} with (most_recent=true)');
+    expect(traceSearchQuery('', 'api"v2', 'GET /orders', 'mysql', 'all')).toBe(
+      '{ resource.service.name = "api\\"v2" && span:name = "GET /orders" && span.peer.service = "mysql" } with (most_recent=true)',
+    );
+    expect(traceSearchQuery('{ duration > 1s }', 'ignored', 'ignored')).toBe(
+      '{ duration > 1s } with (most_recent=true)',
+    );
+    expect(traceSearchQuery('{} with (most_recent=true)', '', '')).toBe('{} with (most_recent=true)');
+  });
+
+  it('defaults to business traces and can select internal traffic', () => {
+    expect(traceSearchQuery('', '', '')).toContain('trace:rootName !~');
+    expect(traceSearchQuery('', '', '', '', 'internal')).toContain('trace:rootName =~');
+  });
+});

--- a/web/src/components/traces/traceSummary.ts
+++ b/web/src/components/traces/traceSummary.ts
@@ -1,0 +1,56 @@
+import type { TempoTraceSummary } from '@/api/traces';
+
+type SearchSpan = { durationNanos?: string | number };
+type SearchSpanSet = { spans?: SearchSpan[] };
+
+export function traceSummaryDurationMs(summary: TempoTraceSummary): number {
+  for (const value of [summary.durationMs, summary.traceDurationMs]) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+  }
+
+  const spanSets: unknown[] = [summary.spanSet];
+  if (Array.isArray(summary.spanSets)) spanSets.push(...summary.spanSets);
+
+  let durationNanos = 0;
+  for (const candidate of spanSets) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const spans = (candidate as SearchSpanSet).spans;
+    if (!Array.isArray(spans)) continue;
+    for (const span of spans) {
+      const value = Number(span.durationNanos);
+      if (Number.isFinite(value) && value > durationNanos) durationNanos = value;
+    }
+  }
+  return durationNanos / 1_000_000;
+}
+
+export function formatTraceSummaryDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '-';
+  if (ms < 0.001) return '<0.001ms';
+  if (ms < 1) return `${Number(ms.toFixed(3))}ms`;
+  if (ms < 1000) return `${ms.toFixed(1)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export type TraceScope = 'business' | 'internal' | 'all';
+
+const INTERNAL_ROOTS = '(GET|POST|PUT|PATCH|DELETE) /(internal|api/v1/traces)/.*|GET /healthz|GET /readyz|HTTP (GET|POST) prometheus|metrics\\..*|alert\\.Evaluate';
+
+export function traceSearchQuery(
+  traceQL: string,
+  service: string,
+  operation: string,
+  peerService = '',
+  scope: TraceScope = 'business',
+): string {
+  const explicit = traceQL.trim();
+  const clauses = [
+    service && `resource.service.name = ${JSON.stringify(service)}`,
+    operation && `span:name = ${JSON.stringify(operation)}`,
+    peerService && `span.peer.service = ${JSON.stringify(peerService)}`,
+    scope === 'business' && `trace:rootName !~ ${JSON.stringify(INTERNAL_ROOTS)}`,
+    scope === 'internal' && `trace:rootName =~ ${JSON.stringify(INTERNAL_ROOTS)}`,
+  ].filter(Boolean);
+  const query = explicit || (clauses.length === 0 ? '{}' : `{ ${clauses.join(' && ')} }`);
+  return /\bwith\s*\(/i.test(query) ? query : `${query} with (most_recent=true)`;
+}

--- a/web/src/components/traces/traceSummary.ts
+++ b/web/src/components/traces/traceSummary.ts
@@ -34,7 +34,7 @@ export function formatTraceSummaryDuration(ms: number): string {
 
 export type TraceScope = 'business' | 'internal' | 'all';
 
-const INTERNAL_ROOTS = '(GET|POST|PUT|PATCH|DELETE) /(internal|api/v1/traces)/.*|GET /healthz|GET /readyz|HTTP (GET|POST) prometheus|metrics\\..*|alert\\.Evaluate';
+const INTERNAL_ROOTS = '(GET|POST|PUT|PATCH|DELETE) /(internal|api/v1/traces)/.*|GET /api/v1/prometheus/auth|GET /healthz|GET /readyz|HTTP (GET|POST) prometheus|metrics\\..*|alert\\.Evaluate';
 
 export function traceSearchQuery(
   traceQL: string,

--- a/web/src/pages/Traces.tsx
+++ b/web/src/pages/Traces.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   AlertTriangle,
-  ChevronDown,
   ChevronRight,
+  ArrowLeft,
+  Braces,
   Clock,
   Copy,
   Filter,
@@ -16,10 +18,6 @@ import {
   getTrace,
   listTraceTagValues,
   searchTraces,
-  type OtlpAttribute,
-  type OtlpResourceSpans,
-  type OtlpScopeSpans,
-  type OtlpSpan,
   type TempoTraceSummary,
   type TraceGetResponse,
 } from '@/api/traces';
@@ -27,6 +25,14 @@ import { ApiError } from '@/api/client';
 import { openObservabilityUrl, buildExploreUrl } from '@/lib/drilldown';
 import { GrafanaLinkButton } from '@/components/GrafanaLinkButton';
 import { NLQueryHelper } from '@/components/NLQueryHelper';
+import { TraceWaterfall } from '@/components/traces/TraceWaterfall';
+import {
+  formatTraceSummaryDuration,
+  traceSearchQuery,
+  traceSummaryDurationMs,
+  type TraceScope,
+} from '@/components/traces/traceSummary';
+import { Button, PageHeader } from '@/components/ui';
 import { useObservability } from '@/store/observability';
 import { cn } from '@/lib/cn';
 import { fullDateTime } from '@/lib/format';
@@ -83,14 +89,14 @@ const TRACES_QUICK_CHIPS: { labelZh: string; labelEn: string; query: string; tit
   {
     labelZh: '出错的 trace',
     labelEn: 'Errored traces',
-    query: '{status=error}',
+    query: '{ span:status = error }',
     titleZh: '只看 status=error 的 trace',
     titleEn: 'Show only status=error traces',
   },
   {
     labelZh: '超过 1s',
     labelEn: 'Over 1s',
-    query: '{duration > 1s}',
+    query: '{ trace:duration > 1s }',
     titleZh: '总时长 > 1 秒的慢 trace',
     titleEn: 'Slow traces with total duration > 1s',
   },
@@ -116,13 +122,8 @@ type TraceRow = {
 };
 
 function normalizeRow(t: TempoTraceSummary): TraceRow {
-  // Tempo 2.x: durationMs; 1.x: traceDurationMs. Default 0 if absent.
-  const durationMs =
-    typeof t.durationMs === 'number'
-      ? t.durationMs
-      : typeof t.traceDurationMs === 'number'
-        ? t.traceDurationMs
-        : 0;
+  // Tempo omits durationMs below 1ms, while spanSet keeps durationNanos.
+  const durationMs = traceSummaryDurationMs(t);
   // Tempo 2.x: startTimeUnixNano (string of nanos); some clients emit
   // startTime (RFC3339). Convert both to ms.
   let startMs = 0;
@@ -145,17 +146,22 @@ function normalizeRow(t: TempoTraceSummary): TraceRow {
 
 export default function TracesPage() {
   const { tr } = useI18n();
+  const navigate = useNavigate();
+  const { traceId: routeTraceId = '' } = useParams<{ traceId?: string }>();
   const [range, setRange] = useState(DEFAULT_RANGE);
   const [serviceFilter, setServiceFilter] = useState('');
   const [operationFilter, setOperationFilter] = useState('');
+  const [peerFilter, setPeerFilter] = useState('');
+  const [scope, setScope] = useState<TraceScope>('business');
   const [traceQL, setTraceQL] = useState(DEFAULT_TRACEQL);
   const [submitted, setSubmitted] = useState({
     range: DEFAULT_RANGE,
     service: '',
     operation: '',
+    peer: '',
+    scope: 'business' as TraceScope,
     traceQL: DEFAULT_TRACEQL,
   });
-  // Default empty: don't fire a query on first render — Tempo searches
   // Auto-query on page load with the default filters (range=1h, no
   // service/operation/TraceQL). Matches the Logs page convention —
   // operators expect "open the page → see something". The earlier
@@ -168,22 +174,78 @@ export default function TracesPage() {
   const [err, setErr] = useState<string | null>(null);
   const [serviceOptions, setServiceOptions] = useState<string[]>([]);
   const [operationOptions, setOperationOptions] = useState<string[]>([]);
+  const [peerOptions, setPeerOptions] = useState<string[]>([]);
   // Trace-ID direct lookup. Operators often have a trace ID from app
   // logs / a customer ticket; paste it here and skip the search.
   const [traceIdInput, setTraceIdInput] = useState('');
-  const [autoOpenTraceId, setAutoOpenTraceId] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [selectedRow, setSelectedRow] = useState<TraceRow | null>(null);
+  const [selectedTrace, setSelectedTrace] = useState<TraceGetResponse | null>(null);
+  const [selectedTraceLoading, setSelectedTraceLoading] = useState(false);
+  const [selectedTraceErr, setSelectedTraceErr] = useState<string | null>(null);
   const requestSeq = useRef(0);
+  const detailRequestSeq = useRef(0);
+
+  const resetTrace = useCallback(() => {
+    detailRequestSeq.current++;
+    setSelectedRow(null);
+    setSelectedTrace(null);
+    setSelectedTraceErr(null);
+    setSelectedTraceLoading(false);
+  }, []);
+
+  const closeTrace = useCallback(() => {
+    resetTrace();
+    setTraceIdInput('');
+    navigate('/traces', { replace: true });
+  }, [navigate, resetTrace]);
+
+  const loadTrace = useCallback(async (row: TraceRow) => {
+    const seq = ++detailRequestSeq.current;
+    setSelectedRow(row);
+    setSelectedTrace(null);
+    setSelectedTraceErr(null);
+    setSelectedTraceLoading(true);
+    try {
+      const trace = await getTrace(row.traceId);
+      if (seq === detailRequestSeq.current) setSelectedTrace(trace);
+    } catch (error) {
+      if (seq === detailRequestSeq.current) {
+        setSelectedTraceErr(error instanceof ApiError ? error.message : (error as Error).message);
+      }
+    } finally {
+      if (seq === detailRequestSeq.current) setSelectedTraceLoading(false);
+    }
+  }, []);
+
+  const openTrace = useCallback((row: TraceRow) => {
+    navigate(`/traces/${encodeURIComponent(row.traceId)}`);
+  }, [navigate]);
+
+  useEffect(() => {
+    const id = routeTraceId.trim();
+    if (!id) {
+      resetTrace();
+      return;
+    }
+    if (selectedRow?.traceId === id) return;
+    const row = rows.find((candidate) => candidate.traceId === id) ?? {
+      traceId: id,
+      service: '',
+      rootName: '',
+      durationMs: 0,
+      startMs: 0,
+      spanCount: 0,
+    };
+    void loadTrace(row);
+  }, [loadTrace, resetTrace, routeTraceId, rows, selectedRow?.traceId]);
 
   const submitTraceId = useCallback(() => {
     const id = traceIdInput.trim();
     if (!id) return;
-    // Render a synthetic row that immediately fetches + expands the trace
-    // by ID. service / rootName / duration / startMs are unknown until
-    // the GET /traces/{id} response comes back; placeholder for now.
-    setRows([{ traceId: id, service: '', rootName: tr('(直接通过 trace_id 查询)', '(direct trace_id lookup)'), durationMs: 0, startMs: 0, spanCount: 0 }]);
-    setAutoOpenTraceId(id);
     setErr(null);
-  }, [traceIdInput]);
+    openTrace({ traceId: id, service: '', rootName: '', durationMs: 0, startMs: 0, spanCount: 0 });
+  }, [openTrace, traceIdInput]);
 
   const fetchTraces = useCallback(async () => {
     const seq = ++requestSeq.current;
@@ -195,9 +257,7 @@ export default function TracesPage() {
       const start = new Date(startMs).toISOString();
       const end = now.toISOString();
       const resp = await searchTraces({
-        q: submitted.traceQL.trim() || undefined,
-        service: submitted.traceQL.trim() ? undefined : submitted.service || undefined,
-        operation: submitted.traceQL.trim() ? undefined : submitted.operation || undefined,
+        q: traceSearchQuery(submitted.traceQL, submitted.service, submitted.operation, submitted.peer, submitted.scope),
         start,
         end,
         limit: PAGE_LIMIT,
@@ -215,7 +275,7 @@ export default function TracesPage() {
     } finally {
       if (seq === requestSeq.current) setLoading(false);
     }
-  }, [submitted.range, submitted.service, submitted.operation, submitted.traceQL]);
+  }, [submitted.range, submitted.service, submitted.operation, submitted.peer, submitted.scope, submitted.traceQL]);
 
   useEffect(() => {
     if (!hasSearched) return;
@@ -234,6 +294,8 @@ export default function TracesPage() {
       range,
       service: serviceFilter,
       operation: operationFilter,
+      peer: peerFilter,
+      scope,
       traceQL,
     });
     setHasSearched(true);
@@ -254,13 +316,15 @@ export default function TracesPage() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const [services, ops] = await Promise.all([
+      const [services, ops, peers] = await Promise.all([
         listTraceTagValues('service.name').then((r) => r.values ?? []).catch(() => []),
         listTraceTagValues('name').then((r) => r.values ?? []).catch(() => []),
+        listTraceTagValues('peer.service').then((r) => r.values ?? []).catch(() => []),
       ]);
       if (!cancelled) {
         setServiceOptions(services ?? []);
         setOperationOptions(ops ?? []);
+        setPeerOptions(peers ?? []);
       }
     })();
     return () => {
@@ -279,10 +343,13 @@ export default function TracesPage() {
       setHasSearched(true);
       return;
     }
+    closeTrace();
     setSubmitted({
       range,
       service: serviceFilter,
       operation: operationFilter,
+      peer: peerFilter,
+      scope,
       traceQL,
     });
     setHasSearched(true);
@@ -292,11 +359,14 @@ export default function TracesPage() {
   // click): commit the pick into `submitted` (keeping current range +
   // TraceQL) and arm hasSearched so the fetch effect fires. A typed
   // trace-id still wins, so skip when a trace-id lookup is in progress.
-  const pickServiceOperation = (svc: string, op: string) => {
+  const pickFacets = (svc: string, op: string, peer: string, nextScope: TraceScope = scope) => {
     setServiceFilter(svc);
     setOperationFilter(op);
+    setPeerFilter(peer);
+    setScope(nextScope);
     if (traceIdInput.trim()) return;
-    setSubmitted({ range, service: svc, operation: op, traceQL });
+    closeTrace();
+    setSubmitted({ range, service: svc, operation: op, peer, scope: nextScope, traceQL });
     setHasSearched(true);
   };
 
@@ -309,13 +379,7 @@ export default function TracesPage() {
   const onOpenGrafana = useCallback(() => {
     const base =
       (grafanaBaseUrl || '').replace(/\/+$/, '') || `${window.location.origin}/grafana`;
-    let expr = traceQL.trim();
-    if (!expr) {
-      const parts: string[] = [];
-      if (serviceFilter) parts.push(`resource.service.name="${serviceFilter}"`);
-      if (operationFilter) parts.push(`name="${operationFilter}"`);
-      expr = `{${parts.join(' && ') || 'true'}}`;
-    }
+    const expr = traceSearchQuery(traceQL, serviceFilter, operationFilter, peerFilter, scope);
     const now = Date.now();
     const from = now - rangeToMs(range);
     const url = buildExploreUrl({
@@ -328,211 +392,138 @@ export default function TracesPage() {
       orgId: grafanaOrgId,
     });
     void openObservabilityUrl(url);
-  }, [grafanaBaseUrl, grafanaOrgId, range, serviceFilter, operationFilter, traceQL]);
+  }, [grafanaBaseUrl, grafanaOrgId, range, serviceFilter, operationFilter, peerFilter, scope, traceQL]);
 
   return (
     <main className="anim-fade flex flex-1 flex-col overflow-hidden">
-      <header className="app-header border-b border-zinc-800 px-6 py-4">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h1 className="text-base font-medium text-zinc-100">{tr('链路', 'Traces')}</h1>
-            <p className="mt-0.5 text-xs text-zinc-500">
-              {tr(
-                '通过 TraceQL / 服务+操作 查询 Tempo 链路数据。每行 = 一条 trace，按开始时间倒序。',
-                'Query Tempo traces by TraceQL or service+operation. Each row is one trace, newest first.',
-              )}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {/* Canonical header action order: 实时 → 在 Grafana 中打开 → 刷新.
-                Mirrors 监控 / 日志 so the toolbar feels the same on every
-                observability page. */}
-            <button
-              type="button"
-              onClick={() => setLive((v) => !v)}
+      <PageHeader
+        title={tr('链路', 'Traces')}
+        subtitle={selectedRow
+          ? tr('正在查看单条 trace 的调用树与时间轴', 'Inspecting the span tree and timeline for one trace')
+          : tr(`Tempo 链路 · ${rows.length} 条结果`, `Tempo traces · ${rows.length} results`)}
+        actions={(
+          <>
+            <Button
+              onClick={() => setLive((value) => !value)}
               title={live ? tr('停止 5 秒自动刷新', 'Stop auto-refresh (5 s)') : tr('每 5 秒自动刷新', 'Auto-refresh every 5 s')}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs',
-                live
-                  ? 'border-emerald-500/60 bg-emerald-500/10 text-emerald-200'
-                  : 'border-zinc-700 text-zinc-200 hover:border-zinc-500 hover:bg-zinc-800',
-              )}
+              className={cn(live && 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300')}
             >
               {live ? <Pause size={12} /> : <Play size={12} />}
               {live ? tr('实时中', 'Live') : tr('实时', 'Live')}
-            </button>
+            </Button>
             <GrafanaLinkButton
               onClick={onOpenGrafana}
               label={tr('在 Grafana 中打开', 'Open in Grafana')}
               title={tr('跳到 Grafana Tempo Explore — 支持火焰图 / 服务图等高级分析', 'Jump to Grafana Tempo Explore — flame graph / service graph / etc.')}
             />
-            <button
-              type="button"
-              onClick={() => void fetchTraces()}
-              disabled={loading}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:border-zinc-500 hover:bg-zinc-800 disabled:opacity-50"
+            <Button
+              onClick={() => void (selectedRow ? loadTrace(selectedRow) : fetchTraces())}
+              disabled={loading || selectedTraceLoading}
             >
-              <RefreshCw size={12} className={cn(loading && 'animate-spin')} /> {tr('刷新', 'Refresh')}
-            </button>
-          </div>
-        </div>
-
-        {/* Two-row filter form:
-              row 1 = facets (service / operation / time / trace_id) + Search
-              row 2 = TraceQL + 快捷 chips
-            Inner divs flex-wrap so each visual row degrades gracefully on
-            narrow screens, but they never re-mix across the two rows. */}
-        <form onSubmit={submit} className="mt-3 flex flex-col gap-2">
-          {/* Facets row — primary scope filters + Search button at the
-              right end (operator feedback 2026-05-18: facet inputs are
-              what people set first, and the Search button should live
-              with them). */}
-          <div className="flex flex-wrap items-end gap-2 order-1">
-          <label className="block w-48 shrink-0">
-            <span className="mb-1 block text-[11px] text-zinc-500">
-              <Filter size={10} className="-mt-0.5 mr-1 inline" />
-              service.name
-            </span>
-            <select
-              value={serviceFilter}
-              onChange={(e) => pickServiceOperation(e.target.value, operationFilter)}
-              className={INPUT_BASE}
-            >
-              <option value="">{tr('全部', 'All')}</option>
-              {serviceOptions.map((v) => (
-                <option key={v} value={v}>{v}</option>
-              ))}
-            </select>
-          </label>
-          <label className="block w-48 shrink-0">
-            <span className="mb-1 block text-[11px] text-zinc-500">
-              <Filter size={10} className="-mt-0.5 mr-1 inline" />
-              operation
-            </span>
-            <select
-              value={operationFilter}
-              onChange={(e) => pickServiceOperation(serviceFilter, e.target.value)}
-              className={cn(INPUT_BASE, 'font-mono')}
-            >
-              <option value="">{tr('全部', 'All')}</option>
-              {operationOptions.map((v) => (
-                <option key={v} value={v}>{v}</option>
-              ))}
-            </select>
-          </label>
-          <label className="block w-36 shrink-0">
-            <span className="mb-1 block text-[11px] text-zinc-500">
-              <Clock size={10} className="-mt-0.5 mr-1 inline" />
-              {tr('时间范围', 'Time range')}
-            </span>
-            <select
-              value={range}
-              onChange={(e) => setRange(e.target.value)}
-              className={INPUT_BASE}
-            >
-              {RANGE_PRESETS.map((o) => (
-                <option key={o.value} value={o.value}>{tr(o.labelZh, o.labelEn)}</option>
-              ))}
-            </select>
-          </label>
-          {/* trace_id — non-empty value short-circuits the search to a
-              single-row result (handled in submit()). Lives inline with
-              the rest of the filters so the user just types + clicks
-              查询; no separate "Open" button or empty-state CTA. */}
-          <label className="block w-44 shrink-0">
-            <span className="mb-1 block text-[11px] text-zinc-500">
-              <SearchIcon size={10} className="-mt-0.5 mr-1 inline" />
-              trace_id
-            </span>
-            <input
-              value={traceIdInput}
-              onChange={(e) => setTraceIdInput(e.target.value)}
-              placeholder={tr('粘贴 ID 跳到这条', 'Paste an ID to jump')}
-              className={cn(INPUT_BASE, 'font-mono')}
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={loading}
-            className="ml-auto inline-flex h-[34px] shrink-0 items-center gap-1.5 self-end rounded-md bg-accent px-3 text-xs font-medium text-accent-fg hover:bg-accent/90 disabled:opacity-50"
-          >
-            {loading ? <Loader2 size={12} className="animate-spin" /> : <SearchIcon size={12} />}
-            {tr('查询', 'Search')}
-          </button>
-          </div>
-          {/* TraceQL row — advanced query language + 快捷 chips. Falls
-              below the facets row (order-2). */}
-          <div className="flex flex-wrap items-end gap-2 order-2">
-          <label className={cn('block w-[520px] max-w-full shrink', traceIdInput.trim() && 'opacity-50')}>
-            <span className="mb-1 block text-[11px] text-zinc-500">
-              <SearchIcon size={10} className="-mt-0.5 mr-1 inline" />
-              {tr('TraceQL（高级；非空覆盖 facet）', 'TraceQL (advanced; overrides facets when set)')}
-            </span>
-            <div className="flex items-center gap-1.5">
-              <input
-                value={traceQL}
-                onChange={(e) => setTraceQL(e.target.value)}
-                placeholder={tr('留空 = 用 facet；或：{ resource.service.name="my-api" && duration > 200ms }', 'Empty = use facets above; or: { resource.service.name="my-api" && duration > 200ms }')}
-                className={cn(INPUT_BASE, 'font-mono')}
-              />
-              <NLQueryHelper
-                dialect="traceql"
-                context={{
-                  range,
-                  service: serviceFilter || undefined,
-                  operation: operationFilter || undefined,
-                }}
-                onAccept={(translated) => {
-                  // Fill back into TraceQL state only — user审核后再提交.
-                  setTraceQL(translated);
-                }}
-              />
-            </div>
-          </label>
-          {/* 快捷 chips — inline next to TraceQL. h-[34px] wrapper
-              baseline-aligns chips with the TraceQL input. */}
-          <div className="flex h-[34px] flex-wrap items-center gap-1.5 self-end">
-            <span className="text-[11px] text-zinc-500">{tr('快捷:', 'Quick:')}</span>
-            {TRACES_QUICK_CHIPS.map((c) => (
-              <button
-                key={c.labelEn}
-                type="button"
-                title={tr(c.titleZh, c.titleEn)}
-                onClick={() => {
-                  // One-click: fill TraceQL + submit. The submit reducer
-                  // re-runs fetchTraces via its dependency on `submitted`.
-                  setTraceQL(c.query);
-                  setSubmitted({
-                    range,
-                    service: serviceFilter,
-                    operation: operationFilter,
-                    traceQL: c.query,
-                  });
-                  setHasSearched(true);
-                }}
-                className={cn(
-                  'rounded-full border px-2 py-0.5 text-[11px]',
-                  submitted.traceQL === c.query
-                    ? 'border-indigo-500/60 bg-indigo-500/15 text-indigo-200'
-                    : 'border-zinc-800 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800',
-                )}
-              >
-                {tr(c.labelZh, c.labelEn)}
-              </button>
-            ))}
-          </div>
-          </div>
-        </form>
-
-        {!err && hasSearched && (
-          <div className="mt-2 text-[11px] text-zinc-500">
-            {tr(`返回 ${rows.length} 条`, `${rows.length} result(s)`)}
-            {rows.length >= PAGE_LIMIT && (
-              <span className="ml-1 text-amber-400">{tr(`（达到 ${PAGE_LIMIT} 条上限，缩小时间窗或加 TraceQL 过滤）`, ` (hit ${PAGE_LIMIT}-row cap — narrow the time window or add TraceQL filters)`)}</span>
-            )}
-          </div>
+              <RefreshCw size={12} className={cn((loading || selectedTraceLoading) && 'animate-spin')} /> {tr('刷新', 'Refresh')}
+            </Button>
+          </>
         )}
-      </header>
+        extra={(
+          <form onSubmit={submit} className="space-y-2">
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="block w-44 shrink-0">
+                <span className="mb-1 block text-[11px] text-zinc-500"><Filter size={10} className="-mt-0.5 mr-1 inline" />service.name</span>
+                <select value={serviceFilter} onChange={(event) => pickFacets(event.target.value, operationFilter, peerFilter)} className={INPUT_BASE}>
+                  <option value="">{tr('全部', 'All')}</option>
+                  {serviceOptions.map((value) => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </label>
+              <label className="block w-44 shrink-0">
+                <span className="mb-1 block text-[11px] text-zinc-500"><Filter size={10} className="-mt-0.5 mr-1 inline" />operation</span>
+                <select value={operationFilter} onChange={(event) => pickFacets(serviceFilter, event.target.value, peerFilter)} className={cn(INPUT_BASE, 'font-mono')}>
+                  <option value="">{tr('全部', 'All')}</option>
+                  {operationOptions.map((value) => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </label>
+              <label className="block w-36 shrink-0">
+                <span className="mb-1 block text-[11px] text-zinc-500"><Filter size={10} className="-mt-0.5 mr-1 inline" />peer.service</span>
+                <select value={peerFilter} onChange={(event) => pickFacets(serviceFilter, operationFilter, event.target.value)} className={INPUT_BASE}>
+                  <option value="">{tr('全部依赖', 'All peers')}</option>
+                  {peerOptions.map((value) => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </label>
+              <label className="block w-28 shrink-0">
+                <span className="mb-1 block text-[11px] text-zinc-500">{tr('请求类型', 'Traffic')}</span>
+                <select value={scope} onChange={(event) => pickFacets(serviceFilter, operationFilter, peerFilter, event.target.value as TraceScope)} className={INPUT_BASE}>
+                  <option value="business">{tr('业务请求', 'Business')}</option>
+                  <option value="internal">{tr('内部请求', 'Internal')}</option>
+                  <option value="all">{tr('全部请求', 'All')}</option>
+                </select>
+              </label>
+              <label className="block w-32 shrink-0">
+                <span className="mb-1 block text-[11px] text-zinc-500"><Clock size={10} className="-mt-0.5 mr-1 inline" />{tr('时间范围', 'Time range')}</span>
+                <select value={range} onChange={(event) => setRange(event.target.value)} className={INPUT_BASE}>
+                  {RANGE_PRESETS.map((option) => <option key={option.value} value={option.value}>{tr(option.labelZh, option.labelEn)}</option>)}
+                </select>
+              </label>
+              <label className="block min-w-44 flex-1">
+                <span className="mb-1 block text-[11px] text-zinc-500"><SearchIcon size={10} className="-mt-0.5 mr-1 inline" />trace_id</span>
+                <input value={traceIdInput} onChange={(event) => setTraceIdInput(event.target.value)} placeholder={tr('粘贴 ID 直接打开', 'Paste an ID to open')} className={cn(INPUT_BASE, 'font-mono')} />
+              </label>
+              <div className="flex h-[34px] items-center gap-1.5 self-end">
+                {TRACES_QUICK_CHIPS.map((chip) => (
+                  <button
+                    key={chip.labelEn}
+                    type="button"
+                    title={tr(chip.titleZh, chip.titleEn)}
+                    onClick={() => {
+                      closeTrace();
+                      setTraceIdInput('');
+                      setTraceQL(chip.query);
+                      setSubmitted({ range, service: serviceFilter, operation: operationFilter, peer: peerFilter, scope, traceQL: chip.query });
+                      setHasSearched(true);
+                    }}
+                    className={cn(
+                      'rounded-full border px-2 py-0.5 text-[11px]',
+                      submitted.traceQL === chip.query
+                        ? 'border-indigo-500/60 bg-indigo-500/15 text-indigo-200'
+                        : 'border-zinc-800 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800',
+                    )}
+                  >
+                    {tr(chip.labelZh, chip.labelEn)}
+                  </button>
+                ))}
+              </div>
+              <Button onClick={() => setAdvancedOpen((value) => !value)} aria-expanded={advancedOpen}>
+                <Braces size={12} /> TraceQL <ChevronRight size={11} className={cn('transition-transform', advancedOpen && 'rotate-90')} />
+              </Button>
+              <Button type="submit" variant="primary" disabled={loading} className="ml-auto h-[34px]">
+                {loading ? <Loader2 size={12} className="animate-spin" /> : <SearchIcon size={12} />}
+                {tr('查询', 'Search')}
+              </Button>
+            </div>
+            {advancedOpen && (
+              <label className={cn('block max-w-3xl', traceIdInput.trim() && 'opacity-50')}>
+                <span className="mb-1 block text-[11px] text-zinc-500">{tr('TraceQL（非空时覆盖上方所有筛选）', 'TraceQL (overrides all filters above when set)')}</span>
+                <div className="flex items-center gap-1.5">
+                  <input
+                    value={traceQL}
+                    onChange={(event) => setTraceQL(event.target.value)}
+                    placeholder={'{ resource.service.name="my-api" && duration > 200ms }'}
+                    className={cn(INPUT_BASE, 'font-mono')}
+                  />
+                  <NLQueryHelper
+                    dialect="traceql"
+                    context={{ range, service: serviceFilter || undefined, operation: operationFilter || undefined }}
+                    onAccept={setTraceQL}
+                  />
+                </div>
+              </label>
+            )}
+            {!err && hasSearched && rows.length >= PAGE_LIMIT && (
+              <p className="text-[11px] text-amber-400">
+                {tr(`达到 ${PAGE_LIMIT} 条上限，请缩小时间窗或增加 TraceQL 过滤`, `Hit the ${PAGE_LIMIT}-row cap; narrow the time range or add a TraceQL filter`)}
+              </p>
+            )}
+          </form>
+        )}
+      />
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
         {err && (
@@ -541,7 +532,32 @@ export default function TracesPage() {
             <span>{err}</span>
           </div>
         )}
-        {!hasSearched && !loading && rows.length === 0 && !err && (
+        {selectedRow && (
+          <div className="space-y-3">
+            <Button onClick={closeTrace}><ArrowLeft size={12} />{tr(`返回链路列表 (${rows.length})`, `Back to traces (${rows.length})`)}</Button>
+            {selectedTraceLoading && (
+              <div className="flex items-center gap-2 rounded-xl border border-zinc-800/60 bg-zinc-900/40 px-4 py-10 text-xs text-zinc-400">
+                <Loader2 size={13} className="animate-spin" /> {tr('正在加载 trace 详情…', 'Loading trace details…')}
+              </div>
+            )}
+            {selectedTraceErr && (
+              <div className="flex flex-wrap items-center gap-3 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-xs text-red-300">
+                <AlertTriangle size={13} />
+                <span className="min-w-0 flex-1">{selectedTraceErr}</span>
+                <Button onClick={() => void loadTrace(selectedRow)}>{tr('重试', 'Retry')}</Button>
+              </div>
+            )}
+            {selectedTrace && !selectedTraceLoading && !selectedTraceErr && (
+              <TraceWaterfall
+                trace={selectedTrace}
+                traceId={selectedRow.traceId}
+                fallbackService={selectedRow.service}
+                fallbackName={selectedRow.rootName}
+              />
+            )}
+          </div>
+        )}
+        {!selectedRow && !hasSearched && !loading && rows.length === 0 && !err && (
           <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-zinc-800 bg-zinc-950/40 px-4 py-12 text-center">
             <SearchIcon size={26} className="text-zinc-600" />
             <div className="text-sm text-zinc-500">{tr('设好上面的筛选再点查询；填了 trace_id 会直接返回那一条', 'Set the filters above and click Search; filling in a trace_id returns just that one trace.')}</div>
@@ -553,7 +569,7 @@ export default function TracesPage() {
             </div>
           </div>
         )}
-        {hasSearched && !loading && rows.length === 0 && !err && (
+        {!selectedRow && hasSearched && !loading && rows.length === 0 && !err && (
           <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-zinc-800 bg-zinc-950/40 px-4 py-12 text-center">
             <SearchIcon size={26} className="text-zinc-600" />
             <div className="text-sm text-zinc-500">{tr('该时间窗内没有匹配的 trace', 'No traces matched this time window')}</div>
@@ -574,17 +590,19 @@ export default function TracesPage() {
               >
                 {tr('扩大到 24 小时', 'Widen to 24 h')}
               </button>
-              {(serviceFilter || operationFilter) && (
+              {(serviceFilter || operationFilter || peerFilter || scope !== 'business') && (
                 <button
                   type="button"
                   onClick={() => {
                     setServiceFilter('');
                     setOperationFilter('');
-                    setSubmitted((s) => ({ ...s, service: '', operation: '' }));
+                    setPeerFilter('');
+                    setScope('business');
+                    setSubmitted((s) => ({ ...s, service: '', operation: '', peer: '', scope: 'business' }));
                   }}
                   className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-[11px] text-zinc-300 hover:bg-zinc-800"
                 >
-                  {tr('清除服务 / 操作筛选', 'Clear service / operation filters')}
+                  {tr('恢复业务请求筛选', 'Reset business filters')}
                 </button>
               )}
               {traceQL.trim() && (
@@ -602,27 +620,49 @@ export default function TracesPage() {
             </div>
           </div>
         )}
-        {rows.length > 0 && (
-          <div className="overflow-hidden rounded-lg border border-zinc-800">
-            <table className="w-full text-left text-xs">
+        {!selectedRow && rows.length > 0 && (
+          <div className="overflow-hidden rounded-xl border border-zinc-800/60 bg-zinc-900/40">
+            <table className="w-full text-left text-xs" aria-label={tr('链路查询结果', 'Trace search results')}>
               <thead className="bg-zinc-900/60 text-[11px] uppercase tracking-wide text-zinc-500">
                 <tr>
-                  <th className="w-8 px-2 py-2"></th>
-                  <th className="px-2 py-2">trace_id</th>
-                  <th className="px-2 py-2">service</th>
-                  <th className="px-2 py-2">root span</th>
+                  <th className="px-3 py-2">{tr('根操作 / 服务', 'Root operation / service')}</th>
                   <th className="px-2 py-2 text-right">duration</th>
                   <th className="px-2 py-2 text-right">spans</th>
                   <th className="px-2 py-2">start</th>
+                  <th className="px-2 py-2">trace_id</th>
+                  <th className="w-8 px-2 py-2"></th>
                 </tr>
               </thead>
-              <tbody>
-                {rows.map((r) => (
-                  <TraceRowItem
-                    key={r.traceId}
-                    row={r}
-                    autoOpen={autoOpenTraceId === r.traceId}
-                  />
+              <tbody className="divide-y divide-zinc-800/60">
+                {rows.map((row) => (
+                  <tr
+                    key={row.traceId}
+                    tabIndex={0}
+                    role="button"
+                    onClick={() => openTrace(row)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        openTrace(row);
+                      }
+                    }}
+                    className="cursor-pointer bg-zinc-900/20 hover:bg-zinc-900/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500"
+                  >
+                    <td className="min-w-64 px-3 py-2.5">
+                      <span className="block truncate font-mono text-zinc-200" title={row.rootName}>{row.rootName || '-'}</span>
+                      <span className="mt-0.5 block truncate text-[10px] text-zinc-500" title={row.service}>{row.service || '-'}</span>
+                    </td>
+                    <td className="px-2 py-2.5 text-right font-mono text-zinc-200">{formatTraceSummaryDuration(row.durationMs)}</td>
+                    <td className="px-2 py-2.5 text-right text-zinc-300">{row.spanCount || '-'}</td>
+                    <td className="whitespace-nowrap px-2 py-2.5 text-zinc-400">{row.startMs ? fullDateTime(row.startMs) : '-'}</td>
+                    <td className="px-2 py-2.5 font-mono text-zinc-400">
+                      <span className="inline-flex items-center gap-1">
+                        <span title={row.traceId}>{shortId(row.traceId)}</span>
+                        <CopyButton value={row.traceId} />
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 text-zinc-500"><ChevronRight size={12} /></td>
+                  </tr>
                 ))}
               </tbody>
             </table>
@@ -631,220 +671,6 @@ export default function TracesPage() {
       </div>
     </main>
   );
-}
-
-function TraceRowItem({ row, autoOpen = false }: { row: TraceRow; autoOpen?: boolean }) {
-  const { tr } = useI18n();
-  const [open, setOpen] = useState(autoOpen);
-  const [trace, setTrace] = useState<TraceGetResponse | null>(null);
-  const [traceErr, setTraceErr] = useState<string | null>(null);
-  const [traceLoading, setTraceLoading] = useState(false);
-
-  // Auto-fetch when row was opened pre-mount (paste-by-id flow).
-  useEffect(() => {
-    if (autoOpen && trace == null && !traceLoading && !traceErr) {
-      setTraceLoading(true);
-      void getTrace(row.traceId)
-        .then(setTrace)
-        .catch((e) => setTraceErr(e instanceof ApiError ? e.message : (e as Error).message))
-        .finally(() => setTraceLoading(false));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoOpen, row.traceId]);
-
-  const onToggle = useCallback(async () => {
-    const next = !open;
-    setOpen(next);
-    if (next && trace == null && !traceLoading) {
-      setTraceLoading(true);
-      setTraceErr(null);
-      try {
-        const t = await getTrace(row.traceId);
-        setTrace(t);
-      } catch (e) {
-        setTraceErr(e instanceof ApiError ? e.message : (e as Error).message);
-      } finally {
-        setTraceLoading(false);
-      }
-    }
-  }, [open, trace, traceLoading, row.traceId]);
-
-  const startLabel = useMemo(() => {
-    if (!row.startMs) return '-';
-    return fullDateTime(row.startMs);
-  }, [row.startMs]);
-
-  return (
-    <>
-      <tr
-        className="cursor-pointer border-t border-zinc-800/60 bg-zinc-900/20 hover:bg-zinc-900/50"
-        onClick={() => void onToggle()}
-      >
-        <td className="px-2 py-2 text-zinc-500">
-          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </td>
-        <td className="px-2 py-2 font-mono text-zinc-200">
-          <span className="inline-flex items-center gap-1">
-            <span title={row.traceId}>{shortId(row.traceId)}</span>
-            <CopyButton value={row.traceId} />
-          </span>
-        </td>
-        <td className="px-2 py-2 text-zinc-200">{row.service || <span className="text-zinc-600">-</span>}</td>
-        <td className="px-2 py-2 font-mono text-[11px] text-zinc-300">
-          {row.rootName || <span className="text-zinc-600">-</span>}
-        </td>
-        <td className="px-2 py-2 text-right text-zinc-200">{formatDuration(row.durationMs)}</td>
-        <td className="px-2 py-2 text-right text-zinc-300">{row.spanCount || '-'}</td>
-        <td className="px-2 py-2 text-zinc-400">{startLabel}</td>
-      </tr>
-      {open && (
-        <tr className="border-t border-zinc-800/60 bg-zinc-950/40">
-          <td colSpan={7} className="px-4 py-3">
-            {traceLoading && (
-              <div className="flex items-center gap-2 text-xs text-zinc-400">
-                <Loader2 size={12} className="animate-spin" /> {tr('加载 trace 详情…', 'Loading trace detail…')}
-              </div>
-            )}
-            {traceErr && (
-              <div className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-xs text-red-300">
-                <AlertTriangle size={12} className="mt-0.5" />
-                <span>{traceErr}</span>
-              </div>
-            )}
-            {trace && !traceLoading && !traceErr && <SpanTable trace={trace} />}
-          </td>
-        </tr>
-      )}
-    </>
-  );
-}
-
-// SpanTable renders a flat list of spans pulled out of the OTLP-shaped
-// trace body. We deliberately don't build a tree (parent/child) for v1
-// — operators who need that go to Grafana Tempo via the deep-link
-// button.
-function SpanTable({ trace }: { trace: TraceGetResponse }) {
-  const { tr } = useI18n();
-  const flat = useMemo(() => flattenSpans(trace), [trace]);
-  if (flat.length === 0) {
-    return <div className="text-xs text-zinc-500">{tr('trace 详情为空（Tempo 可能尚未刷盘）。', 'No span detail (Tempo may not have flushed yet).')}</div>;
-  }
-  return (
-    <div className="overflow-hidden rounded border border-zinc-800">
-      <table className="w-full text-left text-[11px]">
-        <thead className="bg-zinc-900/60 uppercase tracking-wide text-zinc-500">
-          <tr>
-            <th className="px-2 py-1.5">span</th>
-            <th className="px-2 py-1.5">service</th>
-            <th className="px-2 py-1.5">kind</th>
-            <th className="px-2 py-1.5 text-right">duration</th>
-            <th className="px-2 py-1.5">status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {flat.map((s, i) => (
-            <tr key={`${s.spanId ?? i}`} className="border-t border-zinc-800/60">
-              <td className="px-2 py-1 font-mono text-zinc-200">{s.name}</td>
-              <td className="px-2 py-1 text-zinc-300">{s.service || '-'}</td>
-              <td className="px-2 py-1 text-zinc-400">{spanKindLabel(s.kind)}</td>
-              <td className="px-2 py-1 text-right text-zinc-200">{formatDuration(s.durationMs)}</td>
-              <td className="px-2 py-1">
-                <StatusBadge code={s.statusCode} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-type FlatSpan = {
-  name: string;
-  service: string;
-  spanId?: string;
-  kind?: number | string;
-  durationMs: number;
-  statusCode?: number | string;
-};
-
-function flattenSpans(trace: TraceGetResponse): FlatSpan[] {
-  // Tempo / OTLP wraps spans in either `batches` or `resourceSpans`.
-  // Each batch has a Resource (service.name lives there as an attribute)
-  // and a list of scopeSpans (or instrumentationLibrarySpans on older
-  // collectors). We walk both shapes and emit a flat row per span.
-  const groups: OtlpResourceSpans[] = [];
-  if (Array.isArray(trace.batches)) groups.push(...trace.batches);
-  if (Array.isArray(trace.resourceSpans)) groups.push(...trace.resourceSpans);
-
-  const out: FlatSpan[] = [];
-  for (const g of groups) {
-    const service = readAttr(g.resource?.attributes, 'service.name') ?? '';
-    const scopeGroups: OtlpScopeSpans[] = [];
-    if (Array.isArray(g.scopeSpans)) scopeGroups.push(...g.scopeSpans);
-    if (Array.isArray(g.instrumentationLibrarySpans)) scopeGroups.push(...g.instrumentationLibrarySpans);
-    for (const sg of scopeGroups) {
-      for (const sp of sg.spans ?? []) {
-        out.push({
-          name: sp.name,
-          service,
-          spanId: sp.spanId,
-          kind: sp.kind,
-          durationMs: spanDurationMs(sp),
-          statusCode: sp.status?.code,
-        });
-      }
-    }
-  }
-  // Order: longest first (catches the obvious hot spans without a tree).
-  out.sort((a, b) => b.durationMs - a.durationMs);
-  return out;
-}
-
-function spanDurationMs(sp: OtlpSpan): number {
-  const start = Number(sp.startTimeUnixNano);
-  const end = Number(sp.endTimeUnixNano);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) return 0;
-  return Math.max(0, (end - start) / 1_000_000);
-}
-
-function readAttr(attrs: OtlpAttribute[] | undefined, key: string): string | undefined {
-  if (!attrs) return undefined;
-  for (const a of attrs) {
-    if (a.key === key) return a.value?.stringValue ?? String(a.value?.intValue ?? a.value?.doubleValue ?? '');
-  }
-  return undefined;
-}
-
-// OTLP SpanKind enum values; tolerate both numeric and stringified forms.
-function spanKindLabel(k?: number | string): string {
-  if (k === undefined || k === null) return '-';
-  if (typeof k === 'string' && /^[A-Z_]+$/.test(k)) {
-    return k.replace(/^SPAN_KIND_/, '').toLowerCase();
-  }
-  const n = typeof k === 'number' ? k : Number(k);
-  switch (n) {
-    case 1: return 'internal';
-    case 2: return 'server';
-    case 3: return 'client';
-    case 4: return 'producer';
-    case 5: return 'consumer';
-    default: return '-';
-  }
-}
-
-function StatusBadge({ code }: { code?: number | string }) {
-  // OTLP StatusCode: 0=UNSET, 1=OK, 2=ERROR. Tempo sometimes emits
-  // strings — handle both.
-  const isErr = code === 2 || code === '2' || code === 'STATUS_CODE_ERROR';
-  const isOk = code === 1 || code === '1' || code === 'STATUS_CODE_OK';
-  if (isErr) {
-    return <span className="rounded bg-red-500/20 px-1.5 py-0.5 text-[10px] text-red-300">error</span>;
-  }
-  if (isOk) {
-    return <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] text-emerald-300">ok</span>;
-  }
-  return <span className="text-zinc-500">unset</span>;
 }
 
 function CopyButton({ value }: { value: string }) {
@@ -871,11 +697,4 @@ function CopyButton({ value }: { value: string }) {
 function shortId(id: string): string {
   if (id.length <= 12) return id;
   return `${id.slice(0, 8)}…${id.slice(-4)}`;
-}
-
-function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return '-';
-  if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`;
-  if (ms < 1000) return `${ms.toFixed(1)}ms`;
-  return `${(ms / 1000).toFixed(2)}s`;
 }


### PR DESCRIPTION
## Summary

- redesign the Tempo trace list and add a full-screen waterfall detail view with stable `/traces/:traceId` navigation
- improve TraceQL filters, dependency facets, sub-millisecond durations, recent-result ordering, and direct trace ID lookup
- propagate OpenTelemetry context across manager HTTP, database, log, metric, workflow, alert, and AIOps paths, with trace-aware structured logs
- add configurable head sampling, health-probe filtering, and focused unit coverage

## Testing

- affected Go packages: `go test -race` passed
- manager build and affected-package `go vet` passed
- Trace UI tests: 6 passed
- `npm run typecheck` passed
- `npm run build` passed

Repository-wide checks still expose existing unrelated baseline issues: Darwin builds lack several Linux/Windows-only edge symbols, the Linux-only `cmdpolicy` package cannot build natively on macOS, one filesystem-case test assumes NTFS semantics, and the full frontend suite times out in `Sidebar.test.tsx`.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
