### PR TITLE
fix(edge): reconcile stale online presence

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -842,29 +842,12 @@ func main() {
 	deviceUC.SetNetworkDiscovery(networkDiscoveryUC)
 	edgeUC := managerbizedge.NewUsecase(edgeRepo, deviceRepo, edgeDeviceRepo, log)
 
-	// Boot backfill: heal "stale online" edge rows. A manager crash or any
-	// pre-PR-(edge-status-fix) deployment could leave edge.status="online"
-	// even though last_seen_at is hours old (frontier closed the session
-	// without us writing the column). Force them offline once at startup
-	// based on the same threshold the alert pipeline uses.
-	{
-		threshold := cfg.Alert.EdgeOfflineThreshold
-		if threshold <= 0 {
-			threshold = 90 * time.Second
-		}
-		cutoff := time.Now().Add(-threshold)
-		res := db.Exec(
-			"UPDATE edges SET status = ?, updated_at = ? WHERE deleted_at IS NULL AND status = ? AND last_seen_at IS NOT NULL AND last_seen_at < ?",
-			"offline", time.Now(), "online", cutoff,
-		)
-		if res.Error != nil {
-			log.Warn("edge: stale-online backfill failed", slog.Any("err", res.Error))
-		} else if res.RowsAffected > 0 {
-			log.Info("edge: backfilled stale online edges to offline",
-				slog.Int64("rows", res.RowsAffected),
-				slog.Duration("threshold", threshold),
-			)
-		}
+	edgeOfflineThreshold := cfg.Alert.EdgeOfflineThreshold
+	if edgeOfflineThreshold <= 0 {
+		edgeOfflineThreshold = 90 * time.Second
+	}
+	if _, err := edgeUC.ReconcileStaleOnline(rootCtx, time.Now().UTC().Add(-edgeOfflineThreshold)); err != nil {
+		log.Warn("edge presence reconcile (boot) failed", slog.Any("err", err))
 	}
 
 	// Boot backfill: heal orphaned investigation reports. An RCA worker only
@@ -2850,18 +2833,23 @@ func main() {
 		})
 	}
 
-	// Device presence reconciler: per-event MarkOnline/MarkOffline can't
+	// Edge/device presence reconciler: per-event MarkOnline/MarkOffline can't
 	// flip a device offline when its edge no longer exists (hard delete) or
 	// re-registered under a new fingerprint, and a manager restart while an
