### PR TITLE
fix(web): 修复会话切换时运行状态串扰和丢失

### DIFF
--- a/web/src/lib/chatTurnRegistry.test.ts
+++ b/web/src/lib/chatTurnRegistry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getChatTurnController,
+  registerChatTurnController,
+  unregisterChatTurnController,
+} from './chatTurnRegistry';
+
+describe('chat turn registry', () => {
+  it('keeps each session turn available while the user switches sessions', () => {
+    const first = new AbortController();
+    const second = new AbortController();
+
+    registerChatTurnController('session-a', first);
+    registerChatTurnController('session-b', second);
+
+    expect(getChatTurnController('session-a')).toBe(first);
+    expect(getChatTurnController('session-b')).toBe(second);
+
+    unregisterChatTurnController('session-a', first);
+    unregisterChatTurnController('session-b', second);
+  });
+
+  it('does not let an older turn clear its replacement', () => {
+    const oldTurn = new AbortController();
+    const newTurn = new AbortController();
+
+    registerChatTurnController('session-reused', oldTurn);
+    registerChatTurnController('session-reused', newTurn);
+
+    expect(oldTurn.signal.aborted).toBe(true);
+    unregisterChatTurnController('session-reused', oldTurn);
+    expect(getChatTurnController('session-reused')).toBe(newTurn);
+
+    unregisterChatTurnController('session-reused', newTurn);
+  });
+});

--- a/web/src/lib/chatTurnRegistry.ts
+++ b/web/src/lib/chatTurnRegistry.ts
@@ -1,0 +1,14 @@
+const controllers = new Map<string, AbortController>();
+
+export function getChatTurnController(sessionID: string): AbortController | null {
+  return controllers.get(sessionID) ?? null;
+}
+
+export function registerChatTurnController(sessionID: string, controller: AbortController): void {
+  controllers.get(sessionID)?.abort();
+  controllers.set(sessionID, controller);
+}
+
+export function unregisterChatTurnController(sessionID: string, controller: AbortController): void {
+  if (controllers.get(sessionID) === controller) controllers.delete(sessionID);
+}

