### PR TITLE
fix(edgeagent): exclude CNI veths from hardware fingerprint

### DIFF
--- a/internal/edgeagent/collector/hwfingerprint.go
+++ b/internal/edgeagent/collector/hwfingerprint.go
@@ -26,6 +26,11 @@ import (
 // Returns "" when no physical NIC can be found (e.g. exotic netns setups);
 // the caller keeps HostID as the fallback fingerprint so such hosts still
 // register. All components are sorted so the value is stable across reboots.
+//
+// Note the NIC filter in isPhysicalNIC is load-bearing, not cosmetic: K8s
+// CNI host-side veths (Calico cali*, Cilium lxc*) all carry placeholder MACs
+// and sort before eth0 by name, so unfiltered they would occupy the
+// first-two slots and hash every node of a cluster to one fingerprint.
 func hardwareFingerprint() string {
 	macs := physicalMACs()
 	if len(macs) == 0 {
@@ -48,14 +53,28 @@ func physicalMACs() []string {
 	if err != nil {
 		return nil
 	}
+	return selectMACs(ifaces)
+}
+
+// selectMACs implements the physicalMACs policy over a given interface list
+// (split out for testability): keep physical NICs, drop duplicate MACs (a
+// bond/bridge and its slaves share one address — one card must not occupy
+// both slots), sort by interface name, cap at two.
+func selectMACs(ifaces []net.Interface) []string {
 	type ni struct{ name, mac string }
 	list := make([]ni, 0, len(ifaces))
+	seen := make(map[string]struct{}, len(ifaces))
 	for i := range ifaces {
 		iface := ifaces[i]
 		if !isPhysicalNIC(&iface) {
 			continue
 		}
-		list = append(list, ni{name: iface.Name, mac: iface.HardwareAddr.String()})
+		mac := iface.HardwareAddr.String()
+		if _, dup := seen[mac]; dup {
+			continue
+		}
+		seen[mac] = struct{}{}
+		list = append(list, ni{name: iface.Name, mac: mac})
 	}
 	if len(list) == 0 {
 		return nil
@@ -73,7 +92,9 @@ func physicalMACs() []string {
 
 // isPhysicalNIC reports whether iface looks like a real NIC worth keying the
 // fingerprint on — excludes loopback, point-to-point (VPN/tunnel), MAC-less,
-// and name-matched virtual interfaces (docker/veth/bridge/tun/tap/…).
+// name-matched virtual interfaces (docker/veth/bridge/tun/tap/…), CNI
+// host-side veths (Calico cali*, Cilium lxc*, Weave weave*), and placeholder
+// MACs that are identical across hosts.
 func isPhysicalNIC(iface *net.Interface) bool {
 	if iface.Flags&net.FlagLoopback != 0 {
 		return false
@@ -84,6 +105,19 @@ func isPhysicalNIC(iface *net.Interface) bool {
 	if len(iface.HardwareAddr) == 0 {
 		return false
 	}
+	// Placeholder addresses shared by many hosts must never key the
+	// fingerprint, or every such host hashes to the same value:
+	//   ee:ee:ee:ee:ee:ee — Calico hardcodes it on every host-side cali*
+	//     veth; since "cali" sorts before "eth0", unfiltered it occupies the
+	//     first-two slots and collapses all Calico nodes onto one
+	//     fingerprint. This MAC check also catches any future CNI whose
+	//     name prefix the list below misses.
+	//   00:00:00:00:00:00 — uninitialized NIC; its 6-byte length slips past
+	//     the empty check above.
+	switch iface.HardwareAddr.String() {
+	case "ee:ee:ee:ee:ee:ee", "00:00:00:00:00:00":
+		return false
+	}
 	name := strings.ToLower(iface.Name)
 	// Linux uses prefixes; other platforms ship the same virtual NICs under
 	// vendor names. One combined keyword list covers both well enough for a
@@ -92,6 +126,7 @@ func isPhysicalNIC(iface *net.Interface) bool {
 		"docker", "veth", "cni", "flannel", "virbr", "br-", "tun", "tap",
 		"vmnet", "vboxnet", "vmware", "hyper-v", "vbox", "wsl", "vpn",
 		"utun", "bridge", "awdl", "anpi", "isatap", "teredo", "kube",
+		"cali", "lxc", "weave",
 	}
 	for _, v := range virtual {
 		if strings.HasPrefix(name, v) || strings.Contains(name, v) {

--- a/internal/edgeagent/collector/hwfingerprint_test.go
+++ b/internal/edgeagent/collector/hwfingerprint_test.go
@@ -21,6 +21,9 @@ func TestIsPhysicalNIC(t *testing.T) {
 		{"br- compose", net.Interface{Name: "br-abc123", HardwareAddr: mac}, false},
 		{"point-to-point vpn", net.Interface{Name: "tun0", Flags: net.FlagPointToPoint, HardwareAddr: mac}, false},
 		{"cni", net.Interface{Name: "cni0", HardwareAddr: mac}, false},
+		{"calico host veth", net.Interface{Name: "cali1cd2b48238d", HardwareAddr: mac}, false},
+		{"cilium host veth", net.Interface{Name: "lxc1a2b3c4d5", HardwareAddr: mac}, false},
+		{"weave", net.Interface{Name: "weave", HardwareAddr: mac}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -29,6 +32,73 @@ func TestIsPhysicalNIC(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Placeholder MACs shared across hosts are rejected regardless of interface
+// name — the backstop for CNIs the name keyword list doesn't know yet.
+func TestIsPhysicalNICPlaceholderMAC(t *testing.T) {
+	for _, macStr := range []string{"ee:ee:ee:ee:ee:ee", "00:00:00:00:00:00"} {
+		mac, _ := net.ParseMAC(macStr)
+		iface := net.Interface{Name: "eth0", HardwareAddr: mac}
+		if isPhysicalNIC(&iface) {
+			t.Errorf("isPhysicalNIC(eth0, %s) = true, want false (non-unique placeholder MAC)", macStr)
+		}
+	}
+}
+
+func TestSelectMACs(t *testing.T) {
+	mustMAC := func(s string) net.HardwareAddr {
+		m, err := net.ParseMAC(s)
+		if err != nil {
+			t.Fatalf("bad test MAC %q: %v", s, err)
+		}
+		return m
+	}
+	real1, real2 := mustMAC("00:50:56:8d:fc:fc"), mustMAC("00:50:56:8d:32:37")
+	cali1 := net.Interface{Name: "cali1cd2b48238d", HardwareAddr: mustMAC("ee:ee:ee:ee:ee:ee")}
+	cali2 := net.Interface{Name: "calicc4fdafb95b", HardwareAddr: mustMAC("ee:ee:ee:ee:ee:ee")}
+
+	t.Run("calico veths excluded, real NIC kept", func(t *testing.T) {
+		// The reported collision: cali* sorts before eth0, so unfiltered the
+		// first-two slots were both ee:ee:ee:ee:ee:ee on every node.
+		got := selectMACs([]net.Interface{
+			cali1, cali2,
+			{Name: "eth0", HardwareAddr: real1},
+		})
+		if len(got) != 1 || got[0] != real1.String() {
+			t.Errorf("selectMACs = %v, want [%s]", got, real1)
+		}
+	})
+
+	t.Run("duplicate macs deduped", func(t *testing.T) {
+		// bond0 and its slave eth0 share one address; dedupe frees the
+		// second slot for a genuinely different NIC.
+		got := selectMACs([]net.Interface{
+			{Name: "bond0", HardwareAddr: real1},
+			{Name: "eth0", HardwareAddr: real1},
+			{Name: "eth1", HardwareAddr: real2},
+		})
+		if len(got) != 2 || got[0] != real1.String() || got[1] != real2.String() {
+			t.Errorf("selectMACs = %v, want [%s %s]", got, real1, real2)
+		}
+	})
+
+	t.Run("capped at two, sorted by name", func(t *testing.T) {
+		got := selectMACs([]net.Interface{
+			{Name: "eth2", HardwareAddr: mustMAC("00:00:00:00:00:03")},
+			{Name: "eth0", HardwareAddr: mustMAC("00:00:00:00:00:01")},
+			{Name: "eth1", HardwareAddr: mustMAC("00:00:00:00:00:02")},
+		})
+		if len(got) != 2 || got[0] != "00:00:00:00:00:01" || got[1] != "00:00:00:00:00:02" {
+			t.Errorf("selectMACs = %v, want [00:00:00:00:00:01 00:00:00:00:00:02]", got)
+		}
+	})
+
+	t.Run("all filtered returns nil", func(t *testing.T) {
+		if got := selectMACs([]net.Interface{cali1, cali2}); got != nil {
+			t.Errorf("selectMACs = %v, want nil", got)
+		}
+	})
 }
 
 func TestHardwareFingerprintDeterministic(t *testing.T) {


### PR DESCRIPTION
## Problem

On Kubernetes nodes running Calico, every node hashes to the **same** device
fingerprint, so the cloud folds all of them into a single device row.

Root cause chain:

1. Calico hardcodes `ee:ee:ee:ee:ee:ee` as the MAC of every host-side
   `cali*` veth.
2. `isPhysicalNIC` doesn't filter the `cali` prefix, and `"cali..."` sorts
   before `"eth0"` by interface name, so the first-two MACs adopted by
   `hardwareFingerprint` are both `ee:ee:ee:ee:ee:ee` on every Calico node.
3. The remaining hash components are also identical across same-template
   VMs: CPU model (`QEMU Virtual CPU version 2.5+`) and the virtual
   CD-ROM serial (`QM00004` on QEMU / `01000000000000000001` on VMware)
   carry no distinguishing power.

Result: `sha256(macs|cpu|disk)` is identical cluster-wide. A side effect of
the same bug: the number of `cali*` interfaces varies with pod count, so a
single node's fingerprint drifts over time (0 / 1 / >=2 cali interfaces
give three different values).

A second-order effect observed in production: because enrollment is keyed
by host fingerprint, two colliding nodes were issued the **same** edge
identity (same access key), and their agents then fought over the edge's
`device_id` pointer — the devices page intermittently showed empty
Access Key / Edge columns.

## Fix

- `isPhysicalNIC`: add CNI name prefixes (`cali` for Calico, `lxc` for
  Cilium, `weave` for Weave) to the virtual-interface filter.
- `isPhysicalNIC`: reject placeholder MACs that are shared across hosts
  (`ee:ee:ee:ee:ee:ee`, `00:00:00:00:00:00`) regardless of interface name,
  as a backstop for CNIs the keyword list doesn't know yet. The all-zero
  MAC also slips past the previous `len == 0` check since it has length 6.
- `physicalMACs`: dedupe MACs so a bond/bridge and its slaves don't occupy
  both first-two slots; split the policy out into a pure `selectMACs`
  helper for testability.

After the fix, the affected nodes adopt their real `eth0` MAC and register
as distinct devices.

## Tests

- `TestIsPhysicalNIC`: new cases for `cali*` / `lxc*` / `weave` names.
- `TestIsPhysicalNICPlaceholderMAC`: placeholder MACs rejected on any name.
- `TestSelectMACs`: reproduces the reported collision (two cali veths +
  eth0 -> only the real MAC adopted), MAC dedupe, sort + cap, all-filtered.

`go test -race ./internal/edgeagent/collector/` passes.

## Notes for reviewers

- Deliberately out of scope: migration of existing device rows registered
  under the colliding fingerprint. `RebindFingerprint` only covers
  legacy(HostID)->v3 rebinds; v3-old->v3-new re-registration creates fresh
  device rows (the previously folded data wasn't split anyway). Happy to
  add a rebind path in a follow-up if you want to preserve history.
