### PR TITLE
fix(alert): refresh device staleness gauge on its own ticker

### DIFF
--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -2879,6 +2879,7 @@ func main() {
 			DefaultChannels: cfg.Notification.DefaultChannels,
 			Cooldown:        cfg.Alert.Cooldown,
 			Interval:        cfg.Alert.EvaluatorInterval,
+			GaugeInterval:   cfg.Alert.GaugeRefreshInterval,
 			EdgeLister:      edgeUC,
 			PromQuerier:     alertPromQuerier,
 			LogQuerier:      lokiLogClient,

--- a/deploy/install/.env.example
+++ b/deploy/install/.env.example
@@ -181,6 +181,19 @@ ONGRID_ALERT_COOLDOWN=10m
 # ONGRID_ALERT_COOLDOWN above so stretching this doesn't change how
 # often Slack / Feishu / etc. get rung.
 ONGRID_ALERT_EVAL_INTERVAL=
+
+# How often device_last_seen_seconds_ago is recomputed. Go-side default
+# 30s. Deliberately separate from ONGRID_ALERT_EVAL_INTERVAL above:
+# refreshing this gauge is one edge List plus a few gauge Sets and
+# writes no alert_events, so the reason that knob was stretched to 5m
+# does not apply here.
+#
+# Keep it well below the offline threshold you care about. The built-in
+# rule is `device_last_seen_seconds_ago > 90`; if this interval were 5m
+# the gauge would only move every 300s and that rule could not mean 90s
+# — with no error anywhere, the series just stops changing while the
+# device is already gone.
+ONGRID_ALERT_GAUGE_INTERVAL=
 ONGRID_ALERT_CPU_PERCENT=90
 ONGRID_ALERT_MEM_PERCENT=90
 ONGRID_ALERT_DISK_USED_PERCENT=90

--- a/internal/manager/biz/alert/pipeline.go
+++ b/internal/manager/biz/alert/pipeline.go
@@ -75,6 +75,12 @@ type PipelineEvaluatorOpts struct {
 	DefaultChannels []string
 	Cooldown        time.Duration
 	Interval        time.Duration
+	// GaugeInterval is how often refreshDeviceStalenessGauge runs. It is
+	// deliberately decoupled from Interval: the gauge is an input to the
+	// built-in offline rule (`device_last_seen_seconds_ago > 90`), so its
+	// resolution bounds how fast that rule can possibly detect anything.
+	// Zero means 30s.
+	GaugeInterval time.Duration
 
 	EdgeLister  EdgeLister
 	PromQuerier PromQuerier
@@ -109,8 +115,9 @@ type PipelineEvaluator struct {
 	resolver  ChannelResolver
 	inhibitor Inhibitor
 	channels  []string
-	cooldown  time.Duration
-	interval  time.Duration
+	cooldown      time.Duration
+	interval      time.Duration
+	gaugeInterval time.Duration
 
 	edges          EdgeLister
 	prom           PromQuerier
@@ -146,6 +153,9 @@ func NewPipelineEvaluator(opts PipelineEvaluatorOpts) *PipelineEvaluator {
 	if opts.Cooldown <= 0 {
 		opts.Cooldown = 10 * time.Minute
 	}
+	if opts.GaugeInterval <= 0 {
+		opts.GaugeInterval = 30 * time.Second
+	}
 	if opts.Log == nil {
 		opts.Log = slog.Default()
 	}
@@ -161,6 +171,7 @@ func NewPipelineEvaluator(opts PipelineEvaluatorOpts) *PipelineEvaluator {
 		channels:       append([]string(nil), opts.DefaultChannels...),
 		cooldown:       opts.Cooldown,
 		interval:       opts.Interval,
+		gaugeInterval:  opts.GaugeInterval,
 		edges:          opts.EdgeLister,
 		prom:           opts.PromQuerier,
 		logq:           opts.LogQuerier,
@@ -172,12 +183,35 @@ func NewPipelineEvaluator(opts PipelineEvaluatorOpts) *PipelineEvaluator {
 }
 
 // Loop runs the evaluator until ctx is cancelled.
+//
+// Two tickers, on purpose:
+//
+//   - interval (default 5m) drives rule evaluation, which writes
+//     alert_events. That is what the 2026-05-31 slowdown was about.
+//   - gaugeInterval (default 30s) drives only
+//     refreshDeviceStalenessGauge: one edge List plus a few gauge Sets,
+//     no events written.
+//
+// Sharing one ticker made device_last_seen_seconds_ago up to 5 minutes
+// stale, which silently defeats the built-in offline rule — a `> 90`
+// threshold cannot mean 90 seconds when its input only moves every 300.
+// The symptom is nasty because nothing errors: the gauge simply reports
+// the same value on every scrape while the device is already gone.
 func (e *PipelineEvaluator) Loop(ctx context.Context) error {
 	if e.uc == nil || e.rules == nil {
 		return nil
 	}
 	tick := time.NewTicker(e.interval)
 	defer tick.Stop()
+	// Only run the gauge ticker when it is actually faster than the
+	// evaluator; otherwise evaluate() already covers it and a second
+	// ticker would just duplicate the List query.
+	var gaugeC <-chan time.Time
+	if e.edges != nil && e.gaugeInterval > 0 && e.gaugeInterval < e.interval {
+		gt := time.NewTicker(e.gaugeInterval)
+		defer gt.Stop()
+		gaugeC = gt.C
+	}
 	e.evaluate(ctx)
 	for {
 		select {
@@ -185,6 +219,8 @@ func (e *PipelineEvaluator) Loop(ctx context.Context) error {
 			return nil
 		case <-tick.C:
 			e.evaluate(ctx)
+		case <-gaugeC:
+			e.refreshDeviceStalenessGauge(ctx, e.now())
 		}
 	}
 }
@@ -235,9 +271,14 @@ func (e *PipelineEvaluator) evaluate(ctx context.Context) {
 // inventory are deleted so the metric_raw evaluator doesn't keep firing
 // on a removed device.
 //
-// Called every evaluator tick (30s default). Errors here are logged and
-// skipped — gauge staleness for one tick is preferable to a panic in
-// the alert loop.
+// Called on its own ticker (ONGRID_ALERT_GAUGE_INTERVAL, default 30s)
+// and once at the top of every evaluator tick. It is deliberately NOT
+// tied to ONGRID_ALERT_EVAL_INTERVAL (default 5m): this gauge is the
+// input to `device_last_seen_seconds_ago > 90`, so its refresh rate is
+// a hard floor on how fast that rule can detect anything.
+//
+// Errors here are logged and skipped — gauge staleness for one tick is
+// preferable to a panic in the alert loop.
 func (e *PipelineEvaluator) refreshDeviceStalenessGauge(ctx context.Context, now time.Time) {
 	edges, err := e.edges.List(ctx, edgebiz.ListFilter{Limit: 1000})
 	if err != nil {

--- a/internal/manager/biz/alert/pipeline_test.go
+++ b/internal/manager/biz/alert/pipeline_test.go
@@ -8,9 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	edgebiz "github.com/ongridio/ongrid/internal/manager/biz/edge"
 	model "github.com/ongridio/ongrid/internal/manager/model/alert"
 	edgemodel "github.com/ongridio/ongrid/internal/manager/model/edge"
+	"github.com/ongridio/ongrid/internal/pkg/prom"
 	"github.com/ongridio/ongrid/internal/pkg/promquery"
 )
 
@@ -331,4 +335,74 @@ func vectorUp(samples map[string]string) *promquery.InstantResult {
 	}
 	raw, _ := json.Marshal(entries)
 	return &promquery.InstantResult{ResultType: "vector", Result: raw}
+}
+
+// TestPipelineGaugeRefreshesBetweenEvaluatorTicks pins the fix for the
+// bug where device_last_seen_seconds_ago went stale for a whole
+// evaluator interval.
+//
+// Before: refreshDeviceStalenessGauge only ran inside evaluate(), so
+// with the shipped defaults (eval 5m, offline threshold 90s) the gauge
+// reported the same value for up to 300s after a device stopped
+// heartbeating. Nothing errored — the series simply stopped moving —
+// so `device_last_seen_seconds_ago > 90` could not mean what its name
+// says.
+//
+// After: Loop drives the gauge on its own faster ticker. This test
+// advances wall-clock time and refreshes the gauge WITHOUT running an
+// evaluator tick, which is exactly what the old code could not do.
+func TestPipelineGaugeRefreshesBetweenEvaluatorTicks(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	prom.RegisterManagerMetrics(reg, nil)
+
+	repo := newFakeRepo()
+	lastSeen := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	edges := &fakeEdgeLister{edges: []*edgemodel.Edge{
+		{ID: 7, Name: "edge-7", LastSeenAt: &lastSeen},
+	}}
+
+	now := lastSeen
+	ev := newPipelineEvaluator(t, repo, &fakeNotifier{}, NewStaticRulesProvider(), PipelineEvaluatorOpts{
+		EdgeLister:    edges,
+		Interval:      5 * time.Minute,
+		GaugeInterval: 30 * time.Second,
+		Now:           func() time.Time { return now },
+	})
+
+	if ev.gaugeInterval >= ev.interval {
+		t.Fatalf("gauge interval %v must stay below evaluator interval %v — otherwise "+
+			"the offline rule inherits the evaluator's resolution", ev.gaugeInterval, ev.interval)
+	}
+
+	// Two refreshes 120s apart with NO evaluate() in between. 120s is
+	// chosen so the second reading crosses the 90s offline threshold
+	// while still being far below the 5m evaluator tick — i.e. exactly
+	// the window the old code could not observe.
+	ev.refreshDeviceStalenessGauge(context.Background(), now)
+	first := testutil.ToFloat64(prom.DeviceLastSeenSecondsAgo.WithLabelValues("7", "edge-7"))
+
+	now = now.Add(120 * time.Second)
+	ev.refreshDeviceStalenessGauge(context.Background(), now)
+	second := testutil.ToFloat64(prom.DeviceLastSeenSecondsAgo.WithLabelValues("7", "edge-7"))
+
+	if delta := second - first; delta < 119 || delta > 121 {
+		t.Fatalf("gauge advanced by %vs between evaluator ticks, want ~120s "+
+			"(first=%v second=%v)", delta, first, second)
+	}
+	if second <= 90 {
+		t.Fatalf("120s after a 12:00 heartbeat the gauge must exceed the 90s offline "+
+			"threshold, got %v — this is the whole point of the separate ticker", second)
+	}
+}
+
+// TestPipelineGaugeIntervalDefaults documents the zero-value behaviour:
+// callers that do not set GaugeInterval still get a sub-minute refresh
+// rather than silently inheriting the 5m evaluator tick.
+func TestPipelineGaugeIntervalDefaults(t *testing.T) {
+	ev := newPipelineEvaluator(t, newFakeRepo(), &fakeNotifier{}, NewStaticRulesProvider(), PipelineEvaluatorOpts{
+		Interval: 5 * time.Minute,
+	})
+	if ev.gaugeInterval != 30*time.Second {
+		t.Fatalf("default gaugeInterval = %v, want 30s", ev.gaugeInterval)
+	}
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -247,6 +247,20 @@ type AlertConfig struct {
 	// bounded by Alert.Cooldown so stretching this doesn't multiply
 	// notifications — only the storage + evaluator-CPU side.
 	EvaluatorInterval time.Duration
+	// GaugeRefreshInterval is how often the evaluator recomputes the
+	// device_last_seen_seconds_ago gauge. Kept separate from
+	// EvaluatorInterval on purpose.
+	//
+	// EvaluatorInterval was stretched to 5m to stop long-firing rules
+	// from racking up alert_events. That reasoning does not apply to the
+	// gauge: refreshing it is one edge List plus a few gauge Sets, and it
+	// writes no events. Sharing the 5m tick made the gauge up to 5
+	// minutes stale, which silently defeats the built-in offline rule —
+	// `device_last_seen_seconds_ago > 90` cannot mean 90s when its input
+	// only moves every 300s.
+	//
+	// env: ONGRID_ALERT_GAUGE_INTERVAL; default 30s.
+	GaugeRefreshInterval time.Duration
 	// EdgeOfflineThreshold is the heartbeat staleness above which an edge
 	// counts as offline.
 	// env: ONGRID_ALERT_EDGE_OFFLINE_THRESHOLD; default 90s.
@@ -592,6 +606,7 @@ func Load() (*Config, error) {
 	c.Alert.DiskUsedPercent = getEnvFloat("ONGRID_ALERT_DISK_USED_PERCENT", 90)
 	c.Alert.Load1 = getEnvFloat("ONGRID_ALERT_LOAD1", 0)
 	c.Alert.EvaluatorInterval = getEnvDuration("ONGRID_ALERT_EVAL_INTERVAL", 5*time.Minute)
+	c.Alert.GaugeRefreshInterval = getEnvDuration("ONGRID_ALERT_GAUGE_INTERVAL", 30*time.Second)
 	c.Alert.EdgeOfflineThreshold = getEnvDuration("ONGRID_ALERT_EDGE_OFFLINE_THRESHOLD", 90*time.Second)
 	c.Alert.PromIngestFailLimit = getEnvInt("ONGRID_ALERT_PROM_INGEST_FAIL_LIMIT", 5)
 


### PR DESCRIPTION
## The bug

`device_last_seen_seconds_ago` is only recomputed inside the evaluator
tick. With the shipped defaults that tick is **5m**
(`ONGRID_ALERT_EVAL_INTERVAL`), while the built-in offline rule is
`device_last_seen_seconds_ago > 90`.

So the gauge feeding a 90-second rule can be up to **300 seconds stale**.

### How it looks in production

On a live install I stopped an edge and sampled the manager's
`/metrics` every 20s for 3.5 minutes:

```
device_last_seen_seconds_ago{device_id="5",...} 24.777125322
device_last_seen_seconds_ago{device_id="5",...} 24.777125322
device_last_seen_seconds_ago{device_id="5",...} 24.777125322
...   (10 samples, identical)
```

**Nothing errors.** The series just stops moving while the device is
already gone, so the rule cannot detect an outage in anything close to
the 90s its own expression advertises.

## Why splitting the ticker is the right fix

The [2026-05-31 slowdown to 5m](https://github.com/ongridio/ongrid/blob/main/internal/pkg/config/config.go)
was about `alert_events` growth from long-firing rules — the comment
records ~3900 rows in 32h from one always-true rule.

That reasoning does not apply to this gauge. `refreshDeviceStalenessGauge`
is **one edge `List` plus a few gauge `Set`s, and it writes no events**.
The two concerns were simply sharing one ticker.

## What this changes

- `Loop` drives `refreshDeviceStalenessGauge` on its own ticker
  (`ONGRID_ALERT_GAUGE_INTERVAL`, default **30s**); rule evaluation keeps
  the 5m cadence and its `alert_events` characteristics.
- The extra ticker **only starts when it is actually faster** than the
  evaluator, so installs already running a short eval interval are
  unaffected and do not get a duplicate `List`.
- Fixes a stale comment: `refreshDeviceStalenessGauge` claimed *"Called
  every evaluator tick (30s default)"*, which stopped being true when the
  default moved to 5m.

## Tests

`TestPipelineGaugeRefreshesBetweenEvaluatorTicks` advances wall-clock time
and refreshes the gauge **without** running an evaluator tick — precisely
what the old code could not do — and asserts the reading crosses the 90s
threshold. `TestPipelineGaugeIntervalDefaults` pins the zero-value to 30s
so a caller that omits the option does not silently inherit 5m.

```
ok  github.com/ongridio/ongrid/internal/manager/biz/alert  6.245s
ok  github.com/ongridio/ongrid/internal/pkg/config         6.680s
```

`go build ./...` and `go vet` clean.

## Compatibility

Default-on, but conservative: the only behaviour change for an install
that leaves `ONGRID_ALERT_GAUGE_INTERVAL` unset is that the gauge now
tracks reality between evaluator ticks. No schema change, no new
dependency, no notification-cadence change (`ONGRID_ALERT_COOLDOWN`
still bounds that independently).
