### PR TITLE
fix(web): align packet capture and terminal surfaces in light mode

### DIFF
--- a/web/src/components/XTerminal.test.tsx
+++ b/web/src/components/XTerminal.test.tsx
@@ -1,0 +1,79 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { XTerminal } from './XTerminal';
+import { setThemePreference } from '@/store/mode';
+
+const terminalMock = vi.hoisted(() => ({
+  instances: [] as Array<{ options: { theme?: { background?: string; foreground?: string; white?: string } } }>,
+}));
+
+vi.mock('xterm', () => ({
+  Terminal: class Terminal {
+    options: { theme?: { background?: string; foreground?: string; white?: string } };
+
+    constructor(options: { theme?: { background?: string; foreground?: string; white?: string } }) {
+      this.options = options;
+      terminalMock.instances.push(this);
+    }
+
+    loadAddon() {}
+    open() {}
+    onData() { return { dispose() {} }; }
+    onResize() { return { dispose() {} }; }
+    attachCustomKeyEventHandler() {}
+    write() {}
+    writeln() {}
+    clear() {}
+    focus() {}
+    dispose() {}
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class FitAddon { fit() {} },
+}));
+
+vi.mock('xterm-addon-web-links', () => ({
+  WebLinksAddon: class WebLinksAddon {},
+}));
+
+vi.stubGlobal('ResizeObserver', class ResizeObserver {
+  observe() {}
+  disconnect() {}
+});
+
+describe('XTerminal', () => {
+  beforeEach(() => {
+    terminalMock.instances.length = 0;
+    localStorage.clear();
+  });
+
+  it('只读日志启用应用主题后会响应 light 和 dark 切换', () => {
+    setThemePreference('light');
+    const { container } = render(<XTerminal attachRef={() => {}} readOnly followAppTheme />);
+
+    expect(terminalMock.instances).toHaveLength(1);
+    expect(terminalMock.instances[0].options.theme).toMatchObject({
+      background: '#ffffff',
+      foreground: '#27272a',
+      white: '#3f3f46',
+    });
+    expect(container.firstElementChild).toHaveClass('bg-zinc-900');
+
+    act(() => setThemePreference('dark'));
+
+    expect(terminalMock.instances[0].options.theme).toMatchObject({
+      background: '#09090b',
+      foreground: '#e4e4e7',
+    });
+  });
+
+  it('交互终端默认保持现有深色主题', () => {
+    setThemePreference('light');
+    const { container } = render(<XTerminal attachRef={() => {}} />);
+
+    expect(terminalMock.instances[0].options.theme?.background).toBe('#09090b');
+    expect(container.firstElementChild).toHaveClass('bg-zinc-950');
+  });
+});

--- a/web/src/components/XTerminal.tsx
+++ b/web/src/components/XTerminal.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from 'react';
 import { Terminal, type ITheme } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { WebLinksAddon } from 'xterm-addon-web-links';
+import { useThemeMode, type ResolvedTheme } from '@/store/mode';
 import 'xterm/css/xterm.css';
 
 export type XTerminalApi = {
@@ -38,6 +39,7 @@ type Props = {
   className?: string;
   fontSize?: number;
   scrollback?: number;
+  followAppTheme?: boolean;
 };
 
 // Theme tuned to the rest of the app: zinc-950 background, zinc-100 text,
@@ -67,15 +69,45 @@ const THEME: ITheme = {
   brightWhite: '#fafafa',
 };
 
-export function XTerminal({ onData, onResize, attachRef, readOnly = false, className = '', fontSize = 13, scrollback = 5000 }: Props) {
+const LIGHT_THEME: ITheme = {
+  background: '#ffffff',
+  foreground: '#27272a',
+  cursor: '#4f46e5',
+  cursorAccent: '#ffffff',
+  selectionBackground: '#c7d2feaa',
+  black: '#18181b',
+  red: '#b91c1c',
+  green: '#047857',
+  yellow: '#a16207',
+  blue: '#1d4ed8',
+  magenta: '#7e22ce',
+  cyan: '#0e7490',
+  white: '#3f3f46',
+  brightBlack: '#71717a',
+  brightRed: '#dc2626',
+  brightGreen: '#059669',
+  brightYellow: '#ca8a04',
+  brightBlue: '#2563eb',
+  brightMagenta: '#9333ea',
+  brightCyan: '#0891b2',
+  brightWhite: '#18181b',
+};
+
+function terminalTheme(theme: ResolvedTheme): ITheme {
+  return theme === 'light' ? LIGHT_THEME : THEME;
+}
+
+export function XTerminal({ onData, onResize, attachRef, readOnly = false, className = '', fontSize = 13, scrollback = 5000, followAppTheme = false }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const { resolved } = useThemeMode();
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
     const term = new Terminal({
-      theme: THEME,
+      theme: followAppTheme ? terminalTheme(resolved) : THEME,
       // Match Apple Terminal / iTerm defaults — JetBrains Mono is the
       // closest the host stylesheet ships, fall back to ui-monospace.
       fontFamily:
@@ -97,6 +129,7 @@ export function XTerminal({ onData, onResize, attachRef, readOnly = false, class
     term.loadAddon(linksAddon);
 
     term.open(el);
+    terminalRef.current = term;
     // Initial fit must happen after open() lays out the DOM.
     try {
       fitAddon.fit();
@@ -162,6 +195,7 @@ export function XTerminal({ onData, onResize, attachRef, readOnly = false, class
     if (!readOnly) term.focus();
 
     return () => {
+      terminalRef.current = null;
       ro.disconnect();
       dataDisposable?.dispose();
       resizeDisposable.dispose();
@@ -172,10 +206,15 @@ export function XTerminal({ onData, onResize, attachRef, readOnly = false, class
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (!followAppTheme || !terminalRef.current) return;
+    terminalRef.current.options.theme = terminalTheme(resolved);
+  }, [followAppTheme, resolved]);
+
   return (
     <div
       ref={containerRef}
-      className={`h-full w-full bg-zinc-950 ${className}`}
+      className={`h-full w-full ${followAppTheme ? 'bg-zinc-900' : 'bg-zinc-950'} ${className}`}
       // xterm injects its own focusable element; this wrapper doesn't
       // need a tabindex.
     />

--- a/web/src/components/monitor/ProcessTopPanel.tsx
+++ b/web/src/components/monitor/ProcessTopPanel.tsx
@@ -24,6 +24,7 @@ import { Cpu, Loader2, MemoryStick } from 'lucide-react';
 import { queryRange, type PromMatrixSeries } from '@/api/prom';
 import { ApiError } from '@/api/client';
 import { cn } from '@/lib/cn';
+import { chartTooltipStyle } from '@/lib/chartTheme';
 import { useI18n } from '@/i18n/locale';
 
 const TOP_N = 8; // 同屏可读上限；再多线就糊
@@ -191,12 +192,7 @@ export function ProcessTopPanel({
                   width={56}
                 />
                 <Tooltip
-                  contentStyle={{
-                    background: 'rgb(24 24 27)',
-                    border: '1px solid rgb(63 63 70)',
-                    borderRadius: 6,
-                    fontSize: 11,
-                  }}
+                  contentStyle={chartTooltipStyle}
                   formatter={(v: number) => `${v.toFixed(1)} ${unit}`}
                 />
                 <Legend wrapperStyle={{ fontSize: 10 }} />

--- a/web/src/components/ui/PaginationFooter.tsx
+++ b/web/src/components/ui/PaginationFooter.tsx
@@ -43,7 +43,7 @@ export function PaginationFooter({
 
   return (
     <div className={cn(
-      'sticky bottom-0 z-10 mt-2 flex items-center justify-end gap-2 border-t border-zinc-800/60 bg-zinc-950/95 py-3 text-xs text-zinc-400 backdrop-blur',
+      'sticky bottom-0 z-10 mt-2 flex items-center justify-end gap-2 border-t border-zinc-800/60 bg-zinc-950 py-3 text-xs text-zinc-400',
       className,
     )}>
       <span className="mr-2 text-zinc-600">{rangeLabel}</span>

--- a/web/src/lib/chartTheme.test.ts
+++ b/web/src/lib/chartTheme.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chartTooltipItemStyle,
+  chartTooltipLabelStyle,
+  chartTooltipStyle,
+} from './chartTheme';
+
+describe('chart tooltip theme', () => {
+  it('uses application theme tokens instead of fixed dark colors', () => {
+    expect(chartTooltipStyle).toMatchObject({
+      background: 'rgb(var(--card))',
+      border: '1px solid rgb(var(--border))',
+      color: 'rgb(var(--text))',
+    });
+    expect(chartTooltipLabelStyle.color).toBe('rgb(var(--text-muted))');
+    expect(chartTooltipItemStyle.color).toBe('rgb(var(--text))');
+  });
+});

--- a/web/src/lib/chartTheme.ts
+++ b/web/src/lib/chartTheme.ts
@@ -1,0 +1,17 @@
+import type { CSSProperties } from 'react';
+
+export const chartTooltipStyle: CSSProperties = {
+  background: 'rgb(var(--card))',
+  border: '1px solid rgb(var(--border))',
+  borderRadius: 6,
+  color: 'rgb(var(--text))',
+  fontSize: 11,
+};
+
+export const chartTooltipLabelStyle: CSSProperties = {
+  color: 'rgb(var(--text-muted))',
+};
+
+export const chartTooltipItemStyle: CSSProperties = {
+  color: 'rgb(var(--text))',
+};

--- a/web/src/pages/AlertRules.tsx
+++ b/web/src/pages/AlertRules.tsx
@@ -28,6 +28,7 @@ import {
 } from 'recharts';
 import { Modal } from '@/components/Modal';
 import { cn } from '@/lib/cn';
+import { chartTooltipLabelStyle, chartTooltipStyle } from '@/lib/chartTheme';
 import {
   CREATABLE_RULE_KINDS,
   RULE_KINDS,
@@ -1142,8 +1143,8 @@ function PreviewChart({ result }: { result: RulePreviewResp }) {
           <Tooltip
             labelFormatter={(v) => fmtTick(Number(v))}
             formatter={(v: number) => [fmtY(v), result.unit ? tr(`值 (${result.unit})`, `Value (${result.unit})`) : tr('值', 'Value')]}
-            contentStyle={{ background: '#0b0b0e', border: '1px solid #27272a', fontSize: 11 }}
-            labelStyle={{ color: '#a1a1aa' }}
+            contentStyle={chartTooltipStyle}
+            labelStyle={chartTooltipLabelStyle}
           />
           {fireSpans.map((s, i) => (
             <ReferenceArea

--- a/web/src/pages/DailyTools.tsx
+++ b/web/src/pages/DailyTools.tsx
@@ -1778,6 +1778,7 @@ function RunConsole({ title, status, logs, compact }: { title: string; status: R
         <XTerminal
           attachRef={attachTerm}
           readOnly
+          followAppTheme
           fontSize={11}
           scrollback={1000}
           className="rounded-md"

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 import { StatusPill } from '@/components/StatusPill';
 import { Sparkline } from '@/components/Sparkline';
 import { cn } from '@/lib/cn';
+import { chartTooltipStyle } from '@/lib/chartTheme';
 import { openMetricDrilldown } from '@/lib/drilldown';
 import { formatNumber, relativeTime } from '@/lib/format';
 import { usePoll } from '@/lib/usePoll';
@@ -709,12 +710,7 @@ function ClusterPosture({
                 <XAxis dataKey="t" hide />
                 <YAxis domain={[0, onlineMax]} hide />
                 <Tooltip
-                  contentStyle={{
-                    background: 'rgb(24 24 27)',
-                    border: '1px solid rgb(63 63 70)',
-                    borderRadius: 6,
-                    fontSize: 11,
-                  }}
+                  contentStyle={chartTooltipStyle}
                   formatter={(v: number) => [`${v}`, tr('在线', 'Online')]}
                   labelFormatter={(idx: number) => {
                     // 24 hourly buckets — last one is "now". Render
@@ -916,12 +912,7 @@ function AlertSeverityCard({
                   ))}
                 </Pie>
                 <Tooltip
-                  contentStyle={{
-                    background: 'rgb(24 24 27)',
-                    border: '1px solid rgb(63 63 70)',
-                    borderRadius: 6,
-                    fontSize: 11,
-                  }}
+                  contentStyle={chartTooltipStyle}
                   formatter={(v: number) => `${v}`}
                 />
               </PieChart>
@@ -1030,12 +1021,7 @@ function NoisyRulesCard({
               />
               <Tooltip
                 cursor={{ fill: 'rgba(120, 120, 140, 0.12)' }}
-                contentStyle={{
-                  background: 'rgb(24 24 27)',
-                  border: '1px solid rgb(63 63 70)',
-                  borderRadius: 6,
-                  fontSize: 11,
-                }}
+                contentStyle={chartTooltipStyle}
                 formatter={(v: number) => [`${v}`, tr('incident 数', 'incidents')]}
               />
               <Bar dataKey="count" radius={[0, 4, 4, 0]} isAnimationActive={false} cursor="pointer">

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -52,6 +52,7 @@ import { listNodes, type TopologyNode } from '@/api/topology';
 import { onDevicesChanged } from '@/lib/events';
 import { Button, RoleSelect } from '@/components/ui';
 import { cn } from '@/lib/cn';
+import { chartTooltipItemStyle, chartTooltipLabelStyle, chartTooltipStyle } from '@/lib/chartTheme';
 import { useI18n } from '@/i18n/locale';
 
 const RANGE_PRESETS = [
@@ -944,7 +945,7 @@ export default function LogsPage() {
                   <CartesianGrid stroke="#52525b" strokeOpacity={0.28} vertical={false} />
                   <XAxis dataKey="label" minTickGap={48} tick={{ fill: '#71717a', fontSize: 10 }} tickLine={false} axisLine={{ stroke: '#3f3f46' }} />
                   <YAxis allowDecimals={false} width={44} tick={{ fill: '#71717a', fontSize: 10 }} tickLine={false} axisLine={false} />
-                  <Tooltip cursor={{ fill: '#6366f1', opacity: 0.08 }} formatter={(value) => [Number(value).toLocaleString(), tr('日志数', 'Logs')]} contentStyle={{ backgroundColor: '#18181b', border: '1px solid #3f3f46', borderRadius: 6, fontSize: 11 }} labelStyle={{ color: '#a1a1aa' }} itemStyle={{ color: '#e4e4e7' }} />
+                  <Tooltip cursor={{ fill: '#6366f1', opacity: 0.08 }} formatter={(value) => [Number(value).toLocaleString(), tr('日志数', 'Logs')]} contentStyle={chartTooltipStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
                   <Bar dataKey="count" fill="#6366f1" radius={[2, 2, 0, 0]} minPointSize={2} />
                 </BarChart>
               </ResponsiveContainer>

--- a/web/src/pages/PacketCaptureSessionDetail.tsx
+++ b/web/src/pages/PacketCaptureSessionDetail.tsx
@@ -85,7 +85,7 @@ export default function PacketCaptureSessionDetailPage() {
                 <Metric label={tr('成员数据包', 'Member artifacts')} value={`${readyCount}/${captureCount}`} />
                 <Metric label={tr('关联流', 'Correlated flows')} value={String(analysis?.summary.flow_count ?? 0)} />
                 <Metric label={tr('已解析事件', 'Parsed events')} value={String(analysis?.summary.event_count ?? 0)} />
-                <div className="bg-zinc-900/90 p-4">
+                <div className="bg-zinc-900 p-4">
                   <Button onClick={() => void analyzeWithAI()} disabled={analyzing} className="h-8">
                     <Sparkles size={13} /> {tr('AI 分析', 'AI analysis')}
                   </Button>
@@ -113,7 +113,7 @@ export default function PacketCaptureSessionDetailPage() {
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-zinc-900/90 p-4">
+    <div className="bg-zinc-900 p-4">
       <div className="text-[11px] text-zinc-500">{label}</div>
       <div className="mt-1 text-lg font-medium text-zinc-100">{value}</div>
     </div>

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -139,7 +139,8 @@ html.light .bg-zinc-950\/40,
 html.light .bg-zinc-950\/60,
 html.light .bg-zinc-950\/70,
 html.light .bg-zinc-950\/80       { background-color: rgb(var(--bg) / 0.5); }
-html.light .bg-zinc-700\/40       { background-color: rgb(241 245 249); }
+html.light .bg-zinc-700\/40,
+html.light .bg-zinc-700\/50       { background-color: rgb(241 245 249); }
 html.light .bg-zinc-900\/30,
 html.light .bg-zinc-900\/40,
 html.light .bg-zinc-900\/50,
@@ -147,6 +148,7 @@ html.light .bg-zinc-900\/60,
 html.light .bg-zinc-900\/70,
 html.light .bg-zinc-900\/80       { background-color: rgb(var(--card-soft)); }
 html.light .bg-zinc-800\/40,
+html.light .bg-zinc-800\/70,
 html.light .bg-zinc-800\/60,
 html.light .bg-zinc-800\/80       { background-color: rgb(226 232 240 / 0.7); }
 
@@ -201,12 +203,17 @@ html.light .placeholder\:text-zinc-600::placeholder { color: rgb(var(--text-fain
 
 /* hover: variants that flip the same way */
 html.light .hover\:bg-zinc-800:hover       { background-color: rgb(226 232 240); }
+html.light .hover\:bg-zinc-600\/30:hover,
+html.light .hover\:bg-zinc-800\/30:hover   { background-color: rgb(226 232 240 / 0.4); }
 html.light .hover\:bg-zinc-800\/40:hover   { background-color: rgb(226 232 240 / 0.5); }
-html.light .hover\:bg-zinc-800\/60:hover   { background-color: rgb(226 232 240 / 0.7); }
+html.light .hover\:bg-zinc-800\/60:hover,
+html.light .hover\:bg-zinc-800\/70:hover,
+html.light .hover\:bg-zinc-800\/80:hover   { background-color: rgb(226 232 240 / 0.7); }
 html.light .hover\:bg-zinc-900:hover       { background-color: rgb(241 245 249); }  /* slate-100 */
 html.light .hover\:bg-zinc-900\/30:hover,
 html.light .hover\:bg-zinc-900\/40:hover   { background-color: rgb(241 245 249 / 0.7); }
-html.light .hover\:bg-zinc-900\/60:hover   { background-color: rgb(248 250 252); }
+html.light .hover\:bg-zinc-900\/60:hover,
+html.light .hover\:bg-zinc-900\/70:hover   { background-color: rgb(248 250 252); }
 html.light .hover\:bg-zinc-700:hover       { background-color: rgb(203 213 225); }
 html.light .hover\:bg-red-900\/30:hover    { background-color: rgb(254 226 226); }
 html.light .hover\:text-zinc-100:hover     { color: rgb(var(--text)); }


### PR DESCRIPTION
## Summary

- replace the packet-session metric `/90` surfaces with theme-mapped card surfaces
- add an opt-in app-theme mode to `XTerminal` for read-only tool output
- preserve the existing dark theme for interactive WebSSH terminals
- theme Recharts tooltips on Dashboard, Monitor, Alert Rules, and Logs
- cover missing light-mode hover, status, and sticky pagination surfaces
- add terminal and chart-theme unit coverage

Closes #377

## Verification

- `npm test -- --run src/components/XTerminal.test.tsx src/lib/chartTheme.test.ts`
- `npm run typecheck`
- changed-file ESLint with `--quiet`
- `make build-web`
- deployed visual QA: Dashboard light/dark, Logs tooltip, Settings Health, Reports, packet session, and tool console
- all required GitHub CI checks pass

## Known baseline failures

- full frontend lint still reports pre-existing errors on `main` outside this change
- the existing DailyTools profiling test fails locally under Node 25 because MSW receives an AbortSignal from a different realm; the standard CI environment passes the complete web test and build job

## Rollback

Revert commits `23883fb` and `6263a72`; no API, schema, or data migration is involved.

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md