### PR TITLE
feat(traces): ingest SkyWalking traces through edge receivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           npm test -- --run
           src/pages/Kubernetes.test.tsx
           src/pages/Edges.test.tsx
+          src/pages/EdgeDetail.test.tsx
+          src/pages/Traces.test.tsx
+          src/components/traces/TraceWaterfall.test.ts
           src/pages/Dashboard.test.tsx
           src/pages/settings/Upgrade.test.tsx
           src/pages/settings/LLM.test.tsx
@@ -110,7 +113,7 @@ jobs:
         uses: azure/setup-helm@v5
 
       - name: Check release scripts
-        run: bash -n dist/package.sh dist/package-k8s-chart.sh dist/build-edge-attachments.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh deploy/install/public-url.sh deploy/install/data-permissions.sh deploy/install/apply-pending-upgrade.sh deploy/install/edge/fetch-edge-assets.sh deploy/install/edge/verify-edge-deps-archive.sh deploy/install/edge/edge-assets-lib.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/publish-release-image-platform.sh scripts/merge-release-image-manifest.sh scripts/test-publish-release-image.sh scripts/test-release-image-platform-publish.sh scripts/ensure-cnb-release.sh scripts/test-ensure-cnb-release.sh scripts/test-publish-cnb-release-attachments.sh scripts/test-verify-cnb-release-attachments.sh scripts/test-release-workflow.sh scripts/test-edge-assets.sh scripts/test-edge-assets-lib.sh scripts/test-edge-installer-connectivity-guard.sh scripts/test-edge-upgrade-hook-guard.sh scripts/test-public-url.sh scripts/test-upgrade-data-permissions.sh scripts/test-compose-release-package.sh scripts/test-apply-pending-upgrade.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
+        run: bash -n dist/build-otelcol.sh dist/package.sh dist/package-k8s-chart.sh dist/build-edge-attachments.sh deploy/install/install.sh deploy/install/upgrade.sh deploy/install/uninstall.sh deploy/install/public-url.sh deploy/install/data-permissions.sh deploy/install/apply-pending-upgrade.sh deploy/install/edge/fetch-edge-assets.sh deploy/install/edge/verify-edge-deps-archive.sh deploy/install/edge/edge-assets-lib.sh scripts/verify-cnb-compose-images.sh scripts/verify-release-images.sh scripts/publish-release-image.sh scripts/publish-release-image-platform.sh scripts/merge-release-image-manifest.sh scripts/test-publish-release-image.sh scripts/test-release-image-platform-publish.sh scripts/ensure-cnb-release.sh scripts/test-ensure-cnb-release.sh scripts/test-publish-cnb-release-attachments.sh scripts/test-verify-cnb-release-attachments.sh scripts/test-release-workflow.sh scripts/test-edge-assets.sh scripts/test-edge-assets-lib.sh scripts/test-edge-installer-connectivity-guard.sh scripts/test-edge-upgrade-hook-guard.sh scripts/test-public-url.sh scripts/test-upgrade-data-permissions.sh scripts/test-compose-release-package.sh scripts/test-apply-pending-upgrade.sh scripts/publish-helm-chart.sh scripts/test-publish-helm-chart.sh scripts/test-k8s-chart.sh
 
       - name: Verify Edge installer connectivity guard
         run: bash scripts/test-edge-installer-connectivity-guard.sh

