### PR TITLE
fix(platform): secure web shell access and validate integrations

### DIFF
--- a/api/manager/logs/v1/logs.proto
+++ b/api/manager/logs/v1/logs.proto
@@ -17,6 +17,8 @@ service LogsService {
   rpc GetLogContext(GetLogContextRequest) returns (GetLogContextResponse);
   rpc GetLogBackend(GetLogBackendRequest) returns (GetLogBackendResponse);
   rpc PutLogBackend(PutLogBackendRequest) returns (PutLogBackendResponse);
+  // Validates an unsaved Elasticsearch draft without persisting credentials or backend state.
+  rpc ValidateLogBackendDraft(PutLogBackendRequest) returns (TestLogBackendResponse);
   rpc TestLogBackend(TestLogBackendRequest) returns (TestLogBackendResponse);
   rpc SelectLogBackend(SelectLogBackendRequest) returns (SelectLogBackendResponse);
   rpc StartLogBackendConnectionCheck(StartLogBackendConnectionCheckRequest) returns (LogBackendConnectionCheckResponse);

--- a/api/manager/setting/v1/setting.proto
+++ b/api/manager/setting/v1/setting.proto
@@ -11,6 +11,22 @@ service SettingService {
     // HTTP implementation:
     // POST /api/v1/system-settings/observability/{service}/apply.
     rpc ApplyBuiltInObservabilityLimits(ApplyBuiltInObservabilityLimitsRequest) returns (ApplyBuiltInObservabilityLimitsResponse);
+    // ValidatePrometheusConfiguration 使用未落库的查询、写入与认证配置，
+    // 分别执行 PromQL 和空 remote_write 探针，不保存配置或指标。
+    // HTTP 实现：POST /api/v1/integrations/prom/test。
+    rpc ValidatePrometheusConfiguration(ValidatePrometheusConfigurationRequest) returns (ValidatePrometheusConfigurationResponse);
+    // ValidateGrafanaConfiguration 使用未落库的地址和凭证检查 Grafana。
+    // HTTP 实现：POST /api/v1/integrations/grafana/test。
+    rpc ValidateGrafanaConfiguration(ValidateGrafanaConfigurationRequest) returns (ValidateGrafanaConfigurationResponse);
+    // ValidateLokiConfiguration 使用未落库的 URL 和认证检查 /ready。
+    // HTTP 实现：POST /api/v1/integrations/loki/test。
+    rpc ValidateLokiConfiguration(ValidateLokiConfigurationRequest) returns (ValidateLokiConfigurationResponse);
+    // ValidateTempoConfiguration 使用未落库的 URL 和认证检查查询或 OTLP 入口。
+    // HTTP 实现：POST /api/v1/integrations/tempo/test。
+    rpc ValidateTempoConfiguration(ValidateTempoConfigurationRequest) returns (ValidateTempoConfigurationResponse);
+    // ValidateWebSearchConfiguration 使用未落库的 provider 配置执行最小查询。
+    // HTTP 实现：POST /api/v1/integrations/websearch/test。
+    rpc ValidateWebSearchConfiguration(ValidateWebSearchConfigurationRequest) returns (ValidateWebSearchConfigurationResponse);
     // ValidateLLMConfiguration 使用未落库的草稿配置发起最小模型请求，
     // 返回可机器识别的失败原因。HTTP 实现：
     // POST /api/v1/integrations/llm/test。
@@ -30,6 +46,66 @@ message ApplyBuiltInObservabilityLimitsRequest {
 
 message ApplyBuiltInObservabilityLimitsResponse {
     string status = 1 [json_name = "status"];
+}
+
+message ValidatePrometheusConfigurationRequest {
+    string query_url = 1 [json_name = "query_url"];
+    string remote_write_url = 2 [json_name = "remote_write_url"];
+    string bearer_token = 3 [json_name = "bearer_token"];
+    string basic_user = 4 [json_name = "basic_user"];
+    string basic_password = 5 [json_name = "basic_password"];
+    bool tls_insecure = 6 [json_name = "tls_insecure"];
+}
+
+message ValidatePrometheusConfigurationResponse {
+    string status = 1 [json_name = "status"];
+}
+
+message ValidateGrafanaConfigurationRequest {
+    string root_url = 1 [json_name = "root_url"];
+    string sa_token = 2 [json_name = "sa_token"];
+    string api_key = 3 [json_name = "api_key"];
+    string org_id = 4 [json_name = "org_id"];
+    bool tls_insecure = 5 [json_name = "tls_insecure"];
+}
+
+message ValidateGrafanaConfigurationResponse {
+    string status = 1 [json_name = "status"];
+}
+
+message ValidateLokiConfigurationRequest {
+    string url = 1 [json_name = "url"];
+    string basic_user = 2 [json_name = "basic_user"];
+    string basic_password = 3 [json_name = "basic_password"];
+    bool tls_insecure = 4 [json_name = "tls_insecure"];
+}
+
+message ValidateLokiConfigurationResponse {
+    string status = 1 [json_name = "status"];
+}
+
+message ValidateTempoConfigurationRequest {
+    string url = 1 [json_name = "url"];
+    string basic_user = 2 [json_name = "basic_user"];
+    string basic_password = 3 [json_name = "basic_password"];
+    bool tls_insecure = 4 [json_name = "tls_insecure"];
+}
+
+message ValidateTempoConfigurationResponse {
+    string status = 1 [json_name = "status"];
+}
+
+message ValidateWebSearchConfigurationRequest {
+    string provider = 1 [json_name = "provider"];
+    string searxng_url = 2 [json_name = "searxng_url"];
+    string tavily_api_key = 3 [json_name = "tavily_api_key"];
+    string brave_api_key = 4 [json_name = "brave_api_key"];
+}
+
+message ValidateWebSearchConfigurationResponse {
+    string status = 1 [json_name = "status"];
+    string provider = 2 [json_name = "provider"];
+    string sample = 3 [json_name = "sample"];
 }
 
 message ValidateLLMConfigurationRequest {

--- a/cmd/ongrid-edge/main.go
+++ b/cmd/ongrid-edge/main.go
@@ -201,9 +201,9 @@ func main() {
 		operatorLog := log.With(slog.String("comp", "operator"))
 		edgeoperator.Register(client, operatorLog)
 
-		// WebSSH: edge is a stream port-forwarder. Manager opens a
-		// frontier stream with Meta describing the target (sshd at
-		// 127.0.0.1:22), edge io.Copy's bytes both ways. SSH client
+		// WebSSH: edge is a stream port-forwarder. Manager carries the
+		// allowed loopback port in the SSH identification line, then edge
+		// io.Copy's bytes both ways. SSH client
 		// lives entirely on the manager — see internal/manager/server/
 		// webshell. The edge has no SSH lib, no PTY, no session map.
 		webshellLog := log.With(slog.String("comp", "webshell"))

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -1238,6 +1238,7 @@ func main() {
 	// pushes through the live router.
 	webshellRouter := managerwebshellbiz.NewRouter()
 	webshellAuditRepo := managerwebshelldata.NewRepo(db)
+	webshellAccess := managerwebshellbiz.NewAccess(webshellAuditRepo)
 	operatorRunSvc := managerbizoperatorrun.New(fbClient, log.With(slog.String("comp", "operator-run")))
 
 	if err := managersvcfb.Install(rootCtx, fbClient, managersvcfb.Wiring{
@@ -1288,6 +1289,7 @@ func main() {
 		webshellStreamerAdapter{c: fbClient},
 		webshellRouter,
 		webshellAuditAdapter{repo: webshellAuditRepo},
+		webshellAccess,
 		deviceRepo,
 		edgeRepo,
 		log.With(slog.String("comp", "webshell")),
@@ -2446,7 +2448,7 @@ func main() {
 	}
 
 	if secretbox.KeyIsWeak() {
-		log.Warn("secret vault: ONGRID_SECRET_KEY unset — credentials encrypted with an INSECURE built-in key; set ONGRID_SECRET_KEY (32+ random chars) for real at-rest protection")
+		log.Warn("secret vault: no strong ONGRID_SECRET_KEY or ONGRID_JWT_SECRET; credentials use the local-development fallback key")
 	}
 	log.Info("marketplace wired",
 		slog.Bool("dev_mode", mpDevMode),
@@ -2563,6 +2565,7 @@ func main() {
 	// chi.Router.Group.
 	mux.Route("/api", func(api chi.Router) {
 		iamHandler.RegisterPublic(api)
+		webshellHandler.RegisterPublic(api)
 		promProxyHandler.RegisterPublic(api)
 		// IM webhooks live OUTSIDE the bearer group — Feishu / DingTalk
 		// can't carry our manager JWT. Auth comes from the platform
@@ -4368,6 +4371,10 @@ type webshellAuditAdapter struct {
 
 func (a webshellAuditAdapter) Open(ctx context.Context, s *wsmodel.Session) error {
 	return a.repo.Insert(ctx, s)
+}
+
+func (a webshellAuditAdapter) SetHostFingerprint(ctx context.Context, sessionID, fingerprint string) error {
+	return a.repo.SetHostFingerprint(ctx, sessionID, fingerprint)
 }
 
 func (a webshellAuditAdapter) Close(ctx context.Context, sessionID string, endedAt time.Time, bytesIn, bytesOut uint64, exitCode int, terminatedBy string) error {

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -551,8 +551,6 @@ func main() {
 	monitorRepo := managermonitordata.NewRepo(db)
 	monitorSvc := managerbizmonitor.New(monitorRepo, grafanaSvc, log.With(slog.String("comp", "monitor")))
 	monitorHandler := managerservermonitor.NewHandler(monitorSvc)
-	// promTester is wired below if cfg.Prom.Enabled — left nil for the
-	// disabled case so the integration handler can 503 cleanly.
 	var integrationHandler *managerserverintegration.Handler
 
 	// Embedded-Grafana SA bootstrap. Runs in a goroutine because:
@@ -1101,14 +1099,13 @@ func main() {
 		log.Warn("prom disabled — push_prom_samples will be silently dropped, query_promql tool not registered, /v1/edges/{id}/metrics returns 501")
 	}
 
-	// Build the integration handler now that we know whether prom is wired.
-	// promTester is nil when disabled; the handler 503s cleanly in that case.
-	var promTester managerserverintegration.PromQuerier
+	// Build the integration handler now that we know whether Prometheus is
+	// enabled. The probe uses the unsaved UI draft and never mutates settings.
+	var promProbe managerserverintegration.PromConfigProbe
+	var promTester managersvcsystemhealth.PromQuerier
 	if promQueryClient != nil {
-		promTester = managerserverintegration.AdaptPromQuerier(func(ctx context.Context, expr string, ts time.Time) error {
-			_, err := promQueryClient.Query(ctx, expr, ts)
-			return err
-		})
+		promProbe = managerbizsetting.NewPromConfigurationProbe(log.With(slog.String("comp", "prom-config-probe")))
+		promTester = healthPromQuerier{promQueryClient}
 	}
 	// Loki / Tempo URL probes — back the Integrations "测试连接" buttons.
 	// Loki checks /ready; Tempo checks either a query URL or an explicit
@@ -1120,7 +1117,7 @@ func main() {
 	// Web search probe — same WebSearchResolver the skill uses, so a
 	// passing probe means the skill itself will work.
 	webSearchProbe := managerbizsetting.NewWebSearchProbe(managerbizsetting.NewWebSearchResolver(settingSvc))
-	integrationHandler = managerserverintegration.NewHandler(grafanaSvc, promTester, lokiProbe, tempoIngestProbe, webSearchProbe)
+	integrationHandler = managerserverintegration.NewHandler(grafanaSvc, promProbe, lokiProbe, tempoIngestProbe, webSearchProbe)
 	integrationHandler.SetLLMRouter(llmRouter)
 	integrationHandler.SetLLMProbe(managerbizsetting.NewLLMConfigurationService(llmEnvDefaults, settingSvc))
 
@@ -4349,6 +4346,12 @@ func (b *logsPluginReloadBroadcaster) NotifyLogsBackendChanged(ctx context.Conte
 
 type hostDeviceResolverAdapter struct {
 	repo *managerdevicedata.EdgeDeviceRepo
+}
+
+type healthPromQuerier struct{ client *pkgpromquery.Client }
+
+func (q healthPromQuerier) Query(ctx context.Context, expr string, ts time.Time) (any, error) {
+	return q.client.Query(ctx, expr, ts)
 }
 
 func (a hostDeviceResolverAdapter) ResolveHostDeviceID(ctx context.Context, edgeID uint64) (uint64, error) {

--- a/deploy/install/nginx.conf
+++ b/deploy/install/nginx.conf
@@ -132,7 +132,7 @@ http {
             # (e.g. terraform, ~26MiB packed) exceeds the 4M server default and
             # nginx 413s before the request reaches the backend. Lift it here.
             client_max_body_size 70M;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -137,7 +137,7 @@ http {
             # (e.g. terraform, ~26MiB packed) exceeds the 4M server default and
             # nginx 413s before the request reaches the backend. Lift it here.
             client_max_body_size 70M;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/internal/edgeagent/webshell/handler.go
+++ b/internal/edgeagent/webshell/handler.go
@@ -1,6 +1,6 @@
 // Package webshell turns the edge agent into a generic stream port-
-// forwarder. Manager opens a frontier stream into the edge with a
-// Meta blob describing the target (today: `{"target":"127.0.0.1:22"}`);
+// forwarder. Manager carries the loopback SSH port in the SSH client
+// identification line because Frontier does not relay stream Meta;
 // the edge dials that local TCP socket and io.Copy's bytes both ways.
 //
 // SSH lives entirely on the manager side now: manager wraps the
@@ -10,24 +10,20 @@
 // edge tiny and lets the manager be the sole owner of webshell
 // policy / audit / concurrency / kick-out logic.
 //
-// Wire shape (manager → edge stream Meta):
-//
-//	{"target": "127.0.0.1:22"}        # default WebSSH path
-//	{"target": "10.0.0.5:22"}         # future: jumpbox / sidecar SSH
-//
-// Targets are validated against a small allowlist (just localhost +
-// loopback ports today) so the manager can't aim the edge at
-// arbitrary intranet hosts via a forged Meta. Phase 2 may widen this
-// behind a per-edge config setting.
+// Targets are restricted to device loopback so forged metadata cannot aim the
+// edge at arbitrary intranet hosts. Any valid TCP port may be used.
 package webshell
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,34 +80,17 @@ type streamMeta struct {
 	Target string `json:"target"`
 }
 
-// allowedTargets restricts which addresses the edge will dial when
-// the manager opens a stream. Today the only sane target is the
-// host's local sshd; we hardcode 127.0.0.1:22. Phase 2 may widen
-// behind /etc/ongrid-edge/webshell.yaml.
-//
-// The localhost narrow scope is the security boundary — without it
-// a compromised manager could pivot the edge to any reachable IP.
-var allowedTargets = map[string]bool{
-	"127.0.0.1:22": true,
-	"localhost:22": true,
-}
-
 func handleStream(stream tunnel.StreamConn, log *slog.Logger) {
 	defer stream.Close()
-	var m streamMeta
-	if raw := stream.Meta(); len(raw) > 0 {
-		if err := json.Unmarshal(raw, &m); err != nil {
-			writeStreamError(stream, fmt.Sprintf("bad meta: %v", err))
-			return
-		}
+	target, routedStream, err := resolveTarget(stream)
+	if err != nil {
+		writeStreamError(stream, err.Error())
+		return
 	}
-	target := strings.TrimSpace(m.Target)
-	if target == "" {
-		target = "127.0.0.1:22"
-	}
-	if !allowedTargets[target] {
+	stream = routedStream
+	if err := validateTarget(target); err != nil {
 		writeStreamError(stream, fmt.Sprintf("target %q not allowed", target))
-		log.Warn("webshell: rejected target", slog.String("target", target))
+		log.Warn("webshell: rejected target", slog.String("target", target), slog.Any("err", err))
 		return
 	}
 
@@ -139,6 +118,60 @@ func handleStream(stream tunnel.StreamConn, log *slog.Logger) {
 	_ = conn.Close()
 	_ = stream.Close()
 	<-errs
+}
+
+func resolveTarget(stream tunnel.StreamConn) (string, tunnel.StreamConn, error) {
+	var m streamMeta
+	if raw := stream.Meta(); len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return "", stream, fmt.Errorf("bad meta: %w", err)
+		}
+	}
+	target := strings.TrimSpace(m.Target)
+	if target != "" {
+		return target, stream, nil
+	}
+
+	// Frontier v1.2.4 does not copy stream Meta across its service-to-edge
+	// bridge. SSH writes its identification line first, so carry the requested
+	// loopback port there and replay the line unchanged to sshd.
+	reader := bufio.NewReaderSize(stream, 257)
+	line, err := reader.ReadSlice('\n')
+	if err != nil {
+		return "", stream, fmt.Errorf("read SSH identification: %w", err)
+	}
+	replay := &replayStream{
+		StreamConn: stream,
+		reader:     io.MultiReader(bytes.NewReader(bytes.Clone(line)), reader),
+	}
+	port, ok := tunnel.ParseWebshellSSHClientVersion(string(line))
+	if !ok {
+		return "127.0.0.1:22", replay, nil
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(int(port))), replay, nil
+}
+
+type replayStream struct {
+	tunnel.StreamConn
+	reader io.Reader
+}
+
+func (s *replayStream) Read(p []byte) (int, error) {
+	return s.reader.Read(p)
+}
+
+// validateTarget fixes the host to device loopback and accepts any valid TCP
+// port. The manager never gets access to other services on the device network.
+func validateTarget(target string) error {
+	host, rawPort, err := net.SplitHostPort(target)
+	if err != nil || host != "127.0.0.1" {
+		return errors.New("only 127.0.0.1 targets are allowed")
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil || port == 0 {
+		return errors.New("invalid port")
+	}
+	return nil
 }
 
 // writeStreamError sends a brief plain-text error to the stream so

--- a/internal/edgeagent/webshell/handler_test.go
+++ b/internal/edgeagent/webshell/handler_test.go
@@ -1,0 +1,69 @@
+package webshell
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+func TestValidateTargetAllowsAnyLoopbackPort(t *testing.T) {
+	tests := []struct {
+		name, target string
+		wantErr      bool
+	}{
+		{name: "default ssh", target: "127.0.0.1:22"},
+		{name: "custom ssh port", target: "127.0.0.1:2222"},
+		{name: "highest tcp port", target: "127.0.0.1:65535"},
+		{name: "zero port denied", target: "127.0.0.1:0", wantErr: true},
+		{name: "out of range port denied", target: "127.0.0.1:65536", wantErr: true},
+		{name: "remote host denied", target: "10.0.0.2:22", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTarget(tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateTarget(%q) error = %v", tt.target, err)
+			}
+		})
+	}
+}
+
+func TestResolveTargetFromSSHIdentification(t *testing.T) {
+	for _, tt := range []struct {
+		name, version, want string
+	}{
+		{name: "custom port", version: tunnel.WebshellSSHClientVersion(2222), want: "127.0.0.1:2222"},
+		{name: "legacy manager", version: "SSH-2.0-Go", want: "127.0.0.1:22"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wire := tt.version + "\r\npayload"
+			stream := &memoryStream{reader: bytes.NewBufferString(wire)}
+			target, replay, err := resolveTarget(stream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if target != tt.want {
+				t.Fatalf("target = %q, want %q", target, tt.want)
+			}
+			got, err := io.ReadAll(replay)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != wire {
+				t.Fatalf("replayed stream = %q, want %q", got, wire)
+			}
+		})
+	}
+}
+
+type memoryStream struct {
+	reader io.Reader
+	meta   []byte
+}
+
+func (s *memoryStream) Read(p []byte) (int, error)  { return s.reader.Read(p) }
+func (s *memoryStream) Write(p []byte) (int, error) { return len(p), nil }
+func (s *memoryStream) Close() error                { return nil }
+func (s *memoryStream) Meta() []byte                { return s.meta }

--- a/internal/manager/biz/grafana/service.go
+++ b/internal/manager/biz/grafana/service.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -66,6 +67,14 @@ type Service struct {
 
 	logsProviderMu sync.RWMutex
 	logsProvider   func(context.Context) (*pkggrafana.ElasticsearchDatasourceConfig, error)
+}
+
+type ProbeInput struct {
+	RootURL     string `json:"root_url"`
+	SAToken     string `json:"sa_token"`
+	APIKey      string `json:"api_key"`
+	OrgID       string `json:"org_id"`
+	TLSInsecure bool   `json:"tls_insecure"`
 }
 
 // New builds the service. tlsInsecure mirrors cfg.Grafana.TLSInsecure —
@@ -114,6 +123,10 @@ func (s *Service) httpClient(ctx context.Context) *http.Client {
 			tlsInsecure = strings.EqualFold(strings.TrimSpace(value), "true")
 		}
 	}
+	return grafanaHTTPClient(tlsInsecure)
+}
+
+func grafanaHTTPClient(tlsInsecure bool) *http.Client {
 	if !tlsInsecure {
 		return nil // pkg/grafana uses a 15s default
 	}
@@ -213,6 +226,23 @@ func (s *Service) Test(ctx context.Context) error {
 		return err
 	}
 	return c.Health(ctx)
+}
+
+// TestConfiguration checks an unsaved draft without mutating settings.
+func (s *Service) TestConfiguration(ctx context.Context, in ProbeInput) error {
+	root := strings.TrimSpace(in.RootURL)
+	u, err := url.ParseRequestURI(root)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return errors.New("grafana: root_url must be an absolute http(s) URL")
+	}
+	token := strings.TrimSpace(in.SAToken)
+	if token == "" {
+		token = strings.TrimSpace(in.APIKey)
+	}
+	if token == "" {
+		return errors.New("grafana: sa_token / api_key is empty")
+	}
+	return pkggrafana.New(root, token, grafanaHTTPClient(in.TLSInsecure)).Health(ctx)
 }
 
 // Sync runs the full bootstrap flow.

--- a/internal/manager/biz/logs/service.go
+++ b/internal/manager/biz/logs/service.go
@@ -470,6 +470,70 @@ func (s *Service) Test(ctx context.Context, id uint64) (*BackendTestResult, erro
 	}, nil
 }
 
+// TestDraft validates endpoints and credentials without storing either one.
+func (s *Service) TestDraft(ctx context.Context, input SaveInput) (*BackendTestResult, error) {
+	s.operationMu.Lock()
+	defer s.operationMu.Unlock()
+
+	normalized, err := normalizeSaveInput(input)
+	if err != nil {
+		return nil, err
+	}
+	previous, loadErr := s.repo.LatestBackend(ctx)
+	if loadErr != nil && !errors.Is(loadErr, errs.ErrNotFound) {
+		return nil, loadErr
+	}
+	writeRef, queryRef := normalized.WriteCredentialRef, normalized.QueryCredentialRef
+	if loadErr == nil {
+		if writeRef == "" {
+			writeRef = previous.WriteCredentialRef
+		}
+		if queryRef == "" {
+			queryRef = previous.QueryCredentialRef
+		}
+	}
+	writeKey := normalized.WriteAPIKey
+	if writeKey == "" {
+		if writeRef == "" {
+			return nil, fmt.Errorf("%w: write API key or credential ref is required", errs.ErrInvalid)
+		}
+		writeKey, err = s.apiKey(ctx, writeRef)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid write credential", errs.ErrInvalid)
+		}
+	}
+	queryKey := normalized.QueryAPIKey
+	if queryKey == "" {
+		if queryRef == "" {
+			return nil, fmt.Errorf("%w: query API key or credential ref is required", errs.ErrInvalid)
+		}
+		queryKey, err = s.apiKey(ctx, queryRef)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid query credential", errs.ErrInvalid)
+		}
+	}
+	if subtle.ConstantTimeCompare([]byte(writeKey), []byte(queryKey)) == 1 {
+		return nil, fmt.Errorf("%w: write and query API keys must differ", errs.ErrInvalid)
+	}
+	endpointsJSON, err := json.Marshal(normalized.WriteEndpoints)
+	if err != nil {
+		return nil, err
+	}
+	caPEM := normalized.CAPEM
+	if normalized.PreserveCA && caPEM == "" && loadErr == nil {
+		caPEM = previous.CAPEM
+	}
+	backend := &model.Backend{
+		WriteEndpointsJSON: string(endpointsJSON), QueryEndpoint: normalized.QueryEndpoint,
+		IndexPattern: indexPattern(normalized.Namespace), CAPEM: caPEM, TLSInsecure: normalized.TLSInsecure,
+	}
+	version, err := s.probeBackendWithKeys(ctx, backend, writeKey, queryKey)
+	if err != nil {
+		return nil, err
+	}
+	return &BackendTestResult{Status: "ok", DetectedVersion: version, TestedAt: time.Now().UTC()}, nil
+}
+
 func (s *Service) Select(ctx context.Context, id uint64) (*BackendView, error) {
 	s.operationMu.Lock()
 	defer s.operationMu.Unlock()
@@ -1413,6 +1477,14 @@ func (s *Service) probeBackend(ctx context.Context, backend *model.Backend) (str
 	if err != nil {
 		return "", err
 	}
+	writeKey, err := s.apiKey(ctx, backend.WriteCredentialRef)
+	if err != nil {
+		return "", err
+	}
+	return s.probeBackendWithKeys(ctx, backend, writeKey, queryKey)
+}
+
+func (s *Service) probeBackendWithKeys(ctx context.Context, backend *model.Backend, writeKey, queryKey string) (string, error) {
 	queryClient, err := s.newESClient(backend.QueryEndpoint, backend.IndexPattern, queryKey, backend)
 	if err != nil {
 		return "", err
@@ -1426,10 +1498,6 @@ func (s *Service) probeBackend(ctx context.Context, backend *model.Backend) (str
 	}
 	if queryInfo.ClusterUUID == "" {
 		return "", errors.New("Elasticsearch query probe: cluster UUID is missing")
-	}
-	writeKey, err := s.apiKey(ctx, backend.WriteCredentialRef)
-	if err != nil {
-		return "", err
 	}
 	endpoints, err := decodeEndpoints(backend.WriteEndpointsJSON)
 	if err != nil {

--- a/internal/manager/biz/setting/probe.go
+++ b/internal/manager/biz/setting/probe.go
@@ -28,6 +28,13 @@ type LokiURLProbe struct {
 	timeout  time.Duration
 }
 
+type TelemetryProbeInput struct {
+	URL           string `json:"url"`
+	BasicUser     string `json:"basic_user"`
+	BasicPassword string `json:"basic_password"`
+	TLSInsecure   bool   `json:"tls_insecure"`
+}
+
 // NewLokiURLProbe wires a probe against the resolver. resolver must be
 // non-nil; the probe Probe() returns ErrInvalid otherwise.
 func NewLokiURLProbe(r *LokiResolver) *LokiURLProbe {
@@ -39,13 +46,24 @@ func (p *LokiURLProbe) Probe(ctx context.Context) error {
 	if p == nil || p.resolver == nil {
 		return fmt.Errorf("loki probe not wired")
 	}
-	u := p.resolver.URL(ctx)
+	user, pass := p.resolver.Auth(ctx)
+	return p.ProbeConfiguration(ctx, TelemetryProbeInput{
+		URL: p.resolver.URL(ctx), BasicUser: user, BasicPassword: pass, TLSInsecure: p.resolver.TLSInsecure(ctx),
+	})
+}
+
+func (p *LokiURLProbe) ProbeConfiguration(ctx context.Context, in TelemetryProbeInput) error {
+	if p == nil {
+		return fmt.Errorf("loki probe not wired")
+	}
+	u := strings.TrimRight(strings.TrimSpace(in.URL), "/")
 	if u == "" {
 		return fmt.Errorf("loki url is empty")
 	}
-	user, pass := p.resolver.Auth(ctx)
-	tlsInsecure := p.resolver.TLSInsecure(ctx)
-	return probeReadyEndpoint(ctx, u+"/ready", user, pass, tlsInsecure, p.timeout)
+	if err := validateLLMBaseURL(u); err != nil {
+		return fmt.Errorf("loki url: %w", err)
+	}
+	return probeReadyEndpoint(ctx, u+"/ready", in.BasicUser, in.BasicPassword, in.TLSInsecure, p.timeout)
 }
 
 // TempoURLProbe verifies the configured Tempo integration URL. Explicit
@@ -68,16 +86,27 @@ func (p *TempoURLProbe) Probe(ctx context.Context) error {
 	if p == nil || p.resolver == nil {
 		return fmt.Errorf("tempo probe not wired")
 	}
-	u := p.resolver.URL(ctx)
+	user, pass := p.resolver.Auth(ctx)
+	return p.ProbeConfiguration(ctx, TelemetryProbeInput{
+		URL: p.resolver.URL(ctx), BasicUser: user, BasicPassword: pass, TLSInsecure: p.resolver.TLSInsecure(ctx),
+	})
+}
+
+func (p *TempoURLProbe) ProbeConfiguration(ctx context.Context, in TelemetryProbeInput) error {
+	if p == nil {
+		return fmt.Errorf("tempo probe not wired")
+	}
+	u := strings.TrimRight(strings.TrimSpace(in.URL), "/")
 	if u == "" {
 		return fmt.Errorf("tempo url is empty")
 	}
-	user, pass := p.resolver.Auth(ctx)
-	tlsInsecure := p.resolver.TLSInsecure(ctx)
-	if strings.HasSuffix(u, "/v1/traces") {
-		return probeOTLPHTTPTraceEndpoint(ctx, u, user, pass, tlsInsecure, p.timeout)
+	if err := validateLLMBaseURL(u); err != nil {
+		return fmt.Errorf("tempo url: %w", err)
 	}
-	return probeReadyEndpoint(ctx, u+"/ready", user, pass, tlsInsecure, p.timeout)
+	if strings.HasSuffix(u, "/v1/traces") {
+		return probeOTLPHTTPTraceEndpoint(ctx, u, in.BasicUser, in.BasicPassword, in.TLSInsecure, p.timeout)
+	}
+	return probeReadyEndpoint(ctx, u+"/ready", in.BasicUser, in.BasicPassword, in.TLSInsecure, p.timeout)
 }
 
 // TempoReadinessProbe checks the manager-side Tempo query API. This URL is
@@ -122,6 +151,13 @@ type WebSearchProbe struct {
 	timeout  time.Duration
 }
 
+type WebSearchProbeInput struct {
+	Provider     string `json:"provider"`
+	SearxngURL   string `json:"searxng_url"`
+	TavilyAPIKey string `json:"tavily_api_key"`
+	BraveAPIKey  string `json:"brave_api_key"`
+}
+
 // NewWebSearchProbe builds the probe. resolver must be non-nil; the
 // probe Probe() returns an error otherwise.
 func NewWebSearchProbe(r *WebSearchResolver) *WebSearchProbe {
@@ -135,26 +171,38 @@ func (p *WebSearchProbe) Probe(ctx context.Context) (string, string, error) {
 	if p == nil || p.resolver == nil {
 		return "", "", fmt.Errorf("web_search probe not wired")
 	}
-	provider := p.resolver.Provider(ctx)
+	return p.ProbeConfiguration(ctx, WebSearchProbeInput{
+		Provider: p.resolver.Provider(ctx), SearxngURL: p.resolver.SearxngURL(ctx),
+		TavilyAPIKey: p.resolver.TavilyAPIKey(ctx), BraveAPIKey: p.resolver.BraveAPIKey(ctx),
+	})
+}
+
+func (p *WebSearchProbe) ProbeConfiguration(ctx context.Context, in WebSearchProbeInput) (string, string, error) {
+	if p == nil {
+		return "", "", fmt.Errorf("web_search probe not wired")
+	}
+	provider := strings.ToLower(strings.TrimSpace(in.Provider))
 	cctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 	switch provider {
 	case model.ProviderSearxng:
-		return p.probeSearxng(cctx)
+		return p.probeSearxng(cctx, in.SearxngURL)
 	case model.ProviderTavily:
-		return p.probeTavily(cctx)
+		return p.probeTavily(cctx, in.TavilyAPIKey)
 	case model.ProviderBrave:
-		return p.probeBrave(cctx)
+		return p.probeBrave(cctx, in.BraveAPIKey)
 	default:
-		// Defensive — resolver normalises this. Treat unknown as searxng.
-		return p.probeSearxng(cctx)
+		return "", "", fmt.Errorf("unsupported web search provider %q", in.Provider)
 	}
 }
 
-func (p *WebSearchProbe) probeSearxng(ctx context.Context) (string, string, error) {
-	base := strings.TrimRight(p.resolver.SearxngURL(ctx), "/")
+func (p *WebSearchProbe) probeSearxng(ctx context.Context, rawURL string) (string, string, error) {
+	base := strings.TrimRight(strings.TrimSpace(rawURL), "/")
 	if base == "" {
 		base = model.DefaultSearxngURL
+	}
+	if err := validateLLMBaseURL(base); err != nil {
+		return model.ProviderSearxng, "", fmt.Errorf("searxng url: %w", err)
 	}
 	q := url.Values{}
 	q.Set("q", "ongrid web search probe")
@@ -194,8 +242,8 @@ func (p *WebSearchProbe) probeSearxng(ctx context.Context) (string, string, erro
 	return model.ProviderSearxng, sample, nil
 }
 
-func (p *WebSearchProbe) probeTavily(ctx context.Context) (string, string, error) {
-	apiKey := p.resolver.TavilyAPIKey(ctx)
+func (p *WebSearchProbe) probeTavily(ctx context.Context, rawAPIKey string) (string, string, error) {
+	apiKey := strings.TrimSpace(rawAPIKey)
 	if apiKey == "" {
 		return model.ProviderTavily, "", fmt.Errorf("tavily api key not configured")
 	}
@@ -236,8 +284,8 @@ func (p *WebSearchProbe) probeTavily(ctx context.Context) (string, string, error
 	return model.ProviderTavily, sample, nil
 }
 
-func (p *WebSearchProbe) probeBrave(ctx context.Context) (string, string, error) {
-	apiKey := p.resolver.BraveAPIKey(ctx)
+func (p *WebSearchProbe) probeBrave(ctx context.Context, rawAPIKey string) (string, string, error) {
+	apiKey := strings.TrimSpace(rawAPIKey)
 	if apiKey == "" {
 		return model.ProviderBrave, "", fmt.Errorf("brave api key not configured")
 	}

--- a/internal/manager/biz/setting/prom_probe.go
+++ b/internal/manager/biz/setting/prom_probe.go
@@ -1,0 +1,88 @@
+package setting
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/promauth"
+	"github.com/ongridio/ongrid/internal/pkg/promquery"
+	"github.com/ongridio/ongrid/internal/pkg/promwrite"
+)
+
+const maxPromProbeURLBytes = 2048
+
+// PromProbeInput is an unsaved Prometheus-compatible backend draft. Secrets
+// are used only for this probe and are never persisted or returned.
+type PromProbeInput struct {
+	QueryURL       string `json:"query_url"`
+	RemoteWriteURL string `json:"remote_write_url"`
+	BearerToken    string `json:"bearer_token"`
+	BasicUser      string `json:"basic_user"`
+	BasicPassword  string `json:"basic_password"`
+	TLSInsecure    bool   `json:"tls_insecure"`
+}
+
+type PromConfigurationProbe struct {
+	log *slog.Logger
+}
+
+func NewPromConfigurationProbe(log *slog.Logger) *PromConfigurationProbe {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &PromConfigurationProbe{log: log}
+}
+
+// Probe validates the draft, runs a PromQL query, then sends an empty
+// remote_write request. The write probe verifies connectivity without storing
+// a metric.
+func (p *PromConfigurationProbe) Probe(ctx context.Context, in PromProbeInput) error {
+	queryURL := strings.TrimRight(strings.TrimSpace(in.QueryURL), "/")
+	if err := validatePromProbeURL("query URL", queryURL); err != nil {
+		return err
+	}
+	writeURL := strings.TrimSpace(in.RemoteWriteURL)
+	if writeURL == "" {
+		writeURL = promRemoteWriteURL(queryURL)
+	}
+	if err := validatePromProbeURL("remote write URL", writeURL); err != nil {
+		return err
+	}
+
+	httpClient, err := promauth.BuildClient(
+		promauth.TLSConfig{Insecure: in.TLSInsecure},
+		promauth.NewStaticResolver(promauth.Config{
+			BearerToken:   in.BearerToken,
+			BasicUser:     in.BasicUser,
+			BasicPassword: in.BasicPassword,
+		}),
+		10*time.Second,
+	)
+	if err != nil {
+		return fmt.Errorf("build Prometheus probe client: %w", err)
+	}
+	if _, err := promquery.NewWithHTTPClient(queryURL, httpClient, p.log).Query(ctx, "up", time.Now()); err != nil {
+		return fmt.Errorf("PromQL probe failed: %w", err)
+	}
+	if err := promwrite.NewWithWriteURLAndHTTPClient(writeURL, httpClient, p.log).Probe(ctx); err != nil {
+		return fmt.Errorf("remote_write probe failed: %w", err)
+	}
+	return nil
+}
+
+func validatePromProbeURL(name, raw string) error {
+	if raw == "" {
+		return fmt.Errorf("%w: %s is required", errs.ErrInvalid, name)
+	}
+	if len(raw) > maxPromProbeURLBytes {
+		return fmt.Errorf("%w: %s is too long", errs.ErrInvalid, name)
+	}
+	if err := validateLLMBaseURL(raw); err != nil {
+		return fmt.Errorf("%w: invalid %s: %v", errs.ErrInvalid, name, err)
+	}
+	return nil
+}

--- a/internal/manager/biz/setting/prom_probe_test.go
+++ b/internal/manager/biz/setting/prom_probe_test.go
@@ -1,0 +1,62 @@
+package setting
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/snappy"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+func TestPromConfigurationProbe_UsesUnsavedDraftForQueryAndWrite(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if got := r.Header.Get("Authorization"); got != "Bearer draft-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		switch r.URL.Path {
+		case "/select/0/prometheus/api/v1/query":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+		case "/insert/0/prometheus/api/v1/write":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read write probe: %v", err)
+			}
+			decoded, err := snappy.Decode(nil, body)
+			if err != nil || len(decoded) != 0 {
+				t.Errorf("write probe body = %v, err = %v", decoded, err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	probe := NewPromConfigurationProbe(nil)
+	err := probe.Probe(context.Background(), PromProbeInput{
+		QueryURL:       srv.URL + "/select/0/prometheus",
+		RemoteWriteURL: srv.URL + "/insert/0/prometheus/api/v1/write",
+		BearerToken:    "draft-token",
+	})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if got := strings.Join(paths, ","); got != "/select/0/prometheus/api/v1/query,/insert/0/prometheus/api/v1/write" {
+		t.Fatalf("paths = %q", got)
+	}
+}
+
+func TestPromConfigurationProbe_RejectsInvalidDraftURL(t *testing.T) {
+	err := NewPromConfigurationProbe(nil).Probe(context.Background(), PromProbeInput{QueryURL: "file:///tmp/prom"})
+	if err == nil || !strings.Contains(err.Error(), "query URL") || !errors.Is(err, errs.ErrInvalid) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/manager/biz/setting/promauth.go
+++ b/internal/manager/biz/setting/promauth.go
@@ -2,6 +2,8 @@ package setting
 
 import (
 	"context"
+	"net"
+	"net/url"
 	"strings"
 
 	model "github.com/ongridio/ongrid/internal/manager/model/setting"
@@ -94,11 +96,14 @@ func (r *PromResolver) ResolveBaseURL(ctx context.Context) (string, error) {
 }
 
 // ResolveWriteURL implements promwrite.EndpointResolver. Returns the
-// admin-configured remote_write_url if set; otherwise composes
-// query_url + /api/v1/write to mirror the original New() semantics.
+// admin-configured remote_write_url if set; otherwise derives it from the
+// configured query URL before falling back to the env-derived endpoint.
 func (r *PromResolver) ResolveWriteURL(ctx context.Context) (string, error) {
 	if v := r.get(ctx, model.KeyPromRemoteWriteURL); v != "" {
 		return v, nil
+	}
+	if v := r.get(ctx, model.KeyPromQueryURL); v != "" {
+		return promRemoteWriteURL(v), nil
 	}
 	if r.fallbackWriteURL != "" {
 		return r.fallbackWriteURL, nil
@@ -110,5 +115,26 @@ func (r *PromResolver) ResolveWriteURL(ctx context.Context) (string, error) {
 	if base == "" {
 		return "", nil
 	}
-	return base + "/api/v1/write", nil
+	return promRemoteWriteURL(base), nil
+}
+
+func promRemoteWriteURL(queryURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(queryURL), "/")
+	u, err := url.Parse(base)
+	if err != nil {
+		return base + "/api/v1/write"
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 3 || parts[0] != "select" || parts[1] == "" || parts[2] != "prometheus" {
+		return base + "/api/v1/write"
+	}
+
+	u.Path = "/insert/" + parts[1] + "/prometheus/api/v1/write"
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	if u.Port() == "8481" {
+		u.Host = net.JoinHostPort(u.Hostname(), "8480")
+	}
+	return u.String()
 }

--- a/internal/manager/biz/setting/promauth_test.go
+++ b/internal/manager/biz/setting/promauth_test.go
@@ -25,3 +25,20 @@ func TestPromResolverTLSSettingOverridesFallback(t *testing.T) {
 		t.Fatalf("stored TLS config = %#v, %v", cfg, err)
 	}
 }
+
+func TestPromResolverDerivesVictoriaMetricsClusterWriteURL(t *testing.T) {
+	ctx := context.Background()
+	settings := New(newFakeRepo(), nil)
+	resolver := NewPromResolver(settings, "", "http://prometheus:9090/api/v1/write", promauth.TLSConfig{})
+
+	if err := settings.Set(ctx, model.CategoryProm, model.KeyPromQueryURL, "http://host.docker.internal:8481/select/0/prometheus", false); err != nil {
+		t.Fatalf("set query URL: %v", err)
+	}
+	got, err := resolver.ResolveWriteURL(ctx)
+	if err != nil {
+		t.Fatalf("resolve write URL: %v", err)
+	}
+	if want := "http://host.docker.internal:8480/insert/0/prometheus/api/v1/write"; got != want {
+		t.Fatalf("write URL = %q, want %q", got, want)
+	}
+}

--- a/internal/manager/biz/webshell/access.go
+++ b/internal/manager/biz/webshell/access.go
@@ -1,0 +1,134 @@
+package webshell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	wsmodel "github.com/ongridio/ongrid/internal/manager/model/webshell"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"github.com/ongridio/ongrid/internal/pkg/secretbox"
+)
+
+type AccessRepo interface {
+	CreateCredential(context.Context, *wsmodel.Credential) error
+	ListCredentials(context.Context, uint64, uint64) ([]*wsmodel.Credential, error)
+	GetCredential(context.Context, uint64, uint64, uint64) (*wsmodel.Credential, error)
+	DeleteCredential(context.Context, uint64, uint64, uint64) error
+	MarkCredentialUsed(context.Context, uint64, uint64, uint64, time.Time) error
+	GetKnownHost(context.Context, uint64, uint64, uint16) (*wsmodel.KnownHost, error)
+	CreateKnownHost(context.Context, *wsmodel.KnownHost) error
+	DeleteKnownHost(context.Context, uint64, uint64, uint16) error
+}
+
+type CredentialView struct {
+	ID         uint64     `json:"id"`
+	SSHUser    string     `json:"ssh_user"`
+	SSHPort    uint16     `json:"ssh_port"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+type ResolvedCredential struct {
+	ID       uint64
+	SSHUser  string
+	SSHPort  uint16
+	Password string
+}
+
+type HostKeyError struct {
+	Kind     string
+	Expected string
+	Actual   string
+}
+
+func (e *HostKeyError) Error() string { return "ssh host key " + e.Kind }
+
+type Access struct{ repo AccessRepo }
+
+func NewAccess(repo AccessRepo) *Access { return &Access{repo: repo} }
+
+func (a *Access) CreateCredential(ctx context.Context, userID, deviceID uint64, sshUser, password string, port uint16) (*CredentialView, error) {
+	sshUser = strings.TrimSpace(sshUser)
+	if userID == 0 || deviceID == 0 || sshUser == "" || len(sshUser) > 64 || password == "" || len(password) > 4096 || port == 0 {
+		return nil, fmt.Errorf("%w: invalid SSH credential", errs.ErrInvalid)
+	}
+	sealed, err := secretbox.Encrypt(password)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt SSH credential: %w", err)
+	}
+	row := &wsmodel.Credential{OngridUserID: userID, DeviceID: deviceID, Label: sshUser, SSHUser: sshUser, SSHPort: port, PasswordCiphertext: sealed}
+	if err := a.repo.CreateCredential(ctx, row); err != nil {
+		return nil, err
+	}
+	return credentialView(row), nil
+}
+
+func (a *Access) ListCredentials(ctx context.Context, userID, deviceID uint64) ([]*CredentialView, error) {
+	rows, err := a.repo.ListCredentials(ctx, userID, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*CredentialView, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, credentialView(row))
+	}
+	return out, nil
+}
+
+func (a *Access) ResolveCredential(ctx context.Context, id, userID, deviceID uint64) (*ResolvedCredential, error) {
+	row, err := a.repo.GetCredential(ctx, id, userID, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	password, err := secretbox.Decrypt(row.PasswordCiphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt SSH credential: %w", err)
+	}
+	now := time.Now().UTC()
+	if err := a.repo.MarkCredentialUsed(ctx, id, userID, deviceID, now); err != nil {
+		return nil, fmt.Errorf("mark SSH credential used: %w", err)
+	}
+	return &ResolvedCredential{ID: row.ID, SSHUser: row.SSHUser, SSHPort: row.SSHPort, Password: password}, nil
+}
+
+func (a *Access) DeleteCredential(ctx context.Context, id, userID, deviceID uint64) error {
+	return a.repo.DeleteCredential(ctx, id, userID, deviceID)
+}
+
+func (a *Access) VerifyHostKey(ctx context.Context, userID, deviceID uint64, port uint16, actual, accepted string) error {
+	known, err := a.repo.GetKnownHost(ctx, userID, deviceID, port)
+	if err == nil {
+		if known.Fingerprint != actual {
+			return &HostKeyError{Kind: "changed", Expected: known.Fingerprint, Actual: actual}
+		}
+		return nil
+	}
+	if !errors.Is(err, errs.ErrNotFound) {
+		return err
+	}
+	if accepted == "" || accepted != actual {
+		return &HostKeyError{Kind: "unknown", Actual: actual}
+	}
+	if err := a.repo.CreateKnownHost(ctx, &wsmodel.KnownHost{OngridUserID: userID, DeviceID: deviceID, SSHPort: port, Fingerprint: actual}); err != nil {
+		// A concurrent first connection may have won the unique insert.
+		known, getErr := a.repo.GetKnownHost(ctx, userID, deviceID, port)
+		if getErr != nil || known.Fingerprint != actual {
+			return fmt.Errorf("trust SSH host key: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a *Access) DeleteKnownHost(ctx context.Context, userID, deviceID uint64, port uint16) error {
+	if port == 0 {
+		return fmt.Errorf("%w: invalid SSH port", errs.ErrInvalid)
+	}
+	return a.repo.DeleteKnownHost(ctx, userID, deviceID, port)
+}
+
+func credentialView(row *wsmodel.Credential) *CredentialView {
+	return &CredentialView{ID: row.ID, SSHUser: row.SSHUser, SSHPort: row.SSHPort, LastUsedAt: row.LastUsedAt, CreatedAt: row.CreatedAt}
+}

--- a/internal/manager/biz/webshell/router.go
+++ b/internal/manager/biz/webshell/router.go
@@ -38,6 +38,7 @@ type ActiveSession struct {
 	SessionID    string
 	OngridUserID uint64
 	SSHUser      string
+	SSHPort      uint16
 	DeviceID     uint64
 	EdgeID       uint64
 	StartedAt    time.Time
@@ -206,6 +207,7 @@ func (r *Router) StdoutBytes(sid string) uint64 {
 // satisfies it via the small adapter in cmd/ongrid wiring.
 type Recorder interface {
 	Open(ctx context.Context, s *wsmodel.Session) error
+	SetHostFingerprint(ctx context.Context, sessionID, fingerprint string) error
 	Close(ctx context.Context, sessionID string, endedAt time.Time, bytesIn, bytesOut uint64, exitCode int, terminatedBy string) error
 	List(ctx context.Context, limit int) ([]*wsmodel.Session, error)
 }

--- a/internal/manager/data/webshell/store/access_test.go
+++ b/internal/manager/data/webshell/store/access_test.go
@@ -1,0 +1,63 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	bizwebshell "github.com/ongridio/ongrid/internal/manager/biz/webshell"
+	webshellstore "github.com/ongridio/ongrid/internal/manager/data/webshell/store"
+	wsmodel "github.com/ongridio/ongrid/internal/manager/model/webshell"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+)
+
+func TestCredentialIsolationEncryptionAndHostPin(t *testing.T) {
+	t.Setenv("ONGRID_SECRET_KEY", "")
+	t.Setenv("ONGRID_JWT_SECRET", "test-persisted-random-jwt-secret")
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := webshellstore.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	repo := webshellstore.NewRepo(db)
+	access := bizwebshell.NewAccess(repo)
+	ctx := context.Background()
+
+	view, err := access.CreateCredential(ctx, 1, 10, "root", "top-secret", 2222)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored wsmodel.Credential
+	if err := db.First(&stored, view.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.PasswordCiphertext == "top-secret" || stored.PasswordCiphertext == "" {
+		t.Fatalf("password was not encrypted: %q", stored.PasswordCiphertext)
+	}
+	if _, err := access.ResolveCredential(ctx, view.ID, 2, 10); !errors.Is(err, errs.ErrNotFound) {
+		t.Fatalf("other user resolved credential: %v", err)
+	}
+	resolved, err := access.ResolveCredential(ctx, view.ID, 1, 10)
+	if err != nil || resolved.Password != "top-secret" || resolved.SSHPort != 2222 {
+		t.Fatalf("resolved = %#v, %v", resolved, err)
+	}
+
+	err = access.VerifyHostKey(ctx, 1, 10, 2222, "SHA256:first", "")
+	var hostErr *bizwebshell.HostKeyError
+	if !errors.As(err, &hostErr) || hostErr.Kind != "unknown" {
+		t.Fatalf("first host key = %v", err)
+	}
+	if err := access.VerifyHostKey(ctx, 1, 10, 2222, "SHA256:first", "SHA256:first"); err != nil {
+		t.Fatal(err)
+	}
+	err = access.VerifyHostKey(ctx, 1, 10, 2222, "SHA256:changed", "")
+	if !errors.As(err, &hostErr) || hostErr.Kind != "changed" {
+		t.Fatalf("changed host key = %v", err)
+	}
+}

--- a/internal/manager/data/webshell/store/migrate.go
+++ b/internal/manager/data/webshell/store/migrate.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -13,7 +14,70 @@ import (
 
 // Migrate runs AutoMigrate for the webshell_sessions table.
 func Migrate(db *gorm.DB) error {
-	return db.AutoMigrate(&webshell.Session{})
+	return db.AutoMigrate(&webshell.Session{}, &webshell.Credential{}, &webshell.KnownHost{})
+}
+
+func (r *Repo) CreateCredential(ctx context.Context, credential *webshell.Credential) error {
+	return r.db.WithContext(ctx).Create(credential).Error
+}
+
+func (r *Repo) ListCredentials(ctx context.Context, userID, deviceID uint64) ([]*webshell.Credential, error) {
+	var out []*webshell.Credential
+	err := r.db.WithContext(ctx).
+		Where("ongrid_user_id = ? AND device_id = ?", userID, deviceID).
+		Order("label asc").Find(&out).Error
+	return out, err
+}
+
+func (r *Repo) GetCredential(ctx context.Context, id, userID, deviceID uint64) (*webshell.Credential, error) {
+	var out webshell.Credential
+	err := r.db.WithContext(ctx).
+		Where("id = ? AND ongrid_user_id = ? AND device_id = ?", id, userID, deviceID).
+		First(&out).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, errs.ErrNotFound
+	}
+	return &out, err
+}
+
+func (r *Repo) DeleteCredential(ctx context.Context, id, userID, deviceID uint64) error {
+	res := r.db.WithContext(ctx).
+		Where("id = ? AND ongrid_user_id = ? AND device_id = ?", id, userID, deviceID).
+		Delete(&webshell.Credential{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return errs.ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) MarkCredentialUsed(ctx context.Context, id, userID, deviceID uint64, at time.Time) error {
+	return r.db.WithContext(ctx).Model(&webshell.Credential{}).
+		Where("id = ? AND ongrid_user_id = ? AND device_id = ?", id, userID, deviceID).
+		Update("last_used_at", at).Error
+}
+
+func (r *Repo) GetKnownHost(ctx context.Context, userID, deviceID uint64, port uint16) (*webshell.KnownHost, error) {
+	var out webshell.KnownHost
+	err := r.db.WithContext(ctx).
+		Where("ongrid_user_id = ? AND device_id = ? AND ssh_port = ?", userID, deviceID, port).
+		First(&out).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, errs.ErrNotFound
+	}
+	return &out, err
+}
+
+func (r *Repo) CreateKnownHost(ctx context.Context, host *webshell.KnownHost) error {
+	return r.db.WithContext(ctx).Create(host).Error
+}
+
+func (r *Repo) DeleteKnownHost(ctx context.Context, userID, deviceID uint64, port uint16) error {
+	return r.db.WithContext(ctx).
+		Where("ongrid_user_id = ? AND device_id = ? AND ssh_port = ?", userID, deviceID, port).
+		Delete(&webshell.KnownHost{}).Error
 }
 
 // Repo is the GORM-backed audit repo.
@@ -46,6 +110,11 @@ func (r *Repo) Close(ctx context.Context, id string, in CloseInput) error {
 		return errs.ErrNotFound
 	}
 	return nil
+}
+
+func (r *Repo) SetHostFingerprint(ctx context.Context, id, fingerprint string) error {
+	return r.db.WithContext(ctx).Model(&webshell.Session{}).
+		Where("id = ?", id).Update("host_fingerprint", fingerprint).Error
 }
 
 // CloseInput bundles the terminal counters.

--- a/internal/manager/model/secret/model.go
+++ b/internal/manager/model/secret/model.go
@@ -8,7 +8,8 @@
 // owns the injection mapping, the binding owns the choice.
 //
 // At-rest: the field map is JSON-encoded then sealed by pkg/secretbox
-// (AES-256-GCM, key from ONGRID_SECRET_KEY) before it touches the DB, so a
+// (AES-256-GCM, key from optional ONGRID_SECRET_KEY or the persisted JWT
+// secret) before it touches the DB, so a
 // DB dump alone never yields plaintext (cf. n8n's encryption posture).
 package secret
 

--- a/internal/manager/model/webshell/model.go
+++ b/internal/manager/model/webshell/model.go
@@ -7,12 +7,13 @@ import "time"
 
 // Termination reasons. Kept as constants so handlers don't drift.
 const (
-	TerminatedByUser         = "user"          // browser closed
-	TerminatedByIdle         = "idle"          // no input >N minutes
-	TerminatedByDisconnect   = "disconnect"    // tunnel / WS dropped
-	TerminatedByAdminKill    = "admin_kill"    // admin kicked the session
-	TerminatedBySSHAuthFail  = "ssh_auth_fail" // sshd refused creds
-	TerminatedBySSHExit      = "ssh_exit"      // user typed exit / shell ended
+	TerminatedByUser          = "user"          // browser closed
+	TerminatedByIdle          = "idle"          // no input >N minutes
+	TerminatedByDisconnect    = "disconnect"    // tunnel / WS dropped
+	TerminatedByAdminKill     = "admin_kill"    // admin kicked the session
+	TerminatedBySSHAuthFail   = "ssh_auth_fail" // sshd refused creds
+	TerminatedBySSHHostKey    = "ssh_host_key"  // unknown / changed host key
+	TerminatedBySSHExit       = "ssh_exit"      // user typed exit / shell ended
 	TerminatedByDeviceOffline = "device_offline"
 )
 
@@ -21,6 +22,9 @@ type Session struct {
 	ID              string     `gorm:"primaryKey;size:64"`
 	OngridUserID    uint64     `gorm:"not null;column:ongrid_user_id;index"`
 	SSHUser         string     `gorm:"size:64;not null;column:ssh_user"`
+	SSHPort         uint16     `gorm:"not null;default:22;column:ssh_port"`
+	CredentialID    *uint64    `gorm:"column:credential_id"`
+	HostFingerprint string     `gorm:"size:128;column:host_fingerprint"`
 	DeviceID        uint64     `gorm:"not null;column:device_id;index"`
 	EdgeID          uint64     `gorm:"not null;column:edge_id"`
 	ClientIP        string     `gorm:"size:64;column:client_ip"`
@@ -34,3 +38,33 @@ type Session struct {
 
 // TableName pins the table name.
 func (Session) TableName() string { return "webshell_sessions" }
+
+// Credential is a personal, device-bound SSH login. PasswordCiphertext is
+// write-only at the API boundary and encrypted before it reaches the DB.
+type Credential struct {
+	ID                 uint64 `gorm:"primaryKey;autoIncrement"`
+	OngridUserID       uint64 `gorm:"not null;uniqueIndex:uk_webshell_credential_owner_label,priority:1"`
+	DeviceID           uint64 `gorm:"not null;uniqueIndex:uk_webshell_credential_owner_label,priority:2;index"`
+	Label              string `gorm:"size:64;not null;uniqueIndex:uk_webshell_credential_owner_label,priority:3"`
+	SSHUser            string `gorm:"size:64;not null"`
+	SSHPort            uint16 `gorm:"not null;default:22"`
+	PasswordCiphertext string `gorm:"type:text;not null" json:"-"`
+	LastUsedAt         *time.Time
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+func (Credential) TableName() string { return "webshell_credentials" }
+
+// KnownHost pins one SSH host key per user/device/port (TOFU).
+type KnownHost struct {
+	ID           uint64 `gorm:"primaryKey;autoIncrement"`
+	OngridUserID uint64 `gorm:"not null;uniqueIndex:uk_webshell_known_host,priority:1"`
+	DeviceID     uint64 `gorm:"not null;uniqueIndex:uk_webshell_known_host,priority:2"`
+	SSHPort      uint16 `gorm:"not null;uniqueIndex:uk_webshell_known_host,priority:3"`
+	Fingerprint  string `gorm:"size:128;not null"`
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+func (KnownHost) TableName() string { return "webshell_known_hosts" }

--- a/internal/manager/server/integration/http.go
+++ b/internal/manager/server/integration/http.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -27,16 +26,16 @@ import (
 // GrafanaService is the narrow surface the handler depends on. *bizgrafana.Service
 // satisfies it structurally.
 type GrafanaService interface {
-	Test(ctx context.Context) error
+	TestConfiguration(ctx context.Context, in bizgrafana.ProbeInput) error
 	Sync(ctx context.Context) (*bizgrafana.SyncResult, error)
 	SyncLoki(ctx context.Context) error
 	FetchDashboardJSON(ctx context.Context, uid string) ([]byte, error)
 }
 
-// PromQuerier is the narrow surface used to exercise the configured
-// Prometheus on the test endpoint. *promquery.Client satisfies it.
-type PromQuerier interface {
-	Query(ctx context.Context, expr string, ts time.Time) (any, error)
+// PromConfigProbe validates an unsaved query/write configuration without
+// changing the active backend.
+type PromConfigProbe interface {
+	Probe(ctx context.Context, in bizsetting.PromProbeInput) error
 }
 
 // URLProbe is the narrow surface for the Loki / Tempo test endpoints.
@@ -45,25 +44,7 @@ type PromQuerier interface {
 // GET /ready; Tempo: GET /ready or empty OTLP/HTTP export, depending on
 // the configured URL shape). Returning nil = ok.
 type URLProbe interface {
-	Probe(ctx context.Context) error
-}
-
-// promQueryAdapter bridges *promquery.Client (which returns
-// *InstantResult) into the looser PromQuerier shape so the handler
-// doesn't need to import that concrete return type.
-type promQueryAdapter struct {
-	q func(ctx context.Context, expr string, ts time.Time) error
-}
-
-func (a promQueryAdapter) Query(ctx context.Context, expr string, ts time.Time) (any, error) {
-	return nil, a.q(ctx, expr, ts)
-}
-
-// AdaptPromQuerier wraps a function in the PromQuerier shape. cmd/ongrid
-// uses it to inject promquery.Client without leaking that type into the
-// handler package.
-func AdaptPromQuerier(q func(ctx context.Context, expr string, ts time.Time) error) PromQuerier {
-	return promQueryAdapter{q: q}
+	ProbeConfiguration(ctx context.Context, in bizsetting.TelemetryProbeInput) error
 }
 
 // WebSearchProbe is the narrow surface for the web_search test endpoint.
@@ -72,7 +53,7 @@ func AdaptPromQuerier(q func(ctx context.Context, expr string, ts time.Time) err
 // reports the provider name + a sample title back to the SPA so the
 // operator sees a tangible signal that the wiring works.
 type WebSearchProbe interface {
-	Probe(ctx context.Context) (provider, sample string, err error)
+	ProbeConfiguration(ctx context.Context, in bizsetting.WebSearchProbeInput) (provider, sample string, err error)
 }
 
 // LLMRouterInvalidator drops the in-process LLM provider catalog cache
@@ -95,7 +76,7 @@ type LLMConfigProbe interface {
 // Handler bundles the integration routes.
 type Handler struct {
 	grafana   GrafanaService
-	prom      PromQuerier
+	prom      PromConfigProbe
 	loki      URLProbe
 	tempo     URLProbe
 	webSearch WebSearchProbe
@@ -106,7 +87,7 @@ type Handler struct {
 // NewHandler builds the handler. prom may be nil when ONGRID_PROM_ENABLED=false;
 // the test route then 503s instead of crashing. loki/tempo/webSearch probes
 // are optional — when nil the corresponding /test endpoint 503s.
-func NewHandler(grafana GrafanaService, prom PromQuerier, loki URLProbe, tempo URLProbe, webSearch WebSearchProbe) *Handler {
+func NewHandler(grafana GrafanaService, prom PromConfigProbe, loki URLProbe, tempo URLProbe, webSearch WebSearchProbe) *Handler {
 	return &Handler{grafana: grafana, prom: prom, loki: loki, tempo: tempo, webSearch: webSearch}
 }
 
@@ -311,7 +292,11 @@ func (h *Handler) testGrafana(w http.ResponseWriter, r *http.Request) {
 	if !h.requireAdmin(w, r) {
 		return
 	}
-	if err := h.grafana.Test(r.Context()); err != nil {
+	in, ok := decodeDraft[bizgrafana.ProbeInput](w, r)
+	if !ok {
+		return
+	}
+	if err := h.grafana.TestConfiguration(r.Context(), in); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -352,10 +337,21 @@ func (h *Handler) syncLoki(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// testProm runs a tiny PromQL probe ("up") against the configured Prom
-// using the admin-supplied auth + URL. Success means the URL is
-// reachable, the auth header is accepted, and the TSDB returns a valid
-// PromQL response.
+// testProm validates an unsaved draft with a PromQL query and an empty
+// remote_write request. No configuration or metric is persisted.
+//
+// @Summary Validate an unsaved Prometheus-compatible backend configuration
+// @Tags integrations
+// @Accept json
+// @Produce json
+// @Param request body bizsetting.PromProbeInput true "Prometheus backend draft"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} errorBody
+// @Failure 401 {object} errorBody
+// @Failure 403 {object} errorBody
+// @Failure 502 {object} errorBody
+// @Failure 503 {object} errorBody
+// @Router /api/v1/integrations/prom/test [post]
 func (h *Handler) testProm(w http.ResponseWriter, r *http.Request) {
 	if !h.requireAdmin(w, r) {
 		return
@@ -367,11 +363,34 @@ func (h *Handler) testProm(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if _, err := h.prom.Query(r.Context(), "up", time.Now()); err != nil {
+	in, ok := decodeDraft[bizsetting.PromProbeInput](w, r)
+	if !ok {
+		return
+	}
+	if err := h.prom.Probe(r.Context(), in); err != nil {
 		writeErr(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func decodeDraft[T any](w http.ResponseWriter, r *http.Request) (T, bool) {
+	const maxBodyBytes = 64 << 10
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	var in T
+	if err := dec.Decode(&in); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		var zero T
+		return zero, false
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeErr(w, errors.Join(errs.ErrInvalid, errors.New("request body must contain one JSON object")))
+		var zero T
+		return zero, false
+	}
+	return in, true
 }
 
 // testLoki runs a /ready probe against the configured Loki URL. Loki
@@ -387,7 +406,11 @@ func (h *Handler) testLoki(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if err := h.loki.Probe(r.Context()); err != nil {
+	in, ok := decodeDraft[bizsetting.TelemetryProbeInput](w, r)
+	if !ok {
+		return
+	}
+	if err := h.loki.ProbeConfiguration(r.Context(), in); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -410,7 +433,11 @@ func (h *Handler) testWebSearch(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	provider, sample, err := h.webSearch.Probe(r.Context())
+	in, ok := decodeDraft[bizsetting.WebSearchProbeInput](w, r)
+	if !ok {
+		return
+	}
+	provider, sample, err := h.webSearch.ProbeConfiguration(r.Context(), in)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -435,7 +462,11 @@ func (h *Handler) testTempo(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if err := h.tempo.Probe(r.Context()); err != nil {
+	in, ok := decodeDraft[bizsetting.TelemetryProbeInput](w, r)
+	if !ok {
+		return
+	}
+	if err := h.tempo.ProbeConfiguration(r.Context(), in); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/internal/manager/server/integration/http_test.go
+++ b/internal/manager/server/integration/http_test.go
@@ -22,6 +22,7 @@ import (
 // loudly instead of silently passing.
 type stubGrafana struct {
 	test           func(ctx context.Context) error
+	probe          func(ctx context.Context, in bizgrafana.ProbeInput) error
 	sync           func(ctx context.Context) (*bizgrafana.SyncResult, error)
 	syncLoki       func(ctx context.Context) error
 	fetchDashboard func(ctx context.Context, uid string) ([]byte, error)
@@ -30,6 +31,30 @@ type stubGrafana struct {
 type stubLLMConfigProbe struct {
 	probe func(context.Context, bizsetting.LLMProbeInput) (bizsetting.LLMProbeResult, error)
 	save  func(context.Context, bizsetting.LLMProbeInput) (bizsetting.LLMProbeResult, error)
+}
+
+type stubPromConfigProbe struct {
+	probe func(context.Context, bizsetting.PromProbeInput) error
+}
+
+type stubURLConfigProbe struct {
+	probe func(context.Context, bizsetting.TelemetryProbeInput) error
+}
+
+type stubWebSearchConfigProbe struct {
+	probe func(context.Context, bizsetting.WebSearchProbeInput) (string, string, error)
+}
+
+func (s stubPromConfigProbe) Probe(ctx context.Context, in bizsetting.PromProbeInput) error {
+	return s.probe(ctx, in)
+}
+
+func (s stubURLConfigProbe) ProbeConfiguration(ctx context.Context, in bizsetting.TelemetryProbeInput) error {
+	return s.probe(ctx, in)
+}
+
+func (s stubWebSearchConfigProbe) ProbeConfiguration(ctx context.Context, in bizsetting.WebSearchProbeInput) (string, string, error) {
+	return s.probe(ctx, in)
 }
 
 func (s stubLLMConfigProbe) Probe(ctx context.Context, in bizsetting.LLMProbeInput) (bizsetting.LLMProbeResult, error) {
@@ -47,7 +72,12 @@ type stubLLMRouterInvalidator struct{ calls int }
 
 func (s *stubLLMRouterInvalidator) Invalidate() { s.calls++ }
 
-func (s stubGrafana) Test(ctx context.Context) error                           { return s.test(ctx) }
+func (s stubGrafana) TestConfiguration(ctx context.Context, in bizgrafana.ProbeInput) error {
+	if s.probe != nil {
+		return s.probe(ctx, in)
+	}
+	return s.test(ctx)
+}
 func (s stubGrafana) Sync(ctx context.Context) (*bizgrafana.SyncResult, error) { return s.sync(ctx) }
 func (s stubGrafana) SyncLoki(ctx context.Context) error {
 	if s.syncLoki == nil {
@@ -63,6 +93,79 @@ func newRouter(h *Handler) http.Handler {
 	r := chi.NewRouter()
 	h.Register(r)
 	return r
+}
+
+func TestPromConfigurationProbeUsesUnsavedDraft(t *testing.T) {
+	t.Parallel()
+	g := stubGrafana{
+		test:           func(context.Context) error { return nil },
+		sync:           func(context.Context) (*bizgrafana.SyncResult, error) { return nil, nil },
+		fetchDashboard: func(context.Context, string) ([]byte, error) { return nil, nil },
+	}
+	var got bizsetting.PromProbeInput
+	h := NewHandler(g, stubPromConfigProbe{probe: func(_ context.Context, in bizsetting.PromProbeInput) error {
+		got = in
+		return nil
+	}}, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/integrations/prom/test", strings.NewReader(`{
+		"query_url":"https://vm.example/select/0/prometheus",
+		"remote_write_url":"https://vm.example/insert/0/prometheus/api/v1/write",
+		"bearer_token":"secret","tls_insecure":true
+	}`))
+	req = req.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 7, Role: "admin"}))
+	rec := httptest.NewRecorder()
+	newRouter(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got.QueryURL != "https://vm.example/select/0/prometheus" || got.BearerToken != "secret" || !got.TLSInsecure {
+		t.Fatalf("probe input = %+v", got)
+	}
+}
+
+func TestExternalIntegrationProbesUseUnsavedDrafts(t *testing.T) {
+	t.Parallel()
+	var grafanaDraft bizgrafana.ProbeInput
+	var lokiDraft, tempoDraft bizsetting.TelemetryProbeInput
+	var webSearchDraft bizsetting.WebSearchProbeInput
+	h := NewHandler(
+		stubGrafana{
+			probe:          func(_ context.Context, in bizgrafana.ProbeInput) error { grafanaDraft = in; return nil },
+			sync:           func(context.Context) (*bizgrafana.SyncResult, error) { return nil, nil },
+			fetchDashboard: func(context.Context, string) ([]byte, error) { return nil, nil },
+		},
+		nil,
+		stubURLConfigProbe{probe: func(_ context.Context, in bizsetting.TelemetryProbeInput) error { lokiDraft = in; return nil }},
+		stubURLConfigProbe{probe: func(_ context.Context, in bizsetting.TelemetryProbeInput) error { tempoDraft = in; return nil }},
+		stubWebSearchConfigProbe{probe: func(_ context.Context, in bizsetting.WebSearchProbeInput) (string, string, error) {
+			webSearchDraft = in
+			return in.Provider, "sample", nil
+		}},
+	)
+
+	for _, tc := range []struct{ path, body string }{
+		{"/v1/integrations/grafana/test", `{"root_url":"https://grafana.draft","sa_token":"token","tls_insecure":true}`},
+		{"/v1/integrations/loki/test", `{"url":"https://loki.draft","basic_user":"loki-user"}`},
+		{"/v1/integrations/tempo/test", `{"url":"https://tempo.draft/v1/traces","basic_user":"tempo-user"}`},
+		{"/v1/integrations/websearch/test", `{"provider":"brave","brave_api_key":"draft-key"}`},
+	} {
+		req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+		req = req.WithContext(tenantctx.With(context.Background(), tenantctx.Tenant{UserID: 7, Role: "admin"}))
+		rec := httptest.NewRecorder()
+		newRouter(h).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d body=%s", tc.path, rec.Code, rec.Body.String())
+		}
+	}
+
+	if grafanaDraft.RootURL != "https://grafana.draft" || !grafanaDraft.TLSInsecure ||
+		lokiDraft.URL != "https://loki.draft" || lokiDraft.BasicUser != "loki-user" ||
+		tempoDraft.URL != "https://tempo.draft/v1/traces" || tempoDraft.BasicUser != "tempo-user" ||
+		webSearchDraft.Provider != "brave" || webSearchDraft.BraveAPIKey != "draft-key" {
+		t.Fatalf("drafts not forwarded: grafana=%+v loki=%+v tempo=%+v websearch=%+v", grafanaDraft, lokiDraft, tempoDraft, webSearchDraft)
+	}
 }
 
 func TestFetchDashboardPassesUIDAndReturnsRawJSON(t *testing.T) {

--- a/internal/manager/server/logs/backend_http_test.go
+++ b/internal/manager/server/logs/backend_http_test.go
@@ -16,11 +16,17 @@ import (
 
 type stubBackendService struct {
 	saved        *bizlogs.SaveInput
+	draftTested  *bizlogs.SaveInput
 	tested       bool
 	selected     bool
 	lokiSelected bool
 	checks       int
 	checkIDs     []uint64
+}
+
+func (s *stubBackendService) TestDraft(_ context.Context, input bizlogs.SaveInput) (*bizlogs.BackendTestResult, error) {
+	s.draftTested = &input
+	return &bizlogs.BackendTestResult{Status: "ok", DetectedVersion: "8.16.3"}, nil
 }
 
 func (s *stubBackendService) Test(context.Context, uint64) (*bizlogs.BackendTestResult, error) {
@@ -163,6 +169,26 @@ func TestTestBackendCallsServiceWithoutApply(t *testing.T) {
 	}
 	if !svc.tested || svc.selected {
 		t.Fatalf("tested=%v selected=%v", svc.tested, svc.selected)
+	}
+}
+
+func TestTestBackendDraftCallsServiceWithoutSaving(t *testing.T) {
+	svc := &stubBackendService{}
+	router := backendTestRouter(NewHandlerWithServices(nil, nil, svc))
+	req := adminBackendRequest(http.MethodPost, "/v1/logs/backend/test", []byte(`{
+		"write_endpoints":["https://draft-es.example"],
+		"query_endpoint":"https://draft-es-query.example",
+		"dataset":"ongrid.system",
+		"namespace":"draft"
+	}`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if svc.draftTested == nil || svc.draftTested.QueryEndpoint != "https://draft-es-query.example" || svc.saved != nil {
+		t.Fatalf("draft=%+v saved=%+v", svc.draftTested, svc.saved)
 	}
 }
 

--- a/internal/manager/server/logs/http.go
+++ b/internal/manager/server/logs/http.go
@@ -58,6 +58,7 @@ type Handler struct {
 type BackendService interface {
 	Get(ctx context.Context) (*bizlogs.BackendView, error)
 	Save(ctx context.Context, input bizlogs.SaveInput) (*bizlogs.BackendView, error)
+	TestDraft(ctx context.Context, input bizlogs.SaveInput) (*bizlogs.BackendTestResult, error)
 	Test(ctx context.Context, id uint64) (*bizlogs.BackendTestResult, error)
 	Select(ctx context.Context, id uint64) (*bizlogs.BackendView, error)
 	SelectLoki(ctx context.Context) (*bizlogs.BackendView, error)
@@ -106,6 +107,7 @@ func (h *Handler) Register(r chi.Router) {
 	r.Post("/v1/logs/context", h.contextLogs)
 	r.Get("/v1/logs/backend", h.getBackend)
 	r.Put("/v1/logs/backend", h.putBackend)
+	r.Post("/v1/logs/backend/test", h.testBackendDraft)
 	r.Post("/v1/logs/backend/{id}/test", h.testBackend)
 	r.Post("/v1/logs/backend/loki/select", h.selectLoki)
 	r.Post("/v1/logs/backend/{id}/select", h.selectBackend)
@@ -116,6 +118,28 @@ func (h *Handler) Register(r chi.Router) {
 	r.Get("/v1/logs/query_range", h.queryRange)
 	r.Get("/v1/logs/labels", h.labels)
 	r.Get("/v1/logs/labels/{name}/values", h.labelValues)
+}
+
+// testBackendDraft validates an unsaved Elasticsearch configuration.
+func (h *Handler) testBackendDraft(w http.ResponseWriter, r *http.Request) {
+	if !requireBackendAdmin(w, r) {
+		return
+	}
+	if h.backend == nil {
+		writeAPIErr(w, http.StatusServiceUnavailable, "LOG_BACKEND_DISABLED", "log backend management disabled")
+		return
+	}
+	var input bizlogs.SaveInput
+	if err := decodeJSONBody(r, &input); err != nil {
+		writeAPIErr(w, http.StatusBadRequest, "LOG_BACKEND_INVALID", "invalid log backend request")
+		return
+	}
+	out, err := h.backend.TestDraft(r.Context(), input)
+	if err != nil {
+		writeBackendError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, apiEnvelope{Code: http.StatusOK, Message: "success", Data: out})
 }
 
 // getBackend godoc

--- a/internal/manager/server/webshell/http.go
+++ b/internal/manager/server/webshell/http.go
@@ -1,6 +1,6 @@
 // Package webshell wires the WebSSH HTTP route. Manager opens a
-// frontier stream into the edge (Meta = {"target":"127.0.0.1:22"}),
-// wraps the stream with golang.org/x/crypto/ssh.NewClientConn, runs
+// frontier stream into the edge, carries the port in the SSH client
+// identification, wraps it with golang.org/x/crypto/ssh.NewClientConn, runs
 // PTY + Shell, and pumps stdin/stdout to the browser WebSocket.
 //
 // Edge agent is a dumb byte forwarder — see internal/edgeagent/
@@ -12,6 +12,8 @@ package webshell
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +21,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,13 +33,14 @@ import (
 	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/ssh"
 
-	bizwebshell "github.com/ongridio/ongrid/internal/manager/biz/webshell"
 	devicebiz "github.com/ongridio/ongrid/internal/manager/biz/device"
 	edgebiz "github.com/ongridio/ongrid/internal/manager/biz/edge"
+	bizwebshell "github.com/ongridio/ongrid/internal/manager/biz/webshell"
 	edgemodel "github.com/ongridio/ongrid/internal/manager/model/edge"
 	wsmodel "github.com/ongridio/ongrid/internal/manager/model/webshell"
 	"github.com/ongridio/ongrid/internal/pkg/errs"
 	"github.com/ongridio/ongrid/internal/pkg/tenantctx"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
 )
 
 // AuthzMW is the narrow casbin middleware contract.
@@ -59,15 +63,19 @@ type Handler struct {
 	streamer Streamer
 	router   *bizwebshell.Router
 	audit    bizwebshell.Recorder
+	access   *bizwebshell.Access
 	devices  DeviceRepo
 	edges    edgebiz.Repo
 	authz    AuthzMW
 	log      *slog.Logger
 	upgrader websocket.Upgrader
+	mu       sync.Mutex
+	tickets  map[string]shellTicket
+	failures map[string]authFailures
 }
 
 // NewHandler builds the HTTP handler.
-func NewHandler(streamer Streamer, router *bizwebshell.Router, audit bizwebshell.Recorder,
+func NewHandler(streamer Streamer, router *bizwebshell.Router, audit bizwebshell.Recorder, access *bizwebshell.Access,
 	devices DeviceRepo, edges edgebiz.Repo, log *slog.Logger,
 ) *Handler {
 	if log == nil {
@@ -77,6 +85,7 @@ func NewHandler(streamer Streamer, router *bizwebshell.Router, audit bizwebshell
 		streamer: streamer,
 		router:   router,
 		audit:    audit,
+		access:   access,
 		devices:  devices,
 		edges:    edges,
 		log:      log,
@@ -84,8 +93,10 @@ func NewHandler(streamer Streamer, router *bizwebshell.Router, audit bizwebshell
 			ReadBufferSize:  4096,
 			WriteBufferSize: 16384,
 			Subprotocols:    []string{"ongrid.shell.v1"},
-			CheckOrigin:     func(r *http.Request) bool { return true },
+			CheckOrigin:     sameOrigin,
 		},
+		tickets:  make(map[string]shellTicket),
+		failures: make(map[string]authFailures),
 	}
 }
 
@@ -103,6 +114,12 @@ const MaxSessionsPerDevice = 5
 // input frames. Resize / close control frames count as input.
 const IdleTimeout = 15 * time.Minute
 
+const (
+	ticketTTL         = 30 * time.Second
+	authFailureWindow = 10 * time.Minute
+	maxAuthFailures   = 5
+)
+
 // Register attaches the route + the audit-list endpoint on the
 // (auth-wrapped) chi router.
 func (h *Handler) Register(r chi.Router) {
@@ -110,7 +127,10 @@ func (h *Handler) Register(r chi.Router) {
 	if h.authz != nil {
 		mw = h.authz.Require("device:shell", "exec")
 	}
-	r.With(mw).Get("/v1/devices/{device_id}/shell", h.openShell)
+	r.With(mw).Post("/v1/devices/{device_id}/shell/tickets", h.issueTicket)
+	r.With(mw).Get("/v1/devices/{device_id}/shell/credentials", h.listCredentials)
+	r.With(mw).Delete("/v1/devices/{device_id}/shell/credentials/{credential_id}", h.deleteCredential)
+	r.With(mw).Delete("/v1/devices/{device_id}/shell/known-hosts/{port}", h.deleteKnownHost)
 
 	listMW := passthrough
 	if h.authz != nil {
@@ -124,23 +144,40 @@ func (h *Handler) Register(r chi.Router) {
 	r.With(killMW).Delete("/v1/webshell/sessions/{id}", h.killSession)
 }
 
-func passthrough(next http.Handler) http.Handler { return next }
-
-// streamMeta is what we put in the frontier stream's Meta blob so
-// the edge knows where to forward bytes.
-type streamMeta struct {
-	Target string `json:"target"`
+// RegisterPublic attaches the ticket-authenticated WebSocket endpoint. The
+// short-lived ticket is the only credential accepted here; JWTs in query
+// strings and SSH passwords in WebSocket frames are intentionally rejected.
+func (h *Handler) RegisterPublic(r chi.Router) {
+	r.Get("/v1/devices/{device_id}/shell", h.openShell)
 }
+
+func passthrough(next http.Handler) http.Handler { return next }
 
 // openMsg is the first text frame the browser sends.
 type openMsg struct {
-	Type    string `json:"type"` // "open"
-	Cols    uint16 `json:"cols"`
-	Rows    uint16 `json:"rows"`
-	Term    string `json:"term,omitempty"`
-	SSHHost string `json:"ssh_host,omitempty"` // future: jumpbox; today ignored (always 127.0.0.1:22)
-	SSHUser string `json:"ssh_user"`
-	SSHPass string `json:"ssh_pass"`
+	Type string `json:"type"` // "open"
+	Cols uint16 `json:"cols"`
+	Rows uint16 `json:"rows"`
+	Term string `json:"term,omitempty"`
+}
+
+type shellTicket struct {
+	UserID          uint64
+	DeviceID        uint64
+	EdgeID          uint64
+	SSHUser         string
+	Password        string
+	Port            uint16
+	CredentialID    *uint64
+	SaveCredential  bool
+	AcceptedHostKey string
+	ClientIP        string
+	ExpiresAt       time.Time
+}
+
+type authFailures struct {
+	Count   int
+	ResetAt time.Time
 }
 
 // ctlMsg is any subsequent text-frame control message.
@@ -150,46 +187,171 @@ type ctlMsg struct {
 	Rows uint16 `json:"rows,omitempty"`
 }
 
-// openShell is the WS upgrade handler.
-func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
+// issueTicket mints a one-time WebSocket capability after bearer auth.
+// @Summary Create a one-time WebSSH connection ticket
+// @Router /v1/devices/{device_id}/shell/tickets [post]
+// @Success 200 {object} map[string]any
+func (h *Handler) issueTicket(w http.ResponseWriter, r *http.Request) {
 	tenant, ok := tenantctx.From(r.Context())
 	if !ok {
 		writeErr(w, errs.ErrUnauthorized)
 		return
 	}
-	deviceID, err := strconv.ParseUint(chi.URLParam(r, "device_id"), 10, 64)
+	deviceID, err := parseUintParam(r, "device_id")
 	if err != nil {
-		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		writeErr(w, err)
 		return
 	}
-
-	// Find an online edge bound to this device.
-	edges, err := h.edges.List(r.Context(), edgebiz.ListFilter{Limit: 1000})
+	if h.tooManyAuthFailures(tenant.UserID, deviceID, clientIP(r)) {
+		http.Error(w, "too many failed SSH logins; retry later", http.StatusTooManyRequests)
+		return
+	}
+	edge, err := h.onlineEdge(r.Context(), deviceID)
 	if err != nil {
-		writeErr(w, fmt.Errorf("list edges: %w", err))
+		writeErr(w, err)
 		return
 	}
-	var edge *edgemodel.Edge
-	for _, e := range edges {
-		if e.DeviceID != nil && *e.DeviceID == deviceID && e.Status == edgemodel.StatusOnline {
-			edge = e
-			break
-		}
-	}
-	if edge == nil {
-		http.Error(w, "device offline or unknown", http.StatusServiceUnavailable)
-		return
-	}
-
-	// Concurrency limits.
 	if n := h.router.CountByUser(tenant.UserID); n >= MaxSessionsPerUser {
-		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) for this user", n, MaxSessionsPerUser),
-			http.StatusTooManyRequests)
+		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) for this user", n, MaxSessionsPerUser), http.StatusTooManyRequests)
 		return
 	}
 	if n := h.router.CountByDevice(deviceID); n >= MaxSessionsPerDevice {
-		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) on this device", n, MaxSessionsPerDevice),
-			http.StatusTooManyRequests)
+		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) on this device", n, MaxSessionsPerDevice), http.StatusTooManyRequests)
+		return
+	}
+	var in struct {
+		CredentialID   uint64 `json:"credential_id"`
+		SSHUser        string `json:"ssh_user"`
+		SSHPass        string `json:"ssh_pass"`
+		SSHPort        uint16 `json:"ssh_port"`
+		SaveCredential bool   `json:"save_credential"`
+		AcceptHostKey  string `json:"accept_host_key"`
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		writeErr(w, errors.Join(errs.ErrInvalid, err))
+		return
+	}
+	var credentialID *uint64
+	if in.CredentialID != 0 {
+		if in.SSHUser != "" || in.SSHPass != "" || in.SSHPort != 0 || in.SaveCredential {
+			writeErr(w, fmt.Errorf("%w: credential_id cannot be combined with manual login fields", errs.ErrInvalid))
+			return
+		}
+		credential, err := h.access.ResolveCredential(r.Context(), in.CredentialID, tenant.UserID, deviceID)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+		in.SSHUser, in.SSHPass, in.SSHPort = credential.SSHUser, credential.Password, credential.SSHPort
+		credentialID = &credential.ID
+	}
+	in.SSHUser = strings.TrimSpace(in.SSHUser)
+	if in.SSHPort == 0 {
+		in.SSHPort = 22
+	}
+	if in.SSHUser == "" || len(in.SSHUser) > 64 || in.SSHPass == "" || len(in.SSHPass) > 4096 || len(in.AcceptHostKey) > 128 {
+		writeErr(w, fmt.Errorf("%w: invalid SSH login", errs.ErrInvalid))
+		return
+	}
+	token, expiresAt, err := h.mintTicket(shellTicket{
+		UserID: tenant.UserID, DeviceID: deviceID, EdgeID: edge.ID,
+		SSHUser: in.SSHUser, Password: in.SSHPass, Port: in.SSHPort,
+		CredentialID: credentialID, SaveCredential: in.SaveCredential, AcceptedHostKey: in.AcceptHostKey,
+		ClientIP: clientIP(r),
+	})
+	in.SSHPass = ""
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, map[string]any{"ticket": token, "expires_at": expiresAt.Format(time.RFC3339)})
+}
+
+// listCredentials returns redacted personal login metadata.
+// @Summary List personal WebSSH credentials
+// @Router /v1/devices/{device_id}/shell/credentials [get]
+// @Success 200 {object} map[string]any
+func (h *Handler) listCredentials(w http.ResponseWriter, r *http.Request) {
+	tenant, deviceID, ok := callerAndDevice(w, r)
+	if !ok {
+		return
+	}
+	items, err := h.access.ListCredentials(r.Context(), tenant.UserID, deviceID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+// deleteCredential removes only the caller's own device-bound login.
+// @Summary Delete a personal WebSSH credential
+// @Router /v1/devices/{device_id}/shell/credentials/{credential_id} [delete]
+// @Success 204
+func (h *Handler) deleteCredential(w http.ResponseWriter, r *http.Request) {
+	tenant, deviceID, ok := callerAndDevice(w, r)
+	if !ok {
+		return
+	}
+	id, err := parseUintParam(r, "credential_id")
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if err := h.access.DeleteCredential(r.Context(), id, tenant.UserID, deviceID); err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteKnownHost explicitly resets the caller's pinned key for one port.
+// @Summary Reset a personal WebSSH host-key pin
+// @Router /v1/devices/{device_id}/shell/known-hosts/{port} [delete]
+// @Success 204
+func (h *Handler) deleteKnownHost(w http.ResponseWriter, r *http.Request) {
+	tenant, deviceID, ok := callerAndDevice(w, r)
+	if !ok {
+		return
+	}
+	port, err := parseUintParam(r, "port")
+	if err != nil || port == 0 || port > 65535 {
+		writeErr(w, errs.ErrInvalid)
+		return
+	}
+	if err := h.access.DeleteKnownHost(r.Context(), tenant.UserID, deviceID, uint16(port)); err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// openShell is the WS upgrade handler.
+func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
+	if !sameOrigin(r) {
+		http.Error(w, "websocket origin not allowed", http.StatusForbidden)
+		return
+	}
+	deviceID, err := parseUintParam(r, "device_id")
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	ticket, ok := h.consumeTicket(r.URL.Query().Get("ticket"), deviceID, clientIP(r))
+	if !ok {
+		http.Error(w, "invalid or expired shell ticket", http.StatusUnauthorized)
+		return
+	}
+	defer func() { ticket.Password = "" }()
+	if n := h.router.CountByUser(ticket.UserID); n >= MaxSessionsPerUser {
+		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) for this user", n, MaxSessionsPerUser), http.StatusTooManyRequests)
+		return
+	}
+	if n := h.router.CountByDevice(deviceID); n >= MaxSessionsPerDevice {
+		http.Error(w, fmt.Sprintf("too many open shells (%d / %d) on this device", n, MaxSessionsPerDevice), http.StatusTooManyRequests)
 		return
 	}
 
@@ -213,10 +375,6 @@ func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
 		br.closeWith(websocket.CloseProtocolError, "bad open frame")
 		return
 	}
-	if openFrame.SSHUser == "" || openFrame.SSHPass == "" {
-		br.closeWith(websocket.CloseProtocolError, "ssh_user / ssh_pass required")
-		return
-	}
 	cols, rows := openFrame.Cols, openFrame.Rows
 	if cols == 0 {
 		cols = 80
@@ -234,10 +392,12 @@ func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now().UTC()
 	if err := h.audit.Open(r.Context(), &wsmodel.Session{
 		ID:           sid,
-		OngridUserID: tenant.UserID,
-		SSHUser:      openFrame.SSHUser,
+		OngridUserID: ticket.UserID,
+		SSHUser:      ticket.SSHUser,
+		SSHPort:      ticket.Port,
+		CredentialID: ticket.CredentialID,
 		DeviceID:     deviceID,
-		EdgeID:       edge.ID,
+		EdgeID:       ticket.EdgeID,
 		ClientIP:     clientIP(r),
 		StartedAt:    startedAt,
 	}); err != nil {
@@ -246,19 +406,14 @@ func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.router.Register(sid, br, bizwebshell.ActiveSession{
-		SessionID:    sid,
-		OngridUserID: tenant.UserID,
-		SSHUser:      openFrame.SSHUser,
-		DeviceID:     deviceID,
-		EdgeID:       edge.ID,
-		StartedAt:    startedAt,
-		LastInputAt:  startedAt,
+		SessionID: sid, OngridUserID: ticket.UserID, SSHUser: ticket.SSHUser,
+		SSHPort: ticket.Port, DeviceID: deviceID, EdgeID: ticket.EdgeID,
+		StartedAt: startedAt, LastInputAt: startedAt,
 	})
 	defer h.router.Unregister(sid)
 
-	// Open frontier stream to the edge with target meta.
 	streamCtx, cancelStreamOpen := context.WithTimeout(r.Context(), 10*time.Second)
-	stream, err := h.streamer.OpenStream(streamCtx, edge.ID)
+	stream, err := h.streamer.OpenStream(streamCtx, ticket.EdgeID)
 	cancelStreamOpen()
 	if err != nil {
 		h.closeAudit(sid, br, 0, wsmodel.TerminatedByDisconnect)
@@ -266,35 +421,63 @@ func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
 		br.closeWith(websocket.CloseInternalServerErr, "open stream")
 		return
 	}
-	// We can't set Meta on the manager-opened stream via the current
-	// frontierbound surface (geminio.OpenStreamOptions exists but we
-	// don't expose it yet). For now the edge always defaults to
-	// 127.0.0.1:22 when Meta is empty — OK for Phase 1. Phase 2
-	// thread Meta through when we add jumpbox support.
-	_ = streamMeta{Target: "127.0.0.1:22"} // documentation only
-
-	// Wrap stream with SSH client conn.
+	var hostKeyErr *bizwebshell.HostKeyError
+	observedFingerprint := ""
+	password := ticket.Password
+	ticket.Password = ""
+	defer func() { password = "" }()
 	sshCfg := &ssh.ClientConfig{
-		User:            openFrame.SSHUser,
-		Auth:            []ssh.AuthMethod{ssh.Password(openFrame.SSHPass)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // localhost-only path
-		Timeout:         10 * time.Second,
+		User:          ticket.SSHUser,
+		Auth:          []ssh.AuthMethod{ssh.Password(password)},
+		Timeout:       10 * time.Second,
+		ClientVersion: tunnel.WebshellSSHClientVersion(ticket.Port),
+		HostKeyCallback: func(_ string, _ net.Addr, key ssh.PublicKey) error {
+			observedFingerprint = ssh.FingerprintSHA256(key)
+			err := h.access.VerifyHostKey(r.Context(), ticket.UserID, deviceID, ticket.Port, observedFingerprint, ticket.AcceptedHostKey)
+			if errors.As(err, &hostKeyErr) {
+				return hostKeyErr
+			}
+			return err
+		},
 	}
-	openFrame.SSHPass = "" // wipe asap
-
-	sshConn, sshChans, sshReqs, sshErr := ssh.NewClientConn(rwcAdapter{rwc: stream}, "127.0.0.1:22", sshCfg)
+	sshAddress := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(ticket.Port)))
+	sshConn, sshChans, sshReqs, sshErr := ssh.NewClientConn(rwcAdapter{rwc: stream}, sshAddress, sshCfg)
+	if observedFingerprint != "" {
+		if err := h.audit.SetHostFingerprint(r.Context(), sid, observedFingerprint); err != nil {
+			h.log.Warn("webshell: audit host fingerprint", slog.String("session_id", sid), slog.Any("err", err))
+		}
+	}
 	if sshErr != nil {
 		_ = stream.Close()
+		if hostKeyErr != nil {
+			payload := map[string]any{"type": "host_key_" + hostKeyErr.Kind, "fingerprint": hostKeyErr.Actual}
+			if hostKeyErr.Expected != "" {
+				payload["expected"] = hostKeyErr.Expected
+			}
+			br.sendText(payload)
+			h.closeAudit(sid, br, 0, wsmodel.TerminatedBySSHHostKey)
+			br.closeWith(websocket.CloseNormalClosure, "ssh host key")
+			return
+		}
 		failMsg := sshErr.Error()
-		// Map common cases to friendlier messages.
 		if strings.Contains(failMsg, "unable to authenticate") {
 			failMsg = "用户名或密码错误"
+			h.recordAuthFailure(ticket.UserID, deviceID, ticket.ClientIP)
+		} else if strings.Contains(failMsg, "target") && strings.Contains(failMsg, "not allowed") {
+			failMsg = fmt.Sprintf("该 Edge 暂不支持 SSH 端口 %d，请升级 Edge 后重试", ticket.Port)
 		}
 		br.sendText(map[string]any{"type": "auth_error", "message": failMsg})
 		h.closeAudit(sid, br, 0, wsmodel.TerminatedBySSHAuthFail)
 		br.closeWith(websocket.CloseNormalClosure, "ssh auth")
 		return
 	}
+	h.clearAuthFailures(ticket.UserID, deviceID, ticket.ClientIP)
+	if ticket.SaveCredential {
+		if _, err := h.access.CreateCredential(r.Context(), ticket.UserID, deviceID, ticket.SSHUser, password, ticket.Port); err != nil {
+			br.sendText(map[string]any{"type": "credential_save_error", "message": err.Error()})
+		}
+	}
+	password = ""
 	sshClient := ssh.NewClient(sshConn, sshChans, sshReqs)
 	defer sshClient.Close()
 
@@ -345,7 +528,7 @@ func (h *Handler) openShell(w http.ResponseWriter, r *http.Request) {
 	go pumpReaderToBridge(br, stdout, h.router, sid)
 	go pumpReaderToBridge(br, stderr, h.router, sid)
 	go h.pumpBrowserToSSH(r.Context(), sid, br, stdin, sess, pumpDone)
-	go waitSSH(sess, pumpDone)
+	go waitSSH(sess, br, pumpDone)
 	if IdleTimeout > 0 {
 		go h.idleWatchdog(r.Context(), sid, br, pumpDone)
 	}
@@ -381,13 +564,13 @@ func pumpReaderToBridge(br *bridge, r io.Reader, router *bizwebshell.Router, sid
 	}
 }
 
-func waitSSH(sess *ssh.Session, done chan<- terminationCause) {
+func waitSSH(sess *ssh.Session, br *bridge, done chan<- terminationCause) {
 	exitErr := sess.Wait()
 	code := 0
 	if ee := (*ssh.ExitError)(nil); errors.As(exitErr, &ee) {
 		code = ee.ExitStatus()
 	}
-	_ = code // captured by router via Audit; not strictly needed here
+	br.OnExit(code, "")
 	select {
 	case done <- terminationCause(wsmodel.TerminatedBySSHExit):
 	default:
@@ -503,6 +686,7 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 		ID           string  `json:"id"`
 		OngridUserID uint64  `json:"ongrid_user_id"`
 		SSHUser      string  `json:"ssh_user"`
+		SSHPort      uint16  `json:"ssh_port"`
 		DeviceID     uint64  `json:"device_id"`
 		EdgeID       uint64  `json:"edge_id"`
 		StartedAt    string  `json:"started_at"`
@@ -521,6 +705,7 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 			ID:           s.SessionID,
 			OngridUserID: s.OngridUserID,
 			SSHUser:      s.SSHUser,
+			SSHPort:      s.SSHPort,
 			DeviceID:     s.DeviceID,
 			EdgeID:       s.EdgeID,
 			StartedAt:    s.StartedAt.UTC().Format(time.RFC3339),
@@ -541,6 +726,7 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 			ID:           s.ID,
 			OngridUserID: s.OngridUserID,
 			SSHUser:      s.SSHUser,
+			SSHPort:      s.SSHPort,
 			DeviceID:     s.DeviceID,
 			EdgeID:       s.EdgeID,
 			StartedAt:    s.StartedAt.UTC().Format(time.RFC3339),
@@ -580,11 +766,11 @@ type rwcAdapter struct {
 	rwc io.ReadWriteCloser
 }
 
-func (a rwcAdapter) Read(p []byte) (int, error)  { return a.rwc.Read(p) }
-func (a rwcAdapter) Write(p []byte) (int, error) { return a.rwc.Write(p) }
-func (a rwcAdapter) Close() error                { return a.rwc.Close() }
-func (a rwcAdapter) LocalAddr() net.Addr             { return noopAddr{} }
-func (a rwcAdapter) RemoteAddr() net.Addr            { return noopAddr{} }
+func (a rwcAdapter) Read(p []byte) (int, error)       { return a.rwc.Read(p) }
+func (a rwcAdapter) Write(p []byte) (int, error)      { return a.rwc.Write(p) }
+func (a rwcAdapter) Close() error                     { return a.rwc.Close() }
+func (a rwcAdapter) LocalAddr() net.Addr              { return noopAddr{} }
+func (a rwcAdapter) RemoteAddr() net.Addr             { return noopAddr{} }
 func (a rwcAdapter) SetDeadline(time.Time) error      { return nil }
 func (a rwcAdapter) SetReadDeadline(time.Time) error  { return nil }
 func (a rwcAdapter) SetWriteDeadline(time.Time) error { return nil }
@@ -675,7 +861,135 @@ func clientIP(r *http.Request) string {
 		}
 		return strings.TrimSpace(v)
 	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
 	return r.RemoteAddr
+}
+
+func sameOrigin(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.User != nil || u.RawQuery != "" || u.Fragment != "" || (u.Path != "" && u.Path != "/") {
+		return false
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if forwarded := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0]); forwarded == "http" || forwarded == "https" {
+		scheme = forwarded
+	}
+	return strings.EqualFold(u.Scheme, scheme) && strings.EqualFold(u.Host, r.Host)
+}
+
+func callerAndDevice(w http.ResponseWriter, r *http.Request) (tenantctx.Tenant, uint64, bool) {
+	tenant, ok := tenantctx.From(r.Context())
+	if !ok {
+		writeErr(w, errs.ErrUnauthorized)
+		return tenantctx.Tenant{}, 0, false
+	}
+	deviceID, err := parseUintParam(r, "device_id")
+	if err != nil {
+		writeErr(w, err)
+		return tenantctx.Tenant{}, 0, false
+	}
+	return tenant, deviceID, true
+}
+
+func parseUintParam(r *http.Request, name string) (uint64, error) {
+	v, err := strconv.ParseUint(chi.URLParam(r, name), 10, 64)
+	if err != nil || v == 0 {
+		return 0, errors.Join(errs.ErrInvalid, err)
+	}
+	return v, nil
+}
+
+func (h *Handler) onlineEdge(ctx context.Context, deviceID uint64) (*edgemodel.Edge, error) {
+	edges, err := h.edges.List(ctx, edgebiz.ListFilter{Limit: 1000})
+	if err != nil {
+		return nil, fmt.Errorf("list edges: %w", err)
+	}
+	for _, edge := range edges {
+		if edge.DeviceID != nil && *edge.DeviceID == deviceID && edge.Status == edgemodel.StatusOnline {
+			return edge, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: device offline or unknown", errs.ErrEdgeOffline)
+}
+
+func (h *Handler) mintTicket(ticket shellTicket) (string, time.Time, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", time.Time{}, fmt.Errorf("create shell ticket: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw)
+	ticket.ExpiresAt = time.Now().UTC().Add(ticketTTL)
+	h.mu.Lock()
+	h.tickets[token] = ticket
+	h.mu.Unlock()
+	time.AfterFunc(ticketTTL, func() {
+		h.mu.Lock()
+		delete(h.tickets, token)
+		h.mu.Unlock()
+	})
+	return token, ticket.ExpiresAt, nil
+}
+
+func (h *Handler) consumeTicket(token string, deviceID uint64, ip string) (shellTicket, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ticket, ok := h.tickets[token]
+	delete(h.tickets, token)
+	if !ok || token == "" || time.Now().After(ticket.ExpiresAt) || ticket.DeviceID != deviceID || ticket.ClientIP != ip {
+		return shellTicket{}, false
+	}
+	return ticket, true
+}
+
+func failureKey(userID, deviceID uint64, ip string) string {
+	return fmt.Sprintf("%d:%d:%s", userID, deviceID, ip)
+}
+
+func (h *Handler) tooManyAuthFailures(userID, deviceID uint64, ip string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	key, now := failureKey(userID, deviceID, ip), time.Now()
+	failure, ok := h.failures[key]
+	if !ok || now.After(failure.ResetAt) {
+		delete(h.failures, key)
+		return false
+	}
+	return failure.Count >= maxAuthFailures
+}
+
+func (h *Handler) recordAuthFailure(userID, deviceID uint64, ip string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	key, now := failureKey(userID, deviceID, ip), time.Now()
+	failure := h.failures[key]
+	if now.After(failure.ResetAt) {
+		failure = authFailures{ResetAt: now.Add(authFailureWindow)}
+	}
+	failure.Count++
+	h.failures[key] = failure
+}
+
+func (h *Handler) clearAuthFailures(userID, deviceID uint64, ip string) {
+	h.mu.Lock()
+	delete(h.failures, failureKey(userID, deviceID, ip))
+	h.mu.Unlock()
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if body != nil {
+		_ = json.NewEncoder(w).Encode(body)
+	}
 }
 
 func writeErr(w http.ResponseWriter, err error) {

--- a/internal/manager/server/webshell/http_test.go
+++ b/internal/manager/server/webshell/http_test.go
@@ -1,0 +1,80 @@
+package webshell
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestShellTicketIsOneTimeAndBound(t *testing.T) {
+	h := &Handler{tickets: map[string]shellTicket{}, failures: map[string]authFailures{}}
+	token, _, err := h.mintTicket(shellTicket{UserID: 7, DeviceID: 9, ClientIP: "127.0.0.1", Password: "secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := h.consumeTicket(token, 8, "127.0.0.1"); ok {
+		t.Fatal("ticket accepted for another device")
+	}
+	if _, ok := h.consumeTicket(token, 9, "127.0.0.1"); ok {
+		t.Fatal("failed binding attempt did not consume ticket")
+	}
+
+	token, _, err = h.mintTicket(shellTicket{UserID: 7, DeviceID: 9, ClientIP: "127.0.0.1", SaveCredential: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket, ok := h.consumeTicket(token, 9, "127.0.0.1")
+	if !ok {
+		t.Fatal("valid ticket rejected")
+	}
+	if !ticket.SaveCredential {
+		t.Fatal("save intent was not carried by the one-time ticket")
+	}
+	if _, ok := h.consumeTicket(token, 9, "127.0.0.1"); ok {
+		t.Fatal("ticket reused")
+	}
+}
+
+func TestRegisterDoesNotExposeUnverifiedCredentialCreate(t *testing.T) {
+	h := &Handler{}
+	r := chi.NewRouter()
+	h.Register(r)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/devices/9/shell/credentials", nil))
+	if rec.Code != http.StatusNotFound && rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("unverified credential create route returned %d", rec.Code)
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	r := httptest.NewRequest("GET", "https://ops.example/api/v1/devices/1/shell", nil)
+	r.Host = "ops.example"
+	r.Header.Set("Origin", "https://ops.example")
+	if !sameOrigin(r) {
+		t.Fatal("same origin rejected")
+	}
+	r.Host = "ops.example:8443"
+	r.Header.Set("Origin", "https://ops.example:8443")
+	if !sameOrigin(r) {
+		t.Fatal("same origin with a custom port rejected")
+	}
+	r.Host = "ops.example"
+	r.Header.Set("Origin", "https://evil.example")
+	if sameOrigin(r) {
+		t.Fatal("cross origin accepted")
+	}
+	r.Header.Set("Origin", "http://ops.example")
+	if sameOrigin(r) {
+		t.Fatal("cross-scheme origin accepted")
+	}
+	r.Header.Set("Origin", "https://ops.example/path")
+	if sameOrigin(r) {
+		t.Fatal("origin with a path accepted")
+	}
+	r.Header.Del("Origin")
+	if sameOrigin(r) {
+		t.Fatal("missing origin accepted")
+	}
+}

--- a/internal/manager/service/frontierbound/client.go
+++ b/internal/manager/service/frontierbound/client.go
@@ -266,11 +266,7 @@ func (c *Client) OpenStreamWithMeta(ctx context.Context, edgeID uint64, meta []b
 		}
 		return s, nil
 	}
-	s, err := c.svc.OpenStream(ctx, transportID)
-	if err != nil {
-		return nil, fmt.Errorf("frontierbound: open stream edge=%d transport=%d: %w", edgeID, transportID, err)
-	}
-	return s, nil
+	return nil, fmt.Errorf("frontierbound: stream metadata unsupported by current transport")
 }
 
 type rawStreamOpener interface {
@@ -290,6 +286,12 @@ func embeddedStreamOpener(svc service) (rawStreamOpener, bool) {
 		return nil, false
 	}
 	opener, ok := field.Interface().(rawStreamOpener)
+	if ok {
+		value := reflect.ValueOf(opener)
+		if value.Kind() == reflect.Pointer && value.IsNil() {
+			return nil, false
+		}
+	}
 	return opener, ok
 }
 

--- a/internal/manager/service/frontierbound/client_test.go
+++ b/internal/manager/service/frontierbound/client_test.go
@@ -304,6 +304,13 @@ func TestClient_OpenStreamWithMeta_UsesEmbeddedEndOptions(t *testing.T) {
 	}
 }
 
+func TestClient_OpenStreamWithMeta_FailsClosedWithoutMetadataSupport(t *testing.T) {
+	c := newWithService(newFakeService(), slog.Default())
+	if _, err := c.OpenStreamWithMeta(context.Background(), 2, []byte(`{"kind":"webshell"}`)); err == nil {
+		t.Fatal("OpenStreamWithMeta silently dropped required metadata")
+	}
+}
+
 func TestClient_Call_RemoteError(t *testing.T) {
 	fs := newFakeService()
 	fs.respErr = errors.New("edge said no")

--- a/internal/pkg/promwrite/client.go
+++ b/internal/pkg/promwrite/client.go
@@ -129,13 +129,6 @@ func (c *Client) Write(ctx context.Context, samples []Sample) error {
 	if len(samples) == 0 {
 		return nil
 	}
-	url, rerr := c.endpoint.ResolveWriteURL(ctx)
-	if rerr != nil {
-		return fmt.Errorf("promwrite: resolve endpoint: %w", rerr)
-	}
-	if url == "" {
-		return errors.New("promwrite: write endpoint is empty")
-	}
 
 	// Each Sample becomes its own TimeSeries (one sample per series). This
 	// is wire-equivalent to grouping by label hash and saves the manager
@@ -145,7 +138,24 @@ func (c *Client) Write(ctx context.Context, samples []Sample) error {
 		ts := encodeTimeSeries(s.Labels, []sampleEntry{{value: s.Value, tsMs: s.TsMs}})
 		seriesPayloads = append(seriesPayloads, ts)
 	}
-	raw := encodeWriteRequest(seriesPayloads)
+	return c.post(ctx, encodeWriteRequest(seriesPayloads), len(samples))
+}
+
+// Probe sends an empty, valid WriteRequest. Compatible receivers return
+// 200/204 while storing no series, so callers can verify URL/auth/TLS safely.
+func (c *Client) Probe(ctx context.Context) error {
+	return c.post(ctx, encodeWriteRequest(nil), 0)
+}
+
+func (c *Client) post(ctx context.Context, raw []byte, sampleCount int) error {
+	url, rerr := c.endpoint.ResolveWriteURL(ctx)
+	if rerr != nil {
+		return fmt.Errorf("promwrite: resolve endpoint: %w", rerr)
+	}
+	if url == "" {
+		return errors.New("promwrite: write endpoint is empty")
+	}
+
 	compressed := snappy.Encode(nil, raw)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(compressed))
@@ -171,7 +181,7 @@ func (c *Client) Write(ctx context.Context, samples []Sample) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	c.log.WarnContext(ctx, "promwrite: non-2xx",
 		slog.Int("status", resp.StatusCode),
-		slog.Int("samples", len(samples)),
+		slog.Int("samples", sampleCount),
 		slog.String("body", string(body)),
 	)
 	return fmt.Errorf("promwrite: %s returned %d: %s", url, resp.StatusCode, string(body))

--- a/internal/pkg/promwrite/client_test.go
+++ b/internal/pkg/promwrite/client_test.go
@@ -161,6 +161,7 @@ type fakeServer struct {
 	gotEncoding    string
 	gotVersion     string
 	gotSamples     []decodedSample
+	requests       int
 	status         int
 }
 
@@ -177,6 +178,7 @@ func newFakeServer(t *testing.T) (*httptest.Server, *fakeServer) {
 		fs.gotContentType = r.Header.Get("Content-Type")
 		fs.gotEncoding = r.Header.Get("Content-Encoding")
 		fs.gotVersion = r.Header.Get("X-Prometheus-Remote-Write-Version")
+		fs.requests++
 		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -265,7 +267,7 @@ func TestClient_Write_RoundTrip(t *testing.T) {
 }
 
 func TestClient_Write_Empty(t *testing.T) {
-	srv, _ := newFakeServer(t)
+	srv, fs := newFakeServer(t)
 	defer srv.Close()
 	c := New(srv.URL, slog.Default())
 	if err := c.Write(context.Background(), nil); err != nil {
@@ -273,6 +275,21 @@ func TestClient_Write_Empty(t *testing.T) {
 	}
 	if err := c.Write(context.Background(), []Sample{}); err != nil {
 		t.Errorf("empty samples should be no-op, got %v", err)
+	}
+	if fs.requests != 0 {
+		t.Fatalf("empty Write requests = %d, want 0", fs.requests)
+	}
+}
+
+func TestClient_Probe_SendsEmptyWriteRequest(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	defer srv.Close()
+	c := New(srv.URL, slog.Default())
+	if err := c.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if fs.requests != 1 || len(fs.gotSamples) != 0 {
+		t.Fatalf("requests = %d, samples = %d, want 1 empty request", fs.requests, len(fs.gotSamples))
 	}
 }
 

--- a/internal/pkg/secretbox/secretbox.go
+++ b/internal/pkg/secretbox/secretbox.go
@@ -1,7 +1,7 @@
 // Package secretbox is the at-rest encryption used by the credential vault
-// (HLD-017). AES-256-GCM, key derived from ONGRID_SECRET_KEY. Mirrors
-// n8n's posture (encryption key lives OUTSIDE the DB, in the environment)
-// so a DB dump alone never yields plaintext credentials.
+// (HLD-017). AES-256-GCM, key derived from ONGRID_SECRET_KEY or, when it
+// is unset, the already-persisted ONGRID_JWT_SECRET. Either source lives
+// outside the DB, so a DB dump alone never yields plaintext credentials.
 //
 // Ciphertext wire format: "v1:" + base64(nonce || ciphertext+tag). The
 // version prefix lets us rotate the scheme later without ambiguity.
@@ -25,26 +25,34 @@ const prefix = "v1:"
 var (
 	keyOnce sync.Once
 	keyVal  [32]byte
-	keyWeak bool // true when ONGRID_SECRET_KEY was unset (derived fallback)
+	keyWeak bool // true only when neither configured secret is usable
 )
 
-// loadKey derives the 32-byte AES key from ONGRID_SECRET_KEY (sha256 of the
-// env value). When the env is unset it falls back to a fixed-salt derived
-// key so the vault still works out of the box — but KeyIsWeak() reports it
-// so the boot path can warn the operator to set a real key.
+const legacyFallback = "ongrid-insecure-default-secret-key-set-ONGRID_SECRET_KEY"
+
+// loadKey derives the 32-byte AES key from the configured secret source.
 func loadKey() {
 	keyOnce.Do(func() {
-		env := strings.TrimSpace(os.Getenv("ONGRID_SECRET_KEY"))
-		if env == "" {
-			keyWeak = true
-			env = "ongrid-insecure-default-secret-key-set-ONGRID_SECRET_KEY"
-		}
-		keyVal = sha256.Sum256([]byte(env))
+		keyVal, keyWeak = deriveKey(os.Getenv("ONGRID_SECRET_KEY"), os.Getenv("ONGRID_JWT_SECRET"))
 	})
 }
 
-// KeyIsWeak reports whether the encryption key is the insecure built-in
-// fallback (ONGRID_SECRET_KEY unset). main.go logs a warning when true.
+// deriveKey keeps ONGRID_SECRET_KEY as the preferred independent key. A normal
+// install already has a random, persisted JWT secret, so use a domain-separated
+// derivative when no dedicated vault key was configured. The fixed fallback is
+// retained only for local/dev compatibility.
+func deriveKey(secret, jwt string) ([32]byte, bool) {
+	if secret = strings.TrimSpace(secret); secret != "" {
+		return sha256.Sum256([]byte(secret)), false
+	}
+	jwt = strings.TrimSpace(jwt)
+	if jwt != "" && jwt != "dev-insecure-secret-change-me" && jwt != "change-me-to-a-long-random-string" {
+		return sha256.Sum256([]byte("ongrid-secretbox-v1:" + jwt)), false
+	}
+	return sha256.Sum256([]byte(legacyFallback)), true
+}
+
+// KeyIsWeak reports whether neither a dedicated nor a real JWT secret exists.
 func KeyIsWeak() bool {
 	loadKey()
 	return keyWeak
@@ -103,7 +111,28 @@ func Decrypt(enc string) (string, error) {
 	nonce, ct := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
 	out, err := gcm.Open(nil, nonce, ct, nil)
 	if err != nil {
-		return "", fmt.Errorf("secretbox: open (wrong ONGRID_SECRET_KEY?): %w", err)
+		// Rows written before JWT-derived fallback support used the fixed key.
+		// Read them without forcing an operator migration; all new writes use the
+		// stronger derived key when a real JWT secret is available.
+		jwtKey, jwtWeak := deriveKey("", os.Getenv("ONGRID_JWT_SECRET"))
+		legacy := sha256.Sum256([]byte(legacyFallback))
+		for _, candidate := range [][32]byte{jwtKey, legacy} {
+			if (candidate == jwtKey && jwtWeak) || candidate == keyVal {
+				continue
+			}
+			candidateBlock, blockErr := aes.NewCipher(candidate[:])
+			if blockErr != nil {
+				continue
+			}
+			candidateGCM, gcmErr := cipher.NewGCM(candidateBlock)
+			if gcmErr != nil {
+				continue
+			}
+			if candidateOut, openErr := candidateGCM.Open(nil, nonce, ct, nil); openErr == nil {
+				return string(candidateOut), nil
+			}
+		}
+		return "", fmt.Errorf("secretbox: open (wrong encryption key?): %w", err)
 	}
 	return string(out), nil
 }

--- a/internal/pkg/secretbox/secretbox_test.go
+++ b/internal/pkg/secretbox/secretbox_test.go
@@ -1,6 +1,9 @@
 package secretbox
 
-import "testing"
+import (
+	"crypto/sha256"
+	"testing"
+)
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
 	cases := []string{"", "x", `{"secret_id":"AKID123","secret_key":"abc/def+ghi=="}`}
@@ -26,5 +29,13 @@ func TestDecryptLegacyPlaintextPassesThrough(t *testing.T) {
 	// A value stored before encryption (no v1: prefix) reads through as-is.
 	if got, err := Decrypt("legacy-plaintext"); err != nil || got != "legacy-plaintext" {
 		t.Fatalf("legacy passthrough = %q, %v", got, err)
+	}
+}
+
+func TestDeriveKeyUsesPersistedJWTWithoutDedicatedKey(t *testing.T) {
+	got, weak := deriveKey("", "random-persisted-jwt-secret")
+	want := sha256.Sum256([]byte("ongrid-secretbox-v1:random-persisted-jwt-secret"))
+	if weak || got != want {
+		t.Fatalf("deriveKey() = %x, weak=%v; want %x, false", got, weak, want)
 	}
 }

--- a/internal/pkg/tunnel/types.go
+++ b/internal/pkg/tunnel/types.go
@@ -94,10 +94,9 @@ type Client interface {
 	// to/from the sshd socket. The stream is a net.Conn-shaped
 	// io.ReadWriteCloser (geminio.Stream embeds Raw = net.Conn).
 	//
-	// Stream.Meta() carries the manager-supplied target descriptor
-	// (today: JSON {"target":"127.0.0.1:22"}). Edge dispatchers
-	// decode it before dialing the local socket — keeps the tunnel
-	// layer generic.
+	// Stream.Meta() is transport-local metadata. Frontier v1.2.4 does not
+	// relay it across the service-to-edge bridge, so routed protocols must
+	// carry required information in their byte stream.
 	//
 	// Returns an error when the underlying connection is not yet
 	// dialed or has terminated.

--- a/internal/pkg/tunnel/webshell.go
+++ b/internal/pkg/tunnel/webshell.go
@@ -1,0 +1,21 @@
+package tunnel
+
+import (
+	"strconv"
+	"strings"
+)
+
+const webshellSSHClientVersionPrefix = "SSH-2.0-Ongrid-WebShell-"
+
+func WebshellSSHClientVersion(port uint16) string {
+	return webshellSSHClientVersionPrefix + strconv.Itoa(int(port))
+}
+
+func ParseWebshellSSHClientVersion(version string) (uint16, bool) {
+	raw, ok := strings.CutPrefix(strings.TrimSpace(version), webshellSSHClientVersionPrefix)
+	if !ok {
+		return 0, false
+	}
+	port, err := strconv.ParseUint(raw, 10, 16)
+	return uint16(port), err == nil && port > 0
+}

--- a/internal/pkg/tunnel/webshell_test.go
+++ b/internal/pkg/tunnel/webshell_test.go
@@ -1,0 +1,15 @@
+package tunnel
+
+import "testing"
+
+func TestWebshellSSHClientVersionRoundTrip(t *testing.T) {
+	for _, port := range []uint16{22, 2222, 65535} {
+		got, ok := ParseWebshellSSHClientVersion(WebshellSSHClientVersion(port))
+		if !ok || got != port {
+			t.Fatalf("round trip port %d = (%d, %v)", port, got, ok)
+		}
+	}
+	if _, ok := ParseWebshellSSHClientVersion("SSH-2.0-Go"); ok {
+		t.Fatal("ordinary SSH client version parsed as WebShell metadata")
+	}
+}

--- a/web/src/api/logs.ts
+++ b/web/src/api/logs.ts
@@ -173,6 +173,10 @@ export function testLogBackend(id: number) {
   return request<APIEnvelope<LogBackendTestResult>>('POST', `/logs/backend/${id}/test`).then((r) => r.data);
 }
 
+export function testLogBackendDraft(input: SaveLogBackendInput) {
+  return request<APIEnvelope<LogBackendTestResult>>('POST', '/logs/backend/test', input).then((r) => r.data);
+}
+
 export function selectLogBackend(id: number) {
   return request<APIEnvelope<LogBackend>>('POST', `/logs/backend/${id}/select`).then((r) => r.data);
 }

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -74,8 +74,16 @@ export type GrafanaSyncResult = {
   dashboards: string[];
 };
 
-export function testGrafanaConnection(): Promise<{ status: string }> {
-  return request<{ status: string }>('POST', '/integrations/grafana/test');
+export type GrafanaConfigurationProbeInput = {
+  root_url: string;
+  sa_token: string;
+  api_key: string;
+  org_id: string;
+  tls_insecure: boolean;
+};
+
+export function testGrafanaConnection(input: GrafanaConfigurationProbeInput): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/grafana/test', input);
 }
 
 export function syncGrafana(): Promise<GrafanaSyncResult> {
@@ -86,23 +94,39 @@ export function syncLokiDatasource(): Promise<{ status: string }> {
   return request<{ status: string }>('POST', '/integrations/grafana/sync-loki');
 }
 
-// testPromConnection runs a tiny "up" PromQL probe via the manager. Used
-// by the Prom integration card to validate URL + Bearer/Basic before the
-// user trusts that the wiring is good.
-export function testPromConnection(): Promise<{ status: string }> {
-  return request<{ status: string }>('POST', '/integrations/prom/test');
+export type PromConfigurationProbeInput = {
+  query_url: string;
+  remote_write_url: string;
+  bearer_token: string;
+  basic_user: string;
+  basic_password: string;
+  tls_insecure: boolean;
+};
+
+// testPromConnection validates the unsaved query and remote_write draft.
+// The manager uses credentials only for this request and stores no settings
+// or metric samples.
+export function testPromConnection(input: PromConfigurationProbeInput): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/prom/test', input);
 }
 
 // testLokiConnection / testTempoConnection proxy through the manager so
-// auth + TLS-skip + URL come from system_settings rather than the browser.
+// auth + TLS-skip + URL come from the current unsaved browser draft.
 // Loki checks GET /ready; Tempo checks /ready for a query URL or sends an
 // empty OTLP/HTTP export when the configured URL ends in /v1/traces.
-export function testLokiConnection(): Promise<{ status: string }> {
-  return request<{ status: string }>('POST', '/integrations/loki/test');
+export type TelemetryConfigurationProbeInput = {
+  url: string;
+  basic_user: string;
+  basic_password: string;
+  tls_insecure: boolean;
+};
+
+export function testLokiConnection(input: TelemetryConfigurationProbeInput): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/loki/test', input);
 }
 
-export function testTempoConnection(): Promise<{ status: string }> {
-  return request<{ status: string }>('POST', '/integrations/tempo/test');
+export function testTempoConnection(input: TelemetryConfigurationProbeInput): Promise<{ status: string }> {
+  return request<{ status: string }>('POST', '/integrations/tempo/test', input);
 }
 
 // WebSearchProbeResult is what the manager returns when the user clicks
@@ -117,8 +141,15 @@ export type WebSearchProbeResult = {
   sample: string;
 };
 
-export function testWebSearchConnection(): Promise<WebSearchProbeResult> {
-  return request<WebSearchProbeResult>('POST', '/integrations/websearch/test');
+export type WebSearchConfigurationProbeInput = {
+  provider: string;
+  searxng_url: string;
+  tavily_api_key: string;
+  brave_api_key: string;
+};
+
+export function testWebSearchConnection(input: WebSearchConfigurationProbeInput): Promise<WebSearchProbeResult> {
+  return request<WebSearchProbeResult>('POST', '/integrations/websearch/test', input);
 }
 
 // invalidateLLMRouter nudges the manager's in-process LLM provider

--- a/web/src/api/webshell.ts
+++ b/web/src/api/webshell.ts
@@ -6,20 +6,14 @@
 //   GET    /api/v1/webshell/sessions                     (audit list)
 //   DELETE /api/v1/webshell/sessions/{id}                (admin kill)
 //
-// Auth: the manager auth.Middleware reads `Authorization: Bearer <jwt>`,
-// falling back to `?token=<jwt>` for native browser WebSockets — confirmed
-// by reading internal/pkg/auth/middleware.go:extractBearer. So we just
-// append the token as a query string. We still negotiate the
-// `ongrid.shell.v1` subprotocol because the gorilla server-side upgrader
-// declares it; without a matching client subprotocol the server upgrade
-// still succeeds (gorilla treats subprotocol as optional), but echoing it
-// back keeps things tidy and lets the server log a stable name.
+// Auth: an authenticated REST call first mints a one-time 30-second ticket;
+// only that capability appears in the WebSocket URL. SSH passwords never
+// travel in WebSocket frames and JWTs never appear in query strings.
 //
 // The caller is responsible for setting `binaryType = 'arraybuffer'`,
 // sending the first `ShellOpen` text frame, and tearing down on close.
 
 import { request } from './client';
-import { getToken } from '@/store/auth';
 
 export type OpenShellParams = {
   // Optional WS path override (defaults to same-origin /api/v1).
@@ -30,11 +24,11 @@ const SUBPROTOCOL = 'ongrid.shell.v1';
 
 export function openShellSocket(
   deviceId: number | string,
-  token: string,
+  ticket: string,
   params: OpenShellParams = {},
 ): WebSocket {
   const id = encodeURIComponent(String(deviceId));
-  const qs = new URLSearchParams({ token }).toString();
+  const qs = new URLSearchParams({ ticket }).toString();
 
   let url: string;
   if (params.baseUrl) {
@@ -51,17 +45,11 @@ export function openShellSocket(
   return ws;
 }
 
-// ShellOpen is the first text frame the browser must send post-upgrade.
-// `ssh_host` defaults to "127.0.0.1:22" when empty — the edge agent runs
-// on the device's host network so localhost loops back to the OS sshd.
 export type ShellOpenFrame = {
   type: 'open';
   cols: number;
   rows: number;
   term: string;
-  ssh_user: string;
-  ssh_pass: string;
-  ssh_host?: string;
 };
 
 export type ShellResizeFrame = {
@@ -80,11 +68,14 @@ export type ShellControlFrameOut =
   | ShellCloseFrame;
 
 // ShellControlFrameIn is what the manager pushes back over text frames.
-// `ready` confirms the SSH session is up; `auth_error` / `exit` are
-// terminal — the UI should print and let the WS close naturally.
+// `ready` confirms the SSH session is up; `auth_error` is retryable and
+// top-level SSH `exit` leaves the terminal page.
 export type ShellControlFrameIn =
   | { type: 'ready' }
   | { type: 'auth_error'; message: string }
+  | { type: 'credential_save_error'; message: string }
+  | { type: 'host_key_unknown'; fingerprint: string }
+  | { type: 'host_key_changed'; fingerprint: string; expected: string }
   | { type: 'exit'; exit_code: number; message?: string };
 
 export function sendControl(ws: WebSocket, frame: ShellControlFrameOut): void {
@@ -106,6 +97,7 @@ export type WebshellTerminatedBy =
   | 'disconnect'
   | 'admin_kill'
   | 'ssh_auth_fail'
+  | 'ssh_host_key'
   | 'ssh_exit'
   | 'device_offline';
 
@@ -113,6 +105,7 @@ export type ShellSession = {
   id: string;
   ongrid_user_id: number;
   ssh_user: string;
+  ssh_port?: number;
   device_id: number;
   edge_id: number;
   started_at: string;
@@ -137,45 +130,35 @@ export function killShellSession(id: string): Promise<void> {
   return request<void>('DELETE', `/webshell/sessions/${encodeURIComponent(id)}`);
 }
 
-// probeShellPreflight — issue a plain GET against the same WS path so we
-// can surface the HTTP status (429 / 503 / 403) before the WS upgrade
-// errors out. Browsers don't expose upgrade-time HTTP status to JS, so a
-// GET probe is the cheapest way to translate "WS closed 1006 immediately"
-// into a meaningful error. Returns { status, message } on success; null
-// when the probe itself fails (e.g. network).
-//
-// Backend GET on the WS path without an Upgrade header returns
-// http.Error(...) with status 400 ("Bad Request" — gorilla rejects),
-// after the auth + concurrency checks have already run. So 429/503/403
-// are returned authoritatively before the upgrade test.
-export async function probeShellPreflight(
-  deviceId: number | string,
-): Promise<{ status: number; message: string } | null> {
-  const id = encodeURIComponent(String(deviceId));
-  try {
-    const res = await fetch(`/api/v1/devices/${id}/shell`, {
-      method: 'GET',
-      headers: {
-        Accept: 'text/plain',
-        // Reuse the same bearer the WS uses; can't set headers on
-        // native WebSocket so this is the only place auth is in a
-        // header rather than ?token=.
-        ...buildAuthHeader(),
-      },
-    });
-    let message = '';
-    try {
-      message = (await res.text()).trim();
-    } catch {
-      /* noop */
-    }
-    return { status: res.status, message };
-  } catch {
-    return null;
-  }
+export type ShellCredential = {
+  id: number;
+  ssh_user: string;
+  ssh_port: number;
+  last_used_at?: string;
+  created_at: string;
+};
+
+export type ShellTicketInput = {
+  credential_id?: number;
+  ssh_user?: string;
+  ssh_pass?: string;
+  ssh_port?: number;
+  save_credential?: boolean;
+  accept_host_key?: string;
+};
+
+export function createShellTicket(deviceId: number | string, input: ShellTicketInput) {
+  return request<{ ticket: string; expires_at: string }>('POST', `/devices/${encodeURIComponent(String(deviceId))}/shell/tickets`, input);
 }
 
-function buildAuthHeader(): Record<string, string> {
-  const t = getToken();
-  return t ? { Authorization: `Bearer ${t}` } : {};
+export function listShellCredentials(deviceId: number | string) {
+  return request<{ items: ShellCredential[] }>('GET', `/devices/${encodeURIComponent(String(deviceId))}/shell/credentials`);
+}
+
+export function deleteShellCredential(deviceId: number | string, credentialId: number) {
+  return request<void>('DELETE', `/devices/${encodeURIComponent(String(deviceId))}/shell/credentials/${credentialId}`);
+}
+
+export function resetShellKnownHost(deviceId: number | string, port: number) {
+  return request<void>('DELETE', `/devices/${encodeURIComponent(String(deviceId))}/shell/known-hosts/${port}`);
 }

--- a/web/src/pages/DeviceShell.test.tsx
+++ b/web/src/pages/DeviceShell.test.tsx
@@ -1,0 +1,214 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectModal, DeviceShell } from './DeviceShell';
+import { server } from '@/test/msw-server';
+
+const openShellSocket = vi.hoisted(() => vi.fn());
+
+vi.mock('@/components/XTerminal', () => ({ XTerminal: () => null }));
+vi.mock('@/api/webshell', async () => ({
+  ...await vi.importActual<typeof import('@/api/webshell')>('@/api/webshell'),
+  openShellSocket,
+}));
+
+const edge = {
+  id: 70,
+  name: 'test-edge',
+  status: 'online',
+  roles: [],
+  access_key_id: 'test',
+  last_seen_at: '2026-09-04T00:00:00Z',
+  device_id: 42,
+};
+
+function renderShell() {
+  return render(
+    <MemoryRouter initialEntries={['/devices/42/shell']}>
+      <Routes>
+        <Route path="/devices/:deviceId/shell" element={<DeviceShell />} />
+        <Route path="/devices" element={<div>设备列表页</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ConnectModal', () => {
+  beforeEach(() => {
+    localStorage.setItem('ongrid-locale', 'zh-CN');
+    openShellSocket.mockReset();
+    server.use(
+      http.get('/api/v1/edges', () => HttpResponse.json({ items: [edge], total: 1 })),
+      http.get('/api/v1/edges/70', () => HttpResponse.json(edge)),
+      http.get('/api/v1/devices/42/shell/credentials', () => HttpResponse.json({ items: [] })),
+      http.post('/api/v1/devices/42/shell/tickets', () => HttpResponse.json({
+        ticket: 'test-ticket',
+        expires_at: '2026-09-04T00:00:30Z',
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('先展示已保存账户，新增账户时直接连接并延后保存', async () => {
+    server.use(
+      http.get('/api/v1/devices/42/shell/credentials', () =>
+        HttpResponse.json({
+          items: [
+            { id: 1, ssh_user: 'root', ssh_port: 22, created_at: '2026-09-03T00:00:00Z' },
+            { id: 2, ssh_user: 'ops', ssh_port: 2202, created_at: '2026-09-03T00:00:00Z' },
+          ],
+        }),
+      ),
+    );
+    const onSubmit = vi.fn();
+
+    render(
+      <ConnectModal
+        open
+        deviceId="42"
+        title="连接到测试设备"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: '连接到测试设备' });
+    await within(dialog).findByText('root');
+    expect(within(dialog).getByText('127.0.0.1 · 端口 22')).toBeInTheDocument();
+    expect(within(dialog).getByText('127.0.0.1 · 端口 2202')).toBeInTheDocument();
+    expect(within(dialog).queryByText('登录方式')).not.toBeInTheDocument();
+    expect(within(dialog).queryByLabelText('OS 用户')).not.toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: '连接' }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      user: 'root',
+      password: '',
+      port: 22,
+      credentialId: 1,
+    });
+    onSubmit.mockClear();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: '新增账户' }));
+    expect(within(dialog).getByLabelText('OS 用户')).toHaveValue('root');
+    fireEvent.change(within(dialog).getByLabelText('OS 用户'), { target: { value: 'tester' } });
+    fireEvent.change(within(dialog).getByLabelText('SSH 端口'), { target: { value: '2222' } });
+    fireEvent.change(within(dialog).getByLabelText('密码'), { target: { value: 'secret' } });
+    fireEvent.click(within(dialog).getByLabelText('保存此账户，下次可直接登录'));
+    expect(within(dialog).queryByText('凭据名称')).not.toBeInTheDocument();
+    expect(within(dialog).getByText('连接目标固定为设备本机 127.0.0.1，可使用任意有效 SSH 端口。')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: '连接' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      user: 'tester',
+      password: 'secret',
+      port: 2222,
+      saveCredential: true,
+    });
+  });
+
+  it('把保存意图放进一次性票据交给后端在认证后处理', async () => {
+    let ticketBody: Record<string, unknown> | undefined;
+    const socket = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      onclose: null,
+    } as unknown as WebSocket;
+    openShellSocket.mockReturnValue(socket);
+    server.use(
+      http.post('/api/v1/devices/42/shell/tickets', async ({ request }) => {
+        ticketBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ ticket: 'test-ticket', expires_at: '2026-09-04T00:00:30Z' });
+      }),
+    );
+    renderShell();
+
+    fireEvent.change(await screen.findByLabelText('密码'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByLabelText('保存此账户，下次可直接登录'));
+    fireEvent.click(screen.getByRole('button', { name: '连接' }));
+    await waitFor(() => expect(openShellSocket).toHaveBeenCalledWith('42', 'test-ticket'));
+    expect(ticketBody).toMatchObject({ ssh_user: 'root', ssh_pass: 'secret', ssh_port: 22, save_credential: true });
+
+    act(() => socket.onmessage?.({ data: JSON.stringify({ type: 'ready' }) } as MessageEvent));
+    expect(screen.queryByText(/保存账户失败/)).not.toBeInTheDocument();
+  });
+
+  it('SSH 失败时显示具体错误且不保存账户', async () => {
+    let ticketBody: Record<string, unknown> | undefined;
+    const socket = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      onclose: null,
+    } as unknown as WebSocket;
+    openShellSocket.mockReturnValue(socket);
+    server.use(
+      http.post('/api/v1/devices/42/shell/tickets', async ({ request }) => {
+        ticketBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ ticket: 'test-ticket', expires_at: '2026-09-04T00:00:30Z' });
+      }),
+    );
+    renderShell();
+
+    fireEvent.change(await screen.findByLabelText('密码'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByLabelText('保存此账户，下次可直接登录'));
+    fireEvent.click(screen.getByRole('button', { name: '连接' }));
+    await waitFor(() => expect(openShellSocket).toHaveBeenCalledWith('42', 'test-ticket'));
+
+    act(() => socket.onmessage?.({
+      data: JSON.stringify({ type: 'auth_error', message: '用户名或密码错误' }),
+    } as MessageEvent));
+
+    expect(await screen.findByText('SSH 认证失败：用户名或密码错误')).toBeInTheDocument();
+    expect(ticketBody).toMatchObject({ save_credential: true });
+  });
+
+  it('最外层 SSH 会话退出后离开终端页', async () => {
+    const close = vi.spyOn(window, 'close').mockImplementation(() => {});
+    const socket = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      onclose: null,
+    } as unknown as WebSocket;
+    openShellSocket.mockReturnValue(socket);
+    renderShell();
+
+    fireEvent.change(await screen.findByLabelText('密码'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: '连接' }));
+    await waitFor(() => expect(openShellSocket).toHaveBeenCalledWith('42', 'test-ticket'));
+
+    act(() => socket.onmessage?.({
+      data: JSON.stringify({ type: 'exit', exit_code: 0 }),
+    } as MessageEvent));
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(await screen.findByText('设备列表页')).toBeInTheDocument();
+  });
+
+  it('点击关闭直接离开终端页', () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const close = vi.spyOn(window, 'close').mockImplementation(() => {});
+    renderShell();
+
+    fireEvent.click(screen.getByRole('button', { name: '关闭终端' }));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+    expect(screen.getByText('设备列表页')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DeviceShell.tsx
+++ b/web/src/pages/DeviceShell.tsx
@@ -2,44 +2,58 @@
 //
 // Flow:
 //   1. Page mounts → fetch device metadata (hostname for the modal title)
-//      and pop the Connect modal. localStorage may pre-fill the os user.
+//      and pop the Connect modal with any server-side saved accounts.
 //   2. User submits the modal → open WS, send first `open` frame with
 //      cols/rows from the freshly-fitted xterm.
 //   3. Manager replies with `ready` (SSH up) → terminal becomes interactive.
 //      Binary frames are stdout; binary user input is wrapped to stdin.
-//   4. `auth_error` / `exit` / WS close → write a red banner, gate the
-//      reconnect button. The user can hit `重连` to re-show the modal.
+//   4. `auth_error` / WS close → write a banner and allow reconnect;
+//      top-level SSH `exit` → leave the terminal page.
 //
 // Security:
-//   - Password lives only in component state; never logged, never stored.
-//   - Only the os username (opt-in) is persisted to localStorage.
+//   - Manual passwords live only in component state and the ticket request.
+//   - Saved passwords are encrypted server-side and never returned to the UI.
 //   - onbeforeunload sends a polite `{type:"close"}` so the manager can
 //     finalize the audit row without waiting for TCP timeout.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Power, RotateCw, Terminal as TerminalIcon } from 'lucide-react';
+import {
+  ChevronLeft,
+  KeyRound,
+  Plus,
+  Power,
+  RotateCw,
+  Shield,
+  ShieldCheck,
+  Terminal as TerminalIcon,
+  Trash2,
+  UserRound,
+} from 'lucide-react';
 import { Modal } from '@/components/Modal';
 import { Button } from '@/components/ui/Button';
 import { XTerminal, type XTerminalApi } from '@/components/XTerminal';
 import { getEdge, listEdges, type Edge } from '@/api/edges';
 import {
+  createShellTicket,
+  deleteShellCredential,
+  listShellCredentials,
   openShellSocket,
-  probeShellPreflight,
+  resetShellKnownHost,
   sendControl,
+  type ShellCredential,
   type ShellControlFrameIn,
 } from '@/api/webshell';
-import { getToken } from '@/store/auth';
 import { usePermissions } from '@/store/me';
-import { tr as trInline, useI18n } from '@/i18n/locale';
+import { useI18n } from '@/i18n/locale';
 import { Card, EmptyState, PageHeader } from '@/components/ui';
-import { Shield } from 'lucide-react';
 
 type ConnectInputs = {
   user: string;
   password: string;
   port: number;
-  remember: boolean;
+  credentialId?: number;
+  saveCredential?: boolean;
 };
 
 type ConnState =
@@ -47,12 +61,6 @@ type ConnState =
   | { kind: 'connecting' }
   | { kind: 'open' }
   | { kind: 'closed'; reason?: string };
-
-const REMEMBER_USER_KEY_PREFIX = 'webshell.last_user.';
-
-function rememberUserKey(deviceId: string) {
-  return `${REMEMBER_USER_KEY_PREFIX}${deviceId}`;
-}
 
 // ANSI red wrapper for inline error messages. xterm renders the escape
 // sequence so we don't need a separate DOM element for status lines.
@@ -71,8 +79,6 @@ export default function DeviceShellPage() {
   // happens — backend rejects too (skill execute / shell open both
   // require non-viewer), but stopping at the page boundary keeps the
   // user from staring at a half-loaded terminal that 403s on connect.
-  const { deviceId = '' } = useParams<{ deviceId: string }>();
-  const navigate = useNavigate();
   if (!canMutate) {
     return (
       <main className="anim-fade flex flex-1 flex-col overflow-hidden p-6">
@@ -88,10 +94,19 @@ export default function DeviceShellPage() {
     );
   }
 
+  return <DeviceShell />;
+}
+
+export function DeviceShell() {
+  const { tr } = useI18n();
+  const { deviceId = '' } = useParams<{ deviceId: string }>();
+  const navigate = useNavigate();
+
   const [edge, setEdge] = useState<Edge | null>(null);
   const [edgeError, setEdgeError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(true);
   const [conn, setConn] = useState<ConnState>({ kind: 'idle' });
+  const [connectionError, setConnectionError] = useState<string | null>(null);
 
   // The terminal API + ws live on refs — they're side-effectful and
   // outliving any single render is the whole point of this page.
@@ -104,6 +119,7 @@ export default function DeviceShellPage() {
   // Track whether we sent the close frame — onbeforeunload + manual close
   // should never double-fire.
   const closedSentRef = useRef(false);
+  const openConnectionRef = useRef<(inputs: ConnectInputs, acceptHostKey?: string) => Promise<void>>(async () => {});
 
   // Fetch device metadata for the title. The route param is the device_id
   // (Prom label). Manager does not yet expose GET /devices/{id}, so we
@@ -139,7 +155,7 @@ export default function DeviceShellPage() {
     return () => {
       cancelled = true;
     };
-  }, [deviceId]);
+  }, [deviceId, tr]);
 
   const tabTitle = useMemo(() => {
     if (!edge) return `Shell · ${deviceId}`;
@@ -187,6 +203,12 @@ export default function DeviceShellPage() {
     }
   }, [sendCloseOnce]);
 
+  const closeTerminalPage = useCallback(() => {
+    teardown();
+    window.close();
+    if (!window.closed) navigate('/devices', { replace: true });
+  }, [navigate, teardown]);
+
   // beforeunload: best-effort polite close. We can't await the close
   // frame; gorilla writes it on the next read tick.
   useEffect(() => {
@@ -212,56 +234,53 @@ export default function DeviceShellPage() {
   // openConnection: wire WS handshake to the open frame. Called from the
   // modal Connect button.
   const openConnection = useCallback(
-    async (inputs: ConnectInputs) => {
-      const token = getToken();
-      if (!token) {
-        writeBanner(ansiRed(tr('未登录或登录已过期，请重新登录', 'Not logged in or session expired; please log in again')));
-        setModalOpen(true);
-        return;
-      }
+    async (inputs: ConnectInputs, acceptHostKey = '') => {
       // Tear down any previous socket (e.g. user hit "重连").
       teardown();
       closedSentRef.current = false;
 
       setConn({ kind: 'connecting' });
+      setConnectionError(null);
 
-      // Pre-flight HTTP probe so 429 / 503 / 403 can be surfaced with
-      // a real Chinese message — browsers don't expose upgrade-time
-      // HTTP status to JS, only WS code 1006. If the probe returns a
-      // non-OK status we abort before opening the socket.
-      const probe = await probeShellPreflight(deviceId);
-      if (probe) {
-        const fatal = explainPreflight(probe.status, probe.message);
-        if (fatal) {
-          writeBanner(ansiRed(fatal));
-          setConn({ kind: 'closed', reason: 'preflight' });
-          setModalOpen(true);
-          return;
-        }
+      let ticket: string;
+      try {
+        const issued = await createShellTicket(deviceId, inputs.credentialId
+          ? { credential_id: inputs.credentialId, accept_host_key: acceptHostKey || undefined }
+          : {
+            ssh_user: inputs.user,
+            ssh_pass: inputs.password,
+            ssh_port: inputs.port,
+            save_credential: inputs.saveCredential,
+            accept_host_key: acceptHostKey || undefined,
+          });
+        ticket = issued.ticket;
+      } catch (err) {
+        inputs.password = '';
+        const message = (err as Error).message || tr('创建终端连接失败', 'Failed to create terminal connection');
+        writeBanner(ansiRed(message));
+        setConnectionError(message);
+        setConn({ kind: 'closed', reason: 'ticket' });
+        setModalOpen(true);
+        return;
       }
 
-      const ws = openShellSocket(deviceId, token);
+      const ws = openShellSocket(deviceId, ticket);
       wsRef.current = ws;
       const encoder = new TextEncoder();
 
       ws.onopen = () => {
+        if (wsRef.current !== ws) return;
         const { cols, rows } = sizeRef.current;
-        const sshHost = inputs.port && inputs.port !== 22 ? `127.0.0.1:${inputs.port}` : '';
         sendControl(ws, {
           type: 'open',
           cols,
           rows,
           term: 'xterm-256color',
-          ssh_user: inputs.user,
-          ssh_pass: inputs.password,
-          ssh_host: sshHost,
         });
-        // We deliberately do NOT clear inputs.password from the closure —
-        // it's already only in stack memory + the WS frame buffer. Once
-        // ws.send returns, the only reference is the GCable closure.
       };
 
       ws.onmessage = (ev) => {
+        if (wsRef.current !== ws) return;
         // Binary == stdout/stderr. xterm handles it directly.
         if (ev.data instanceof ArrayBuffer) {
           termRef.current?.write(new Uint8Array(ev.data));
@@ -276,50 +295,78 @@ export default function DeviceShellPage() {
         }
         if (!frame || typeof frame.type !== 'string') return;
         switch (frame.type) {
-          case 'ready':
+          case 'ready': {
+            inputs.password = '';
             setConn({ kind: 'open' });
             writeBanner(ansiDim(tr(`-- SSH 已连接 (${inputs.user}@${edge?.name ?? deviceId}) --`, `-- SSH connected (${inputs.user}@${edge?.name ?? deviceId}) --`)));
             break;
-          case 'auth_error':
-            writeBanner(ansiRed(tr(`SSH 认证失败：${frame.message || '用户名或密码错误'}`, `SSH auth failed: ${frame.message || 'invalid username or password'}`)));
+          }
+          case 'credential_save_error':
+            writeBanner(ansiRed(tr(
+              `SSH 已连接，但保存账户失败：${frame.message}`,
+              `SSH connected, but saving the account failed: ${frame.message}`,
+            )));
+            break;
+          case 'auth_error': {
+            inputs.password = '';
+            const message = tr(
+              `SSH 认证失败：${frame.message || '用户名或密码错误'}`,
+              `SSH auth failed: ${frame.message || 'invalid username or password'}`,
+            );
+            writeBanner(ansiRed(message));
+            setConnectionError(message);
             setConn({ kind: 'closed', reason: 'auth' });
             // Re-open the modal so the user can retry without leaving.
             setModalOpen(true);
             break;
-          case 'exit': {
-            const code = frame.exit_code ?? 0;
-            const tail = frame.message ? `: ${frame.message}` : '';
-            writeBanner(
-              code === 0
-                ? ansiDim(tr(`-- 会话已结束 (exit code 0)${tail} --`, `-- Session ended (exit code 0)${tail} --`))
-                : ansiRed(tr(`-- 会话已结束 (exit code ${code})${tail} --`, `-- Session ended (exit code ${code})${tail} --`)),
+          }
+          case 'host_key_unknown':
+            if (confirm(tr(
+              `首次连接此 SSH 服务。确认信任主机指纹？\n${frame.fingerprint}`,
+              `First connection to this SSH service. Trust this host key?\n${frame.fingerprint}`,
+            ))) {
+              teardown();
+              void openConnectionRef.current(inputs, frame.fingerprint);
+            } else {
+              inputs.password = '';
+              setConnectionError(tr('未信任 SSH 主机指纹，连接已取消', 'SSH host key was not trusted; connection cancelled'));
+              setConn({ kind: 'closed', reason: 'host-key' });
+              setModalOpen(true);
+            }
+            break;
+          case 'host_key_changed': {
+            inputs.password = '';
+            const message = tr(
+              `SSH 主机指纹已变化，已阻止连接。原指纹：${frame.expected}，当前：${frame.fingerprint}`,
+              `SSH host key changed; connection blocked. Expected: ${frame.expected}, actual: ${frame.fingerprint}`,
             );
-            setConn({ kind: 'closed', reason: 'exit' });
+            writeBanner(ansiRed(message));
+            setConnectionError(message);
+            setConn({ kind: 'closed', reason: 'host-key' });
+            setModalOpen(true);
             break;
           }
+          case 'exit':
+            inputs.password = '';
+            closeTerminalPage();
+            break;
         }
       };
 
       ws.onerror = () => {
-        writeBanner(ansiRed(tr('WebSocket 连接错误', 'WebSocket connection error')));
+        if (wsRef.current !== ws) return;
+        const message = tr('WebSocket 连接错误', 'WebSocket connection error');
+        writeBanner(ansiRed(message));
+        setConnectionError(message);
       };
 
       ws.onclose = (ev) => {
-        // 1006 = abnormal close (no close frame); usually means the
-        // upgrade failed (auth, route, network) or the server cut the
-        // socket without a close frame. Run the post-mortem probe to
-        // see if the manager has a real HTTP status to report.
+        if (wsRef.current !== ws) return;
+        inputs.password = '';
         if (!closedSentRef.current && ev.code === 1006) {
-          writeBanner(ansiRed(tr('连接异常断开', 'Connection dropped unexpectedly')));
-          // Best-effort post-mortem: hit GET on the same path; if the
-          // manager replies with 429 / 503 / 403 we now know what went
-          // wrong and can retell the user. Probe is fire-and-forget so
-          // we don't block the close handler.
-          void probeShellPreflight(deviceId).then((p) => {
-            if (!p) return;
-            const detail = explainPreflight(p.status, p.message);
-            if (detail) writeBanner(ansiRed(detail));
-          });
+          const message = tr('连接异常断开', 'Connection dropped unexpectedly');
+          writeBanner(ansiRed(message));
+          setConnectionError(message);
           setModalOpen(true);
         } else if (ev.code !== 1000 && ev.code !== 1005) {
           writeBanner(
@@ -340,8 +387,9 @@ export default function DeviceShellPage() {
         ws.send(encoder.encode(data));
       };
     },
-    [deviceId, edge, teardown, writeBanner],
+    [closeTerminalPage, deviceId, edge, teardown, tr, writeBanner],
   );
+  openConnectionRef.current = openConnection;
 
   // Wire xterm onData → ws via a ref-based pump so we don't have to
   // re-mount the terminal when the socket changes (reconnect).
@@ -363,34 +411,14 @@ export default function DeviceShellPage() {
     termRef.current = api;
   }, []);
 
-  // Modal submit handler. Persists the username choice and kicks off the
-  // WS handshake; password is dropped on the floor after this returns.
+  // Modal submit handler. Password is dropped on the floor after this returns.
   const handleConnect = useCallback(
     (inputs: ConnectInputs) => {
-      if (inputs.remember) {
-        try {
-          localStorage.setItem(rememberUserKey(deviceId), inputs.user);
-        } catch {
-          /* private mode / quota — non-fatal */
-        }
-      } else {
-        try {
-          localStorage.removeItem(rememberUserKey(deviceId));
-        } catch {
-          /* noop */
-        }
-      }
       setModalOpen(false);
       openConnection(inputs);
     },
-    [deviceId, openConnection],
+    [openConnection],
   );
-
-  const handleManualClose = useCallback(() => {
-    if (!confirm(tr('确定要关闭终端会话？', 'Close this terminal session?'))) return;
-    teardown();
-    navigate('/devices');
-  }, [navigate, teardown]);
 
   const handleReconnect = useCallback(() => {
     teardown();
@@ -447,7 +475,7 @@ export default function DeviceShellPage() {
           </Button>
           <Button
             variant="ghost"
-            onClick={handleManualClose}
+            onClick={closeTerminalPage}
             aria-label={tr('关闭终端', 'Close terminal')}
           >
             <Power size={12} />
@@ -468,6 +496,7 @@ export default function DeviceShellPage() {
         open={modalOpen}
         deviceId={deviceId}
         title={tr(`连接到 ${hostname}`, `Connect to ${hostname}`)}
+        connectionError={connectionError}
         onCancel={() => {
           // If we never connected, leave the page; otherwise just hide
           // the modal (terminal is still useful for reading prior output).
@@ -485,45 +514,73 @@ export default function DeviceShellPage() {
 
 // ConnectModal collects ssh user / password / port. We keep it inline so
 // the password lifetime is bounded by this component's mount window.
-function ConnectModal({
+export function ConnectModal({
   open,
   deviceId,
   title,
+  connectionError,
   onSubmit,
   onCancel,
 }: {
   open: boolean;
   deviceId: string;
   title: string;
+  connectionError?: string | null;
   onSubmit(inputs: ConnectInputs): void;
   onCancel(): void;
 }) {
   const { tr } = useI18n();
-  const [user, setUser] = useState('');
+  const [user, setUser] = useState('root');
   const [password, setPassword] = useState('');
   const [port, setPort] = useState<string>('22');
-  const [remember, setRemember] = useState(true);
-  const [advanced, setAdvanced] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [credentials, setCredentials] = useState<ShellCredential[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [saveCredential, setSaveCredential] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
 
-  // Pre-fill the username from localStorage on first open. We don't
-  // depend on `deviceId` for the lifetime — the hook re-runs when the
-  // modal toggles open so reconnects keep the user remembered.
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setErr(null);
+    setUser('root');
     setPassword('');
-    try {
-      const last = localStorage.getItem(rememberUserKey(deviceId));
-      if (last) setUser(last);
-    } catch {
-      /* noop */
-    }
+    setSelected(null);
+    setLoading(true);
+    void listShellCredentials(deviceId)
+      .then((result) => {
+        if (cancelled) return;
+        const items = result.items ?? [];
+        setCredentials(items);
+        setSelected(items[0] ? String(items[0].id) : 'new');
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        setCredentials([]);
+        setSelected('new');
+        setErr((cause as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open, deviceId]);
 
   if (!open) return null;
 
   const submit = () => {
+    if (selected && selected !== 'new') {
+      const credential = credentials.find((item) => String(item.id) === selected);
+      if (!credential) {
+        setErr(tr('保存的凭据不存在，请刷新后重试', 'Saved credential no longer exists; refresh and retry'));
+        return;
+      }
+      onSubmit({ user: credential.ssh_user, password: '', port: credential.ssh_port, credentialId: credential.id });
+      return;
+    }
     const u = user.trim();
     if (!u) {
       setErr(tr('请输入 OS 用户名', 'Please enter the OS username'));
@@ -538,7 +595,35 @@ function ConnectModal({
       setErr(tr('端口必须在 1-65535 之间', 'Port must be between 1 and 65535'));
       return;
     }
-    onSubmit({ user: u, password, port: p, remember });
+    onSubmit({ user: u, password, port: p, saveCredential });
+    setPassword('');
+  };
+
+  const removeCredential = async (credential: ShellCredential) => {
+    if (!confirm(tr(`删除账户“${credential.ssh_user}”？`, `Delete account “${credential.ssh_user}”?`))) return;
+    setBusy(true);
+    try {
+      await deleteShellCredential(deviceId, credential.id);
+      const next = credentials.filter((item) => item.id !== credential.id);
+      setCredentials(next);
+      setSelected(next[0] ? String(next[0].id) : 'new');
+    } catch (cause) {
+      setErr((cause as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const resetKnownHost = async (sshPort: number) => {
+    if (!confirm(tr(`重置端口 ${sshPort} 的主机指纹信任？`, `Reset trusted host key for port ${sshPort}?`))) return;
+    setBusy(true);
+    try {
+      await resetShellKnownHost(deviceId, sshPort);
+    } catch (cause) {
+      setErr((cause as Error).message);
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -552,93 +637,182 @@ function ConnectModal({
           <Button variant="ghost" onClick={onCancel}>
             {tr('取消', 'Cancel')}
           </Button>
-          <Button variant="primary" onClick={submit}>
-            {tr('连接', 'Connect')}
+          <Button variant="primary" onClick={() => void submit()} disabled={busy || loading || !selected}>
+            {busy ? tr('连接中…', 'Connecting…') : tr('连接', 'Connect')}
           </Button>
         </>
       }
     >
       <div className="space-y-3">
-        <div>
-          <label htmlFor="webssh-user" className="mb-1 block text-[11px] text-zinc-500">
-            {tr('OS 用户', 'OS user')}
-          </label>
-          <input
-            id="webssh-user"
-            autoFocus
-            autoComplete="username"
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-            placeholder="root"
-            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') submit();
-            }}
-          />
-        </div>
-        <div>
-          <label htmlFor="webssh-pass" className="mb-1 block text-[11px] text-zinc-500">
-            {tr('密码', 'Password')}
-          </label>
-          <input
-            id="webssh-pass"
-            type="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') submit();
-            }}
-          />
-        </div>
-        <div>
-          <button
-            type="button"
-            onClick={() => setAdvanced((v) => !v)}
-            className="text-[11px] text-zinc-500 hover:text-zinc-300"
-          >
-            {advanced ? tr('收起高级', 'Hide advanced') : tr('高级选项 ▸', 'Advanced ▸')}
-          </button>
-          {advanced && (
-            <div className="mt-2">
-              <label htmlFor="webssh-port" className="mb-1 block text-[11px] text-zinc-500">
-                {tr('SSH 端口', 'SSH port')}
+        {loading && (
+          <div className="py-8 text-center text-xs text-zinc-500">
+            {tr('正在加载已保存账户…', 'Loading saved accounts…')}
+          </div>
+        )}
+
+        {!loading && selected !== 'new' && (
+          <>
+            <div className="flex items-center gap-2 text-[11px] font-medium text-zinc-500">
+              <KeyRound size={13} />
+              {tr('已保存账户', 'Saved accounts')}
+            </div>
+            <div role="radiogroup" aria-label={tr('已保存账户', 'Saved accounts')} className="space-y-2">
+              {credentials.map((credential) => {
+                const checked = selected === String(credential.id);
+                return (
+                  <div
+                    key={credential.id}
+                    className={`flex items-center rounded-lg border transition-colors ${checked ? 'border-indigo-500/50 bg-indigo-500/10' : 'border-zinc-800 bg-zinc-950 hover:border-zinc-700'}`}
+                  >
+                    <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 px-3 py-2.5">
+                      <input
+                        type="radio"
+                        name="webssh-account"
+                        value={credential.id}
+                        checked={checked}
+                        onChange={() => setSelected(String(credential.id))}
+                        className="h-3.5 w-3.5 accent-indigo-500"
+                      />
+                      <UserRound size={16} className="shrink-0 text-zinc-500" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-xs font-medium text-zinc-100">{credential.ssh_user}</span>
+                        <span className="mt-0.5 block text-[11px] text-zinc-500">127.0.0.1 · {tr('端口', 'Port')} {credential.ssh_port}</span>
+                      </span>
+                    </label>
+                    <div className="flex items-center gap-0.5 pr-2">
+                      <button
+                        type="button"
+                        onClick={() => void resetKnownHost(credential.ssh_port)}
+                        disabled={busy}
+                        aria-label={tr(`重置 ${credential.ssh_user} 的主机信任`, `Reset host trust for ${credential.ssh_user}`)}
+                        title={tr('重置主机信任', 'Reset host trust')}
+                        className="rounded-md p-1.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200 disabled:opacity-40"
+                      >
+                        <ShieldCheck size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void removeCredential(credential)}
+                        disabled={busy}
+                        aria-label={tr(`删除 ${credential.ssh_user}`, `Delete ${credential.ssh_user}`)}
+                        title={tr('删除账户', 'Delete account')}
+                        className="rounded-md p-1.5 text-zinc-500 hover:bg-red-500/10 hover:text-red-400 disabled:opacity-40"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setSelected('new');
+                setUser('root');
+                setPassword('');
+                setPort('22');
+                setSaveCredential(false);
+                setErr(null);
+              }}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-zinc-700 px-3 py-2.5 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-100"
+            >
+              <Plus size={14} />
+              {tr('新增账户', 'Add account')}
+            </button>
+          </>
+        )}
+
+        {!loading && selected === 'new' && (
+          <>
+            {credentials.length > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSelected(String(credentials[0].id));
+                  setErr(null);
+                }}
+                className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-200"
+              >
+                <ChevronLeft size={13} />
+                {tr('返回已保存账户', 'Back to saved accounts')}
+              </button>
+            )}
+            <div className="flex items-center gap-2 text-[11px] font-medium text-zinc-500">
+              <Plus size={13} />
+              {tr('新增账户', 'Add account')}
+            </div>
+            <div className="grid grid-cols-[minmax(0,1fr)_96px] gap-3">
+              <div>
+                <label htmlFor="webssh-user" className="mb-1 block text-[11px] text-zinc-500">
+                  {tr('OS 用户', 'OS user')}
+                </label>
+                <input
+                  id="webssh-user"
+                  autoFocus
+                  autoComplete="off"
+                  value={user}
+                  onChange={(e) => setUser(e.target.value)}
+                  className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-2 text-xs text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="webssh-port" className="mb-1 block text-[11px] text-zinc-500">
+                  {tr('SSH 端口', 'SSH port')}
+                </label>
+                <input
+                  id="webssh-port"
+                  inputMode="numeric"
+                  value={port}
+                  onChange={(e) => setPort(e.target.value.replace(/[^0-9]/g, ''))}
+                  placeholder="22"
+                  className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-2 text-xs text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+            </div>
+            <div>
+              <label htmlFor="webssh-pass" className="mb-1 block text-[11px] text-zinc-500">
+                {tr('密码', 'Password')}
               </label>
               <input
-                id="webssh-port"
-                inputMode="numeric"
-                value={port}
-                onChange={(e) => setPort(e.target.value.replace(/[^0-9]/g, ''))}
-                placeholder="22"
-                className="w-32 rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+                id="webssh-pass"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-2 text-xs text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void submit();
+                }}
               />
-              <p className="mt-1 text-[11px] text-zinc-600">
-                {tr('默认走设备本地 sshd（127.0.0.1:22）。改端口仅在本机另起 sshd 时有用。', "Defaults to the device's local sshd (127.0.0.1:22). Change only if you've started another sshd on a different port.")}
-              </p>
             </div>
-          )}
-        </div>
-        <label className="flex cursor-pointer items-center gap-2 text-xs text-zinc-300">
-          <input
-            type="checkbox"
-            checked={remember}
-            onChange={(e) => setRemember(e.target.checked)}
-            className="h-3.5 w-3.5 accent-zinc-300"
-          />
-          {tr('记住此用户名（仅本浏览器，不保存密码）', 'Remember this username (this browser only; password is never stored)')}
-        </label>
-        {err && (
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-zinc-300">
+              <input
+                type="checkbox"
+                checked={saveCredential}
+                onChange={(e) => setSaveCredential(e.target.checked)}
+                className="h-3.5 w-3.5 accent-indigo-500"
+              />
+              {tr('保存此账户，下次可直接登录', 'Save this account for one-click login next time')}
+            </label>
+            <p className="text-[11px] leading-4 text-zinc-600">
+              {tr('连接目标固定为设备本机 127.0.0.1，可使用任意有效 SSH 端口。', 'Connections target device loopback 127.0.0.1 and may use any valid SSH port.')}
+            </p>
+          </>
+        )}
+        {(err || connectionError) && (
           <div
             role="alert"
             className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-300"
           >
-            {err}
+            {err || connectionError}
           </div>
         )}
-        <p className="text-[11px] text-zinc-600">
-          {tr('提示：密码不会被写入浏览器存储；关闭弹窗或刷新页面后立即丢弃。', 'Note: the password is never persisted in browser storage; it is discarded as soon as the dialog closes or the page reloads.')}
-        </p>
+        {!loading && selected !== 'new' && (
+          <p className="text-[11px] leading-4 text-zinc-600">
+            {tr('保存的密码由 Manager 加密，仅对你的 Ongrid 账号和当前设备可用。', 'Saved passwords are encrypted by Manager and available only to your Ongrid account on this device.')}
+          </p>
+        )}
       </div>
     </Modal>
   );
@@ -665,35 +839,6 @@ function extractHostname(hostInfo: Edge['host_info']): string | null {
     }
   }
   return null;
-}
-
-// explainPreflight maps a probe HTTP status to a Chinese error string.
-// Returns null when the status is fine (200/400-from-WS-upgrade-attempt
-// without an Upgrade header — that's the "all good" signal).
-//
-// Status mapping:
-//   429 → "并发会话过多（每用户最多 5 / 每设备最多 5）"
-//   503 → "设备离线"
-//   403 → "权限不足，请联系管理员"
-//   401 → "未登录或登录已过期，请重新登录"
-//   404 → "设备不存在或未上线"
-//   500+ → "服务端错误"
-function explainPreflight(status: number, _message: string): string | null {
-  switch (status) {
-    case 429:
-      return trInline('并发会话过多（每用户最多 5 / 每设备最多 5）', 'Too many concurrent sessions (per user max 5 / per device max 5)');
-    case 503:
-      return trInline('设备离线', 'Device offline');
-    case 403:
-      return trInline('权限不足，请联系管理员', 'Insufficient permission; contact an admin');
-    case 401:
-      return trInline('未登录或登录已过期，请重新登录', 'Not logged in or session expired; please log in again');
-    case 404:
-      return trInline('设备不存在或未上线', 'Device not found or offline');
-    default:
-      if (status >= 500) return trInline('服务端错误，请稍后重试', 'Server error; please retry shortly');
-      return null;
-  }
 }
 
 function safeParse(s: string): Record<string, unknown> | null {

--- a/web/src/pages/settings/Integrations.test.tsx
+++ b/web/src/pages/settings/Integrations.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SettingsIntegrations from './Integrations';
-import { listSettings, setSetting } from '@/api/settings';
+import { listSettings, revealSetting, setSetting, testGrafanaConnection, testPromConnection } from '@/api/settings';
 import {
   getLogBackend,
   getLogBackendConnectionCheck,
@@ -13,6 +13,7 @@ import {
   selectLokiLogBackend,
   startLogBackendConnectionCheck,
   testLogBackend,
+  testLogBackendDraft,
   type LogBackend,
   type LogBackendConnectionCheck,
 } from '@/api/logs';
@@ -41,6 +42,7 @@ vi.mock('@/api/logs', async (importOriginal) => {
     selectLokiLogBackend: vi.fn(),
     startLogBackendConnectionCheck: vi.fn(),
     testLogBackend: vi.fn(),
+    testLogBackendDraft: vi.fn(),
   };
 });
 
@@ -91,6 +93,11 @@ describe('SettingsIntegrations log backend presentation', () => {
       detected_version: '8.16.3',
       tested_at: '2026-08-21T00:00:00Z',
     });
+    vi.mocked(testLogBackendDraft).mockResolvedValue({
+      status: 'ok',
+      detected_version: '8.16.3',
+      tested_at: '2026-08-21T00:00:00Z',
+    });
     localStorage.setItem('ongrid-locale', 'zh-CN');
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
@@ -103,13 +110,14 @@ describe('SettingsIntegrations log backend presentation', () => {
   });
 
   it('saves self-signed TLS switches for Prometheus and Grafana', async () => {
+    vi.mocked(revealSetting).mockResolvedValue({ value: 'glsa_test' });
     vi.mocked(listSettings).mockImplementation(async (category?: string) => ({
       items: category === 'prom'
         ? [{ category: 'prom', key: 'query_url', value: 'https://prom.example', sensitive: false, updated_at: '' }]
         : category === 'grafana'
           ? [
               { category: 'grafana', key: 'root_url', value: 'https://grafana.example', sensitive: false, updated_at: '' },
-              { category: 'grafana', key: 'sa_token', value: '', sensitive: true, updated_at: '' },
+              { category: 'grafana', key: 'sa_token', value: 'configured', sensitive: true, updated_at: '' },
             ]
           : [],
       total: 0,
@@ -124,13 +132,92 @@ describe('SettingsIntegrations log backend presentation', () => {
     const user = userEvent.setup();
     const prometheus = (await screen.findByRole('heading', { name: 'Prometheus 集成' })).closest('section')!;
     await act(async () => user.click(within(prometheus).getByRole('checkbox', { name: '跳过 TLS 校验（自签证书时勾选）' })));
+    await act(async () => user.click(within(prometheus).getByRole('button', { name: '测试连接' })));
+    await waitFor(() => expect(within(prometheus).getByRole('button', { name: '保存' })).toBeEnabled());
     await act(async () => user.click(within(prometheus).getByRole('button', { name: '保存' })));
     await waitFor(() => expect(setSetting).toHaveBeenCalledWith('prom', 'tls_insecure', 'true', false));
 
     const grafana = screen.getByRole('heading', { name: 'Grafana 集成' }).closest('section')!;
     await act(async () => user.click(within(grafana).getByRole('checkbox', { name: '跳过 TLS 校验（自签证书时勾选）' })));
+    await act(async () => user.click(within(grafana).getByRole('button', { name: '测试连接' })));
+    await waitFor(() => expect(within(grafana).getByRole('button', { name: '保存' })).toBeEnabled());
+    expect(testGrafanaConnection).toHaveBeenCalledWith(expect.objectContaining({
+      root_url: 'https://grafana.example',
+      tls_insecure: true,
+    }));
     await act(async () => user.click(within(grafana).getByRole('button', { name: '保存' })));
     await waitFor(() => expect(setSetting).toHaveBeenCalledWith('grafana', 'tls_insecure', 'true', false));
+  });
+
+  it('matches the VictoriaMetrics cluster remote write URL from the query URL', async () => {
+    vi.mocked(listSettings).mockImplementation(async (category?: string) => ({
+      items: category === 'prom'
+        ? [{ category: 'prom', key: 'query_url', value: 'http://host.docker.internal:8481/select/0/prometheus', sensitive: false, updated_at: '' }]
+        : [],
+      total: 0,
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <SettingsIntegrations />
+      </MemoryRouter>,
+    );
+
+    const prometheus = (await screen.findByRole('heading', { name: 'Prometheus 集成' })).closest('section')!;
+    expect(within(prometheus).getByRole('textbox', { name: /^Remote Write URL/ })).toHaveValue(
+      'http://host.docker.internal:8480/insert/0/prometheus/api/v1/write',
+    );
+
+    fireEvent.change(within(prometheus).getByRole('textbox', { name: /^Query URL/ }), {
+      target: { value: 'http://host.docker.internal:8481/select/42/prometheus' },
+    });
+    expect(within(prometheus).getByRole('textbox', { name: /^Remote Write URL/ })).toHaveValue(
+      'http://host.docker.internal:8480/insert/42/prometheus/api/v1/write',
+    );
+  });
+
+  it('tests the unsaved Prometheus draft before enabling save', async () => {
+    vi.mocked(listSettings).mockImplementation(async (category?: string) => ({
+      items: category === 'prom'
+        ? [{ category: 'prom', key: 'query_url', value: 'http://prom.example', sensitive: false, updated_at: '' }]
+        : [],
+      total: 0,
+    }));
+    vi.mocked(testPromConnection).mockRejectedValueOnce(new Error('connection refused'));
+
+    render(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <SettingsIntegrations />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const prometheus = (await screen.findByRole('heading', { name: 'Prometheus 集成' })).closest('section')!;
+    const query = within(prometheus).getByRole('textbox', { name: /^Query URL/ });
+    const save = within(prometheus).getByRole('button', { name: '保存' });
+    const test = within(prometheus).getByRole('button', { name: '测试连接' });
+
+    fireEvent.change(query, { target: { value: 'http://vm.example/select/0/prometheus' } });
+    expect(save).toBeDisabled();
+    expect(test).toBeEnabled();
+
+    await user.click(test);
+    expect(await within(prometheus).findByText(/connection refused/)).toBeVisible();
+    expect(save).toBeDisabled();
+    expect(setSetting).not.toHaveBeenCalled();
+
+    vi.mocked(testPromConnection).mockResolvedValueOnce({ status: 'ok' });
+    await user.click(test);
+    await waitFor(() => expect(save).toBeEnabled());
+    expect(testPromConnection).toHaveBeenLastCalledWith(expect.objectContaining({
+      query_url: 'http://vm.example/select/0/prometheus',
+      remote_write_url: 'http://vm.example/insert/0/prometheus/api/v1/write',
+    }));
+
+    fireEvent.change(within(prometheus).getByRole('textbox', { name: /^Basic User/ }), {
+      target: { value: 'changed-after-test' },
+    });
+    expect(save).toBeDisabled();
   });
 
   it('places built-in storage limits under each integration advanced section', async () => {
@@ -213,6 +300,8 @@ describe('SettingsIntegrations log backend presentation', () => {
     const elasticsearch = await screen.findByRole('region', { name: 'Elasticsearch 日志后端配置' });
     const queryEndpoint = within(elasticsearch).getByRole('textbox', { name: /Manager 查询 endpoint/ });
     fireEvent.change(queryEndpoint, { target: { value: 'https://es-query.example.com:9200' } });
+    await act(async () => user.click(within(elasticsearch).getByRole('button', { name: '测试连接' })));
+    await waitFor(() => expect(within(elasticsearch).getByRole('button', { name: '保存' })).toBeEnabled());
     await act(async () => user.click(within(elasticsearch).getByRole('button', { name: '保存' })));
 
     await waitFor(() => expect(saveLogBackend).toHaveBeenCalledOnce());
@@ -447,7 +536,9 @@ describe('SettingsIntegrations log backend presentation', () => {
     const elasticsearch = await screen.findByRole('region', { name: 'Elasticsearch 日志后端配置' });
     await act(async () => user.click(within(elasticsearch).getByRole('button', { name: '测试连接' })));
 
-    await waitFor(() => expect(testLogBackend).toHaveBeenCalledWith(7));
+    await waitFor(() => expect(testLogBackendDraft).toHaveBeenCalledWith(expect.objectContaining({
+      query_endpoint: 'https://es.example.com:9200',
+    })));
     expect(selectLogBackend).not.toHaveBeenCalled();
     expect(screen.getByText(/连接测试通过；查询\/写入端点及 API Key 权限有效（Elasticsearch 8\.16\.3）/)).toBeVisible();
   });
@@ -461,7 +552,7 @@ describe('SettingsIntegrations log backend presentation', () => {
       </MemoryRouter>,
     );
 
-    const allExpected = ['保存', '测试连接', '设为当前', '检查设备连接', '在 Grafana 中查看日志'];
+    const allExpected = ['测试连接', '保存', '设为当前', '检查设备连接', '在 Grafana 中查看日志'];
     const actionOrder = (region: HTMLElement) => within(region)
       .getAllByRole('button')
       .map((button) => button.textContent?.trim() ?? '')

--- a/web/src/pages/settings/Integrations.tsx
+++ b/web/src/pages/settings/Integrations.tsx
@@ -47,7 +47,7 @@ import {
   selectLokiLogBackend,
   saveLogBackend,
   startLogBackendConnectionCheck,
-  testLogBackend,
+  testLogBackendDraft,
   type LogBackend,
   type LogBackendConnectionCheck,
   type LogBackendKind,
@@ -130,6 +130,23 @@ const emptyPromForm: PromForm = {
   tls_insecure: '',
 };
 
+function promRemoteWriteURL(queryURL: string): string {
+  const base = queryURL.trim().replace(/\/+$/, '');
+  if (!base) return '';
+  try {
+    const url = new URL(base);
+    const match = url.pathname.match(/^\/select\/([^/]+)\/prometheus\/?$/);
+    if (!match) return `${base}/api/v1/write`;
+    url.pathname = `/insert/${match[1]}/prometheus/api/v1/write`;
+    url.search = '';
+    url.hash = '';
+    if (url.port === '8481') url.port = '8480';
+    return url.toString();
+  } catch {
+    return `${base}/api/v1/write`;
+  }
+}
+
 function PrometheusCard() {
   const { tr } = useI18n();
   // Both sensitive and non-sensitive fields land in draft as cleartext.
@@ -145,6 +162,7 @@ function PrometheusCard() {
   const [saving, setSaving] = useState(false);
   const [savedOk, setSavedOk] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const probeRequest = useRef(0);
   // Probe state — separate from form state so saving doesn't reset the
   // last known test outcome and probe failures don't make the form look
   // dirty.
@@ -156,6 +174,8 @@ function PrometheusCard() {
   >({ kind: 'idle' });
 
   const refresh = useCallback(async () => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setLoading(true);
     setErr(null);
     try {
@@ -181,8 +201,12 @@ function PrometheusCard() {
             }
           })
       );
-      setServer(next);
-      setDraft(next);
+      const effective = {
+        ...next,
+        remote_write_url: next.remote_write_url || promRemoteWriteURL(next.query_url),
+      };
+      setServer(effective);
+      setDraft(effective);
       setRevealed({});
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : (e as Error).message);
@@ -199,11 +223,28 @@ function PrometheusCard() {
   const dirty = PROM_KEYS.some((k) => draft[k] !== server[k]);
 
   const update = (k: keyof PromForm, v: string) => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setSavedOk(false);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
 
+  const updateQueryURL = (value: string) => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
+    setSavedOk(false);
+    setDraft((current) => ({
+      ...current,
+      query_url: value,
+      remote_write_url:
+        current.remote_write_url === '' || current.remote_write_url === promRemoteWriteURL(current.query_url)
+          ? promRemoteWriteURL(value)
+          : current.remote_write_url,
+    }));
+  };
+
   const submit = async () => {
+    if (probe.kind !== 'ok') return;
     setSaving(true);
     setErr(null);
     try {
@@ -221,11 +262,21 @@ function PrometheusCard() {
   };
 
   const probeProm = async () => {
+    const requestID = ++probeRequest.current;
     setProbe({ kind: 'testing' });
     try {
-      await testPromConnection();
+      await testPromConnection({
+        query_url: draft.query_url,
+        remote_write_url: draft.remote_write_url,
+        bearer_token: draft.bearer_token,
+        basic_user: draft.basic_user,
+        basic_password: draft.basic_password,
+        tls_insecure: draft.tls_insecure === 'true',
+      });
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'ok' });
     } catch (e) {
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'error', msg: e instanceof ApiError ? e.message : (e as Error).message });
     }
   };
@@ -265,12 +316,12 @@ function PrometheusCard() {
             label="Query URL"
             hint={tr('PromQL 查询根，例 http://prom:9090 或 https://vm.example.com', 'PromQL query root, e.g. http://prom:9090 or https://vm.example.com')}
             value={draft.query_url}
-            onChange={(v) => update('query_url', v)}
+            onChange={updateQueryURL}
             placeholder="http://prometheus:9090/prometheus"
           />
           <PromField
             label="Remote Write URL"
-            hint={tr('留空则取 Query URL + /api/v1/write', 'Empty = Query URL + /api/v1/write')}
+            hint={tr('根据 Query URL 自动匹配；VictoriaMetrics 集群会使用 /insert/.../api/v1/write', 'Auto-matched from Query URL; VictoriaMetrics clusters use /insert/.../api/v1/write')}
             value={draft.remote_write_url}
             onChange={(v) => update('remote_write_url', v)}
             placeholder="https://vm.example.com/api/v1/write"
@@ -313,20 +364,24 @@ function PrometheusCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
-          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
-          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
-        </Button>
         <Button
           onClick={probeProm}
-          disabled={probe.kind === 'testing' || dirty || server.query_url.trim() === ''}
+          disabled={probe.kind === 'testing' || draft.query_url.trim() === ''}
           variant="ghost"
         >
           {probe.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{tr('测试连接', 'Test connection')}</span>
         </Button>
+        <Button onClick={submit} disabled={!dirty || saving || probe.kind !== 'ok'} variant="primary">
+          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
+          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
+        </Button>
         <span className="text-xs text-zinc-500">
-          {dirty ? tr('有未保存修改', 'Unsaved changes') : tr('保存后 ~5 秒内自动生效（无需重启）', 'Takes effect within ~5 s of saving (no restart needed)')}
+          {dirty
+            ? probe.kind === 'ok'
+              ? tr('测试通过，可以保存', 'Test passed; ready to save')
+              : tr('请先测试连接，通过后才能保存', 'Test the connection before saving')
+            : tr('保存后 ~5 秒内自动生效（无需重启）', 'Takes effect within ~5 s of saving (no restart needed)')}
         </span>
         {err && <span className="text-xs text-red-400">{err}</span>}
       </div>
@@ -347,7 +402,7 @@ function PromProbeLine({
   const { tr } = useI18n();
   switch (probe.kind) {
     case 'ok':
-      return <p className="mt-3 text-xs text-emerald-400">{tr('✓ Prom 可达，PromQL 探针 (up) 返回成功', '✓ Prom reachable, PromQL probe (up) returned success')}</p>;
+      return <p className="mt-3 text-xs text-emerald-400">{tr('✓ PromQL 查询与 Remote Write 写入入口均可用', '✓ PromQL query and Remote Write endpoint are both reachable')}</p>;
     case 'error':
       return <p className="mt-3 break-all text-xs text-red-400">✗ {probe.msg}</p>;
     default:
@@ -452,8 +507,11 @@ function GrafanaCard() {
   const [saving, setSaving] = useState(false);
   const [savedOk, setSavedOk] = useState(false);
   const [status, setStatus] = useState<SyncStatus>({ kind: 'idle' });
+  const probeRequest = useRef(0);
 
   const refresh = useCallback(async () => {
+    probeRequest.current += 1;
+    setStatus({ kind: 'idle' });
     setLoading(true);
     try {
       const r = await listSettings('grafana');
@@ -493,11 +551,14 @@ function GrafanaCard() {
   const dirty = GRAFANA_KEYS.some((k) => draft[k] !== server[k]);
 
   const update = (k: keyof GrafanaForm, v: string) => {
+    probeRequest.current += 1;
+    setStatus({ kind: 'idle' });
     setSavedOk(false);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
 
   const save = async () => {
+    if (status.kind !== 'tested-ok') return;
     setSaving(true);
     setStatus({ kind: 'idle' });
     try {
@@ -519,11 +580,20 @@ function GrafanaCard() {
   };
 
   const test = async () => {
+    const requestID = ++probeRequest.current;
     setStatus({ kind: 'testing' });
     try {
-      await testGrafanaConnection();
+      await testGrafanaConnection({
+        root_url: draft.root_url,
+        sa_token: draft.sa_token,
+        api_key: draft.api_key,
+        org_id: draft.org_id,
+        tls_insecure: draft.tls_insecure === 'true',
+      });
+      if (requestID !== probeRequest.current) return;
       setStatus({ kind: 'tested-ok' });
     } catch (e) {
+      if (requestID !== probeRequest.current) return;
       setStatus({ kind: 'error', msg: e instanceof ApiError ? e.message : (e as Error).message });
     }
   };
@@ -614,17 +684,17 @@ function GrafanaCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={save} disabled={!dirty || saving} variant="primary">
-          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
-          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
-        </Button>
         <Button
           onClick={test}
-          disabled={status.kind === 'testing' || dirty || !canTestSync(server)}
+          disabled={status.kind === 'testing' || !canTestSync(draft)}
           variant="ghost"
         >
           {status.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{tr('测试连接', 'Test connection')}</span>
+        </Button>
+        <Button onClick={save} disabled={!dirty || saving || status.kind !== 'tested-ok'} variant="primary">
+          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
+          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
         <button
           type="button"
@@ -743,7 +813,9 @@ function canTestSync(form: GrafanaForm): boolean {
 function StatusLine({ status, dirty }: { status: SyncStatus; dirty: boolean }) {
   const { tr } = useI18n();
   if (dirty) {
-    return <p className="mt-3 text-xs text-zinc-500">{tr('有未保存修改，先保存才能测试 / 同步', 'Unsaved changes — save first to test / sync')}</p>;
+    if (status.kind === 'tested-ok') return <p className="mt-3 text-xs text-emerald-400">{tr('✓ 测试通过，可以保存', '✓ Test passed; ready to save')}</p>;
+    if (status.kind === 'error') return <p className="mt-3 break-all text-xs text-red-400">✗ {status.msg}</p>;
+    return <p className="mt-3 text-xs text-zinc-500">{tr('请先测试连接，通过后才能保存', 'Test the connection before saving')}</p>;
   }
   switch (status.kind) {
     case 'tested-ok':
@@ -1067,6 +1139,7 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  const [validated, setValidated] = useState(false);
   const [message, setMessage] = useState<{ ok: boolean; text: string } | null>(null);
   const [connectionCheck, setConnectionCheck] = useState<LogBackendConnectionCheck | null>(null);
   const [connectionCheckError, setConnectionCheckError] = useState<string | null>(null);
@@ -1080,11 +1153,13 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
         setBackend(value);
         setForm(backendToForm(value));
         setDirty(false);
+        setValidated(false);
       } catch (error) {
         if (error instanceof ApiError && error.status === 404) {
           setBackend(null);
           setForm(emptyElasticsearchLogsForm);
           setDirty(false);
+          setValidated(false);
         } else {
           throw error;
         }
@@ -1123,6 +1198,7 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
   const update = <K extends keyof ElasticsearchLogsForm>(key: K, value: ElasticsearchLogsForm[K]) => {
     setMessage(null);
     setDirty(true);
+    setValidated(false);
     setForm((current) => ({ ...current, [key]: value }));
   };
 
@@ -1159,6 +1235,7 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
   };
 
   const save = async () => {
+    if (!validated) return;
     const input = saveInput();
     if (!input) return;
     setBusy('save');
@@ -1168,6 +1245,7 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
       setBackend(value);
       setForm(backendToForm(value));
       setDirty(false);
+      setValidated(false);
       setRevealedKeys({ write: false, query: false });
       setMessage({ ok: true, text: tr('配置已保存；点击“设为当前”后切换日志链路。', 'Configuration saved. Select it to switch the log pipeline.') });
     } catch (error) {
@@ -1215,11 +1293,13 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
   };
 
   const testElasticsearch = async () => {
-    if (!backend || dirty) return;
+    const input = saveInput();
+    if (!input) return;
     setBusy('test');
+    setValidated(false);
     setMessage(null);
     try {
-      const result = await testLogBackend(backend.id);
+      const result = await testLogBackendDraft(input);
       const version = result.detected_version
         ? tr(`（Elasticsearch ${result.detected_version}）`, ` (Elasticsearch ${result.detected_version})`)
         : '';
@@ -1230,7 +1310,9 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
           `Connection test passed. Query/write endpoints and API key privileges are valid${version}.`,
         ),
       });
+      setValidated(true);
     } catch (error) {
+      setValidated(false);
       setMessage({ ok: false, text: integrationError(error) });
     } finally {
       setBusy(null);
@@ -1239,8 +1321,8 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
 
   const canEdit = true;
   const editingCurrent = current && backend?.status === 'selected';
-  const canSave = canEdit && dirty;
-  const canTest = backend != null && !dirty;
+  const canSave = canEdit && dirty && validated;
+  const canTest = true;
   const canSelect = backend != null && !dirty && backend.status === 'unselected';
   const canCheckConnections = backend != null && current && backend.status === 'selected' && !dirty;
 
@@ -1292,8 +1374,9 @@ function ElasticsearchLogsCard({ current, exploreUrl, onBackendChange }: { curre
           <div className="mt-2 text-[11px] leading-5 text-zinc-500">{tr('API Key 是只写字段：Manager 接收后立即放入加密凭证库，读取后端配置时不会回显；Edge 只通过专用密钥通道取得写 Key。', 'API keys are write-only: Manager immediately stores them in the encrypted credential vault and never echoes them when reading backend configuration; Edge receives only the write key through the dedicated secret channel.')}</div>
 
           <div className="mt-5 flex flex-wrap items-end gap-3 border-t border-zinc-800/70 pt-4">
-            <Button onClick={() => void save()} disabled={!canSave || busy !== null} variant="primary">{busy === 'save' ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}<span>{tr('保存', 'Save')}</span></Button>
             <Button onClick={() => void testElasticsearch()} disabled={!canTest || busy !== null} variant="ghost">{busy === 'test' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}<span>{tr('测试连接', 'Test connection')}</span></Button>
+            <Button onClick={() => void save()} disabled={!canSave || busy !== null} variant="primary">{busy === 'save' ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}<span>{tr('保存', 'Save')}</span></Button>
+            {dirty && <span className="text-xs text-zinc-500">{validated ? tr('测试通过，可以保存', 'Test passed; ready to save') : tr('请先测试连接，通过后才能保存', 'Test the connection before saving')}</span>}
             <Button onClick={() => void selectElasticsearch()} disabled={!canSelect || busy !== null} variant="primary">{busy === 'select' ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}<span>{tr('设为当前', 'Select')}</span></Button>
             <Button onClick={() => void checkDeviceConnections()} disabled={!canCheckConnections || busy !== null} variant="ghost">{busy === 'connections' ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}<span>{tr('检查设备连接', 'Check device connections')}</span></Button>
             <button
@@ -1361,8 +1444,11 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
     | { kind: 'ok' }
     | { kind: 'error'; msg: string }
   >({ kind: 'idle' });
+  const probeRequest = useRef(0);
 
   const refresh = useCallback(async () => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setLoading(true);
     setErr(null);
     try {
@@ -1423,11 +1509,14 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
 
   const dirty = LOKI_KEYS.some((k) => draft[k] !== server[k]);
   const update = (k: keyof LokiForm, v: string) => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setSavedOk(false);
     setGrafanaSyncWarning(null);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
   const submit = async () => {
+    if (probe.kind !== 'ok') return;
     setSaving(true);
     setErr(null);
     setGrafanaSyncWarning(null);
@@ -1456,11 +1545,19 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
     }
   };
   const probeLoki = async () => {
+    const requestID = ++probeRequest.current;
     setProbe({ kind: 'testing' });
     try {
-      await testLokiConnection();
+      await testLokiConnection({
+        url: draft.url,
+        basic_user: draft.basic_user,
+        basic_password: draft.basic_password,
+        tls_insecure: draft.tls_insecure === 'true',
+      });
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'ok' });
     } catch (e) {
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'error', msg: e instanceof ApiError ? e.message : (e as Error).message });
     }
   };
@@ -1548,17 +1645,17 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
-          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
-          <span>{saving ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}</span>
-        </Button>
         <Button
           onClick={probeLoki}
-          disabled={probe.kind === 'testing' || dirty}
+          disabled={probe.kind === 'testing' || draft.url.trim() === ''}
           variant="ghost"
         >
           {probe.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{tr('测试连接', 'Test connection')}</span>
+        </Button>
+        <Button onClick={submit} disabled={!dirty || saving || probe.kind !== 'ok'} variant="primary">
+          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
+          <span>{saving ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}</span>
         </Button>
         <Button onClick={() => void switchToLoki()} disabled={current || !backend || switching || dirty || probe.kind === 'testing'} variant="primary">
           {switching ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
@@ -1584,6 +1681,7 @@ function LokiCard({ current, backend, exploreUrl, onBackendChange }: { current: 
         </button>
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
         {grafanaSyncWarning && <span className="break-all text-xs text-amber-400">{grafanaSyncWarning}</span>}
+        {dirty && <span className="text-xs text-zinc-500">{probe.kind === 'ok' ? tr('测试通过，可以保存', 'Test passed; ready to save') : tr('请先测试连接，通过后才能保存', 'Test the connection before saving')}</span>}
       </div>
       {switchMessage && <p className="mt-3 text-xs text-emerald-400">✓ {switchMessage}</p>}
       <ConnectionCheckProgress value={connectionCheck} error={connectionCheckError} />
@@ -1625,8 +1723,11 @@ function TempoCard() {
     | { kind: 'ok' }
     | { kind: 'error'; msg: string }
   >({ kind: 'idle' });
+  const probeRequest = useRef(0);
 
   const refresh = useCallback(async () => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setLoading(true);
     setErr(null);
     try {
@@ -1668,10 +1769,13 @@ function TempoCard() {
 
   const dirty = TEMPO_KEYS.some((k) => draft[k] !== server[k]);
   const update = (k: keyof TempoForm, v: string) => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setSavedOk(false);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
   const submit = async () => {
+    if (probe.kind !== 'ok') return;
     setSaving(true);
     setErr(null);
     try {
@@ -1688,11 +1792,19 @@ function TempoCard() {
     }
   };
   const probeTempo = async () => {
+    const requestID = ++probeRequest.current;
     setProbe({ kind: 'testing' });
     try {
-      await testTempoConnection();
+      await testTempoConnection({
+        url: draft.url,
+        basic_user: draft.basic_user,
+        basic_password: draft.basic_password,
+        tls_insecure: draft.tls_insecure === 'true',
+      });
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'ok' });
     } catch (e) {
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'error', msg: e instanceof ApiError ? e.message : (e as Error).message });
     }
   };
@@ -1754,17 +1866,17 @@ function TempoCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
-          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
-          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
-        </Button>
         <Button
           onClick={probeTempo}
-          disabled={probe.kind === 'testing' || dirty}
+          disabled={probe.kind === 'testing' || draft.url.trim() === ''}
           variant="ghost"
         >
           {probe.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{tr('测试连接', 'Test connection')}</span>
+        </Button>
+        <Button onClick={submit} disabled={!dirty || saving || probe.kind !== 'ok'} variant="primary">
+          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
+          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
         <button
           type="button"
@@ -1780,6 +1892,7 @@ function TempoCard() {
           <ExternalLink size={14} />
           <span>{tr('在 Grafana 中查看链路', 'Open traces in Grafana')}</span>
         </button>
+        {dirty && <span className="text-xs text-zinc-500">{probe.kind === 'ok' ? tr('测试通过，可以保存', 'Test passed; ready to save') : tr('请先测试连接，通过后才能保存', 'Test the connection before saving')}</span>}
         {err && <span className="break-all text-xs text-red-400">{err}</span>}
       </div>
       <ProbeLine probe={probe} okLabel={tr('✓ Tempo 连接测试成功', '✓ Tempo connection test succeeded')} />
@@ -1833,8 +1946,7 @@ function PluginCountLine({ label, count }: { label: string; count: number | null
 //
 // Per-provider fields are shown contextually so the form doesn't ask
 // the operator for irrelevant credentials. The 测试连接 button issues
-// a 1-result probe to whatever's currently selected & saved server-side
-// (so save first, then test — same discipline as Loki/Tempo cards).
+// a 1-result probe to the unsaved draft before the save button is enabled.
 
 type WebSearchForm = {
   provider: string; // "searxng" | "tavily" | "brave"
@@ -1875,8 +1987,11 @@ function WebSearchCard() {
     | { kind: 'ok'; provider: string; sample: string }
     | { kind: 'error'; msg: string }
   >({ kind: 'idle' });
+  const probeRequest = useRef(0);
 
   const refresh = useCallback(async () => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setLoading(true);
     setErr(null);
     try {
@@ -1922,11 +2037,14 @@ function WebSearchCard() {
 
   const dirty = WEBSEARCH_KEYS.some((k) => draft[k] !== server[k]);
   const update = (k: keyof WebSearchForm, v: string) => {
+    probeRequest.current += 1;
+    setProbe({ kind: 'idle' });
     setSavedOk(false);
     setDraft((cur) => ({ ...cur, [k]: v }));
   };
 
   const submit = async () => {
+    if (probe.kind !== 'ok') return;
     setSaving(true);
     setErr(null);
     try {
@@ -1944,11 +2062,14 @@ function WebSearchCard() {
   };
 
   const probeWebSearch = async () => {
+    const requestID = ++probeRequest.current;
     setProbe({ kind: 'testing' });
     try {
-      const r = await testWebSearchConnection();
+      const r = await testWebSearchConnection(draft);
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'ok', provider: r.provider, sample: r.sample });
     } catch (e) {
+      if (requestID !== probeRequest.current) return;
       setProbe({ kind: 'error', msg: e instanceof ApiError ? e.message : (e as Error).message });
     }
   };
@@ -1956,7 +2077,7 @@ function WebSearchCard() {
   // Status hint at the bottom of the card. Encodes the provider-specific
   // "ok / missing key" verdict the same way the skill itself decides.
   const statusHint = (() => {
-    if (dirty) return tr('有未保存修改', 'Unsaved changes');
+    if (dirty) return probe.kind === 'ok' ? tr('测试通过，可以保存', 'Test passed; ready to save') : tr('请先测试连接，通过后才能保存', 'Test the connection before saving');
     switch (server.provider) {
       case 'searxng':
         return tr(`已选 SearXNG · ${server.searxng_url || 'http://searxng:8080'}`, `Using SearXNG · ${server.searxng_url || 'http://searxng:8080'}`);
@@ -2086,17 +2207,17 @@ function WebSearchCard() {
       )}
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
-        <Button onClick={submit} disabled={!dirty || saving} variant="primary">
-          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
-          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
-        </Button>
         <Button
           onClick={probeWebSearch}
-          disabled={probe.kind === 'testing' || dirty}
+          disabled={probe.kind === 'testing'}
           variant="ghost"
         >
           {probe.kind === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
           <span>{tr('测试连接', 'Test connection')}</span>
+        </Button>
+        <Button onClick={submit} disabled={!dirty || saving || probe.kind !== 'ok'} variant="primary">
+          {savedOk && !dirty ? <Check size={14} /> : <Save size={14} />}
+          <span>{saving ? tr('保存中…', 'Saving…') : savedOk && !dirty ? tr('已保存', 'Saved') : tr('保存', 'Save')}</span>
         </Button>
         <span className="text-xs text-zinc-500">{statusHint}</span>
         {err && <span className="break-all text-xs text-red-400">{err}</span>}

--- a/web/src/pages/settings/Secrets.tsx
+++ b/web/src/pages/settings/Secrets.tsx
@@ -127,8 +127,8 @@ export default function SecretsPage() {
           </button>
         </div>
         {tr(
-          '凭据库。选一个类型（腾讯云 / AWS / GitHub …）会自动列出该填的字段，并自带"注入到哪些环境变量"的规则；技能 / 外部 MCP 用上这份凭据时按类型规则注入。类型选"自定义"则自由填字段，按同名环境变量注入。字段值只写不读，AES 加密落库（设 ONGRID_SECRET_KEY）。',
-          'Credential vault. Pick a type (Tencent Cloud / AWS / GitHub …) and it lists the right fields plus a built-in "which env vars to inject" rule; skills / external MCP that use this credential inject by that rule. Pick "Custom" to enter free-form fields injected as same-named env vars. Values are write-only and AES-encrypted at rest (set ONGRID_SECRET_KEY).'
+          '凭据库。选一个类型（腾讯云 / AWS / GitHub …）会自动列出该填的字段，并自带"注入到哪些环境变量"的规则；技能 / 外部 MCP 用上这份凭据时按类型规则注入。类型选"自定义"则自由填字段，按同名环境变量注入。字段值只写不读，使用现有系统密钥进行 AES 加密后落库。',
+          'Credential vault. Pick a type (Tencent Cloud / AWS / GitHub …) and it lists the right fields plus a built-in "which env vars to inject" rule; skills / external MCP that use this credential inject by that rule. Pick "Custom" to enter free-form fields injected as same-named env vars. Values are write-only and AES-encrypted at rest with the existing system secret.'
         )}
       </div>
 

--- a/web/src/pages/settings/Webshell.tsx
+++ b/web/src/pages/settings/Webshell.tsx
@@ -44,6 +44,7 @@ const TERMINATED_LABELS: Record<string, { zh: string; en: string; tone: Tone }> 
   disconnect: { zh: '连接断开', en: 'Disconnected', tone: 'warning' },
   admin_kill: { zh: '管理员强制', en: 'Admin kill', tone: 'danger' },
   ssh_auth_fail: { zh: 'SSH 认证失败', en: 'SSH auth failed', tone: 'warning' },
+  ssh_host_key: { zh: 'SSH 指纹校验失败', en: 'SSH host key rejected', tone: 'warning' },
   ssh_exit: { zh: '退出', en: 'Exited', tone: 'default' },
   device_offline: { zh: '设备离线', en: 'Device offline', tone: 'warning' },
 };
@@ -181,7 +182,7 @@ export default function SettingsWebshell() {
       ).toLowerCase();
       return haystack.includes(q);
     });
-  }, [items, statusFilter, search, userMap, edgeMap]);
+  }, [items, statusFilter, search, userMap, edgeMap, tr]);
 
   const handleKill = useCallback(
     async (s: ShellSession) => {
@@ -209,7 +210,7 @@ export default function SettingsWebshell() {
         setKillBusy(null);
       }
     },
-    [refresh],
+    [refresh, tr],
   );
 
   const filterChip = (key: StatusFilter, label: string, n: number) => (
@@ -421,7 +422,9 @@ function SessionTable({
                   <div className="text-zinc-100">{deviceLabel}</div>
                   <div className="font-mono text-[11px] text-zinc-500">device #{s.device_id}</div>
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[12px] text-zinc-300">{s.ssh_user}</td>
+                <td className="px-4 py-2.5 font-mono text-[12px] text-zinc-300">
+                  {s.ssh_user}:{s.ssh_port || 22}
+                </td>
                 <td className="px-4 py-2.5 text-zinc-300">
                   {duration}
                   <span className="text-[11px] text-zinc-600">{exitInfo}</span>


### PR DESCRIPTION
## Summary

- secure WebShell with one-time tickets, same-origin checks, SSH host-key pinning, custom ports, server-verified credential persistence, and direct close on top-level shell exit
- validate unsaved Prometheus, Grafana, Loki, Elasticsearch, Tempo, and web-search drafts before enabling Save
- derive VictoriaMetrics cluster remote-write URLs from `/select/<tenant>/prometheus`, including the default 8481-to-8480 port mapping

## Testing

- `go test -race` for the changed WebShell, integration, Prometheus, secretbox, tunnel, and Frontier packages
- targeted `go vet` for all changed Go packages
- native Manager compile and Linux/amd64 Edge compile
- `npm test -- --run src/pages/DeviceShell.test.tsx src/pages/settings/Integrations.test.tsx` (19 tests)
- changed-file ESLint and `npm run build`

## Rollback

- revert the two commits; existing WebShell audit rows and integration settings remain backward compatible

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
