### PR TITLE
fix(profiles): allow self-signed TLS for profile uploads

### DIFF
--- a/web/src/pages/DailyTools.test.tsx
+++ b/web/src/pages/DailyTools.test.tsx
@@ -524,11 +524,13 @@ describe('DailyToolsPage', () => {
     expect(saved.spec).toMatchObject({
       mode: 'pprof',
       duration_seconds: 30,
+      tls_insecure_skip_verify: true,
       runtime_target: {
         url: 'http://127.0.0.1:16060/debug/pprof/heap',
         profile_type: 'heap',
         service_name: 'ongrid-edge',
         collection_interval_seconds: 10,
+        tls_insecure_skip_verify: false,
       },
     });
 

--- a/web/src/pages/DailyTools.tsx
+++ b/web/src/pages/DailyTools.tsx
@@ -2096,7 +2096,7 @@ function profileSpec(form: ProfileForm): Record<string, unknown> {
   return {
     mode: 'pprof',
     duration_seconds,
-    tls_insecure_skip_verify: false,
+    tls_insecure_skip_verify: true,
     runtime_target: {
       url: form.url.trim(),
       profile_type: form.kind,


### PR DESCRIPTION
## Summary

Profiles started from Daily Tools fail to upload when the Manager ingress uses the default self-signed certificate or its certificate does not match the upload address. Set the top-level `tls_insecure_skip_verify` to `true` in the submitted Profiles configuration so the Edge Collector can upload in these deployments, matching the exporter's existing default.

This disables certificate identity and trust verification for Profiles uploads to Manager. The application pprof target retains certificate verification. Add assertions to the existing sampling test to cover both settings.

## Validation

- GitHub CI passed: Linux Go build, vet and full race tests; web tests and build; deployment manifests; required contribution checklist.
- `npm run test -- --run src/pages/DailyTools.test.tsx`: 11 tests passed.
- `npm run build`: passed.
- `git diff --check`: passed.
- Local full Go build/tests could not pass because Edge lacks macOS platform definitions and the sandbox blocks test listeners and some dependency access. No Go files changed.
- Remote deployment and sample ingestion have not been verified. After deploying the updated frontend, start a new sampling session to send the configuration to Edge.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