-	// edge is offline leaves the denormalised flag stale. This sweep flips
-	// online devices back offline when no linked edge is online — healing
-	// orphan "ghost" devices that otherwise read as perpetually online in
-	// the device list / query_devices. Runs once at boot, then every 60s
-	// (same cadence as edge offline detection). See #145.
+	// edge is offline leaves the denormalised flag stale. Frontier can also
+	// miss a final disconnect event after an abrupt host deletion, so mark
+	// stale edge rows offline before syncing device presence. Runs once at
+	// boot, then every 60s. See #145.
 	eg.Go(func() error {
-		if _, err := deviceUC.ReconcilePresence(egCtx); err != nil {
-			log.Warn("device presence reconcile (boot) failed", slog.Any("err", err))
+		reconcilePresence := func() {
+			if _, err := edgeUC.ReconcileStaleOnline(egCtx, time.Now().UTC().Add(-edgeOfflineThreshold)); err != nil {
+				log.Warn("edge presence reconcile failed", slog.Any("err", err))
+			}
+			if _, err := deviceUC.ReconcilePresence(egCtx); err != nil {
+				log.Warn("device presence reconcile failed", slog.Any("err", err))
+			}
 		}
+		reconcilePresence()
 		t := time.NewTicker(60 * time.Second)
 		defer t.Stop()
 		for {
@@ -2869,9 +2857,7 @@ func main() {
 			case <-egCtx.Done():
 				return nil
 			case <-t.C:
-				if _, err := deviceUC.ReconcilePresence(egCtx); err != nil {
-					log.Warn("device presence reconcile failed", slog.Any("err", err))
-				}
+				reconcilePresence()
 			}
 		}
 	})

--- a/internal/manager/biz/aiops/agent/agent_test.go
+++ b/internal/manager/biz/aiops/agent/agent_test.go
@@ -279,6 +279,9 @@ func (r *fakeEdgeRepoAgent) UpdateSecretHash(_ context.Context, _ uint64, _ stri
 func (r *fakeEdgeRepoAgent) UpdateStatus(_ context.Context, _ uint64, _ string, _ time.Time) error {
 	return nil
 }
+func (r *fakeEdgeRepoAgent) MarkStaleOffline(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
 func (r *fakeEdgeRepoAgent) MarkRegistered(_ context.Context, _ uint64, _ time.Time) error {
 	return nil
 }

--- a/internal/manager/biz/aiops/tools/registry_test.go
+++ b/internal/manager/biz/aiops/tools/registry_test.go
@@ -61,6 +61,9 @@ func (r *fakeEdgeRepo) UpdateSecretHash(_ context.Context, _ uint64, _ string) e
 func (r *fakeEdgeRepo) UpdateStatus(_ context.Context, _ uint64, _ string, _ time.Time) error {
 	return nil
 }
+func (r *fakeEdgeRepo) MarkStaleOffline(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
 func (r *fakeEdgeRepo) MarkRegistered(_ context.Context, _ uint64, _ time.Time) error {
 	return nil
 }

--- a/internal/manager/biz/edge/repo.go
+++ b/internal/manager/biz/edge/repo.go
@@ -33,6 +33,7 @@ type Repo interface {
 	List(ctx context.Context, f ListFilter) ([]*model.Edge, error)
 	UpdateSecretHash(ctx context.Context, id uint64, hash string) error
 	UpdateStatus(ctx context.Context, id uint64, status string, lastSeen time.Time) error
+	MarkStaleOffline(ctx context.Context, cutoff time.Time) (int64, error)
 	// MarkRegistered records a completed register_edge handshake. The
 	// timestamp changes only on registration, not on heartbeat, so upgrade
 	// orchestration can distinguish a newly started agent session.

--- a/internal/manager/biz/edge/usecase.go
+++ b/internal/manager/biz/edge/usecase.go
@@ -610,6 +610,22 @@ func (u *Usecase) HandleHeartbeat(ctx context.Context, edgeID uint64, ts time.Ti
 	return nil
 }
 
+// ReconcileStaleOnline heals online state when Frontier misses a transport
+// close event, for example after a VM or host is force-deleted.
+func (u *Usecase) ReconcileStaleOnline(ctx context.Context, cutoff time.Time) (int64, error) {
+	if u.repo == nil {
+		return 0, errs.ErrNotWiredYet
+	}
+	n, err := u.repo.MarkStaleOffline(ctx, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 && u.log != nil {
+		u.log.Info("edge presence reconcile: flipped stale edges offline", "count", n)
+	}
+	return n, nil
+}
+
 // HandleOffline flips an edge's status to offline. Called from the
 // frontierbound EdgeOffline lifecycle callback when the tunnel session
 // closes (graceful disconnect or transport drop). last_seen_at is bumped

--- a/internal/manager/biz/edge/usecase_test.go
+++ b/internal/manager/biz/edge/usecase_test.go
@@ -307,6 +307,19 @@ func (r *fakeRepo) UpdateStatus(_ context.Context, id uint64, status string, las
 	return nil
 }
 
+func (r *fakeRepo) MarkStaleOffline(_ context.Context, cutoff time.Time) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var n int64
+	for _, edge := range r.byID {
+		if edge.DeletedAt == nil && edge.Status == model.StatusOnline && edge.LastSeenAt != nil && edge.LastSeenAt.Before(cutoff) {
+			edge.Status = model.StatusOffline
+			n++
+		}
+	}
+	return n, nil
+}
+
 func (r *fakeRepo) MarkRegistered(_ context.Context, id uint64, registeredAt time.Time) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/manager/data/edge/store/edge.go
+++ b/internal/manager/data/edge/store/edge.go
@@ -147,6 +147,18 @@ func (r *Repo) UpdateStatus(ctx context.Context, id uint64, status string, lastS
 	return nil
 }
 
+// MarkStaleOffline flips online edges whose last heartbeat predates cutoff.
+// The conditional update is atomic with concurrent heartbeat writes.
+func (r *Repo) MarkStaleOffline(ctx context.Context, cutoff time.Time) (int64, error) {
+	res := r.db.WithContext(ctx).Model(&model.Edge{}).
+		Where("status = ? AND last_seen_at IS NOT NULL AND last_seen_at < ?", model.StatusOnline, cutoff).
+		Update("status", model.StatusOffline)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
 // MarkRegistered records the completion of register_edge and marks the edge
 // online. Heartbeats intentionally use UpdateStatus instead so this timestamp
 // remains a stable session-generation marker.

--- a/internal/manager/data/edge/store/edge_test.go
+++ b/internal/manager/data/edge/store/edge_test.go
@@ -135,6 +135,58 @@ func TestSQLiteRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMarkStaleOfflineOnlyUpdatesStaleOnlineEdges(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	cutoff := time.Date(2026, 9, 3, 9, 0, 0, 0, time.UTC)
+
+	create := func(name, accessKey, status string, lastSeen *time.Time) *model.Edge {
+		t.Helper()
+		edge := &model.Edge{
+			Name:          name,
+			AccessKeyID:   accessKey,
+			SecretKeyHash: "hash",
+			Status:        status,
+			LastSeenAt:    lastSeen,
+		}
+		if err := repo.Create(ctx, edge); err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		return edge
+	}
+
+	staleAt := cutoff.Add(-time.Second)
+	freshAt := cutoff.Add(time.Second)
+	stale := create("stale", "ak-stale", model.StatusOnline, &staleAt)
+	fresh := create("fresh", "ak-fresh", model.StatusOnline, &freshAt)
+	missing := create("missing", "ak-missing", model.StatusOnline, nil)
+	alreadyOffline := create("offline", "ak-offline", model.StatusOffline, &staleAt)
+
+	n, err := repo.MarkStaleOffline(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("MarkStaleOffline: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("MarkStaleOffline updated %d edges, want 1", n)
+	}
+
+	wants := map[uint64]string{
+		stale.ID:          model.StatusOffline,
+		fresh.ID:          model.StatusOnline,
+		missing.ID:        model.StatusOnline,
+		alreadyOffline.ID: model.StatusOffline,
+	}
+	for id, want := range wants {
+		got, getErr := repo.GetByID(ctx, id)
+		if getErr != nil {
+			t.Fatalf("GetByID(%d): %v", id, getErr)
+		}
+		if got.Status != want {
+			t.Errorf("edge %d status = %q, want %q", id, got.Status, want)
+		}
+	}
+}
+
 func TestSQLiteSetAgentVersion(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- reconcile stale online Edge records during the existing 60-second presence sweep
- update device presence only after stale Edge state is repaired
- cover stale, fresh, missing-heartbeat, and already-offline records with a regression test

## Validation

- `go test -race ./internal/manager/data/edge/store ./internal/manager/biz/edge ./internal/manager/biz/aiops/agent`
- `go test -race ./internal/manager/data/device/store ./internal/manager/biz/device`
- `go test ./cmd/ongrid`
- rebuilt and restarted the local `ongrid:dev` container
- verified an online Edge with an expired heartbeat was automatically changed to offline on the next presence sweep

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