--- a/.github/workflows/collector-compat.yml
+++ b/.github/workflows/collector-compat.yml
@@ -1,0 +1,49 @@
+name: Collector compatibility
+on:
+  pull_request:
+    paths:
+      - Makefile
+      - dist/build-otelcol.sh
+      - dist/patches/**
+      - deploy/Dockerfile.ongrid-edge
+      - internal/edgeagent/plugins/traces/**
+      - internal/pkg/tracequery/**
+      - .github/workflows/collector-compat.yml
+  push:
+    branches: [main]
+    paths:
+      - Makefile
+      - dist/build-otelcol.sh
+      - dist/patches/**
+      - deploy/Dockerfile.ongrid-edge
+      - internal/edgeagent/plugins/traces/**
+      - internal/pkg/tracequery/**
+      - .github/workflows/collector-compat.yml
+permissions:
+  contents: read
+jobs:
+  collector:
+    name: SkyWalking real Collector + bind isolation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache: true
+      - name: Build patched official distribution
+        run: make fetch-otelcol EDGE_PLUGIN_ARCHES=linux-amd64
+      - name: Fetch unpatched Collector for upgrade compatibility
+        run: |
+          base=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.157.0
+          curl -fsSL --retry 3 "$base/otelcol-contrib_0.157.0_linux_amd64.tar.gz" -o /tmp/otelcol-legacy.tgz
+          curl -fsSL --retry 3 "$base/opentelemetry-collector-releases_otelcol-contrib_checksums.txt" -o /tmp/otelcol-checksums.txt
+          awk '$2 == "otelcol-contrib_0.157.0_linux_amd64.tar.gz" {print $1 "  /tmp/otelcol-legacy.tgz"}' /tmp/otelcol-checksums.txt | sha256sum -c -
+          mkdir -p /tmp/otelcol-legacy
+          tar -xzf /tmp/otelcol-legacy.tgz -C /tmp/otelcol-legacy otelcol-contrib
+      - name: Verify reception, ID conversion and network isolation
+        env:
+          ONGRID_TEST_LEGACY_OTELCOL_BINARY: /tmp/otelcol-legacy/otelcol-contrib
+          ONGRID_TEST_OTELCOL_BINARY: ${{ github.workspace }}/bin/linux-amd64/otelcol-contrib
+        run: go test -race ./internal/pkg/tracequery ./internal/edgeagent/plugins/traces

--- a/Makefile
+++ b/Makefile
@@ -418,35 +418,13 @@ FETCH_CURL_FLAGS ?= -fL --retry 3 --retry-all-errors --retry-delay 3 --connect-t
 # ~200MB uncompressed per platform — operators wanting a slimmer agent can
 # swap in a custom OCB build (otel-collector-builder); we ship contrib so
 # default install works without forcing users to compile their own.
-OTELCOL_VERSION ?= 0.157.0
+OTELCOL_VERSION ?= 0.157.0-ongrid.1
 
 .PHONY: fetch-otelcol
-fetch-otelcol: ## [release] 下载 otelcol-contrib 到 bin/<os>-<arch>/otelcol-contrib (linux-only)
+fetch-otelcol: ## [release] 构建带 SkyWalking 监听修复的官方 contrib 发行版
 	@for target in $(EDGE_PLUGIN_ARCHES); do \
-		dest=$(BIN_DIR)/$$target/otelcol-contrib; \
-		if [ -f $$dest ]; then \
-			echo "[otelcol] $$dest already present — skip"; \
-			continue; \
-		fi; \
-		mkdir -p $(BIN_DIR)/$$target; \
-		os=$${target%-*}; arch=$${target##*-}; \
-		asset=otelcol-contrib_$(OTELCOL_VERSION)_$${os}_$${arch}.tar.gz; \
-		base=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTELCOL_VERSION); \
-		tmpdir=$$(mktemp -d); tgz=$$tmpdir/$$asset; checksums=$$tmpdir/checksums.txt; \
-		url=$$base/$$asset; \
-		echo "[otelcol] downloading $$url"; \
-		curl $(FETCH_CURL_FLAGS) -o $$tgz $$url || { rm -rf $$tmpdir; echo "otelcol-contrib download failed for $$target"; exit 1; }; \
-		curl $(FETCH_CURL_FLAGS) -o $$checksums $$base/opentelemetry-collector-releases_otelcol-contrib_checksums.txt || { rm -rf $$tmpdir; echo "otelcol-contrib checksums download failed"; exit 1; }; \
-		expected=$$(awk -v asset="$$asset" '$$2 == asset || $$2 == "*" asset { print $$1; exit }' $$checksums); \
-		test -n "$$expected" || { rm -rf $$tmpdir; echo "otelcol-contrib checksum missing for $$asset"; exit 1; }; \
-		if command -v sha256sum >/dev/null 2>&1; then actual=$$(sha256sum $$tgz | awk '{print $$1}'); else actual=$$(shasum -a 256 $$tgz | awk '{print $$1}'); fi; \
-		test "$$actual" = "$$expected" || { rm -rf $$tmpdir; echo "otelcol-contrib checksum mismatch for $$asset"; exit 1; }; \
-		tar -xzf $$tgz -C $(BIN_DIR)/$$target otelcol-contrib || { rm -rf $$tmpdir; echo "extract failed for $$target"; exit 1; }; \
-		chmod +x $$dest; \
-		rm -rf $$tmpdir; \
-		echo "[otelcol] staged $$dest"; \
+		bash dist/build-otelcol.sh "$(OTELCOL_VERSION)" "$$target" "$(BIN_DIR)/$$target/otelcol-contrib" || exit $$?; \
 	done
-	@echo "[otelcol] note: contrib distro is ~200MB per platform; operators wanting smaller agent can build a custom OCB collector and drop it under /usr/local/lib/ongrid-edge/otelcol-contrib"
 
 # node_exporter — host metric source bundled with the edge package
 # (CPU / memory / disk / network / load). Without this, install-edge

--- a/deploy/Dockerfile.ongrid-edge
+++ b/deploy/Dockerfile.ongrid-edge
@@ -11,7 +11,7 @@
 ARG VERSION=dev
 ARG NODE_EXPORTER_VERSION=1.8.2
 ARG PROCESS_EXPORTER_VERSION=0.8.4
-ARG OTELCOL_VERSION=0.157.0
+ARG OTELCOL_VERSION=0.157.0-ongrid.1
 
 # ---------- Stage 1: builder ----------
 # The edge binary is pure Go, so cross-compile on the native build platform.
@@ -88,28 +88,19 @@ RUN set -eux; \
     rm -f /tmp/process_exporter.tgz
 
 # ---------- Stage 4: bundled OpenTelemetry logs/traces plugin ----------
-FROM --platform=$BUILDPLATFORM alpine:3.20 AS otelcol-contrib
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS otelcol-contrib
 
 ARG OTELCOL_VERSION
 ARG TARGETARCH
-RUN set -eux; \
-    apk add --no-cache ca-certificates curl tar; \
-    arch="${TARGETARCH:-$(apk --print-arch)}"; \
-    case "$arch" in \
-        x86_64) arch=amd64 ;; \
-        aarch64) arch=arm64 ;; \
-        amd64|arm64) ;; \
-        *) echo "unsupported otelcol-contrib arch: $arch" >&2; exit 1 ;; \
-    esac; \
-    mkdir -p /out; \
-    asset="otelcol-contrib_${OTELCOL_VERSION}_linux_${arch}.tar.gz"; \
-    base="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_VERSION}"; \
-    curl -fL --retry 3 --retry-all-errors --retry-delay 3 --connect-timeout 15 -o /tmp/otelcol-contrib.tgz "${base}/${asset}"; \
-    curl -fL --retry 3 --retry-all-errors --retry-delay 3 --connect-timeout 15 -o /tmp/checksums.txt "${base}/opentelemetry-collector-releases_otelcol-contrib_checksums.txt"; \
-    awk -v asset="${asset}" '$2 == asset { print $1 "  /tmp/otelcol-contrib.tgz" }' /tmp/checksums.txt | sha256sum -c -; \
-    tar -xzf /tmp/otelcol-contrib.tgz -C /out otelcol-contrib; \
-    chmod 0755 /out/otelcol-contrib; \
-    rm -f /tmp/otelcol-contrib.tgz
+WORKDIR /app
+RUN apk add --no-cache bash ca-certificates curl make patch tar
+COPY Makefile ./
+COPY dist/build-otelcol.sh dist/build-otelcol.sh
+COPY dist/patches/skywalking-grpc-bind.patch dist/patches/skywalking-grpc-bind.patch
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make fetch-otelcol OTELCOL_VERSION="${OTELCOL_VERSION}" EDGE_PLUGIN_ARCHES="linux-${TARGETARCH}" BIN_DIR=/out && \
+    cp "/out/linux-${TARGETARCH}/otelcol-contrib" /out/otelcol-contrib
 
 # ---------- Stage 5: runtime (distroless, nonroot) ----------
 FROM gcr.io/distroless/base-debian12:nonroot

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             - name: skywalking-grpc
               containerPort: 11800
               protocol: TCP
+            - name: skywalking-http
+              containerPort: 12800
+              protocol: TCP
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
+            - name: skywalking-grpc
+              containerPort: 11800
+              protocol: TCP
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
@@ -97,6 +97,9 @@ spec:
             - name: skywalking-grpc
               containerPort: 11800
               protocol: TCP
+            - name: skywalking-http
+              containerPort: 12800
+              protocol: TCP
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-deployment.yaml
@@ -94,6 +94,9 @@ spec:
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
+            - name: skywalking-grpc
+              containerPort: 11800
+              protocol: TCP
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
@@ -27,6 +27,10 @@ spec:
       port: {{ default 11800 $svc.skywalkingGrpcPort }}
       targetPort: skywalking-grpc
       protocol: TCP
+    - name: skywalking-http
+      port: {{ default 12800 $svc.skywalkingHttpPort }}
+      targetPort: skywalking-http
+      protocol: TCP
     - name: otlp-http
       port: {{ default 4318 $svc.httpPort }}
       targetPort: otlp-http

--- a/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
+++ b/deploy/kubernetes/ongrid-edge/templates/telemetry-gateway-service.yaml
@@ -23,6 +23,10 @@ spec:
       port: {{ default 4317 $svc.grpcPort }}
       targetPort: otlp-grpc
       protocol: TCP
+    - name: skywalking-grpc
+      port: {{ default 11800 $svc.skywalkingGrpcPort }}
+      targetPort: skywalking-grpc
+      protocol: TCP
     - name: otlp-http
       port: {{ default 4318 $svc.httpPort }}
       targetPort: otlp-http

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -176,6 +176,7 @@ telemetryGateway:
   service:
     type: ClusterIP
     grpcPort: 4317
+    skywalkingGrpcPort: 11800
     httpPort: 4318
 
 podSecurity:

--- a/deploy/kubernetes/ongrid-edge/values.yaml
+++ b/deploy/kubernetes/ongrid-edge/values.yaml
@@ -177,6 +177,7 @@ telemetryGateway:
     type: ClusterIP
     grpcPort: 4317
     skywalkingGrpcPort: 11800
+    skywalkingHttpPort: 12800
     httpPort: 4318
 
 podSecurity:

--- a/dist/build-otelcol.sh
+++ b/dist/build-otelcol.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build the official contrib distribution with the pinned SkyWalking bind fix.
+set -euo pipefail
+version=${1:?version required}
+target=${2:?os-arch required}
+dest=${3:?output binary required}
+[[ "$version" == 0.157.0-ongrid.1 ]] || { echo "unsupported patched Collector version: $version" >&2; exit 1; }
+case "$target" in linux-amd64|linux-arm64|darwin-amd64|darwin-arm64) ;; *) echo "unsupported Collector target: $target" >&2; exit 1 ;; esac
+go_bin=$(go env GOROOT)/bin/go
+root=$(cd "$(dirname "$0")/.." && pwd)
+mkdir -p "$(dirname "$dest")"
+dest=$(cd "$(dirname "$dest")" && pwd)/$(basename "$dest")
+sha256() { if command -v sha256sum >/dev/null; then sha256sum "$1"; else shasum -a 256 "$1"; fi | awk '{print $1}'; }
+revision="$version $(sha256 "$root/dist/patches/skywalking-grpc-bind.patch")"
+if [[ -s "$dest" && -f "$dest.version" && "$(cat "$dest.version")" == "$revision $(sha256 "$dest")" ]]; then
+    echo "[otelcol] verified cached $version: $dest"
+    exit 0
+fi
+work=$(mktemp -d /tmp/ongrid-otelcol.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+curl -fsSL --retry 3 --connect-timeout 15 https://codeload.github.com/open-telemetry/opentelemetry-collector-releases/tar.gz/refs/tags/v0.157.0 -o "$work/releases.tgz"
+[[ "$(sha256 "$work/releases.tgz")" == b8058145292617c87b5acf7c316a801790a58899dfb88114ea71395795706c09 ]] || { echo 'Collector source checksum mismatch' >&2; exit 1; }
+tar -xzf "$work/releases.tgz" --strip-components=1 -C "$work"
+# Go verifies the receiver module through go.sum / the module checksum database.
+module=github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
+"$go_bin" mod download "$module@v0.157.0"
+cp -R "$("$go_bin" env GOMODCACHE)/$module@v0.157.0" "$work/skywalkingreceiver"
+chmod -R u+w "$work/skywalkingreceiver"
+(cd "$work/skywalkingreceiver" && patch -p1 < "$root/dist/patches/skywalking-grpc-bind.patch")
+bash "$work/scripts/prepare-obi.sh" otelcol-contrib
+cd "$work/distributions/otelcol-contrib"
+printf '\n  - "%s => %s"\n' "$module" "$work/skywalkingreceiver" >> manifest.yaml
+sed "s/version: 0.157.0/version: $version/" manifest.yaml > patched.yaml
+"$go_bin" run go.opentelemetry.io/collector/cmd/builder@v0.157.0 --config=patched.yaml --skip-compilation
+cd _build
+CGO_ENABLED=0 GOOS=${target%-*} GOARCH=${target##*-} "$go_bin" build -p "${ONGRID_COLLECTOR_BUILD_JOBS:-4}" -trimpath -tags grpcnotrace -ldflags='-s -w' -o "$work/otelcol-contrib" .
+# Replace only a successful build; leave the previous binary intact on failure.
+install -m 0755 "$work/otelcol-contrib" "$dest.new"
+mv -f "$dest.new" "$dest"
+printf '%s %s\n' "$revision" "$(sha256 "$dest")" > "$dest.version"
+echo "[otelcol] built $version: $dest"

--- a/dist/patches/skywalking-grpc-bind.patch
+++ b/dist/patches/skywalking-grpc-bind.patch
@@ -1,0 +1,28 @@
+--- a/skywalking_receiver.go
++++ b/skywalking_receiver.go
+@@ -90,11 +90,10 @@
+ }
+ 
+ func (sr *swReceiver) collectorGRPCAddr() string {
+-	var port int
+ 	if sr.config != nil {
+-		port = sr.config.CollectorGRPCPort
++		return sr.config.CollectorGRPCServerSettings.NetAddr.Endpoint
+ 	}
+-	return fmt.Sprintf(":%d", port)
++	return ":0"
+ }
+ 
+ func (sr *swReceiver) collectorGRPCEnabled() bool {
+--- a/config.go
++++ b/config.go
+@@ -27,6 +27,9 @@
+ // Config defines configuration for skywalking receiver.
+ type Config struct {
+ 	Protocols `mapstructure:"protocols"`
++	// RequireGRPCBindHost is a capability marker for Ongrid's bind-host fix.
++	// Older upstream binaries reject this field instead of opening all interfaces.
++	RequireGRPCBindHost bool `mapstructure:"require_grpc_bind_host"`
+ 	// prevent unkeyed literal initialization
+ 	_ struct{}
+ }

--- a/docs/runbooks/skywalking-traces.md
+++ b/docs/runbooks/skywalking-traces.md
@@ -31,3 +31,8 @@ make test-k8s-chart
 ```
 
 真实 Collector 测试使用 SkyWalking v3 gRPC 报文，验证转换后的 span、父子关系、服务名、设备归属、原有 OTLP 接收，以及原始 SkyWalking ID 查询与实际转换结果的一致性。它不替代实际 Java agent 与已部署平台的联调。
+
+## 协议开关
+
+SkyWalking 接收器分别支持 gRPC `11800` 和 HTTP `12800`（`POST /v3/segments`，SkyWalking JSON）。插件面板与 OTLP 一样提供两个开关，默认均开启。`skywalking_receivers.grpc/http` 与 `receivers.grpc/http` 设置为 false 可关闭对应协议；至少保留一个 Trace 接收协议，日志/指标管道需要保留 OTLP。
+HTTP 地址通过 `skywalking_http_endpoint` 设置，默认继承 OTLP HTTP 的监听 IP。Kubernetes Service 端口通过 `telemetryGateway.service.skywalkingHttpPort` 设置。

--- a/docs/runbooks/skywalking-traces.md
+++ b/docs/runbooks/skywalking-traces.md
@@ -17,7 +17,7 @@
 - 如端口被占用，可在已有插件 JSON 配置中设置 `skywalking_grpc_endpoint`，例如 `"127.0.0.1:21800"`。应用上报地址需同步修改；Kubernetes 自定义 Service 对外端口用 `telemetryGateway.service.skywalkingGrpcPort`，其容器目标端口仍为 `11800`。
 - SkyWalking 和 OTLP 不能监听同一 IP、同一 TCP 端口。无效配置在渲染/校验阶段拒绝；其他进程占用端口时，Collector 启动失败，具体绑定错误见插件工作目录的 `traces/traces.log`。
 - 不要手改生成的 `otelcol.yaml`：配置下发会重新生成它。
-- SkyWalking trace ID 会经上游转换器映射为 OTLP trace ID，不能假设原始 ID 可直接用于平台的 trace ID 精确查询；先按服务名定位。
+- 平台的 trace ID 输入框可直接粘贴日志中的原始 SkyWalking ID，无需先按服务名查找。查询端自动按 Collector 的规则转换并直查 Tempo，不受列表筛选时间窗限制（数据仍须在存储保留期内）。原始 ID 同时保存在 `sw8.trace_id`，详情页支持查看和复制；已有 OTLP ID 仍可照常使用。
 
 ## 回滚
 
@@ -30,4 +30,4 @@ ONGRID_TEST_OTELCOL_BINARY=/absolute/path/to/otelcol-contrib go test -race ./int
 make test-k8s-chart
 ```
 
-真实 Collector 测试使用 SkyWalking v3 gRPC 报文，验证转换后的 span、父子关系、服务名、设备归属和原有 OTLP 接收。它不替代实际 Java agent 与已部署平台的联调。
+真实 Collector 测试使用 SkyWalking v3 gRPC 报文，验证转换后的 span、父子关系、服务名、设备归属、原有 OTLP 接收，以及原始 SkyWalking ID 查询与实际转换结果的一致性。它不替代实际 Java agent 与已部署平台的联调。

--- a/docs/runbooks/skywalking-traces.md
+++ b/docs/runbooks/skywalking-traces.md
@@ -5,7 +5,7 @@
 ## 接入
 
 1. 升级包含本功能的 edge，确认 `traces` 插件处于运行状态。只升级 manager 不会改变旧 edge 的接收能力。
-2. SkyWalking gRPC 配置默认继承 OTLP gRPC 的监听 IP，端口为 `11800`；HTTP 继承 OTLP HTTP 的监听 IP，端口为 `12800`。**合并阻塞：Collector 0.157.0 的 gRPC 实现只使用端口，实际监听所有网卡，未遵守配置的 IP；修复依赖或加入有效隔离前不能按 localhost-only 能力发布。** HTTP 遵守监听 IP。Kubernetes Chart 提供两个 Service 端口。
+2. SkyWalking gRPC 配置默认继承 OTLP gRPC 的监听 IP，端口为 `11800`；HTTP 继承 OTLP HTTP 的监听 IP，端口为 `12800`。发行包使用 `0.157.0-ongrid.1`，修正上游 gRPC 丢弃监听 IP 的问题；gRPC 和 HTTP 均遵守监听 IP。Kubernetes Chart 提供两个 Service 端口。
 3. 将 SkyWalking Java agent 的 `collector.backend_service`（环境变量 `SW_AGENT_COLLECTOR_BACKEND_SERVICES`）设置为应用可达的 `host:11800`，按应用的发布流程重启以加载配置。
 4. 发起一笔业务请求，在平台 Trace 页面按服务名和时间范围查询。
 
@@ -13,7 +13,7 @@
 
 ## 高级配置和排错
 
-- HTTP 默认 localhost 只允许本机应用接入。gRPC 存在上述监听范围问题，不能依赖 endpoint 的 IP 限制来源。
+- 两种协议默认 localhost，只允许本机应用接入；远程应用需配置可达的监听地址，并按网络策略限制来源。
 - 如端口被占用，可在已有插件 JSON 配置中设置 `skywalking_grpc_endpoint`，例如 `"127.0.0.1:21800"`。应用上报地址需同步修改；Kubernetes 自定义 Service 对外端口用 `telemetryGateway.service.skywalkingGrpcPort`，其容器目标端口仍为 `11800`。
 - SkyWalking 和 OTLP 不能监听同一 IP、同一 TCP 端口。无效配置在渲染/校验阶段拒绝；其他进程占用端口时，Collector 启动失败，具体绑定错误见插件工作目录的 `traces/traces.log`。
 - 不要手改生成的 `otelcol.yaml`：配置下发会重新生成它。
@@ -36,3 +36,11 @@ make test-k8s-chart
 
 SkyWalking 接收器分别支持 gRPC `11800` 和 HTTP `12800`（`POST /v3/segments`，SkyWalking JSON）。插件面板与 OTLP 一样提供两个开关，默认均开启。`skywalking_receivers.grpc/http` 与 `receivers.grpc/http` 设置为 false 可关闭对应协议；至少保留一个 Trace 接收协议，日志/指标管道需要保留 OTLP。
 HTTP 地址通过 `skywalking_http_endpoint` 设置，默认继承 OTLP HTTP 的监听 IP。Kubernetes Service 端口通过 `telemetryGateway.service.skywalkingHttpPort` 设置。
+
+## Collector 监听修复与升级
+
+上游 0.157.0 的 SkyWalking gRPC 接收器忽略 endpoint 的主机部分。`make fetch-otelcol` 从固定且经 SHA256 校验的官方发行版源码构建完整 contrib 组件清单，应用 `dist/patches/skywalking-grpc-bind.patch`，得到 `0.157.0-ongrid.1`。HTTP 实现未修改。
+
+gRPC 配置包含 `require_grpc_bind_host: true` 能力标记。旧上游二进制会在配置校验阶段拒绝此字段，避免只升级 Edge 后意外打开全网卡监听。升级时应同时安装新版 Collector 依赖附件；新版依赖标签包含 `0.157.0-ongrid.1`，旧二进制缓存不会被复用。Kubernetes 镜像和完整升级包使用同一构建入口。
+
+真实 Collector 测试同时验证本机 gRPC/HTTP 上报成功，以及非 loopback 地址无法连接两种协议端口。CI 对相关改动构建修补版并运行该测试。待上游正式修复后，应先通过此测试再移除补丁及能力标记。

--- a/docs/runbooks/skywalking-traces.md
+++ b/docs/runbooks/skywalking-traces.md
@@ -1,11 +1,11 @@
 # SkyWalking agent 接入 Trace
 
-开启 edge 现有的 `traces` 插件后，OTLP 和 SkyWalking gRPC 同时接收，经过同一条资源补充、批处理和 OTLP 转发链路进入平台。无需额外的 SkyWalking 开关，也不需要另部署 Collector。
+开启 edge 现有的 `traces` 插件后，OTLP 和 SkyWalking gRPC/HTTP 默认同时接收，经过同一条资源补充、批处理和 OTLP 转发链路进入平台。两种协议可分别关闭，不需要另部署 Collector。
 
 ## 接入
 
 1. 升级包含本功能的 edge，确认 `traces` 插件处于运行状态。只升级 manager 不会改变旧 edge 的接收能力。
-2. SkyWalking gRPC 默认使用 OTLP gRPC 的监听 IP，端口为 `11800`。普通 edge 默认 `127.0.0.1:11800`；Kubernetes telemetry gateway 为 `0.0.0.0:11800`，Chart 同时提供 Service 端口。
+2. SkyWalking gRPC 配置默认继承 OTLP gRPC 的监听 IP，端口为 `11800`；HTTP 继承 OTLP HTTP 的监听 IP，端口为 `12800`。**合并阻塞：Collector 0.157.0 的 gRPC 实现只使用端口，实际监听所有网卡，未遵守配置的 IP；修复依赖或加入有效隔离前不能按 localhost-only 能力发布。** HTTP 遵守监听 IP。Kubernetes Chart 提供两个 Service 端口。
 3. 将 SkyWalking Java agent 的 `collector.backend_service`（环境变量 `SW_AGENT_COLLECTOR_BACKEND_SERVICES`）设置为应用可达的 `host:11800`，按应用的发布流程重启以加载配置。
 4. 发起一笔业务请求，在平台 Trace 页面按服务名和时间范围查询。
 
@@ -13,7 +13,7 @@
 
 ## 高级配置和排错
 
-- 默认 localhost 只允许本机应用接入。容器或远程应用需使用可达的监听地址，并按现有网络策略限制来源。
+- HTTP 默认 localhost 只允许本机应用接入。gRPC 存在上述监听范围问题，不能依赖 endpoint 的 IP 限制来源。
 - 如端口被占用，可在已有插件 JSON 配置中设置 `skywalking_grpc_endpoint`，例如 `"127.0.0.1:21800"`。应用上报地址需同步修改；Kubernetes 自定义 Service 对外端口用 `telemetryGateway.service.skywalkingGrpcPort`，其容器目标端口仍为 `11800`。
 - SkyWalking 和 OTLP 不能监听同一 IP、同一 TCP 端口。无效配置在渲染/校验阶段拒绝；其他进程占用端口时，Collector 启动失败，具体绑定错误见插件工作目录的 `traces/traces.log`。
 - 不要手改生成的 `otelcol.yaml`：配置下发会重新生成它。
@@ -30,7 +30,7 @@ ONGRID_TEST_OTELCOL_BINARY=/absolute/path/to/otelcol-contrib go test -race ./int
 make test-k8s-chart
 ```
 
-真实 Collector 测试使用 SkyWalking v3 gRPC 报文，验证转换后的 span、父子关系、服务名、设备归属、原有 OTLP 接收，以及原始 SkyWalking ID 查询与实际转换结果的一致性。它不替代实际 Java agent 与已部署平台的联调。
+真实 Collector 测试使用 SkyWalking v3 gRPC 报文和 HTTP JSON 数组，验证转换后的 span、父子关系、服务名、设备归属、原有 OTLP 接收，以及原始 SkyWalking ID 查询与实际转换结果的一致性。它不替代实际 Java agent 与已部署平台的联调。
 
 ## 协议开关
 

--- a/docs/runbooks/skywalking-traces.md
+++ b/docs/runbooks/skywalking-traces.md
@@ -1,0 +1,33 @@
+# SkyWalking agent 接入 Trace
+
+开启 edge 现有的 `traces` 插件后，OTLP 和 SkyWalking gRPC 同时接收，经过同一条资源补充、批处理和 OTLP 转发链路进入平台。无需额外的 SkyWalking 开关，也不需要另部署 Collector。
+
+## 接入
+
+1. 升级包含本功能的 edge，确认 `traces` 插件处于运行状态。只升级 manager 不会改变旧 edge 的接收能力。
+2. SkyWalking gRPC 默认使用 OTLP gRPC 的监听 IP，端口为 `11800`。普通 edge 默认 `127.0.0.1:11800`；Kubernetes telemetry gateway 为 `0.0.0.0:11800`，Chart 同时提供 Service 端口。
+3. 将 SkyWalking Java agent 的 `collector.backend_service`（环境变量 `SW_AGENT_COLLECTOR_BACKEND_SERVICES`）设置为应用可达的 `host:11800`，按应用的发布流程重启以加载配置。
+4. 发起一笔业务请求，在平台 Trace 页面按服务名和时间范围查询。
+
+支持边界以 Collector 0.157.0 的 [SkyWalking receiver 文档](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/skywalkingreceiver/README.md) 为准：Java agent 8.9.0+，traces 为 beta。此接入只启用 SkyWalking traces，不提供 OAP 的完整管理、日志或 JVM 指标能力，也不会自动双写原 OAP。
+
+## 高级配置和排错
+
+- 默认 localhost 只允许本机应用接入。容器或远程应用需使用可达的监听地址，并按现有网络策略限制来源。
+- 如端口被占用，可在已有插件 JSON 配置中设置 `skywalking_grpc_endpoint`，例如 `"127.0.0.1:21800"`。应用上报地址需同步修改；Kubernetes 自定义 Service 对外端口用 `telemetryGateway.service.skywalkingGrpcPort`，其容器目标端口仍为 `11800`。
+- SkyWalking 和 OTLP 不能监听同一 IP、同一 TCP 端口。无效配置在渲染/校验阶段拒绝；其他进程占用端口时，Collector 启动失败，具体绑定错误见插件工作目录的 `traces/traces.log`。
+- 不要手改生成的 `otelcol.yaml`：配置下发会重新生成它。
+- SkyWalking trace ID 会经上游转换器映射为 OTLP trace ID，不能假设原始 ID 可直接用于平台的 trace ID 精确查询；先按服务名定位。
+
+## 回滚
+
+回滚 edge 到升级前版本即可恢复原来的 OTLP-only 配置；如已调整 agent 上报目标，同步恢复到原 OAP。关闭 `traces` 插件会同时关闭 OTLP 与 SkyWalking 接收。
+
+## 开发验证
+
+```sh
+ONGRID_TEST_OTELCOL_BINARY=/absolute/path/to/otelcol-contrib go test -race ./internal/edgeagent/plugins/traces
+make test-k8s-chart
+```
+
+真实 Collector 测试使用 SkyWalking v3 gRPC 报文，验证转换后的 span、父子关系、服务名、设备归属和原有 OTLP 接收。它不替代实际 Java agent 与已部署平台的联调。

--- a/internal/edgeagent/plugins/traces/plugin.go
+++ b/internal/edgeagent/plugins/traces/plugin.go
@@ -3,7 +3,7 @@
 // It wraps an OpenTelemetry Collector (otelcol-contrib) subprocess:
 // ongrid-edge writes an otelcol config derived from the manager-pushed
 // PluginConfig, spawns otelcol-contrib, and lets it accept OTLP gRPC/HTTP
-// from local applications and push directly to manager nginx /v1/traces.
+// and SkyWalking gRPC from local applications and push directly to manager nginx /v1/traces.
 // ongrid-edge does not touch the trace byte stream.
 //
 // Plugin name "traces" is plural — OTel signal naming convention

--- a/internal/edgeagent/plugins/traces/plugin.go
+++ b/internal/edgeagent/plugins/traces/plugin.go
@@ -3,7 +3,7 @@
 // It wraps an OpenTelemetry Collector (otelcol-contrib) subprocess:
 // ongrid-edge writes an otelcol config derived from the manager-pushed
 // PluginConfig, spawns otelcol-contrib, and lets it accept OTLP gRPC/HTTP
-// and SkyWalking gRPC from local applications and push directly to manager nginx /v1/traces.
+// and SkyWalking gRPC/HTTP from local applications and push directly to manager nginx /v1/traces.
 // ongrid-edge does not touch the trace byte stream.
 //
 // Plugin name "traces" is plural — OTel signal naming convention

--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -15,7 +15,7 @@ import (
 
 // otelcolTemplate is the OTel Collector config we render per edge.
 //
-// Receivers: OTLP gRPC + HTTP and SkyWalking gRPC. SkyWalking inherits the
+// Receivers: OTLP gRPC + HTTP and SkyWalking gRPC + HTTP. SkyWalking inherits the
 // OTLP gRPC bind host, keeping standalone edges on localhost and Kubernetes
 // gateways on their configured interface.
 //
@@ -34,16 +34,30 @@ const otelcolTemplate = `# Rendered by ongrid-edge traces plugin.
 # DO NOT EDIT — regenerated from manager-pushed PluginConfig on every reconcile.
 
 receivers:
+{{- if .OTLPEnabled }}
   otlp:
     protocols:
+{{- if .GRPCEnabled }}
       grpc:
         endpoint: {{ printf "%q" .GRPCEndpoint }}
+{{- end }}
+{{- if .HTTPEnabled }}
       http:
         endpoint: {{ printf "%q" .HTTPEndpoint }}
+{{- end }}
+{{- end }}
+{{- if .SkyWalkingEnabled }}
   skywalking:
     protocols:
+{{- if .SkyWalkingGRPCEnabled }}
       grpc:
         endpoint: {{ printf "%q" .SkyWalkingGRPCEndpoint }}
+{{- end }}
+{{- if .SkyWalkingHTTPEnabled }}
+      http:
+        endpoint: {{ printf "%q" .SkyWalkingHTTPEndpoint }}
+{{- end }}
+{{- end }}
 
 processors:
 {{- if .BoundedPipelines }}
@@ -248,7 +262,7 @@ service:
                 without_units: true
   pipelines:
     traces:
-      receivers: [otlp, skywalking]
+      receivers: [{{ if .OTLPEnabled }}otlp{{ if .SkyWalkingEnabled }}, {{ end }}{{ end }}{{ if .SkyWalkingEnabled }}skywalking{{ end }}]
       processors: [{{ if .BoundedPipelines }}memory_limiter, {{ end }}{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, {{ if .BoundedPipelines }}batch/traces{{ else }}batch{{ end }}]
       exporters: [otlphttp/manager]
 {{- if .LogsEnabled }}
@@ -269,6 +283,9 @@ service:
 //
 //	grpc_endpoint : string (default "127.0.0.1:4317")
 //	http_endpoint : string (default "127.0.0.1:4318")
+//	skywalking_http_endpoint : string (default OTLP HTTP host with port 12800)
+//	skywalking_receivers : object with grpc/http booleans (default both true)
+//	receivers : object with grpc/http booleans (default both true)
 //	skywalking_grpc_endpoint : string (default OTLP gRPC host with port 11800)
 //	extra_attrs : map[string]string (extra resource attributes)
 //	tls_insecure_skip_verify : bool (default TRUE — skip cert verification
@@ -299,10 +316,27 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 
 	grpcEP := stringOr(cfg.Spec, "grpc_endpoint", "127.0.0.1:4317")
 	httpEP := stringOr(cfg.Spec, "http_endpoint", "127.0.0.1:4318")
-	skywalkingEP, err := skywalkingEndpoint(cfg.Spec, grpcEP, httpEP)
+	skywalkingEP, err := skywalkingEndpoint(cfg.Spec, "skywalking_grpc_endpoint", "11800", grpcEP, grpcEP, httpEP)
 	if err != nil {
 		return nil, err
 	}
+	skywalkingHTTP, err := skywalkingEndpoint(cfg.Spec, "skywalking_http_endpoint", "12800", httpEP, grpcEP, httpEP, skywalkingEP)
+	if err != nil {
+		return nil, err
+	}
+	grpcEnabled := receiverEnabled(cfg.Spec, "receivers", "grpc")
+	httpEnabled := receiverEnabled(cfg.Spec, "receivers", "http")
+	swGRPCEnabled := receiverEnabled(cfg.Spec, "skywalking_receivers", "grpc")
+	swHTTPEnabled := receiverEnabled(cfg.Spec, "skywalking_receivers", "http")
+	if !grpcEnabled && !httpEnabled {
+		if !swGRPCEnabled && !swHTTPEnabled {
+			return nil, fmt.Errorf("traces plugin: at least one receiver must be enabled")
+		}
+		if boolSpec(cfg.Spec, "enable_logs") || boolSpec(cfg.Spec, "enable_metrics") {
+			return nil, fmt.Errorf("traces plugin: OTLP receiver required for logs or metrics")
+		}
+	}
+
 	extra := stringMap(cfg.Spec, "extra_attrs")
 	k8sAttributes := boolSpec(cfg.Spec, "enable_k8sattributes")
 	logsEnabled := boolSpec(cfg.Spec, "enable_logs")
@@ -396,6 +430,13 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 		"GRPCEndpoint":               grpcEP,
 		"HTTPEndpoint":               httpEP,
 		"SkyWalkingGRPCEndpoint":     skywalkingEP,
+		"SkyWalkingHTTPEndpoint":     skywalkingHTTP,
+		"GRPCEnabled":                grpcEnabled,
+		"HTTPEnabled":                httpEnabled,
+		"OTLPEnabled":                grpcEnabled || httpEnabled,
+		"SkyWalkingGRPCEnabled":      swGRPCEnabled,
+		"SkyWalkingHTTPEnabled":      swHTTPEnabled,
+		"SkyWalkingEnabled":          swGRPCEnabled || swHTTPEnabled,
 		"ExtraAttrs":                 extra,
 		"Endpoint":                   strings.TrimRight(cfg.Endpoint, "/"),
 		"AuthHeader":                 authHeader,
@@ -540,29 +581,36 @@ func intSpec(spec map[string]interface{}, key string, fallback int) int {
 }
 
 // skywalkingEndpoint keeps the existing listener scope unless explicitly overridden.
-func skywalkingEndpoint(spec map[string]interface{}, grpcEP, httpEP string) (string, error) {
-	host, _, err := net.SplitHostPort(grpcEP)
+func skywalkingEndpoint(spec map[string]interface{}, key, defaultPort, baseEndpoint string, occupied ...string) (string, error) {
+	host, _, err := net.SplitHostPort(baseEndpoint)
 	if err != nil {
-		return "", fmt.Errorf("traces plugin: invalid grpc_endpoint: %w", err)
+		return "", fmt.Errorf("traces plugin: invalid base listener for %s: %w", key, err)
 	}
-	endpoint := net.JoinHostPort(host, "11800")
-	if raw, ok := spec["skywalking_grpc_endpoint"]; ok {
+	endpoint := net.JoinHostPort(host, defaultPort)
+	if raw, ok := spec[key]; ok {
 		value, ok := raw.(string)
 		if !ok || strings.TrimSpace(value) == "" {
-			return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint must be a non-empty host:port string")
+			return "", fmt.Errorf("traces plugin: %s must be a non-empty host:port string", key)
 		}
 		endpoint = strings.TrimSpace(value)
 	}
 	_, port, err := net.SplitHostPort(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("traces plugin: invalid skywalking_grpc_endpoint: %w", err)
+		return "", fmt.Errorf("traces plugin: invalid %s: %w", key, err)
 	}
 	portNumber, err := strconv.Atoi(port)
 	if err != nil || portNumber < 1 || portNumber > 65535 || strings.ContainsAny(endpoint, "\r\n\t ") {
-		return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint requires host:port with port between 1 and 65535")
+		return "", fmt.Errorf("traces plugin: %s requires host:port with port between 1 and 65535", key)
 	}
-	if endpoint == grpcEP || endpoint == httpEP {
-		return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint conflicts with an OTLP listener; use a separate port")
+	for _, other := range occupied {
+		if endpoint == other {
+			return "", fmt.Errorf("traces plugin: %s conflicts with another listener; use a separate port", key)
+		}
 	}
 	return endpoint, nil
+}
+
+func receiverEnabled(spec map[string]interface{}, group, protocol string) bool {
+	receivers, _ := spec[group].(map[string]interface{})
+	return receivers[protocol] != false
 }

--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -48,6 +48,9 @@ receivers:
 {{- end }}
 {{- if .SkyWalkingEnabled }}
   skywalking:
+{{- if .SkyWalkingGRPCEnabled }}
+    require_grpc_bind_host: true
+{{- end }}
     protocols:
 {{- if .SkyWalkingGRPCEnabled }}
       grpc:

--- a/internal/edgeagent/plugins/traces/render.go
+++ b/internal/edgeagent/plugins/traces/render.go
@@ -15,10 +15,9 @@ import (
 
 // otelcolTemplate is the OTel Collector config we render per edge.
 //
-// Receivers: OTLP gRPC + HTTP, bound to docker bridge / localhost addresses
-// the application can reach. We intentionally do NOT bind 0.0.0.0 — the edge
-// is meant to ingest from local apps (host or sibling containers on the
-// docker bridge), not from the public internet.
+// Receivers: OTLP gRPC + HTTP and SkyWalking gRPC. SkyWalking inherits the
+// OTLP gRPC bind host, keeping standalone edges on localhost and Kubernetes
+// gateways on their configured interface.
 //
 // Exporters: a single OTLP HTTP exporter pointing at the manager /v1/traces
 // endpoint. Use traces_endpoint, not endpoint: otlphttp.endpoint is a base URL
@@ -38,9 +37,13 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: {{ .GRPCEndpoint }}
+        endpoint: {{ printf "%q" .GRPCEndpoint }}
       http:
-        endpoint: {{ .HTTPEndpoint }}
+        endpoint: {{ printf "%q" .HTTPEndpoint }}
+  skywalking:
+    protocols:
+      grpc:
+        endpoint: {{ printf "%q" .SkyWalkingGRPCEndpoint }}
 
 processors:
 {{- if .BoundedPipelines }}
@@ -245,7 +248,7 @@ service:
                 without_units: true
   pipelines:
     traces:
-      receivers: [otlp]
+      receivers: [otlp, skywalking]
       processors: [{{ if .BoundedPipelines }}memory_limiter, {{ end }}{{ if .K8sAttributesEnabled }}k8sattributes, {{ end }}resource/device, {{ if .BoundedPipelines }}batch/traces{{ else }}batch{{ end }}]
       exporters: [otlphttp/manager]
 {{- if .LogsEnabled }}
@@ -266,6 +269,7 @@ service:
 //
 //	grpc_endpoint : string (default "127.0.0.1:4317")
 //	http_endpoint : string (default "127.0.0.1:4318")
+//	skywalking_grpc_endpoint : string (default OTLP gRPC host with port 11800)
 //	extra_attrs : map[string]string (extra resource attributes)
 //	tls_insecure_skip_verify : bool (default TRUE — skip cert verification
 //	                          on the OTLP/HTTPS push so the standard
@@ -295,6 +299,10 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 
 	grpcEP := stringOr(cfg.Spec, "grpc_endpoint", "127.0.0.1:4317")
 	httpEP := stringOr(cfg.Spec, "http_endpoint", "127.0.0.1:4318")
+	skywalkingEP, err := skywalkingEndpoint(cfg.Spec, grpcEP, httpEP)
+	if err != nil {
+		return nil, err
+	}
 	extra := stringMap(cfg.Spec, "extra_attrs")
 	k8sAttributes := boolSpec(cfg.Spec, "enable_k8sattributes")
 	logsEnabled := boolSpec(cfg.Spec, "enable_logs")
@@ -387,6 +395,7 @@ func render(cfg plugins.PluginConfig) ([]byte, error) {
 		"EmitDeviceID":               !omitDeviceID,
 		"GRPCEndpoint":               grpcEP,
 		"HTTPEndpoint":               httpEP,
+		"SkyWalkingGRPCEndpoint":     skywalkingEP,
 		"ExtraAttrs":                 extra,
 		"Endpoint":                   strings.TrimRight(cfg.Endpoint, "/"),
 		"AuthHeader":                 authHeader,
@@ -528,4 +537,32 @@ func intSpec(spec map[string]interface{}, key string, fallback int) int {
 	default:
 		return fallback
 	}
+}
+
+// skywalkingEndpoint keeps the existing listener scope unless explicitly overridden.
+func skywalkingEndpoint(spec map[string]interface{}, grpcEP, httpEP string) (string, error) {
+	host, _, err := net.SplitHostPort(grpcEP)
+	if err != nil {
+		return "", fmt.Errorf("traces plugin: invalid grpc_endpoint: %w", err)
+	}
+	endpoint := net.JoinHostPort(host, "11800")
+	if raw, ok := spec["skywalking_grpc_endpoint"]; ok {
+		value, ok := raw.(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint must be a non-empty host:port string")
+		}
+		endpoint = strings.TrimSpace(value)
+	}
+	_, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("traces plugin: invalid skywalking_grpc_endpoint: %w", err)
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 || strings.ContainsAny(endpoint, "\r\n\t ") {
+		return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint requires host:port with port between 1 and 65535")
+	}
+	if endpoint == grpcEP || endpoint == httpEP {
+		return "", fmt.Errorf("traces plugin: skywalking_grpc_endpoint conflicts with an OTLP listener; use a separate port")
+	}
+	return endpoint, nil
 }

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -525,3 +525,34 @@ func TestRenderSkyWalkingEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestReceiverSwitches(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		spec         map[string]interface{}
+		want, absent string
+		invalid      bool
+	}{
+		{"HTTP only", map[string]interface{}{"receivers": map[string]interface{}{"grpc": false, "http": false}, "skywalking_receivers": map[string]interface{}{"grpc": false}}, "receivers: [skywalking]", "grpc:", false},
+		{"OTLP only", map[string]interface{}{"skywalking_receivers": map[string]interface{}{"grpc": false, "http": false}}, "receivers: [otlp]", "skywalking:", false},
+		{"all off", map[string]interface{}{"receivers": map[string]interface{}{"grpc": false, "http": false}, "skywalking_receivers": map[string]interface{}{"grpc": false, "http": false}}, "", "", true},
+		{"HTTP conflict", map[string]interface{}{"skywalking_http_endpoint": "127.0.0.1:11800"}, "", "", true},
+		{"HTTP custom", map[string]interface{}{"skywalking_http_endpoint": "127.0.0.1:22800"}, `endpoint: "127.0.0.1:22800"`, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := render(plugins.PluginConfig{EdgeID: 42, Endpoint: "http://manager/v1/traces", Spec: tc.spec})
+			if tc.invalid {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(out), tc.want) || (tc.absent != "" && strings.Contains(string(out), tc.absent)) {
+				t.Fatalf("unexpected receivers: %s", out)
+			}
+		})
+	}
+}

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -85,8 +86,9 @@ func TestRenderHappyPath(t *testing.T) {
 		"otlp:",
 		"grpc:",
 		"http:",
-		"endpoint: 0.0.0.0:4317",
-		"endpoint: 0.0.0.0:4318",
+		`endpoint: "0.0.0.0:4317"`,
+		`endpoint: "0.0.0.0:4318"`,
+		`endpoint: "0.0.0.0:11800"`,
 		// Exporter URL points at the full manager public trace endpoint.
 		// Use traces_endpoint so otelcol does not append /v1/traces again.
 		"traces_endpoint: https://manager.example.com/v1/traces",
@@ -100,7 +102,7 @@ func TestRenderHappyPath(t *testing.T) {
 		// otlphttp/manager.
 		"pipelines:",
 		"traces:",
-		"receivers: [otlp]",
+		"receivers: [otlp, skywalking]",
 		"processors: [resource/device, batch]",
 		"exporters: [otlphttp/manager]",
 	} {
@@ -142,10 +144,10 @@ func TestRenderDefaultEndpoints(t *testing.T) {
 	body := string(out)
 	// Defaults bind to localhost so the receiver isn't accidentally
 	// reachable from the public network on multi-homed hosts.
-	if !strings.Contains(body, "endpoint: 127.0.0.1:4317") {
+	if !strings.Contains(body, `endpoint: "127.0.0.1:4317"`) {
 		t.Errorf("default gRPC endpoint missing: %s", body)
 	}
-	if !strings.Contains(body, "endpoint: 127.0.0.1:4318") {
+	if !strings.Contains(body, `endpoint: "127.0.0.1:4318"`) {
 		t.Errorf("default HTTP endpoint missing: %s", body)
 	}
 }
@@ -294,8 +296,8 @@ func TestRenderOmitDeviceIDForGateway(t *testing.T) {
 		t.Fatalf("gateway config must not inject device_id:\n%s", body)
 	}
 	for _, want := range []string{
-		"endpoint: 0.0.0.0:4317",
-		"endpoint: 0.0.0.0:4318",
+		`endpoint: "0.0.0.0:4317"`,
+		`endpoint: "0.0.0.0:4318"`,
 		"k8sattributes:",
 		"auth_type: serviceAccount",
 		"k8s.namespace.name",
@@ -481,5 +483,45 @@ func TestRenderRejectsMissingEdgeID(t *testing.T) {
 	cfg := plugins.PluginConfig{Enabled: true, Endpoint: "https://x/v1/traces"}
 	if _, err := render(cfg); err == nil {
 		t.Errorf("render must reject missing edge_id")
+	}
+}
+
+func TestRenderSkyWalkingEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec map[string]interface{}
+		want string
+	}{
+		{"default", nil, "127.0.0.1:11800"},
+		{"gateway", map[string]interface{}{"grpc_endpoint": "0.0.0.0:4317"}, "0.0.0.0:11800"},
+		{"ipv6", map[string]interface{}{"grpc_endpoint": "[::1]:4317"}, "[::1]:11800"},
+		{"override", map[string]interface{}{"skywalking_grpc_endpoint": "127.0.0.1:21800"}, "127.0.0.1:21800"},
+		{"invalid", map[string]interface{}{"skywalking_grpc_endpoint": "http://localhost:11800"}, ""},
+		{"empty", map[string]interface{}{"skywalking_grpc_endpoint": ""}, ""},
+		{"wrong type", map[string]interface{}{"skywalking_grpc_endpoint": 11800}, ""},
+		{"zero port", map[string]interface{}{"skywalking_grpc_endpoint": "localhost:0"}, ""},
+		{"overflow", map[string]interface{}{"skywalking_grpc_endpoint": "localhost:65536"}, ""},
+		{"grpc conflict", map[string]interface{}{"skywalking_grpc_endpoint": "127.0.0.1:4317"}, ""},
+		{"http conflict", map[string]interface{}{"skywalking_grpc_endpoint": "127.0.0.1:4318"}, ""},
+		{"default conflict", map[string]interface{}{"grpc_endpoint": "127.0.0.1:11800"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := render(plugins.PluginConfig{EdgeID: 42, Endpoint: "https://manager.example.com/v1/traces", Spec: tc.spec})
+			if tc.want == "" {
+				if err == nil {
+					t.Fatal("expected invalid listener to be rejected")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(out), "skywalking:\n    protocols:\n      grpc:\n        endpoint: "+strconv.Quote(tc.want)) {
+				t.Fatalf("SkyWalking listener missing: %s", out)
+			}
+			if !strings.Contains(string(out), "receivers: [otlp, skywalking]") {
+				t.Fatal("SkyWalking must share the existing traces pipeline")
+			}
+		})
 	}
 }

--- a/internal/edgeagent/plugins/traces/render_test.go
+++ b/internal/edgeagent/plugins/traces/render_test.go
@@ -516,7 +516,7 @@ func TestRenderSkyWalkingEndpoints(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !strings.Contains(string(out), "skywalking:\n    protocols:\n      grpc:\n        endpoint: "+strconv.Quote(tc.want)) {
+			if !strings.Contains(string(out), "skywalking:\n    require_grpc_bind_host: true\n    protocols:\n      grpc:\n        endpoint: "+strconv.Quote(tc.want)) {
 				t.Fatalf("SkyWalking listener missing: %s", out)
 			}
 			if !strings.Contains(string(out), "receivers: [otlp, skywalking]") {
@@ -554,5 +554,35 @@ func TestReceiverSwitches(t *testing.T) {
 				t.Fatalf("unexpected receivers: %s", out)
 			}
 		})
+	}
+}
+
+// Older dependencies must reject default-on gRPC rather than silently bind '*'.
+func TestLegacyCollectorRejectsSkyWalkingGRPC(t *testing.T) {
+	binary := os.Getenv("ONGRID_TEST_LEGACY_OTELCOL_BINARY")
+	if binary == "" {
+		t.Skip("ONGRID_TEST_LEGACY_OTELCOL_BINARY is not set")
+	}
+	for _, enabled := range []bool{true, false} {
+		raw, err := render(plugins.PluginConfig{EdgeID: 42, Endpoint: "http://localhost:4318/v1/traces", Spec: map[string]interface{}{
+			"skywalking_receivers": map[string]interface{}{"grpc": enabled},
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "otelcol.yaml")
+		if err := os.WriteFile(path, raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		out, err := exec.CommandContext(ctx, binary, "validate", "--config="+path).CombinedOutput()
+		cancel()
+		if enabled {
+			if err == nil || !strings.Contains(string(out), "require_grpc_bind_host") {
+				t.Fatalf("legacy gRPC did not fail closed: %v %s", err, out)
+			}
+		} else if err != nil {
+			t.Fatalf("legacy HTTP-only configuration rejected: %v %s", err, out)
+		}
 	}
 }

--- a/internal/edgeagent/plugins/traces/skywalking_integration_test.go
+++ b/internal/edgeagent/plugins/traces/skywalking_integration_test.go
@@ -136,6 +136,32 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
+	// A localhost endpoint must not become a wildcard listener. Use the
+	// machine's other IPv4 address so the pre-fix Collector fails this check.
+	addresses, err := net.InterfaceAddrs()
+	require.NoError(t, err)
+	checked := false
+	for _, address := range addresses {
+		network, ok := address.(*net.IPNet)
+		if !ok || network.IP.IsLoopback() || network.IP.To4() == nil {
+			continue
+		}
+		for _, endpoint := range []string{swEP, swHTTP} {
+			_, port, err := net.SplitHostPort(endpoint)
+			require.NoError(t, err)
+			external, err := net.DialTimeout("tcp", net.JoinHostPort(network.IP.String(), port), time.Second)
+			if external != nil {
+				require.NoError(t, external.Close())
+			}
+			require.Error(t, err, "localhost receiver unexpectedly reachable through %s", network.IP)
+		}
+		checked = true
+		break
+	}
+	if !checked {
+		t.Log("no non-loopback IPv4 interface; network-isolation check unavailable")
+	}
+
 	// OTLP must still work concurrently through the same processing/export path.
 	otlp, err := grpc.NewClient(grpcEP, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)

--- a/internal/edgeagent/plugins/traces/skywalking_integration_test.go
+++ b/internal/edgeagent/plugins/traces/skywalking_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -67,12 +68,12 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 		w.Header().Set("Content-Type", "application/x-protobuf")
 	}))
 	t.Cleanup(sink.Close)
-	grpcEP, httpEP, swEP := freeTraceEndpoint(t), freeTraceEndpoint(t), freeTraceEndpoint(t)
+	grpcEP, httpEP, swEP, swHTTP := freeTraceEndpoint(t), freeTraceEndpoint(t), freeTraceEndpoint(t), freeTraceEndpoint(t)
 	raw, err := render(plugins.PluginConfig{
 		EdgeID: 42, Endpoint: sink.URL + "/v1/traces", AuthPass: "test-token",
 		Spec: map[string]interface{}{
 			"grpc_endpoint": grpcEP, "http_endpoint": httpEP,
-			"skywalking_grpc_endpoint": swEP, "collector_metrics_endpoint": freeTraceEndpoint(t),
+			"skywalking_grpc_endpoint": swEP, "skywalking_http_endpoint": swHTTP, "collector_metrics_endpoint": freeTraceEndpoint(t),
 		},
 	})
 	require.NoError(t, err)
@@ -129,6 +130,12 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	var response []byte
 	require.NoError(t, stream.RecvMsg(&response))
 
+	body := fmt.Sprintf(`{"traceId":%q,"traceSegmentId":"0123456789abcdef0123456789abcdef.2.17887680000000002","service":"skywalking-test-service","serviceInstance":"test-instance","spans":[{"spanId":0,"parentSpanId":-1,"startTime":%d,"endTime":%d,"operationName":"skywalking-http-test","spanType":0,"spanLayer":3}]}`, originalID, start, start+15)
+	resp, err := http.Post("http://"+swHTTP+"/v3/segments", "application/json", strings.NewReader("["+body+"]"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
 	// OTLP must still work concurrently through the same processing/export path.
 	otlp, err := grpc.NewClient(grpcEP, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
@@ -142,7 +149,7 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	require.NoError(t, err)
 
 	spans := map[string]*tracepb.Span{}
-	for len(spans) < 3 {
+	for len(spans) < 4 {
 		select {
 		case batch := <-batches:
 			for _, resource := range batch.ResourceSpans {
@@ -169,6 +176,7 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	require.NotNil(t, parent)
 	require.NotNil(t, childSpan)
 	require.NotNil(t, spans["otlp-still-works"])
+	require.NotNil(t, spans["skywalking-http-test"])
 	require.Equal(t, tracepb.Span_SPAN_KIND_SERVER, parent.Kind)
 	require.Equal(t, tracepb.Status_STATUS_CODE_ERROR, parent.Status.Code)
 	require.Equal(t, uint64(20_000_000), parent.EndTimeUnixNano-parent.StartTimeUnixNano)

--- a/internal/edgeagent/plugins/traces/skywalking_integration_test.go
+++ b/internal/edgeagent/plugins/traces/skywalking_integration_test.go
@@ -3,6 +3,7 @@ package traces
 import (
 	"compress/gzip"
 	"context"
+	"encoding/hex"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ongridio/ongrid/internal/edgeagent/plugins"
+	"github.com/ongridio/ongrid/internal/pkg/tracequery"
 	"github.com/stretchr/testify/require"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -116,7 +118,8 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	child = append(child, swInt(4, start+10)...)
 	child = append(child, swString(6, "child-operation")...)
 	child = append(child, swInt(8, 2)...)
-	segment := append(swString(1, "0123456789abcdef0123456789abcdef.1.17887680000000001"), swString(2, "0123456789abcdef0123456789abcdef.1.17887680000000002")...)
+	const originalID = "0123456789abcdef0123456789abcdef.1.17887680000000001"
+	segment := append(swString(1, originalID), swString(2, "0123456789abcdef0123456789abcdef.1.17887680000000002")...)
 	segment = append(segment, swString(3, string(root))...)
 	segment = append(segment, swString(3, string(child))...)
 	segment = append(segment, swString(4, "skywalking-test-service")...)
@@ -152,6 +155,7 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 					for _, span := range scope.Spans {
 						if span.Name != "otlp-still-works" {
 							require.Equal(t, "skywalking-test-service", attrs["service.name"])
+							require.Equal(t, originalID, attrs["sw8.trace_id"])
 						}
 						spans[span.Name] = span
 					}
@@ -173,6 +177,24 @@ func TestSkyWalkingCollectorForwarding(t *testing.T) {
 	require.Empty(t, parent.ParentSpanId)
 	require.Equal(t, parent.TraceId, childSpan.TraceId)
 	require.Equal(t, parent.SpanId, childSpan.ParentSpanId)
+
+	// Verify query normalization against the actual Collector output, not a
+	// second copy of its conversion algorithm. Original-ID lookup stays direct.
+	query := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/traces/"+hex.EncodeToString(parent.TraceId) {
+			t.Errorf("original ID resolved to %s, actual Collector ID is %x", r.URL.Path, parent.TraceId)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"batches":[]}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(query.Close)
+	_, err = tracequery.New(query.URL, nil).GetTrace(ctx, originalID)
+	require.NoError(t, err)
+
 }
 
 func freeTraceEndpoint(t *testing.T) string {

--- a/internal/edgeagent/plugins/traces/skywalking_integration_test.go
+++ b/internal/edgeagent/plugins/traces/skywalking_integration_test.go
@@ -1,0 +1,202 @@
+package traces
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/edgeagent/plugins"
+	"github.com/stretchr/testify/require"
+	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+// Opt-in alongside TestRenderedStandaloneConfigAcceptedByCollector. Uses the
+// real receiver/exporter, with a local OTLP sink replacing the manager.
+func TestSkyWalkingCollectorForwarding(t *testing.T) {
+	binary := os.Getenv("ONGRID_TEST_OTELCOL_BINARY")
+	if binary == "" {
+		t.Skip("ONGRID_TEST_OTELCOL_BINARY is not set")
+	}
+	batches := make(chan *collectortrace.ExportTraceServiceRequest, 4)
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/traces" || r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("wrong exporter destination or authentication")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var reader io.Reader = r.Body
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			z, err := gzip.NewReader(r.Body)
+			if err != nil {
+				t.Error(err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			defer z.Close()
+			reader = z
+		}
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		batch := &collectortrace.ExportTraceServiceRequest{}
+		if err := proto.Unmarshal(body, batch); err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		batches <- batch
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(sink.Close)
+	grpcEP, httpEP, swEP := freeTraceEndpoint(t), freeTraceEndpoint(t), freeTraceEndpoint(t)
+	raw, err := render(plugins.PluginConfig{
+		EdgeID: 42, Endpoint: sink.URL + "/v1/traces", AuthPass: "test-token",
+		Spec: map[string]interface{}{
+			"grpc_endpoint": grpcEP, "http_endpoint": httpEP,
+			"skywalking_grpc_endpoint": swEP, "collector_metrics_endpoint": freeTraceEndpoint(t),
+		},
+	})
+	require.NoError(t, err)
+	// Keep this check isolated from collectors already running on the machine.
+	raw = []byte(strings.ReplaceAll(string(raw), "127.0.0.1:13133", "127.0.0.1:0"))
+	configPath := filepath.Join(t.TempDir(), "otelcol.yaml")
+	require.NoError(t, os.WriteFile(configPath, raw, 0600))
+	logFile, err := os.CreateTemp(t.TempDir(), "collector-*.log")
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, "--config="+configPath)
+	cmd.Stdout, cmd.Stderr = logFile, logFile
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		cancel()
+		// Cancellation terminates the test-owned process; its exit is expected.
+		_ = cmd.Wait()
+		require.NoError(t, logFile.Close())
+		if t.Failed() {
+			output, err := os.ReadFile(logFile.Name())
+			require.NoError(t, err)
+			t.Log(string(output))
+		}
+	})
+	conn, err := grpc.NewClient(swEP, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	stream, err := conn.NewStream(ctx, &grpc.StreamDesc{ClientStreams: true},
+		"/skywalking.v3.TraceSegmentReportService/collect", grpc.ForceCodec(skywalkingWireCodec{}), grpc.WaitForReady(true))
+	require.NoError(t, err)
+
+	// SkyWalking v3 SegmentObject/SpanObject wire fields from Apache's
+	// skywalking-data-collect-protocol/language-agent/Tracing.proto. Encode the
+	// small fixture with the existing protobuf dependency instead of adding an SDK.
+	start := uint64(time.Now().UnixMilli())
+	root := append(swInt(2, ^uint64(0)), swInt(3, start)...)
+	root = append(root, swInt(4, start+20)...)
+	root = append(root, swString(6, "GET /skywalking-test")...)
+	root = append(root, swInt(9, 3)...)
+	root = append(root, swInt(11, 1)...)
+	child := append(swInt(1, 1), swInt(3, start+1)...)
+	child = append(child, swInt(4, start+10)...)
+	child = append(child, swString(6, "child-operation")...)
+	child = append(child, swInt(8, 2)...)
+	segment := append(swString(1, "0123456789abcdef0123456789abcdef.1.17887680000000001"), swString(2, "0123456789abcdef0123456789abcdef.1.17887680000000002")...)
+	segment = append(segment, swString(3, string(root))...)
+	segment = append(segment, swString(3, string(child))...)
+	segment = append(segment, swString(4, "skywalking-test-service")...)
+	segment = append(segment, swString(5, "test-instance")...)
+	require.NoError(t, stream.SendMsg(segment))
+	require.NoError(t, stream.CloseSend())
+	var response []byte
+	require.NoError(t, stream.RecvMsg(&response))
+
+	// OTLP must still work concurrently through the same processing/export path.
+	otlp, err := grpc.NewClient(grpcEP, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, otlp.Close()) })
+	_, err = collectortrace.NewTraceServiceClient(otlp).Export(ctx, &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{
+			Name: "otlp-still-works", TraceId: []byte("0123456789abcdef"), SpanId: []byte("01234567"),
+			StartTimeUnixNano: start * 1_000_000, EndTimeUnixNano: (start + 1) * 1_000_000,
+		}}}}}},
+	}, grpc.WaitForReady(true))
+	require.NoError(t, err)
+
+	spans := map[string]*tracepb.Span{}
+	for len(spans) < 3 {
+		select {
+		case batch := <-batches:
+			for _, resource := range batch.ResourceSpans {
+				attrs := map[string]string{}
+				for _, attr := range resource.Resource.Attributes {
+					attrs[attr.Key] = attr.Value.GetStringValue()
+				}
+				require.Equal(t, "42", attrs["device_id"])
+				for _, scope := range resource.ScopeSpans {
+					for _, span := range scope.Spans {
+						if span.Name != "otlp-still-works" {
+							require.Equal(t, "skywalking-test-service", attrs["service.name"])
+						}
+						spans[span.Name] = span
+					}
+				}
+			}
+		case <-ctx.Done():
+			t.Fatalf("missing converted spans: %v", spans)
+		}
+	}
+	parent, childSpan := spans["GET /skywalking-test"], spans["child-operation"]
+	require.NotNil(t, parent)
+	require.NotNil(t, childSpan)
+	require.NotNil(t, spans["otlp-still-works"])
+	require.Equal(t, tracepb.Span_SPAN_KIND_SERVER, parent.Kind)
+	require.Equal(t, tracepb.Status_STATUS_CODE_ERROR, parent.Status.Code)
+	require.Equal(t, uint64(20_000_000), parent.EndTimeUnixNano-parent.StartTimeUnixNano)
+	require.Len(t, parent.TraceId, 16)
+	require.Len(t, parent.SpanId, 8)
+	require.Empty(t, parent.ParentSpanId)
+	require.Equal(t, parent.TraceId, childSpan.TraceId)
+	require.Equal(t, parent.SpanId, childSpan.ParentSpanId)
+}
+
+func freeTraceEndpoint(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	endpoint := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return endpoint
+}
+
+func swString(field protowire.Number, value string) []byte {
+	return protowire.AppendString(protowire.AppendTag(nil, field, protowire.BytesType), value)
+}
+
+func swInt(field protowire.Number, value uint64) []byte {
+	return protowire.AppendVarint(protowire.AppendTag(nil, field, protowire.VarintType), value)
+}
+
+type skywalkingWireCodec struct{}
+
+func (skywalkingWireCodec) Name() string                          { return "proto" }
+func (skywalkingWireCodec) Marshal(v interface{}) ([]byte, error) { return v.([]byte), nil }
+func (skywalkingWireCodec) Unmarshal(data []byte, v interface{}) error {
+	*v.(*[]byte) = append([]byte(nil), data...)
+	return nil
+}

--- a/internal/pkg/tracequery/client.go
+++ b/internal/pkg/tracequery/client.go
@@ -2,6 +2,8 @@ package tracequery
 
 import (
 	"context"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,8 +11,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	oteltracing "github.com/ongridio/ongrid/internal/pkg/tracing"
 )
@@ -187,7 +192,7 @@ func (c *Client) TagValues(ctx context.Context, tag string) ([]string, error) {
 	return env.TagValues, nil
 }
 
-// GetTrace fetches a single trace by ID.
+// GetTrace accepts an OTLP ID or an original SkyWalking ID.
 func (c *Client) GetTrace(ctx context.Context, traceID string) (*TraceResult, error) {
 	if traceID == "" {
 		return nil, errors.New("tracequery: traceID is empty")
@@ -195,7 +200,7 @@ func (c *Client) GetTrace(ctx context.Context, traceID string) (*TraceResult, er
 	// /api/traces/<id> — id is path-encoded; Tempo accepts hex or
 	// 0x-prefixed forms. We don't validate format here so callers can
 	// surface Tempo's own 4xx error message verbatim.
-	path := "/api/traces/" + url.PathEscape(traceID)
+	path := "/api/traces/" + url.PathEscape(tempoTraceID(traceID))
 	body, err := c.do(ctx, path, nil)
 	if err != nil {
 		return nil, err
@@ -252,4 +257,39 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// tempoTraceID applies the bundled Collector's SkyWalking-to-OTLP mapping so
+// logs' original IDs can use direct lookup without a time-bounded attribute scan.
+// See collector-contrib/pkg/translator/skywalking/skywalkingproto_to_traces.go.
+// The real Collector integration test guards this mapping on dependency upgrades.
+func tempoTraceID(id string) string {
+	if len(id) == 36 {
+		if parsed, err := uuid.Parse(id); err == nil {
+			return hex.EncodeToString(parsed[:])
+		}
+	}
+	// The Collector treats IDs up to 36 characters as UUIDs, not Java IDs.
+	if len(id) <= 36 {
+		return id
+	}
+	parts := strings.SplitN(id, ".", 3)
+	if len(parts) != 3 || len(parts[0]) != 32 {
+		return id
+	}
+	mapped, err := hex.DecodeString(parts[0])
+	if err != nil {
+		return id
+	}
+	thread, err := strconv.ParseUint(parts[1], 10, 63)
+	if err != nil {
+		return id
+	}
+	sequence, err := strconv.ParseUint(parts[2], 10, 63)
+	if err != nil {
+		return id
+	}
+	binary.LittleEndian.PutUint32(mapped[4:8], binary.LittleEndian.Uint32(mapped[4:8])^uint32(thread))
+	binary.LittleEndian.PutUint64(mapped[8:], binary.LittleEndian.Uint64(mapped[8:])^sequence)
+	return hex.EncodeToString(mapped)
 }

--- a/internal/pkg/tracequery/client_test.go
+++ b/internal/pkg/tracequery/client_test.go
@@ -104,3 +104,31 @@ func TestClient_GetTrace_EmptyID(t *testing.T) {
 		t.Errorf("expected error for empty traceID")
 	}
 }
+
+func TestClient_GetTraceOriginalSkyWalkingID(t *testing.T) {
+	for _, tc := range []struct{ name, input, want string }{
+		{"java", "00000000000000000000000000000000.1.1000", "0000000001000000e803000000000000"},
+		{"uuid", "de5980b8-fce3-4a37-aab9-b4ac3af7eedd", "de5980b8fce34a37aab9b4ac3af7eedd"},
+		{"otlp", "abc123", "abc123"},
+		{"otlp prefixed", "0xabc123", "0xabc123"},
+		{"bad thread", "00000000000000000000000000000000.bad.1000", "00000000000000000000000000000000.bad.1000"},
+		{"bad uuid", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.1.1000", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.1.1000"},
+		{"overflow", "00000000000000000000000000000000.1.9223372036854775808", "00000000000000000000000000000000.1.9223372036854775808"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/traces/"+tc.want || r.URL.RawQuery != "" {
+					t.Errorf("lookup = %s, want direct ID lookup %s", r.URL, tc.want)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := w.Write([]byte(`{"batches":[]}`)); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer srv.Close()
+			if _, err := New(srv.URL, nil).GetTrace(context.Background(), tc.input); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -47,6 +47,7 @@ extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/default.yaml" "$
 extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-scraper.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-service.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway-service.yaml"
+grep -q 'containerPort: 12800' "$tmp_dir/default-gateway.yaml"
 grep -q 'containerPort: 11800' "$tmp_dir/default-gateway.yaml"
 grep -q 'targetPort: skywalking-grpc' "$tmp_dir/default-gateway-service.yaml"
 grep -q 'port: 11800' "$tmp_dir/default-gateway-service.yaml"

--- a/scripts/test-k8s-chart.sh
+++ b/scripts/test-k8s-chart.sh
@@ -47,6 +47,9 @@ extract_source 'ongrid-edge/templates/daemonset.yaml' "$tmp_dir/default.yaml" "$
 extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-scraper.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway.yaml"
 extract_source 'ongrid-edge/templates/telemetry-gateway-service.yaml' "$tmp_dir/default.yaml" "$tmp_dir/default-gateway-service.yaml"
+grep -q 'containerPort: 11800' "$tmp_dir/default-gateway.yaml"
+grep -q 'targetPort: skywalking-grpc' "$tmp_dir/default-gateway-service.yaml"
+grep -q 'port: 11800' "$tmp_dir/default-gateway-service.yaml"
 grep -q 'type: Recreate' "$tmp_dir/default.yaml"
 ! grep -q 'kubernetes.io/arch:' "$tmp_dir/default.yaml"
 if [[ -n "$expected_image" ]]; then
@@ -118,12 +121,16 @@ extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/compatibility.y
 ! grep -q '# Source: ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/compatibility.yaml"
 grep -q 'ONGRID_K8S_METRICS_ENDPOINT' "$tmp_dir/compatibility-controller.yaml"
 grep -q 'containerPort: 4317' "$tmp_dir/compatibility-controller.yaml"
+grep -q 'containerPort: 11800' "$tmp_dir/compatibility-controller.yaml"
 grep -q 'ongrid.io/telemetry-backend: "true"' "$tmp_dir/compatibility-controller.yaml"
 
 helm template split "$chart_package" "${common_args[@]}" \
+  --set telemetryGateway.service.skywalkingGrpcPort=21800 \
   --set telemetryGateway.mode=deployment \
   --set kubernetesMetrics.mode=scraper \
   >"$tmp_dir/split.yaml"
+grep -q 'port: 21800' "$tmp_dir/split.yaml"
+grep -q 'containerPort: 11800' "$tmp_dir/split.yaml"
 extract_source 'ongrid-edge/templates/deployment.yaml' "$tmp_dir/split.yaml" "$tmp_dir/split-controller.yaml"
 extract_source 'ongrid-edge/templates/metrics-scraper-deployment.yaml' "$tmp_dir/split.yaml" "$tmp_dir/scraper.yaml"
 grep -q '# Source: ongrid-edge/templates/telemetry-gateway-deployment.yaml' "$tmp_dir/split.yaml"

--- a/web/src/components/traces/TraceWaterfall.test.ts
+++ b/web/src/components/traces/TraceWaterfall.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createElement } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import type { TraceGetResponse } from '@/api/traces';
-import { buildTraceWaterfallModel } from './TraceWaterfall';
+import { TraceWaterfall, buildTraceWaterfallModel } from './TraceWaterfall';
 
 describe('buildTraceWaterfallModel', () => {
   it('builds an ordered span tree and keeps orphan spans visible', () => {
@@ -37,4 +40,27 @@ describe('buildTraceWaterfallModel', () => {
     expect(model.byKey.get('root')?.children.map((span) => span.spanId)).toEqual(['early', 'late']);
     expect(model.byKey.get('early')?.peerService).toBe('mysql');
   });
+});
+
+
+it('shows and copies the original SkyWalking ID when opened by an OTLP ID', async () => {
+  localStorage.setItem('ongrid-locale', 'en-US');
+  const user = userEvent.setup();
+  const copy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+  const originalID = '0123456789abcdef0123456789abcdef.1.17887680000000001';
+  render(createElement(TraceWaterfall, {
+    traceId: '0123456788abcdef001c9cf74a26f2ef',
+    trace: {
+      resourceSpans: [{
+        resource: { attributes: [
+          { key: 'service.name', value: { stringValue: 'orders' } },
+          { key: 'sw8.trace_id', value: { stringValue: originalID } },
+        ] },
+        scopeSpans: [{ spans: [{ spanId: 'root', name: 'GET /orders', startTimeUnixNano: '1000000000', endTimeUnixNano: '1020000000' }] }],
+      }],
+    },
+  }));
+  expect(screen.getByTitle(originalID)).toBeInTheDocument();
+  await act(async () => { await user.click(screen.getByRole('button', { name: 'Copy SkyWalking trace ID' })); });
+  expect(copy).toHaveBeenCalledWith(originalID);
 });

--- a/web/src/components/traces/TraceWaterfall.test.ts
+++ b/web/src/components/traces/TraceWaterfall.test.ts
@@ -64,3 +64,16 @@ it('shows and copies the original SkyWalking ID when opened by an OTLP ID', asyn
   await act(async () => { await user.click(screen.getByRole('button', { name: 'Copy SkyWalking trace ID' })); });
   expect(copy).toHaveBeenCalledWith(originalID);
 });
+
+it.each([
+  ['STATUS_CODE_OK', 'SUCCESS', false],
+  ['STATUS_CODE_ERROR', 'request failed', true],
+  [0, 'status detail', false],
+] as const)('styles status messages by status code %s', (code, message, error) => {
+  render(createElement(TraceWaterfall, { traceId: 'trace', trace: { resourceSpans: [{ scopeSpans: [{ spans: [{
+    spanId: 'root', name: 'operation', startTimeUnixNano: '1000000000', endTimeUnixNano: '1020000000', status: { code, message },
+  }] }] }] } }));
+  const banner = screen.getByText(message).parentElement!;
+  expect(banner.classList.contains('text-red-300')).toBe(error);
+  expect(Boolean(banner.querySelector('svg'))).toBe(error);
+});

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -91,6 +91,10 @@ export function TraceWaterfall({ trace, traceId, fallbackService, fallbackName }
   const root = model.roots[0] ?? model.spans[0];
   const service = root?.service || fallbackService || '-';
   const name = root?.name || fallbackName || tr('未命名 trace', 'Unnamed trace');
+  const skywalkingId = model.spans
+    .map((span) => span.resourceAttributes.find((attr) => attr.key === 'sw8.trace_id')?.value?.stringValue)
+    .find(Boolean);
+
 
   if (model.spans.length === 0) {
     return (
@@ -133,6 +137,13 @@ export function TraceWaterfall({ trace, traceId, fallbackService, fallbackName }
             <span>·</span>
             <span className="font-mono" title={traceId}>{shortId(traceId)}</span>
             <CopyValueButton value={traceId} label={tr('复制 trace_id', 'Copy trace_id')} />
+            {skywalkingId && skywalkingId !== traceId && (
+              <>
+                <span>· SkyWalking</span>
+                <span className="font-mono" title={skywalkingId}>{shortId(skywalkingId)}</span>
+                <CopyValueButton value={skywalkingId} label={tr('复制 SkyWalking trace ID', 'Copy SkyWalking trace ID')} />
+              </>
+            )}
           </div>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-1.5">

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -309,8 +309,8 @@ function SpanDetails({ span, traceStartMs }: { span: TraceSpanNode; traceStartMs
       </div>
 
       {span.statusMessage && (
-        <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
-          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+        <div className={cn('flex items-start gap-2 rounded-md border px-3 py-2 text-xs', isErrorStatus(span.statusCode) ? 'border-red-500/30 bg-red-500/10 text-red-300' : 'border-zinc-800/60 text-zinc-400')}>
+          {isErrorStatus(span.statusCode) && <AlertTriangle size={12} className="mt-0.5 shrink-0" />}
           <span className="break-words">{span.statusMessage}</span>
         </div>
       )}

--- a/web/src/pages/EdgeDetail.test.tsx
+++ b/web/src/pages/EdgeDetail.test.tsx
@@ -239,10 +239,10 @@ describe('findNearestTooltipEntry', () => {
 
 describe('EdgeDetailPage SkyWalking receiver', () => {
   it.each([
-    ['zh-CN', {}, '127.0.0.1:11800', '编辑配置', '随 Trace 采集自动开启'],
-    ['en-US', { grpc_endpoint: '0.0.0.0:4317' }, '0.0.0.0:11800', 'Edit config', 'enabled automatically with Trace collection'],
-    ['zh-CN', { skywalking_grpc_endpoint: '127.0.0.1:21800' }, '127.0.0.1:21800', '编辑配置', '随 Trace 采集自动开启'],
-  ] as const)('shows the receiver address for %s %j without another toggle', async (locale, spec, endpoint, edit, hint) => {
+    ['zh-CN', {}, '127.0.0.1:11800', '编辑配置', '默认监听 localhost'],
+    ['en-US', { grpc_endpoint: '0.0.0.0:4317' }, '0.0.0.0:11800', 'Edit config', 'Listens on localhost by default'],
+    ['zh-CN', { skywalking_grpc_endpoint: '127.0.0.1:21800' }, '127.0.0.1:21800', '编辑配置', '默认监听 localhost'],
+  ] as const)('shows the receiver address for %s %j with both protocol toggles', async (locale, spec, endpoint, edit, hint) => {
     localStorage.setItem('ongrid-locale', locale);
     server.use(
       http.get('/api/v1/edges/42', () => HttpResponse.json({ id: 42, name: 'skywalking-edge', status: 'online', roles: [] })),
@@ -254,8 +254,12 @@ describe('EdgeDetailPage SkyWalking receiver', () => {
       </MemoryRouter>,
     );
     fireEvent.click(await screen.findByRole('button', { name: edit }));
-    expect(await screen.findByText(endpoint)).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(hint))).toBeInTheDocument();
-    expect(screen.getAllByRole('checkbox')).toHaveLength(2); // Existing OTLP controls only.
+    expect(await screen.findByTitle(endpoint)).toBeInTheDocument();
+    expect(screen.getAllByText(new RegExp(hint))).toHaveLength(2);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+    const swHTTP = screen.getAllByRole('checkbox')[3];
+    expect(swHTTP).toBeChecked();
+    fireEvent.click(swHTTP);
+    expect(swHTTP).not.toBeChecked();
   });
 });

--- a/web/src/pages/EdgeDetail.test.tsx
+++ b/web/src/pages/EdgeDetail.test.tsx
@@ -236,3 +236,26 @@ describe('findNearestTooltipEntry', () => {
     );
   });
 });
+
+describe('EdgeDetailPage SkyWalking receiver', () => {
+  it.each([
+    ['zh-CN', {}, '127.0.0.1:11800', '编辑配置', '随 Trace 采集自动开启'],
+    ['en-US', { grpc_endpoint: '0.0.0.0:4317' }, '0.0.0.0:11800', 'Edit config', 'enabled automatically with Trace collection'],
+    ['zh-CN', { skywalking_grpc_endpoint: '127.0.0.1:21800' }, '127.0.0.1:21800', '编辑配置', '随 Trace 采集自动开启'],
+  ] as const)('shows the receiver address for %s %j without another toggle', async (locale, spec, endpoint, edit, hint) => {
+    localStorage.setItem('ongrid-locale', locale);
+    server.use(
+      http.get('/api/v1/edges/42', () => HttpResponse.json({ id: 42, name: 'skywalking-edge', status: 'online', roles: [] })),
+      http.get('/api/v1/edges/42/plugins', () => HttpResponse.json({ items: [{ plugin_name: 'traces', enabled: true, spec }] })),
+    );
+    render(
+      <MemoryRouter initialEntries={['/edges/42?tab=plugins']}>
+        <Routes><Route path="/edges/:edgeId" element={<EdgeDetailPage />} /></Routes>
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: edit }));
+    expect(await screen.findByText(endpoint)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(hint))).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2); // Existing OTLP controls only.
+  });
+});

--- a/web/src/pages/EdgeDetail.tsx
+++ b/web/src/pages/EdgeDetail.tsx
@@ -1256,7 +1256,7 @@ const PLUGIN_META: Record<
   traces: {
     label: 'traces',
     pill: 'bg-violet-500/10 text-violet-300 ring-violet-500/30',
-    getHint: () => 'subprocess otelcol-contrib, OTLP gRPC :4317 / HTTP :4318',
+    getHint: () => 'OTLP gRPC :4317 / HTTP :4318 · SkyWalking gRPC :11800',
   },
   profiles: {
     label: 'profiles',
@@ -4306,6 +4306,10 @@ function TracesSpecForm({
   const samplingRate =
     typeof draft.sampling_rate === 'number' ? draft.sampling_rate : 1.0;
   const receivers = (draft.receivers ?? {}) as Record<string, unknown>;
+  const grpcEndpoint = typeof draft.grpc_endpoint === 'string' && draft.grpc_endpoint
+    ? draft.grpc_endpoint : '127.0.0.1:4317';
+  const skywalkingEndpoint = typeof draft.skywalking_grpc_endpoint === 'string'
+    ? draft.skywalking_grpc_endpoint.trim() : grpcEndpoint.replace(/:[^:]*$/, ':11800');
   const grpcEnabled = receivers.grpc !== false; // default on
   const httpEnabled = receivers.http !== false; // default on
 
@@ -4366,8 +4370,18 @@ function TracesSpecForm({
           </label>
         </div>
         <div className="mt-1 text-[11px] text-zinc-500">
-          {tr('监听 localhost / docker bridge；应用 SDK 直接 export 到 edge:4317。', 'Listens on localhost / docker bridge; app SDKs export directly to edge:4317.')}
+          {tr('默认监听 localhost；远程应用需要配置可达的监听地址。', 'Listens on localhost by default; remote apps require a reachable bind address.')}
         </div>
+      </div>
+
+      <div className="text-xs text-zinc-400">
+        <div>SkyWalking gRPC · {tr('监听地址', 'Listen address')} <code className="font-mono text-zinc-300">{skywalkingEndpoint}</code></div>
+        <p className="mt-1 text-[11px] text-zinc-500">
+          {tr(
+            '升级 edge 后，随 Trace 采集自动开启，无需单独配置。将 SkyWalking Java agent（8.9.0+）的 collector.backend_service 指向该地址；远程应用请使用可达的 edge 地址。',
+            'After upgrading edge, enabled automatically with Trace collection. Point SkyWalking Java agent (8.9.0+) collector.backend_service to this address; remote apps must use a reachable edge address.',
+          )}
+        </p>
       </div>
     </div>
   );

--- a/web/src/pages/EdgeDetail.tsx
+++ b/web/src/pages/EdgeDetail.tsx
@@ -1256,7 +1256,7 @@ const PLUGIN_META: Record<
   traces: {
     label: 'traces',
     pill: 'bg-violet-500/10 text-violet-300 ring-violet-500/30',
-    getHint: () => 'OTLP gRPC :4317 / HTTP :4318 · SkyWalking gRPC :11800',
+    getHint: () => 'OTLP gRPC :4317 / HTTP :4318 · SkyWalking gRPC :11800 / HTTP :12800',
   },
   profiles: {
     label: 'profiles',
@@ -4308,8 +4308,13 @@ function TracesSpecForm({
   const receivers = (draft.receivers ?? {}) as Record<string, unknown>;
   const grpcEndpoint = typeof draft.grpc_endpoint === 'string' && draft.grpc_endpoint
     ? draft.grpc_endpoint : '127.0.0.1:4317';
+  const skywalkingReceivers = (draft.skywalking_receivers ?? {}) as Record<string, unknown>;
   const skywalkingEndpoint = typeof draft.skywalking_grpc_endpoint === 'string'
     ? draft.skywalking_grpc_endpoint.trim() : grpcEndpoint.replace(/:[^:]*$/, ':11800');
+  const httpEndpoint = typeof draft.http_endpoint === 'string' ? draft.http_endpoint : '127.0.0.1:4318';
+  const skywalkingHTTPEndpoint = typeof draft.skywalking_http_endpoint === 'string'
+    ? draft.skywalking_http_endpoint.trim() : httpEndpoint.replace(/:[^:]*$/, ':12800');
+
   const grpcEnabled = receivers.grpc !== false; // default on
   const httpEnabled = receivers.http !== false; // default on
 
@@ -4374,14 +4379,27 @@ function TracesSpecForm({
         </div>
       </div>
 
-      <div className="text-xs text-zinc-400">
-        <div>SkyWalking gRPC · {tr('监听地址', 'Listen address')} <code className="font-mono text-zinc-300">{skywalkingEndpoint}</code></div>
-        <p className="mt-1 text-[11px] text-zinc-500">
-          {tr(
-            '升级 edge 后，随 Trace 采集自动开启，无需单独配置。将 SkyWalking Java agent（8.9.0+）的 collector.backend_service 指向该地址；远程应用请使用可达的 edge 地址。',
-            'After upgrading edge, enabled automatically with Trace collection. Point SkyWalking Java agent (8.9.0+) collector.backend_service to this address; remote apps must use a reachable edge address.',
-          )}
-        </p>
+      <div>
+        <span className="mb-1 block text-xs text-zinc-400">SkyWalking receivers</span>
+        <div className="space-y-1.5">
+          {(['grpc', 'http'] as const).map((protocol) => (
+            <label key={protocol} className="flex items-center gap-2 text-[12px] text-zinc-300">
+              <input
+                type="checkbox"
+                checked={skywalkingReceivers[protocol] !== false}
+                onChange={(e) => onChange({ ...draft, skywalking_receivers: { ...skywalkingReceivers, [protocol]: e.target.checked } })}
+                className="h-3.5 w-3.5 rounded border-zinc-700 bg-zinc-900"
+              />
+              {protocol === 'grpc' ? 'gRPC' : 'HTTP'}
+              <span className="font-mono text-[11px] text-zinc-500" title={protocol === 'grpc' ? skywalkingEndpoint : skywalkingHTTPEndpoint}>
+                :{(protocol === 'grpc' ? skywalkingEndpoint : skywalkingHTTPEndpoint).split(':').pop()}
+              </span>
+            </label>
+          ))}
+        </div>
+        <div className="mt-1 text-[11px] text-zinc-500">
+          {tr('默认监听 localhost；远程应用需要配置可达的监听地址。', 'Listens on localhost by default; remote apps require a reachable bind address.')}
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/Edges.test.tsx
+++ b/web/src/pages/Edges.test.tsx
@@ -231,7 +231,6 @@ describe("EdgesPage", () => {
       "bg-indigo-500/10",
       "text-indigo-300",
     );
-    expect(screen.getByRole("table")).toHaveClass("min-w-full", "table-fixed");
   });
 
   it("点击 K8s 托管设备行进入设备详情，操作列只保留 WebSSH", async () => {

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -851,7 +851,7 @@ export default function EdgesPage() {
                 "min-w-full text-xs",
                 compactNetworkTable
                   ? "w-full min-w-[1120px] table-fixed"
-                  : "w-[1637px] table-fixed",
+                  : "w-max table-auto",
               )}
             >
               {compactNetworkTable ? (
@@ -1123,12 +1123,7 @@ export default function EdgesPage() {
                           navigate(`/devices/${encodeURIComponent(d.id)}`)
                         }
                       >
-                        {/* Identity columns are pinned `whitespace-nowrap`
-                          — when the table is squeezed (sidebar + many
-                          columns) we'd rather let the action column
-                          wrap than have a name break across lines.
-                          Heartbeat / access-key / agent are short and
-                          formatted to a known width. */}
+
                         <td
                           className="px-2.5 py-2.5"
                           onClick={(ev) => ev.stopPropagation()}