--- a/web/src/pages/ChatThread.tsx
+++ b/web/src/pages/ChatThread.tsx
@@ -50,6 +50,9 @@ export default function ChatThreadPage() {
   // abortRef holds the in-flight turn's AbortController so Esc can cancel the
   // stream client-side (instant UI) alongside the server-side stop call.
   const abortRef = useRef<AbortController | null>(null);
+  // React Router reuses this page between /chat/:sessionId routes. Keep the
+  // visible session explicit so callbacks from an older stream cannot mutate it.
+  const activeSessionRef = useRef(sessionId);
   // stickToBottomRef tracks whether new messages should auto-scroll the
   // viewport down. Default true (fresh thread starts at bottom); flips
   // to false when the user manually scrolls up to read older context,
@@ -110,6 +113,21 @@ export default function ChatThreadPage() {
   // in-progress reply being streamed into `messages` from `send()`.
   const submittingRef = useRef(false);
   useEffect(() => { submittingRef.current = submitting; }, [submitting]);
+
+  useEffect(() => {
+    // Detach from the previous browser stream without stopping its server-side
+    // turn. The persisted result will be available when that session is opened.
+    activeSessionRef.current = sessionId;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    submittingRef.current = false;
+    setSubmitting(false);
+    setError(null);
+    setMessages([]);
+    setLoading(true);
+    sentInitialRef.current = false;
+    stickToBottomRef.current = true;
+  }, [sessionId]);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -225,6 +243,7 @@ export default function ChatThreadPage() {
     opts: { expectedTool?: string; displayContent?: string } = {},
   ): Promise<boolean> {
     if (!sessionId || !content.trim()) return false;
+    const turnSessionID = sessionId;
     setError(null);
     setSubmitting(true);
     const ac = new AbortController();
@@ -249,6 +268,7 @@ export default function ChatThreadPage() {
         content,
         {
           onAssistant: (e) => {
+            if (activeSessionRef.current !== turnSessionID) return;
             // Tool-only turn (no text, agent is just dispatching tools);
             // suppress the bubble entirely.
             if (!e.content || e.content.length === 0) return;
@@ -279,6 +299,7 @@ export default function ChatThreadPage() {
             });
           },
           onToolStart: (t) => {
+            if (activeSessionRef.current !== turnSessionID) return;
             const card: ChatMessage = {
               id: toolCardId(t.tool_call_id),
               role: 'tool',
@@ -295,6 +316,7 @@ export default function ChatThreadPage() {
             setMessages((prev) => [...prev, card]);
           },
           onToolEnd: (t) => {
+            if (activeSessionRef.current !== turnSessionID) return;
             if (opts.expectedTool && t.name === opts.expectedTool) {
               expectedToolSeen = true;
               expectedToolFailed = !!t.error || t.status === 'error' || t.status === 'timeout';
@@ -324,6 +346,7 @@ export default function ChatThreadPage() {
             );
           },
           onApprovalPending: (a) => {
+            if (activeSessionRef.current !== turnSessionID) return;
             // HLD-021: a confirmation-gated tool is blocking on a human
             // decision. Drive
             // the inline approve/reject card from this live frame by stamping
@@ -381,9 +404,11 @@ export default function ChatThreadPage() {
             });
           },
           onDone: () => {
+            if (activeSessionRef.current !== turnSessionID) return;
             invalidateChatSessions();
           },
           onError: (err) => {
+            if (activeSessionRef.current !== turnSessionID) return;
             throw err;
           },
         },
@@ -404,6 +429,7 @@ export default function ChatThreadPage() {
       if (ac.signal.aborted || (err as Error).name === 'AbortError') {
         return false;
       }
+      if (activeSessionRef.current !== turnSessionID) return false;
       const msg = (err as Error).message || tr('请求失败', 'Request failed');
       setError(msg);
       setMessages((prev) => [
@@ -417,7 +443,10 @@ export default function ChatThreadPage() {
       ]);
       return false;
     } finally {
-      setSubmitting(false);
+      if (activeSessionRef.current === turnSessionID) {
+        submittingRef.current = false;
+        setSubmitting(false);
+      }
       if (abortRef.current === ac) abortRef.current = null;
     }
   }

--- a/web/src/pages/ChatThread.tsx
+++ b/web/src/pages/ChatThread.tsx
@@ -26,6 +26,11 @@ import { usePermissions } from '@/store/me';
 import { useModelSelection } from '@/store/modelSelection';
 import { useI18n } from '@/i18n/locale';
 import { buildConfigDraftConfirmMessage, configDraftApplyTool } from '@/lib/configDraftConfirmation';
+import {
+  getChatTurnController,
+  registerChatTurnController,
+  unregisterChatTurnController,
+} from '@/lib/chatTurnRegistry';
 
 type LocationState = { initialPrompt?: string } | null;
 
@@ -115,13 +120,12 @@ export default function ChatThreadPage() {
   useEffect(() => { submittingRef.current = submitting; }, [submitting]);
 
   useEffect(() => {
-    // Detach from the previous browser stream without stopping its server-side
-    // turn. The persisted result will be available when that session is opened.
     activeSessionRef.current = sessionId;
-    abortRef.current?.abort();
-    abortRef.current = null;
-    submittingRef.current = false;
-    setSubmitting(false);
+    const controller = getChatTurnController(sessionId);
+    abortRef.current = controller;
+    const sessionSubmitting = controller !== null;
+    submittingRef.current = sessionSubmitting;
+    setSubmitting(sessionSubmitting);
     setError(null);
     setMessages([]);
     setLoading(true);
@@ -248,6 +252,7 @@ export default function ChatThreadPage() {
     setSubmitting(true);
     const ac = new AbortController();
     abortRef.current = ac;
+    registerChatTurnController(turnSessionID, ac);
     let expectedToolSeen = !opts.expectedTool;
     let expectedToolFailed = false;
 
@@ -443,6 +448,7 @@ export default function ChatThreadPage() {
       ]);
       return false;
     } finally {
+      unregisterChatTurnController(turnSessionID, ac);
       if (activeSessionRef.current === turnSessionID) {
         submittingRef.current = false;
         setSubmitting(false);


### PR DESCRIPTION
- 隔离不同会话的流式回调，避免旧会话状态串入当前会话
- 按会话保存流式请求及运行状态
- 切换会话时保持原会话任务继续运行
- 返回运行中的会话时恢复“正在分析”和停止操作
- 防止旧请求结束后误清除新请求状态
- 补充会话运行状态注册表：
  1. 会话 A 运行时切换到会话 B，不再显示 A 的运行状态
  2. 从会话 B 返回会话 A，正确恢复 A 的运行状态

## Summary

<!-- Describe what changed and why. -->

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
