### PR TITLE
feat(observability): support self-signed TLS endpoints

### DIFF
--- a/cmd/ongrid/k8s_telemetry_target_test.go
+++ b/cmd/ongrid/k8s_telemetry_target_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"context"
 	"testing"
+
+	managerbizsetting "github.com/ongridio/ongrid/internal/manager/biz/setting"
+	"github.com/ongridio/ongrid/internal/pkg/config"
+	"github.com/ongridio/ongrid/internal/pkg/promauth"
 )
 
 type staticTelemetryBackendResolver struct {
@@ -88,5 +92,22 @@ func TestPluginEndpointResolverFallsBackToManagerForInternalSeeds(t *testing.T) 
 	}
 	if traces.Endpoint != "https://manager.example/v1/traces" || !traces.UseTelemetryCredential {
 		t.Fatalf("traces target = %#v", traces)
+	}
+}
+
+func TestK8sRemoteWriteResolverPublishesPrometheusTLSSettings(t *testing.T) {
+	promResolver := managerbizsetting.NewPromResolver(nil, "https://prom.example", "https://prom.example/api/v1/write", promauth.TLSConfig{
+		Insecure: true,
+		CAPEM:    "test-ca",
+	})
+	target, err := (k8sRemoteWriteResolver{
+		resolver: promResolver,
+		prom:     config.PromConfig{Enabled: true},
+	}).ResolveRemoteWrite(context.Background())
+	if err != nil {
+		t.Fatalf("resolve remote write: %v", err)
+	}
+	if target.Endpoint != "https://prom.example/api/v1/write" || !target.TLSInsecure || target.TLSCAPEM != "test-ca" {
+		t.Fatalf("remote write target = %#v", target)
 	}
 }

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -449,7 +449,10 @@ func main() {
 	if cfg.Prom.QueryURL != "" {
 		queryFallback = cfg.Prom.QueryURL
 	}
-	promResolver := managerbizsetting.NewPromResolver(settingSvc, queryFallback, cfg.Prom.RemoteWriteURL)
+	promResolver := managerbizsetting.NewPromResolver(settingSvc, queryFallback, cfg.Prom.RemoteWriteURL, promauth.TLSConfig{
+		Insecure: cfg.Prom.TLSInsecure,
+		CAPath:   cfg.Prom.TLSCAPath,
+	})
 
 	// HLD-010 audit log — append-only "who did what" trail. Built early
 	// so the auth middleware factory below can capture login attempts.
@@ -487,6 +490,7 @@ func main() {
 	}{
 		{settingmodel.KeyPromQueryURL, cfg.Prom.QueryURL, false},
 		{settingmodel.KeyPromRemoteWriteURL, cfg.Prom.RemoteWriteURL, false},
+		{settingmodel.KeyPromTLSInsecure, strconv.FormatBool(cfg.Prom.TLSInsecure), false},
 	} {
 		if err := settingSvc.SetIfAbsent(rootCtx, settingmodel.CategoryProm, seed.key, seed.val, seed.sensitive); err != nil {
 			log.Warn("seed prom setting", slog.String("key", seed.key), slog.Any("err", err))
@@ -499,6 +503,9 @@ func main() {
 	// across restarts.
 	if err := settingSvc.SetIfAbsent(rootCtx, settingmodel.CategoryGrafana, settingmodel.KeyGrafanaRootURL, cfg.Grafana.InternalRootURL, false); err != nil {
 		log.Warn("seed grafana root_url", slog.Any("err", err))
+	}
+	if err := settingSvc.SetIfAbsent(rootCtx, settingmodel.CategoryGrafana, settingmodel.KeyGrafanaTLSInsecure, strconv.FormatBool(cfg.Grafana.TLSInsecure), false); err != nil {
+		log.Warn("seed grafana tls_insecure", slog.Any("err", err))
 	}
 	// Loki / Tempo seeds. Mirrors the Prom seed pattern — first-boot
 	// only, admin edits in UI persist across restarts. The URL is the
@@ -1104,7 +1111,7 @@ func main() {
 			slog.String("query_fallback", queryFallback),
 			slog.String("write_fallback", cfg.Prom.RemoteWriteURL),
 			slog.Bool("tls_insecure", cfg.Prom.TLSInsecure),
-			slog.String("note", "URLs hot-reload from system_settings within ~5s; TLS still requires restart"),
+			slog.String("note", "URLs, auth and TLS hot-reload from system_settings"),
 		)
 	} else {
 		log.Warn("prom disabled — push_prom_samples will be silently dropped, query_promql tool not registered, /v1/edges/{id}/metrics returns 501")
@@ -3228,20 +3235,27 @@ func (r k8sRemoteWriteResolver) ResolveRemoteWrite(ctx context.Context) (manager
 	if err != nil {
 		return managerbizk8s.RemoteWriteTarget{}, err
 	}
-	var caPEM string
-	if path := strings.TrimSpace(r.prom.TLSCAPath); path != "" {
+	tlsConfig, err := r.resolver.ResolveTLS(ctx)
+	if err != nil {
+		return managerbizk8s.RemoteWriteTarget{}, err
+	}
+	caPEM := strings.TrimSpace(tlsConfig.CAPEM)
+	if path := strings.TrimSpace(tlsConfig.CAPath); path != "" {
 		raw, err := os.ReadFile(path)
 		if err != nil {
 			return managerbizk8s.RemoteWriteTarget{}, fmt.Errorf("read prometheus TLS CA: %w", err)
 		}
-		caPEM = string(raw)
+		if caPEM != "" {
+			caPEM += "\n"
+		}
+		caPEM += string(raw)
 	}
 	return managerbizk8s.RemoteWriteTarget{
 		Endpoint:      writeURL,
 		BearerToken:   authConfig.BearerToken,
 		BasicUser:     authConfig.BasicUser,
 		BasicPassword: authConfig.BasicPassword,
-		TLSInsecure:   r.prom.TLSInsecure,
+		TLSInsecure:   tlsConfig.Insecure,
 		TLSCAPEM:      caPEM,
 	}, nil
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -88,6 +88,8 @@ services:
       ONGRID_PROM_URL: ${ONGRID_PROM_URL:-http://prometheus:9090/prometheus}
       ONGRID_PROM_REMOTE_WRITE_URL: ${ONGRID_PROM_REMOTE_WRITE_URL:-}
       ONGRID_PROM_QUERY_URL: ${ONGRID_PROM_QUERY_URL:-http://prometheus:9090/prometheus}
+      ONGRID_PROM_TLS_INSECURE: ${ONGRID_PROM_TLS_INSECURE:-false}
+      ONGRID_PROM_TLS_CA_FILE: ${ONGRID_PROM_TLS_CA_FILE:-}
       # Root-span head sampling. Keep local development at 100%; production
       # can lower this without rebuilding the manager image.
       ONGRID_OTEL_SAMPLING_RATIO: ${ONGRID_OTEL_SAMPLING_RATIO:-1}

--- a/internal/manager/biz/grafana/datasource_test.go
+++ b/internal/manager/biz/grafana/datasource_test.go
@@ -137,6 +137,35 @@ func TestLokiDatasourceEmptyURLSkipsSync(t *testing.T) {
 	}
 }
 
+func TestPrometheusDatasourceUsesTLSSettings(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	for key, value := range map[string]string{
+		settingmodel.KeyPromBearerToken: "prom-token",
+		settingmodel.KeyPromTLSInsecure: "true",
+		settingmodel.KeyPromTLSCAPEM:    "test-ca",
+	} {
+		if err := settings.Set(ctx, settingmodel.CategoryProm, key, value, key == settingmodel.KeyPromBearerToken); err != nil {
+			t.Fatalf("set %s: %v", key, err)
+		}
+	}
+
+	ds := New(settings, false, nil).prometheusDatasource(ctx, "https://prom.example.com")
+	if got := ds.JSONData["tlsSkipVerify"]; got != true {
+		t.Fatalf("tlsSkipVerify = %v", got)
+	}
+	if got := ds.JSONData["tlsAuthWithCACert"]; got != true {
+		t.Fatalf("tlsAuthWithCACert = %v", got)
+	}
+	if got := ds.SecureJSONData["tlsCACert"]; got != "test-ca" {
+		t.Fatalf("tlsCACert = %q", got)
+	}
+	if got := ds.SecureJSONData["httpHeaderValue1"]; got != "Bearer prom-token" {
+		t.Fatalf("authorization = %q", got)
+	}
+}
+
 func TestElasticsearchDatasourceUsesReadOnlyQuerySettings(t *testing.T) {
 	t.Parallel()
 	ds, err := elasticsearchDatasource(pkggrafana.ElasticsearchDatasourceConfig{
@@ -249,5 +278,36 @@ func TestSyncLogsDatasourceCreatesActiveElasticsearchDatasource(t *testing.T) {
 	}
 	if got := created.SecureJSONData["httpHeaderValue1"]; got != "ApiKey query-only-key" {
 		t.Fatalf("created query authorization = %q", got)
+	}
+}
+
+func TestConnectionReloadsTLSInsecureSetting(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"database":"ok"}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	settings := settingbiz.New(newFakeSettingRepo(), nil)
+	for key, value := range map[string]string{
+		settingmodel.KeyGrafanaRootURL:     server.URL,
+		settingmodel.KeyGrafanaSAToken:     "grafana-token",
+		settingmodel.KeyGrafanaTLSInsecure: "false",
+	} {
+		if err := settings.Set(ctx, settingmodel.CategoryGrafana, key, value, key == settingmodel.KeyGrafanaSAToken); err != nil {
+			t.Fatalf("set %s: %v", key, err)
+		}
+	}
+
+	svc := New(settings, false, nil)
+	if err := svc.Test(ctx); err == nil {
+		t.Fatal("self-signed Grafana unexpectedly passed with TLS verification enabled")
+	}
+	if err := settings.Set(ctx, settingmodel.CategoryGrafana, settingmodel.KeyGrafanaTLSInsecure, "true", false); err != nil {
+		t.Fatalf("enable TLS skip verify: %v", err)
+	}
+	if err := svc.Test(ctx); err != nil {
+		t.Fatalf("test after enabling TLS skip verify: %v", err)
 	}
 }

--- a/internal/manager/biz/grafana/service.go
+++ b/internal/manager/biz/grafana/service.go
@@ -60,7 +60,7 @@ var dashboardsFS embed.FS
 type Service struct {
 	settings           *settingbiz.Service
 	log                *slog.Logger
-	tlsInsecure        bool   // skip cert verify when calling Grafana
+	tlsInsecure        bool   // env fallback for skip cert verify when calling Grafana
 	panelDashboardUID  string // Monitor-page mirror dashboard uid (HLD-monitor-panels)
 	panelDashboardName string // human title shown in Grafana
 
@@ -107,8 +107,14 @@ func (s *Service) SetLogsDatasourceProvider(provider func(context.Context) (*pkg
 // httpClient builds the *http.Client used by both bootstrap and the
 // Test/Sync paths. Single source of truth for TLS handling on the
 // Grafana side; pkg/grafana.New(c.baseURL, c.token, hc) accepts it.
-func (s *Service) httpClient() *http.Client {
-	if !s.tlsInsecure {
+func (s *Service) httpClient(ctx context.Context) *http.Client {
+	tlsInsecure := s.tlsInsecure
+	if s.settings != nil {
+		if value, found, err := s.settings.Get(ctx, settingmodel.CategoryGrafana, settingmodel.KeyGrafanaTLSInsecure); err == nil && found {
+			tlsInsecure = strings.EqualFold(strings.TrimSpace(value), "true")
+		}
+	}
+	if !tlsInsecure {
 		return nil // pkg/grafana uses a 15s default
 	}
 	return &http.Client{
@@ -156,7 +162,7 @@ func (s *Service) BootstrapEmbedded(ctx context.Context, adminUser, adminPasswor
 		return
 	}
 
-	c := pkggrafana.NewWithBasicAuth(rootURL, adminUser, adminPassword, s.httpClient())
+	c := pkggrafana.NewWithBasicAuth(rootURL, adminUser, adminPassword, s.httpClient(ctx))
 	if err := c.Health(ctx); err != nil {
 		// Grafana not up yet, or admin creds wrong, or DNS fails. Don't
 		// crash startup — operator can still configure manually via UI.
@@ -230,33 +236,7 @@ func (s *Service) Sync(ctx context.Context) (*SyncResult, error) {
 		return nil, fmt.Errorf("ensure folder: %w", err)
 	}
 
-	// Forward the ongrid-side prom credentials into Grafana's encrypted
-	// secureJsonData so the user's external Grafana can actually query
-	// the same TSDB ongrid is writing to. Bearer wins over Basic; if
-	// neither is set, datasource is anonymous.
-	bearer, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBearerToken)
-	basicUser, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicUser)
-	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicPassword)
-
-	ds := pkggrafana.Datasource{
-		UID:    promDatasourceUID,
-		Name:   promDatasourceName,
-		Type:   "prometheus",
-		URL:    promURL,
-		Access: "proxy",
-		JSONData: map[string]any{
-			"httpMethod":   "POST",
-			"timeInterval": "30s",
-		},
-	}
-	if bearer = strings.TrimSpace(bearer); bearer != "" {
-		ds.JSONData["httpHeaderName1"] = "Authorization"
-		ds.SecureJSONData = map[string]string{"httpHeaderValue1": "Bearer " + bearer}
-	} else if basicUser = strings.TrimSpace(basicUser); basicUser != "" {
-		ds.BasicAuth = true
-		ds.BasicAuthUser = basicUser
-		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
-	}
+	ds := s.prometheusDatasource(ctx, promURL)
 	if err := c.UpsertDatasource(ctx, ds); err != nil {
 		return nil, fmt.Errorf("upsert prometheus datasource: %w", err)
 	}
@@ -430,6 +410,42 @@ func (s *Service) lokiDatasource(ctx context.Context) *pkggrafana.Datasource {
 	return ds
 }
 
+func (s *Service) prometheusDatasource(ctx context.Context, promURL string) pkggrafana.Datasource {
+	ds := pkggrafana.Datasource{
+		UID:    promDatasourceUID,
+		Name:   promDatasourceName,
+		Type:   "prometheus",
+		URL:    strings.TrimSpace(promURL),
+		Access: "proxy",
+		JSONData: map[string]any{
+			"httpMethod":   "POST",
+			"timeInterval": "30s",
+		},
+	}
+	bearer, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBearerToken)
+	basicUser, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicUser)
+	basicPass, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromBasicPassword)
+	if bearer = strings.TrimSpace(bearer); bearer != "" {
+		ds.JSONData["httpHeaderName1"] = "Authorization"
+		ds.SecureJSONData = map[string]string{"httpHeaderValue1": "Bearer " + bearer}
+	} else if basicUser = strings.TrimSpace(basicUser); basicUser != "" {
+		ds.BasicAuth = true
+		ds.BasicAuthUser = basicUser
+		ds.SecureJSONData = map[string]string{"basicAuthPassword": basicPass}
+	}
+	if tlsInsecure, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromTLSInsecure); strings.EqualFold(strings.TrimSpace(tlsInsecure), "true") {
+		ds.JSONData["tlsSkipVerify"] = true
+	}
+	if caPEM, _, _ := s.settings.Get(ctx, settingmodel.CategoryProm, settingmodel.KeyPromTLSCAPEM); strings.TrimSpace(caPEM) != "" {
+		ds.JSONData["tlsAuthWithCACert"] = true
+		if ds.SecureJSONData == nil {
+			ds.SecureJSONData = make(map[string]string)
+		}
+		ds.SecureJSONData["tlsCACert"] = strings.TrimSpace(caPEM)
+	}
+	return ds
+}
+
 // client builds a pkg/grafana.Client from settings; returns a friendly
 // error if config is incomplete.
 //
@@ -456,7 +472,7 @@ func (s *Service) client(ctx context.Context) (*pkggrafana.Client, error) {
 	if token == "" {
 		return nil, errors.New("grafana: sa_token / api_key empty (create a Grafana service account and paste its token, or paste an api_key for external Grafana)")
 	}
-	return pkggrafana.New(root, token, s.httpClient()), nil
+	return pkggrafana.New(root, token, s.httpClient(ctx)), nil
 }
 
 // FetchDashboardJSON returns the raw `{ dashboard, meta }` envelope for

--- a/internal/manager/biz/setting/promauth.go
+++ b/internal/manager/biz/setting/promauth.go
@@ -8,10 +8,11 @@ import (
 	"github.com/ongridio/ongrid/internal/pkg/promauth"
 )
 
-// PromResolver implements three resolver interfaces against the
+// PromResolver implements four resolver interfaces against the
 // system_settings table:
 //
-//   - promauth.Resolver       (Bearer / Basic)
+//   - promauth.Resolver         (Bearer / Basic)
+//   - promauth.TLSResolver      (TLS verification / custom CA)
 //   - promwrite.EndpointResolver (full remote_write URL with fallback)
 //   - promquery.BaseURLResolver  (PromQL API root with fallback)
 //
@@ -24,18 +25,20 @@ import (
 // row is missing or empty. This way a fresh install with nothing in the
 // DB still talks to the embedded Prometheus.
 type PromResolver struct {
-	svc               *Service
-	fallbackQueryURL  string
-	fallbackWriteURL  string
+	svc              *Service
+	fallbackQueryURL string
+	fallbackWriteURL string
+	fallbackTLS      promauth.TLSConfig
 }
 
-// NewPromResolver wires the resolver. svc must be non-nil. fallback*URL
-// are taken from cfg.Prom.URL and cfg.Prom.RemoteWriteURL respectively.
-func NewPromResolver(svc *Service, fallbackQueryURL, fallbackWriteURL string) *PromResolver {
+// NewPromResolver wires the resolver. svc must be non-nil. The fallback
+// values come from cfg.Prom and remain available when settings rows are absent.
+func NewPromResolver(svc *Service, fallbackQueryURL, fallbackWriteURL string, fallbackTLS promauth.TLSConfig) *PromResolver {
 	return &PromResolver{
 		svc:              svc,
 		fallbackQueryURL: strings.TrimRight(fallbackQueryURL, "/"),
 		fallbackWriteURL: fallbackWriteURL,
+		fallbackTLS:      fallbackTLS,
 	}
 }
 
@@ -58,6 +61,27 @@ func (r *PromResolver) Resolve(ctx context.Context) (promauth.Config, error) {
 		BasicUser:     r.get(ctx, model.KeyPromBasicUser),
 		BasicPassword: r.get(ctx, model.KeyPromBasicPassword),
 	}, nil
+}
+
+// ResolveTLS implements promauth.TLSResolver. Stored values override the
+// env-derived startup defaults and are read through the settings cache, which
+// is invalidated immediately after a UI save.
+func (r *PromResolver) ResolveTLS(ctx context.Context) (promauth.TLSConfig, error) {
+	cfg := r.fallbackTLS
+	if r.svc == nil {
+		return cfg, nil
+	}
+	if value, found, err := r.svc.Get(ctx, model.CategoryProm, model.KeyPromTLSInsecure); err != nil {
+		return cfg, err
+	} else if found {
+		cfg.Insecure = strings.EqualFold(strings.TrimSpace(value), "true")
+	}
+	if value, found, err := r.svc.Get(ctx, model.CategoryProm, model.KeyPromTLSCAPEM); err != nil {
+		return cfg, err
+	} else if found {
+		cfg.CAPEM = strings.TrimSpace(value)
+	}
+	return cfg, nil
 }
 
 // ResolveBaseURL implements promquery.BaseURLResolver. Falls back to

--- a/internal/manager/biz/setting/promauth_test.go
+++ b/internal/manager/biz/setting/promauth_test.go
@@ -1,0 +1,27 @@
+package setting
+
+import (
+	"context"
+	"testing"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/setting"
+	"github.com/ongridio/ongrid/internal/pkg/promauth"
+)
+
+func TestPromResolverTLSSettingOverridesFallback(t *testing.T) {
+	ctx := context.Background()
+	settings := New(newFakeRepo(), nil)
+	resolver := NewPromResolver(settings, "", "", promauth.TLSConfig{Insecure: true})
+
+	cfg, err := resolver.ResolveTLS(ctx)
+	if err != nil || !cfg.Insecure {
+		t.Fatalf("fallback TLS config = %#v, %v", cfg, err)
+	}
+	if err := settings.Set(ctx, model.CategoryProm, model.KeyPromTLSInsecure, "false", false); err != nil {
+		t.Fatalf("disable TLS skip verify: %v", err)
+	}
+	cfg, err = resolver.ResolveTLS(ctx)
+	if err != nil || cfg.Insecure {
+		t.Fatalf("stored TLS config = %#v, %v", cfg, err)
+	}
+}

--- a/internal/manager/model/setting/model.go
+++ b/internal/manager/model/setting/model.go
@@ -171,9 +171,8 @@ const (
 	LLMProviderCustom    = "custom"
 )
 
-// Well-known keys under CategoryProm. internal/pkg/promauth reads bearer/
-// basic on every request via the Resolver; URLs are read at startup (env
-// seed → DB) and changes require a manager restart.
+// Well-known keys under CategoryProm. Manager-side clients resolve these
+// settings at request time so UI edits do not require a restart.
 const (
 	KeyPromQueryURL       = "query_url"
 	KeyPromRemoteWriteURL = "remote_write_url"
@@ -202,6 +201,7 @@ const (
 	KeyGrafanaSAToken = "sa_token" // sensitive — Grafana service-account token
 	KeyGrafanaAPIKey  = "api_key"  // sensitive — alternative bearer for external Grafana
 	KeyGrafanaOrgID   = "org_id"
+	KeyGrafanaTLSInsecure = "tls_insecure"
 )
 
 // Well-known keys under CategoryLoki. The PluginConfigUC reads these on

--- a/internal/pkg/promauth/client.go
+++ b/internal/pkg/promauth/client.go
@@ -2,9 +2,8 @@
 // promquery clients to talk to a Prometheus-compatible TSDB. It centralises
 // two concerns:
 //
-//   - TLS: optional skip-verify and / or a custom root CA. These are
-//     resolved at construction time; changing TLS material requires
-//     restarting the manager (the http.Transport is built once).
+//   - TLS: optional skip-verify and / or a custom root CA. A Resolver that
+//     also implements TLSResolver can update these settings at runtime.
 //
 //   - Auth: Bearer / Basic credentials. These are resolved per-request via
 //     a Resolver so admin edits to system_settings take effect within the
@@ -58,6 +57,13 @@ type Resolver interface {
 	Resolve(ctx context.Context) (Config, error)
 }
 
+// TLSResolver returns the current dialer-level TLS settings. BuildClient
+// detects this optional interface so existing static resolvers keep their
+// original behaviour.
+type TLSResolver interface {
+	ResolveTLS(ctx context.Context) (TLSConfig, error)
+}
+
 // staticResolver is the trivial Resolver — always returns the same config.
 // Useful for tests and as a fallback when system_settings is empty.
 type staticResolver struct{ cfg Config }
@@ -78,28 +84,55 @@ const authTTL = 5 * time.Second
 //
 // timeout caps the total round-trip. resolver may be nil — pass-through.
 func BuildClient(tlsCfg TLSConfig, resolver Resolver, timeout time.Duration) (*http.Client, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
-	if tlsCfg.Insecure || tlsCfg.CAPath != "" || tlsCfg.CAPEM != "" {
-		t := &tls.Config{MinVersion: tls.VersionTLS12}
-		if tlsCfg.Insecure {
-			t.InsecureSkipVerify = true
-		}
-		if tlsCfg.CAPath != "" || tlsCfg.CAPEM != "" {
-			pool, err := buildPool(tlsCfg)
-			if err != nil {
-				return nil, err
-			}
-			t.RootCAs = pool
-		}
-		transport.TLSClientConfig = t
+	transport, err := buildTransport(tlsCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	var rt http.RoundTripper = transport
+	if tlsResolver, ok := resolver.(TLSResolver); ok {
+		rt = &tlsRoundTripper{resolver: tlsResolver, cachedConfig: tlsCfg, cached: transport}
+	}
 	if resolver != nil {
-		rt = &authRoundTripper{base: transport, resolver: resolver}
+		rt = &authRoundTripper{base: rt, resolver: resolver}
 	}
 	return &http.Client{Transport: rt, Timeout: timeout}, nil
+}
+
+type tlsRoundTripper struct {
+	resolver TLSResolver
+
+	mu           sync.Mutex
+	cachedConfig TLSConfig
+	cached       *http.Transport
+}
+
+func (t *tlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cfg, err := t.resolver.ResolveTLS(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("promauth: resolve TLS config: %w", err)
+	}
+	transport, err := t.transport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return transport.RoundTrip(req)
+}
+
+func (t *tlsRoundTripper) transport(cfg TLSConfig) (*http.Transport, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if cfg == t.cachedConfig {
+		return t.cached, nil
+	}
+	next, err := buildTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	t.cached.CloseIdleConnections()
+	t.cachedConfig = cfg
+	t.cached = next
+	return next, nil
 }
 
 // authRoundTripper decorates an http.RoundTripper with auth headers
@@ -165,4 +198,21 @@ func buildPool(tlsCfg TLSConfig) (*x509.CertPool, error) {
 		}
 	}
 	return pool, nil
+}
+
+func buildTransport(tlsCfg TLSConfig) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if !tlsCfg.Insecure && tlsCfg.CAPath == "" && tlsCfg.CAPEM == "" {
+		return transport, nil
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: tlsCfg.Insecure}
+	if tlsCfg.CAPath != "" || tlsCfg.CAPEM != "" {
+		pool, err := buildPool(tlsCfg)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = pool
+	}
+	transport.TLSClientConfig = tlsConfig
+	return transport, nil
 }

--- a/internal/pkg/promauth/client_test.go
+++ b/internal/pkg/promauth/client_test.go
@@ -17,6 +17,7 @@ type stubResolver struct {
 	mu    sync.Mutex
 	calls int32
 	cfg   Config
+	tls   TLSConfig
 	err   error
 }
 
@@ -25,6 +26,12 @@ func (s *stubResolver) Resolve(_ context.Context) (Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.cfg, s.err
+}
+
+func (s *stubResolver) ResolveTLS(_ context.Context) (TLSConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tls, s.err
 }
 
 func TestBuildClientInjectsBearerHeader(t *testing.T) {
@@ -134,4 +141,31 @@ func TestNilResolverPassesThrough(t *testing.T) {
 	if h := <-got; h != "" {
 		t.Fatalf("expected no auth header, got %q", h)
 	}
+}
+
+func TestBuildClientReloadsTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := &stubResolver{}
+	hc, err := BuildClient(TLSConfig{}, res, 5*time.Second)
+	if err != nil {
+		t.Fatalf("BuildClient: %v", err)
+	}
+	if _, err := hc.Get(srv.URL); err == nil {
+		t.Fatal("self-signed server unexpectedly passed with TLS verification enabled")
+	}
+
+	res.mu.Lock()
+	res.tls.Insecure = true
+	res.mu.Unlock()
+	resp, err := hc.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get after enabling TLS skip verify: %v", err)
+	}
+	resp.Body.Close()
 }

--- a/web/src/pages/settings/Integrations.test.tsx
+++ b/web/src/pages/settings/Integrations.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SettingsIntegrations from './Integrations';
+import { listSettings, setSetting } from '@/api/settings';
 import {
   getLogBackend,
   getLogBackendConnectionCheck,
@@ -99,6 +100,37 @@ describe('SettingsIntegrations log backend presentation', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('saves self-signed TLS switches for Prometheus and Grafana', async () => {
+    vi.mocked(listSettings).mockImplementation(async (category?: string) => ({
+      items: category === 'prom'
+        ? [{ category: 'prom', key: 'query_url', value: 'https://prom.example', sensitive: false, updated_at: '' }]
+        : category === 'grafana'
+          ? [
+              { category: 'grafana', key: 'root_url', value: 'https://grafana.example', sensitive: false, updated_at: '' },
+              { category: 'grafana', key: 'sa_token', value: '', sensitive: true, updated_at: '' },
+            ]
+          : [],
+      total: 0,
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <SettingsIntegrations />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const prometheus = (await screen.findByRole('heading', { name: 'Prometheus 集成' })).closest('section')!;
+    await act(async () => user.click(within(prometheus).getByRole('checkbox', { name: '跳过 TLS 校验（自签证书时勾选）' })));
+    await act(async () => user.click(within(prometheus).getByRole('button', { name: '保存' })));
+    await waitFor(() => expect(setSetting).toHaveBeenCalledWith('prom', 'tls_insecure', 'true', false));
+
+    const grafana = screen.getByRole('heading', { name: 'Grafana 集成' }).closest('section')!;
+    await act(async () => user.click(within(grafana).getByRole('checkbox', { name: '跳过 TLS 校验（自签证书时勾选）' })));
+    await act(async () => user.click(within(grafana).getByRole('button', { name: '保存' })));
+    await waitFor(() => expect(setSetting).toHaveBeenCalledWith('grafana', 'tls_insecure', 'true', false));
   });
 
   it('places built-in storage limits under each integration advanced section', async () => {

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -62,7 +62,7 @@ import BuiltInStorageAdvanced from './Advanced';
 
 // Settings → 集成. Four cards, all backend-driven, parallel naming:
 //   - Prometheus 集成   → system_settings.prom; manager reads on every
-//     remote_write / PromQL call (auth ~5s TTL, URLs at restart)
+//     remote_write / PromQL call (auth ~5s TTL, URL/TLS live)
 //   - Grafana 集成      → system_settings.grafana; "测试" + "同步"
 //   - Loki 集成 (日志)  → system_settings.loki; the URL feeds both
 //     edge-side push (logs plugin) and Grafana datasource
@@ -107,6 +107,7 @@ type PromForm = {
   bearer_token: string;
   basic_user: string;
   basic_password: string;
+  tls_insecure: string;
 };
 
 const PROM_KEYS: (keyof PromForm)[] = [
@@ -115,6 +116,7 @@ const PROM_KEYS: (keyof PromForm)[] = [
   'bearer_token',
   'basic_user',
   'basic_password',
+  'tls_insecure',
 ];
 
 const PROM_SENSITIVE: Set<keyof PromForm> = new Set(['bearer_token', 'basic_password']);
@@ -125,6 +127,7 @@ const emptyPromForm: PromForm = {
   bearer_token: '',
   basic_user: '',
   basic_password: '',
+  tls_insecure: '',
 };
 
 function PrometheusCard() {
@@ -297,6 +300,15 @@ function PrometheusCard() {
             onChange={(v) => update('basic_password', v)}
             placeholder={tr('（留空 = 不用 Basic）', '(empty = no Basic)')}
           />
+          <label className="flex items-center gap-2 text-xs text-zinc-300">
+            <input
+              type="checkbox"
+              checked={draft.tls_insecure === 'true'}
+              onChange={(e) => update('tls_insecure', e.target.checked ? 'true' : 'false')}
+              className="h-3.5 w-3.5 rounded border-zinc-600 bg-zinc-900 accent-emerald-500"
+            />
+            {tr('跳过 TLS 校验（自签证书时勾选）', 'Skip TLS verification (check this for self-signed certs)')}
+          </label>
         </div>
       )}
 
@@ -414,10 +426,11 @@ type GrafanaForm = {
   sa_token: string;
   api_key: string;
   org_id: string;
+  tls_insecure: string;
 };
-const GRAFANA_KEYS: (keyof GrafanaForm)[] = ['root_url', 'sa_token', 'api_key', 'org_id'];
+const GRAFANA_KEYS: (keyof GrafanaForm)[] = ['root_url', 'sa_token', 'api_key', 'org_id', 'tls_insecure'];
 const GRAFANA_SENSITIVE: Set<keyof GrafanaForm> = new Set(['sa_token', 'api_key']);
-const emptyGrafanaForm: GrafanaForm = { root_url: '', sa_token: '', api_key: '', org_id: '' };
+const emptyGrafanaForm: GrafanaForm = { root_url: '', sa_token: '', api_key: '', org_id: '', tls_insecure: '' };
 
 type SyncStatus =
   | { kind: 'idle' }
@@ -588,6 +601,15 @@ function GrafanaCard() {
             onChange={(v) => update('org_id', v)}
             placeholder="1"
           />
+          <label className="flex items-center gap-2 text-xs text-zinc-300">
+            <input
+              type="checkbox"
+              checked={draft.tls_insecure === 'true'}
+              onChange={(e) => update('tls_insecure', e.target.checked ? 'true' : 'false')}
+              className="h-3.5 w-3.5 rounded border-zinc-600 bg-zinc-900 accent-emerald-500"
+            />
+            {tr('跳过 TLS 校验（自签证书时勾选）', 'Skip TLS verification (check this for self-signed certs)')}
+          </label>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- add live self-signed TLS switches for Prometheus and Grafana integrations
- reload Prometheus TLS transports without restarting Manager and publish the same policy to Kubernetes remote write targets
- propagate Prometheus TLS verification and custom CA settings to managed Grafana datasources
- verify the local self-signed baseline fails with `x509: certificate signed by unknown authority` and succeeds immediately after enabling each switch

## Testing

- `go test -race ./internal/pkg/promauth ./internal/manager/biz/setting ./internal/manager/biz/grafana ./cmd/ongrid`
- `npm test -- --run src/pages/settings/Integrations.test.tsx`
- `npm run typecheck`
- local Docker self-signed Prometheus/Grafana proxy: disabled fails, enabled passes; light/dark UI checked

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