--- a/web/src/pages/Traces.tsx
+++ b/web/src/pages/Traces.tsx
@@ -464,7 +464,7 @@ export default function TracesPage() {
               </label>
               <label className="block min-w-44 flex-1">
                 <span className="mb-1 block text-[11px] text-zinc-500"><SearchIcon size={10} className="-mt-0.5 mr-1 inline" />trace_id</span>
-                <input value={traceIdInput} onChange={(event) => setTraceIdInput(event.target.value)} placeholder={tr('粘贴 ID 直接打开', 'Paste an ID to open')} className={cn(INPUT_BASE, 'font-mono')} />
+                <input value={traceIdInput} onChange={(event) => setTraceIdInput(event.target.value)} placeholder={tr('粘贴 OTLP 或 SkyWalking ID', 'Paste OTLP or SkyWalking ID')} className={cn(INPUT_BASE, 'font-mono')} />
               </label>
               <div className="flex h-[34px] items-center gap-1.5 self-end">
                 {TRACES_QUICK_CHIPS.map((chip) => (


### PR DESCRIPTION
## Summary

Accept SkyWalking v3 traces through the existing Edge Collector alongside OTLP. Add independent gRPC/HTTP controls (11800/12800), Kubernetes Service ports, original SkyWalking trace-ID lookup/copy, and shared status-message rendering that marks only errors red. Let the device table grow to fit long Edge versions and scroll horizontally.

Existing configurations default to both SkyWalking protocols enabled when the traces plugin is enabled; explicit protocol opt-outs are retained. No database migration or additional SDK dependency.

## Review blocker — do not merge

**P1: the bundled Collector does not honor the SkyWalking gRPC bind host.** With `endpoint: "127.0.0.1:11800"`, Collector 0.157.0 binds `*:11800`, and a TCP connection from outside the Edge VM succeeds. Enabling this receiver by default therefore exposes an unauthenticated ingest listener beyond the intended localhost scope. HTTP honors its configured host.

Upstream `collectorGRPCAddr()` returns only `:<port>` and `startCollector()` passes it to `net.Listen`: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/skywalkingreceiver/skywalking_receiver.go#L91-L97 . The current upstream main branch still has this implementation. A dependency fix or equivalent verified isolation is needed before releasing the default-on gRPC behavior. Updating the endpoint YAML alone does not fix it.

## Validation

- `go test -race ./internal/pkg/tracequery ./internal/edgeagent/plugins/...` with the real bundled Collector enabled: passed, including SkyWalking gRPC + HTTP conversion and OTLP coexistence.
- Targeted frontend tests: 15 passed; production frontend build passed.
- `make test-k8s-chart`: passed.
- Local end-to-end: 10 SkyWalking traces / 30 spans, including two error traces; all original IDs, parent links and durations verified through Manager/Tempo.
- Browser verification: horizontal table scrolling exposes the full version/status; SUCCESS uses neutral styling with no warning icon.
- These checks do not establish that the receiver respects loopback binding; the live network check above demonstrates the blocking failure.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
