### PR TITLE
feat(manager): map windows edges to windows-amd64 upgrade bundles

### DIFF
--- a/internal/manager/server/edge/bundle.go
+++ b/internal/manager/server/edge/bundle.go
@@ -176,6 +176,8 @@ func knownArch(a string) bool {
 		return true
 	case "linux-arm64":
 		return true
+	case "windows-amd64":
+		return true
 	default:
 		return false
 	}

--- a/internal/manager/server/edge/http.go
+++ b/internal/manager/server/edge/http.go
@@ -723,13 +723,27 @@ func (h *Handler) packageArchForEdge(ctx context.Context, edgeID uint64) (string
 	if device == nil {
 		return "", fmt.Errorf("%w: host device %d is unavailable", errs.ErrInvalid, *edge.DeviceID)
 	}
-	if osName := strings.ToLower(strings.TrimSpace(device.OS)); osName != "" && osName != "linux" {
+	// An empty OS marks legacy devices that predate host-fact reporting;
+	// they are linux-only, so treat them as linux.
+	osName := strings.ToLower(strings.TrimSpace(device.OS))
+	switch osName {
+	case "", "linux", "windows":
+	default:
 		return "", fmt.Errorf("%w: unsupported device OS %q", errs.ErrInvalid, device.OS)
 	}
+	// Most arch aliases carry no OS prefix (e.g. "amd64", "x86_64"), so the
+	// resolved bundle arch follows the device OS. Windows edges ship amd64
+	// binaries only; arm64 stays linux-only.
 	switch strings.ToLower(strings.TrimSpace(device.Arch)) {
-	case "amd64", "x86_64", "x64", "linux-amd64", "linux/amd64":
+	case "amd64", "x86_64", "x64", "linux-amd64", "linux/amd64", "windows-amd64", "windows/amd64":
+		if osName == "windows" {
+			return "windows-amd64", nil
+		}
 		return "linux-amd64", nil
 	case "arm64", "aarch64", "linux-arm64", "linux/arm64":
+		if osName == "windows" {
+			return "", fmt.Errorf("%w: unsupported windows architecture %q (only amd64)", errs.ErrInvalid, device.Arch)
+		}
 		return "linux-arm64", nil
 	default:
 		return "", fmt.Errorf("%w: unsupported device architecture %q", errs.ErrInvalid, device.Arch)

--- a/internal/manager/server/edge/http_test.go
+++ b/internal/manager/server/edge/http_test.go
@@ -226,15 +226,63 @@ func buildRouter(h *Handler, t tenantctx.Tenant) http.Handler {
 }
 
 func TestKnownArch(t *testing.T) {
-	for _, arch := range []string{"linux-amd64", "linux-arm64"} {
+	for _, arch := range []string{"linux-amd64", "linux-arm64", "windows-amd64"} {
 		if !knownArch(arch) {
 			t.Fatalf("knownArch(%q) = false, want true", arch)
 		}
 	}
-	for _, arch := range []string{"darwin-amd64", "darwin-arm64", "linux-arm"} {
+	for _, arch := range []string{"darwin-amd64", "darwin-arm64", "linux-arm", "windows-arm64"} {
 		if knownArch(arch) {
 			t.Fatalf("knownArch(%q) = true, want false", arch)
 		}
+	}
+}
+
+func TestPackageArchForEdge(t *testing.T) {
+	const edgeID = 10
+	devID := uint64(2148)
+	newHandler := func(osName, arch string) *Handler {
+		devPtr := devID
+		svc := &fakeSvc{getResp: &model.Edge{ID: edgeID, DeviceID: &devPtr}}
+		devices := newFakeDeviceRepo(&devicemodel.Device{ID: devID, OS: osName, Arch: arch})
+		return NewHandler(svc, devices, nil)
+	}
+
+	cases := []struct {
+		name    string
+		osName  string
+		arch    string
+		want    string
+		wantErr bool
+	}{
+		{"linux amd64", "linux", "amd64", "linux-amd64", false},
+		{"legacy empty OS treated as linux", "", "amd64", "linux-amd64", false},
+		{"linux x86_64", "linux", "x86_64", "linux-amd64", false},
+		{"linux arm64", "linux", "aarch64", "linux-arm64", false},
+		{"windows amd64", "windows", "amd64", "windows-amd64", false},
+		{"windows os-prefixed arch", "windows", "windows-amd64", "windows-amd64", false},
+		{"windows cli-style arch", "windows", "x64", "windows-amd64", false},
+		{"windows arm64 rejected", "windows", "arm64", "", true},
+		{"unsupported OS rejected", "darwin", "amd64", "", true},
+		{"missing arch rejected", "linux", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandler(tc.osName, tc.arch)
+			got, err := h.packageArchForEdge(context.Background(), edgeID)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("packageArchForEdge(os=%q, arch=%q) = %q, want error", tc.osName, tc.arch, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("packageArchForEdge(os=%q, arch=%q) error = %v", tc.osName, tc.arch, err)
+			}
+			if got != tc.want {
+				t.Fatalf("packageArchForEdge(os=%q, arch=%q) = %q, want %q", tc.osName, tc.arch, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- #229 already lets Windows edges install the supervisor, but `packageArchForEdge` still accepted a linux-only OS/arch matrix — so `upgrade-package` fail-closed and rejected every Windows edge. The merged Windows support was silently incomplete; this closes that gap.
- `packageArchForEdge` now accepts an empty (legacy, linux-only) / `linux` / `windows` OS. amd64-family arch aliases resolve to `windows-amd64` on Windows edges; `windows-arm64` is explicitly rejected (Windows edges ship amd64 binaries only).
- `knownArch` learns `windows-amd64` so the resolver accepts Windows upgrade bundles.

## Changes

- `internal/manager/server/edge/http.go` — OS whitelist + per-OS arch routing in `packageArchForEdge`; windows-arm64 explicit rejection.
- `internal/manager/server/edge/bundle.go` — `knownArch`: add `windows-amd64`.
- `internal/manager/server/edge/http_test.go` — `TestPackageArchForEdge` covers the new matrix (empty/linux/windows × amd64 aliases × arm64-on-windows); `TestKnownArch` covers `windows-amd64` / `windows-arm64`.

## Follow-up

Windows bundle build/release scripts (producing the `windows-amd64` artifacts consumed here) will be proposed in a separate PR to keep this one reviewable.

## Notes on local verification (pre-existing failures, not introduced by this PR)

Both reproduced on the base commit `8161d965` in a clean worktree:

1. `TestFileBundleResolverReportsInaccessibleBundle` fails on Windows dev hosts — the test relies on `chmod`-based permission denial, which Windows does not enforce. Passes on Linux CI.
2. Module-level `GOOS=linux go build ./...` fails on Windows hosts — `onnxruntime_go` requires cgo cross-compilation setup. Pre-existing at base.

## Test plan

- [x] `go test -race ./internal/manager/server/edge` (all new tests pass; the one failure above is the documented pre-existing chmod case)
- [x] `GOOS=windows` / `GOOS=linux` package-level build of changed packages
- [x] gofmt clean (blob-level)

---

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
