### PR TITLE
feat(devices): support renaming and unify device actions

### DIFF
--- a/web/src/api/devices.ts
+++ b/web/src/api/devices.ts
@@ -185,6 +185,10 @@ export function configureNetworkPolling(id: string | number, input: NetworkPolli
   );
 }
 
+export function renameDevice(id: string | number, name: string) {
+  return request<void>('PATCH', `/devices/${encodeURIComponent(String(id))}`, { name });
+}
+
 export function deleteDevice(id: string | number) {
   return request<void>('DELETE', `/devices/${encodeURIComponent(String(id))}`);
 }

--- a/web/src/pages/Edges.test.tsx
+++ b/web/src/pages/Edges.test.tsx
@@ -7,13 +7,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import EdgesPage from "./Edges";
 import { server } from "@/test/msw-server";
+import { openMetricDrilldown } from "@/lib/drilldown";
 
-vi.mock("@/store/me", () => ({
-  usePermissions: () => ({ isAdmin: true, canMutate: true, role: "admin" }),
-}));
+vi.mock("@/lib/drilldown", () => ({ openMetricDrilldown: vi.fn().mockResolvedValue(undefined) }));
+
+const permissions = vi.hoisted(() => ({ isAdmin: true, canMutate: true, role: "admin" }));
+vi.mock("@/store/me", () => ({ usePermissions: () => permissions }));
 
 describe("EdgesPage", () => {
   beforeEach(() => {
+    Object.assign(permissions, { isAdmin: true, canMutate: true, role: "admin" });
     localStorage.setItem("ongrid-locale", "zh-CN");
     server.use(
       http.get("/api/v1/version", () =>
@@ -188,10 +191,10 @@ describe("EdgesPage", () => {
     );
 
     const k8sNameCells = await screen.findAllByText("ongrid-k8s-control-plane");
-    expect(k8sNameCells).toHaveLength(2);
+    expect(k8sNameCells).toHaveLength(1);
     expect(
-      screen.queryByText("k8s:kind-local:ongrid-k8s-control-plane"),
-    ).not.toBeInTheDocument();
+      screen.getByText("k8s:kind-local:ongrid-k8s-control-plane"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("kind-controller")).not.toBeInTheDocument();
     expect(screen.queryByText("K8s Node")).not.toBeInTheDocument();
     expect(screen.queryByText("K8s Controller")).not.toBeInTheDocument();
@@ -219,8 +222,8 @@ describe("EdgesPage", () => {
     expect(terminalLink).toHaveAttribute("href", "/devices/17/shell");
     expect(terminalLink).toHaveAttribute("target", "_blank");
     expect(
-      within(k8sRow as HTMLTableRowElement).queryByText("查看图表"),
-    ).not.toBeInTheDocument();
+      within(k8sRow as HTMLTableRowElement).getByText("查看图表"),
+    ).toBeInTheDocument();
     expect(
       within(k8sRow as HTMLTableRowElement).queryByLabelText(/选择/),
     ).not.toBeInTheDocument();
@@ -234,7 +237,7 @@ describe("EdgesPage", () => {
     expect(screen.getByRole("table")).toHaveClass("min-w-full", "table-fixed");
   });
 
-  it("点击 K8s 托管设备行进入设备详情，操作列只保留 WebSSH", async () => {
+  it("点击 K8s 托管设备行进入设备详情，操作列支持 WebSSH 和修改名称", async () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter initialEntries={["/devices"]}>
@@ -260,13 +263,83 @@ describe("EdgesPage", () => {
     expect(
       within(k8sRow).getByRole("link", { name: /打开.*终端/ }),
     ).toHaveAttribute("href", "/devices/17/shell");
-    expect(within(k8sRow).queryByText("查看图表")).not.toBeInTheDocument();
+    expect(within(k8sRow).getByText("查看图表")).toBeInTheDocument();
     expect(
-      within(k8sRow).queryByRole("button", { name: /更多/ }),
-    ).not.toBeInTheDocument();
+      within(k8sRow).getByRole("button", { name: "操作" }),
+    ).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByTestId("location")).toHaveTextContent("/devices/17"),
     );
+  });
+
+  it.each([
+    [19, "bare-metal-1", "bm-1"],
+    [17, "k8s:kind-local:ongrid-k8s-control-plane", "ongrid-k8s-control-plane"],
+  ])("修改设备 %s 名称，保存后优先展示名称并保留主机名", async (id, oldName, hostname) => {
+    const user = userEvent.setup();
+    let submitted: unknown;
+    server.use(http.patch(`/api/v1/devices/${id}`, async ({ request }) => {
+      submitted = await request.json();
+      return new HttpResponse(null, { status: 204 });
+    }));
+    render(<MemoryRouter><EdgesPage /></MemoryRouter>);
+    const row = (await screen.findByText(oldName)).closest("tr")!;
+    await user.click(within(row).getByRole("button", { name: "操作" }));
+    await user.click(screen.getByRole("button", { name: "修改设备名称" }));
+    const dialog = screen.getByRole("dialog", { name: "修改设备名称" });
+    const input = within(dialog).getByLabelText("设备名称");
+    expect(input).toHaveValue(oldName);
+    await user.clear(input);
+    await user.type(input, "   ");
+    expect(within(dialog).getByRole("button", { name: "保存" })).toBeDisabled();
+    await user.clear(input);
+    await user.type(input, "  数据库主机  ");
+    await user.click(within(dialog).getByRole("button", { name: "保存" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(submitted).toEqual({ name: "数据库主机" });
+    expect(within(row).getByText("数据库主机")).toBeInTheDocument();
+    expect(within(row).getByText(hostname)).toBeInTheDocument();
+  });
+
+  it("K8s 设备查看图表使用设备 ID", async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><EdgesPage /></MemoryRouter>);
+    await user.click(await screen.findByRole("button", { name: "在 Grafana 查看 k8s:kind-local:ongrid-k8s-control-plane 图表" }));
+    expect(openMetricDrilldown).toHaveBeenCalledWith(expect.objectContaining({
+      deviceId: 17,
+      expr: expect.stringContaining('device_id="17"'),
+    }));
+  });
+
+  it("只读用户不能修改设备名称", async () => {
+    Object.assign(permissions, { isAdmin: false, canMutate: false, role: "viewer" });
+    const user = userEvent.setup();
+    render(<MemoryRouter><EdgesPage /></MemoryRouter>);
+    const row = (await screen.findByText("bare-metal-1")).closest("tr")!;
+    await user.click(within(row).getByRole("button", { name: "操作" }));
+    expect(screen.queryByRole("button", { name: "修改设备名称" })).not.toBeInTheDocument();
+  });
+
+  it("名称保存失败时保留输入，允许重试", async () => {
+    const user = userEvent.setup();
+    server.use(http.patch("/api/v1/devices/19", () =>
+      HttpResponse.json({ message: "保存失败" }, { status: 500 }),
+    ));
+    render(<MemoryRouter><EdgesPage /></MemoryRouter>);
+    const row = (await screen.findByText("bare-metal-1")).closest("tr")!;
+    await user.click(within(row).getByRole("button", { name: "操作" }));
+    await user.click(screen.getByRole("button", { name: "修改设备名称" }));
+    const input = screen.getByLabelText("设备名称");
+    await user.clear(input);
+    await user.type(input, "新名称");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(input).toHaveValue("新名称");
+    expect(within(row).getByText("bare-metal-1")).toBeInTheDocument();
+    server.use(http.patch("/api/v1/devices/19", () => new HttpResponse(null, { status: 204 })));
+    await user.click(screen.getByRole("button", { name: "保存" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(within(row).getByText("新名称")).toBeInTheDocument();
   });
 
   it("让设备操作菜单在视口内翻转或滚动", async () => {
@@ -289,7 +362,7 @@ describe("EdgesPage", () => {
     const rectSpy = vi
       .spyOn(Element.prototype, "getBoundingClientRect")
       .mockImplementation(function (this: Element) {
-        if (this.getAttribute("aria-label") === "更多操作") return triggerRect;
+        if (this.getAttribute("aria-label") === "操作") return triggerRect;
         if (this.getAttribute("role") === "menu") return menuRect;
         return originalGetBoundingClientRect.call(this);
       });
@@ -303,7 +376,7 @@ describe("EdgesPage", () => {
 
       await screen.findByText("bare-metal-1");
       await act(async () => {
-        await user.click(screen.getByRole("button", { name: "更多操作" }));
+        await user.click(within(screen.getByText("bare-metal-1").closest("tr")!).getByRole("button", { name: "操作" }));
       });
 
       const menu = await screen.findByRole("menu");
@@ -376,7 +449,7 @@ describe("EdgesPage", () => {
       );
       await screen.findByText("bare-metal-1");
       await act(async () => {
-        await user.click(screen.getByRole("button", { name: "更多操作" }));
+        await user.click(within(screen.getByText("bare-metal-1").closest("tr")!).getByRole("button", { name: "操作" }));
       });
       await act(async () => {
         await user.click(

--- a/web/src/pages/Edges.test.tsx
+++ b/web/src/pages/Edges.test.tsx
@@ -832,7 +832,7 @@ describe("EdgesPage", () => {
 
     await screen.findAllByText("core-switch");
     const table = screen.getByRole("table");
-    expect(table).toHaveClass("w-full", "min-w-[1120px]", "table-fixed");
+    expect(table).toHaveClass("w-full", "min-w-[1200px]", "table-fixed");
     expect(table.querySelectorAll("col")).toHaveLength(10);
     expect(screen.queryByRole("button", { name: "网络发现" })).not.toBeInTheDocument();
     expect(screen.queryByText("WebSSH 会话")).not.toBeInTheDocument();

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -13,7 +13,9 @@ import {
   Plus,
   RotateCw,
   Trash2,
-  MoreVertical,
+  Pencil,
+  Settings2,
+  ChevronDown,
   Copy,
   Check,
   ExternalLink,
@@ -65,6 +67,7 @@ import {
 } from "@/api/topology";
 import {
   deleteDevice,
+  renameDevice,
   getNetworkDeviceDetail,
   listDevices,
   listNetworkCandidates,
@@ -312,6 +315,7 @@ export default function EdgesPage() {
       .then((r) => setManagerVersion(r.manager_version || ""))
       .catch(() => setManagerVersion(""));
   }, []);
+  const [renameTarget, setRenameTarget] = useState<DeviceRow | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [batchInstallOpen, setBatchInstallOpen] = useState(false);
   const [secretReveal, setSecretReveal] = useState<{
@@ -851,7 +855,7 @@ export default function EdgesPage() {
                 "min-w-full text-xs",
                 compactNetworkTable
                   ? "w-full min-w-[1120px] table-fixed"
-                  : "w-[1637px] table-fixed",
+                  : "w-[1727px] table-fixed",
               )}
             >
               {compactNetworkTable ? (
@@ -880,7 +884,7 @@ export default function EdgesPage() {
                   <col className="w-[110px]" />
                   <col className="w-[110px]" />
                   <col className="w-[145px]" />
-                  <col className="w-[190px]" />
+                  <col className="w-[280px]" />
                 </colgroup>
               )}
               <thead className="device-list-table__header border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">
@@ -949,7 +953,7 @@ export default function EdgesPage() {
                       <th className="px-2.5 py-2.5 text-left">Edge</th>
                     </>
                   )}
-                  <th className="sticky right-0 z-20 border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-left">
+                  <th className="sticky right-0 z-20 border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-right">
                     {tr("操作", "Actions")}
                   </th>
                 </tr>
@@ -990,11 +994,8 @@ export default function EdgesPage() {
                       ? (k8sAttachments?.[edge.id] ?? [])
                       : [];
                     const managedByK8s = isK8sManagedEdge(attachments);
-                    const displayName = managedByK8s
-                      ? d.hostname ||
-                        (edge ? displayEdgeName(edge, attachments) : "") ||
-                        d.name
-                      : d.name || d.hostname || edge?.name || "";
+                    const displayName = d.name || d.hostname ||
+                      (edge ? displayEdgeName(edge, attachments) : "");
                     if (compactNetworkTable) {
                       const detail = networkDetails[d.id];
                       const reachability = detail?.reachability_status
@@ -1086,31 +1087,34 @@ export default function EdgesPage() {
                               : "—"}
                           </td>
                           <td
-                            className="sticky right-0 z-10 whitespace-nowrap border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-left"
+                            className="sticky right-0 z-10 whitespace-nowrap border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-right"
                             onClick={(event) => event.stopPropagation()}
                           >
-                            <button
-                              type="button"
-                              onClick={() =>
-                                navigate(
-                                  `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
-                                )
-                              }
-                              className="mr-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
-                            >
-                              <ExternalLink size={14} />
-                              {tr("查看拓扑", "View topology")}
-                            </button>
-                            <RowMenu
-                              onViewTopology={() =>
-                                navigate(
-                                  `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
-                                )
-                              }
-                              onDeleteDevice={() => void onDeleteDevice(d)}
-                              deviceOnline={false}
-                              upgradePackageBusy={false}
-                            />
+                            <div className="flex items-center justify-end gap-1">
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  navigate(
+                                    `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
+                                  )
+                                }
+                                className="inline-flex h-6 items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                              >
+                                <ExternalLink size={14} />
+                                {tr("查看拓扑", "View topology")}
+                              </button>
+                              <RowMenu
+                                onRename={canMutate ? () => setRenameTarget(d) : undefined}
+                                onViewTopology={() =>
+                                  navigate(
+                                    `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
+                                  )
+                                }
+                                onDeleteDevice={() => void onDeleteDevice(d)}
+                                deviceOnline={false}
+                                upgradePackageBusy={false}
+                              />
+                            </div>
                           </td>
                         </tr>
                       );
@@ -1285,95 +1289,97 @@ export default function EdgesPage() {
                           </>
                         )}
                         <td
-                          className="sticky right-0 z-10 whitespace-nowrap border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-left"
+                          className="sticky right-0 z-10 whitespace-nowrap border-l border-zinc-800/60 bg-zinc-900 px-2.5 py-2.5 text-right"
                           onClick={(ev) => ev.stopPropagation()}
                         >
-                          {networkDevice ? (
-                            <>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  navigate(
-                                    `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
-                                  )
-                                }
-                                className="mr-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
-                              >
-                                <ExternalLink size={14} />
-                                {tr("查看拓扑", "View topology")}
-                              </button>
-                              <RowMenu
-                                onViewTopology={() =>
-                                  navigate(
-                                    `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
-                                  )
-                                }
-                                onDeleteDevice={() => void onDeleteDevice(d)}
-                                deviceOnline={false}
-                                upgradePackageBusy={false}
-                              />
-                            </>
-                          ) : managedByK8s ? (
-                            <ShellButton device={d} canMutate={canMutate} />
-                          ) : (
-                            <>
-                              <button
-                                type="button"
-                                onClick={() => void openServerChart(d)}
-                                title={tr(
-                                  `在 Grafana 查看 ${displayName} 图表`,
-                                  `View ${displayName} chart in Grafana`,
-                                )}
-                                aria-label={tr(
-                                  `在 Grafana 查看 ${displayName} 图表`,
-                                  `View ${displayName} chart in Grafana`,
-                                )}
-                                className="mr-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
-                              >
-                                <ExternalLink size={14} />
-                                <span>{tr("查看图表", "View chart")}</span>
-                              </button>
-                              <ShellButton device={d} canMutate={canMutate} />
-                              <RowMenu
-                                onAssignRoles={() => setRolesEditTarget(d)}
-                                onViewTopology={() =>
-                                  navigate(
-                                    `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
-                                  )
-                                }
-                                onDeleteDevice={() => void onDeleteDevice(d)}
-                                deviceOnline={d.online === true}
-                                onRotate={
-                                  edge
-                                    ? () =>
-                                        onRotate(
-                                          edge.id,
-                                          displayName,
-                                          edge.access_key_id,
-                                        )
-                                    : undefined
-                                }
-                                onDelete={
-                                  edge
-                                    ? () => onDelete(edge.id, displayName)
-                                    : undefined
-                                }
-                                onUpgrade={
-                                  edge
-                                    ? () => setUpgradeTarget(edge)
-                                    : undefined
-                                }
-                                onUpgradePackage={
-                                  edge
-                                    ? () => void onPackageUpgrade(edge)
-                                    : undefined
-                                }
-                                upgradePackageBusy={
-                                  edge ? pkgUpgradingId === edge.id : false
-                                }
-                              />
-                            </>
-                          )}
+                          <div className="flex items-center justify-end gap-1">
+                            {networkDevice ? (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    navigate(
+                                      `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
+                                    )
+                                  }
+                                  className="inline-flex h-6 items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                                >
+                                  <ExternalLink size={14} />
+                                  {tr("查看拓扑", "View topology")}
+                                </button>
+                                <RowMenu
+                                onRename={canMutate ? () => setRenameTarget(d) : undefined}
+                                  onViewTopology={() =>
+                                    navigate(
+                                      `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
+                                    )
+                                  }
+                                  onDeleteDevice={() => void onDeleteDevice(d)}
+                                  deviceOnline={false}
+                                  upgradePackageBusy={false}
+                                />
+                              </>
+                            ) : (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => void openServerChart(d)}
+                                  title={tr(
+                                    `在 Grafana 查看 ${displayName} 图表`,
+                                    `View ${displayName} chart in Grafana`,
+                                  )}
+                                  aria-label={tr(
+                                    `在 Grafana 查看 ${displayName} 图表`,
+                                    `View ${displayName} chart in Grafana`,
+                                  )}
+                                  className="inline-flex h-6 items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+                                >
+                                  <ExternalLink size={14} />
+                                  <span>{tr("查看图表", "View chart")}</span>
+                                </button>
+                                <ShellButton device={d} canMutate={canMutate} />
+                                <RowMenu
+                                onRename={canMutate ? () => setRenameTarget(d) : undefined}
+                                  onAssignRoles={managedByK8s ? undefined : () => setRolesEditTarget(d)}
+                                  onViewTopology={() =>
+                                    navigate(
+                                      `/devices/${encodeURIComponent(String(d.id))}?tab=topology`,
+                                    )
+                                  }
+                                  onDeleteDevice={managedByK8s ? undefined : () => void onDeleteDevice(d)}
+                                  deviceOnline={d.online === true}
+                                  onRotate={
+                                    edge && !managedByK8s
+                                      ? () =>
+                                          onRotate(
+                                            edge.id,
+                                            displayName,
+                                            edge.access_key_id,
+                                          )
+                                      : undefined
+                                  }
+                                  onDelete={
+                                    edge && !managedByK8s
+                                      ? () => onDelete(edge.id, displayName)
+                                      : undefined
+                                  }
+                                  onUpgrade={
+                                    edge && !managedByK8s
+                                      ? () => setUpgradeTarget(edge)
+                                      : undefined
+                                  }
+                                  onUpgradePackage={
+                                    edge && !managedByK8s
+                                      ? () => void onPackageUpgrade(edge)
+                                      : undefined
+                                  }
+                                  upgradePackageBusy={
+                                    edge ? pkgUpgradingId === edge.id : false
+                                  }
+                                />
+                              </>
+                            )}
+                          </div>
                         </td>
                       </tr>
                     );
@@ -1386,6 +1392,19 @@ export default function EdgesPage() {
         </div>
       </main>
 
+      {renameTarget && (
+        <RenameDeviceModal
+          device={renameTarget}
+          onClose={() => setRenameTarget(null)}
+          onSaved={(name) => {
+            setDevices((current) => current.map((d) =>
+              d.id === renameTarget.id ? { ...d, name } : d,
+            ));
+            setRenameTarget(null);
+            notifyDevicesChanged();
+          }}
+        />
+      )}
       <CreateEdgeModal
         open={createOpen}
         onClose={() => setCreateOpen(false)}
@@ -2360,7 +2379,7 @@ function ShellButton({
       <span
         title={reason}
         aria-label={`${displayName} ${reason}`}
-        className="mr-1 inline-flex cursor-not-allowed items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-600"
+        className="inline-flex h-6 cursor-not-allowed items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-600"
       >
         <TerminalSquare size={14} />
         <span>{tr("终端", "Terminal")}</span>
@@ -2380,7 +2399,7 @@ function ShellButton({
         `打开 ${displayName} 终端，新标签页`,
         `Open ${displayName} terminal in a new tab`,
       )}
-      className="mr-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+      className="inline-flex h-6 items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
     >
       <TerminalSquare size={14} />
       <span>{tr("终端", "Terminal")}</span>
@@ -2389,6 +2408,7 @@ function ShellButton({
 }
 
 function RowMenu({
+  onRename,
   onAssignRoles,
   onViewTopology,
   onDeleteDevice,
@@ -2399,9 +2419,10 @@ function RowMenu({
   onUpgradePackage,
   upgradePackageBusy,
 }: {
+  onRename?: () => void;
   onAssignRoles?: () => void;
   onViewTopology(): void;
-  onDeleteDevice(): void;
+  onDeleteDevice?: () => void;
   deviceOnline: boolean;
   onRotate?: () => void;
   onDelete?: () => void;
@@ -2469,6 +2490,15 @@ function RowMenu({
           <div className="px-3 pb-1 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">
             {tr("设备操作", "Device actions")}
           </div>
+          {onRename && (
+            <button
+              type="button"
+              onClick={() => { setOpen(false); onRename(); }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-zinc-200 hover:bg-zinc-800"
+            >
+              <Pencil size={13} /> {tr("修改设备名称", "Rename device")}
+            </button>
+          )}
           {onAssignRoles && (
             <button
               type="button"
@@ -2491,42 +2521,46 @@ function RowMenu({
           >
             <ExternalLink size={13} /> {tr("查看拓扑", "View topology")}
           </button>
-          <button
-            type="button"
-            disabled={deviceOnline}
-            title={tr(
-              deviceOnline
-                ? "在线设备不可删除，请先让它离线。"
-                : "离线可删除，并清理关联 Edge 和密钥。",
-              deviceOnline
-                ? "Online devices cannot be deleted. Bring it offline first."
-                : "Offline devices can be deleted; linked Edges and credentials are cleaned too.",
-            )}
-            onClick={() => {
-              if (deviceOnline) return;
-              setOpen(false);
-              onDeleteDevice();
-            }}
-            className={cn(
-              "flex w-full items-center gap-2 px-3 py-2 text-left text-xs",
-              deviceOnline
-                ? "cursor-not-allowed text-zinc-600"
-                : "text-red-300 hover:bg-red-500/10",
-            )}
-          >
-            <Trash2 size={13} /> {tr("删除设备", "Delete device")}
-          </button>
-          <div className="px-3 pb-2 text-[11px] leading-4 text-zinc-500">
-            {tr(
-              deviceOnline
-                ? "在线设备不可删除。"
-                : "离线可删除，并清理 Edge 和密钥。",
-              deviceOnline
-                ? "Online devices cannot be deleted."
-                : "Offline devices can be deleted; Edges and credentials are cleaned too.",
-            )}
-          </div>
+          {onDeleteDevice && (
+            <>
+              <button
+                type="button"
+                disabled={deviceOnline}
+                title={tr(
+                  deviceOnline
+                    ? "在线设备不可删除，请先让它离线。"
+                    : "离线可删除，并清理关联 Edge 和密钥。",
+                  deviceOnline
+                    ? "Online devices cannot be deleted. Bring it offline first."
+                    : "Offline devices can be deleted; linked Edges and credentials are cleaned too.",
+                )}
+                onClick={() => {
+                  if (deviceOnline) return;
+                  setOpen(false);
+                  onDeleteDevice();
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 px-3 py-2 text-left text-xs",
+                  deviceOnline
+                    ? "cursor-not-allowed text-zinc-600"
+                    : "text-red-300 hover:bg-red-500/10",
+                )}
+              >
+                <Trash2 size={13} /> {tr("删除设备", "Delete device")}
+              </button>
+              <div className="px-3 pb-2 text-[11px] leading-4 text-zinc-500">
+                {tr(
+                  deviceOnline
+                    ? "在线设备不可删除。"
+                    : "离线可删除，并清理 Edge 和密钥。",
+                  deviceOnline
+                    ? "Online devices cannot be deleted."
+                    : "Offline devices can be deleted; Edges and credentials are cleaned too.",
+                )}
+              </div>
 
+            </>
+          )}
           {onRotate && onDelete && onUpgrade && onUpgradePackage && (
             <>
               <div className="my-1 border-t border-zinc-800" />
@@ -2590,6 +2624,7 @@ function RowMenu({
     );
   }, [
     deviceOnline,
+    onRename,
     onAssignRoles,
     onDelete,
     onDeleteDevice,
@@ -2604,7 +2639,7 @@ function RowMenu({
   ]);
 
   return (
-    <div className="relative inline-block">
+    <div className="relative inline-flex">
       <button
         ref={triggerRef}
         type="button"
@@ -2616,13 +2651,71 @@ function RowMenu({
           setPosition(null);
           setOpen(true);
         }}
-        aria-label={tr("更多操作", "More actions")}
-        className="rounded-md p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+        aria-label={tr("操作", "Actions")}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex h-6 items-center gap-1 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
       >
-        <MoreVertical size={15} />
+        <Settings2 size={14} aria-hidden="true" />
+        <span>{tr("操作", "Actions")}</span>
+        <ChevronDown size={14} aria-hidden="true" />
       </button>
       {menu}
     </div>
+  );
+}
+
+function RenameDeviceModal({
+  device,
+  onClose,
+  onSaved,
+}: {
+  device: Device;
+  onClose(): void;
+  onSaved(name: string): void;
+}) {
+  const { tr } = useI18n();
+  const [name, setName] = useState(device.name || "");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    if (pending || !name.trim()) return;
+    setPending(true);
+    setError(null);
+    try {
+      await renameDevice(device.id, name.trim());
+      onSaved(name.trim());
+    } catch (e) {
+      setError((e as Error).message || tr("保存失败", "Save failed"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Modal
+      open
+      onClose={() => { if (!pending) onClose(); }}
+      title={tr("修改设备名称", "Rename device")}
+      footer={
+        <>
+          <Button disabled={pending} onClick={onClose}>{tr("取消", "Cancel")}</Button>
+          <Button variant="primary" type="submit" form="rename-device" disabled={pending || !name.trim()}>
+            {pending ? tr("保存中…", "Saving…") : tr("保存", "Save")}
+          </Button>
+        </>
+      }
+    >
+      <form id="rename-device" onSubmit={(event) => { event.preventDefault(); void save(); }}>
+        <label htmlFor="device-name" className="mb-1 block text-xs text-zinc-400">{tr("设备名称", "Device name")}</label>
+        <input id="device-name" autoFocus required value={name} disabled={pending}
+          onChange={(event) => setName(event.target.value)}
+          className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+        />
+        {error && <p role="alert" className="mt-2 text-xs text-red-400">{error}</p>}
+      </form>
+    </Modal>
   );
 }
 

--- a/web/src/pages/Edges.tsx
+++ b/web/src/pages/Edges.tsx
@@ -854,8 +854,8 @@ export default function EdgesPage() {
               className={cn(
                 "min-w-full text-xs",
                 compactNetworkTable
-                  ? "w-full min-w-[1120px] table-fixed"
-                  : "w-[1727px] table-fixed",
+                  ? "w-full min-w-[1200px] table-fixed"
+                  : "w-[1767px] table-fixed",
               )}
             >
               {compactNetworkTable ? (
@@ -869,7 +869,7 @@ export default function EdgesPage() {
                   <col style={{ width: 105 }} />
                   <col style={{ width: 130 }} />
                   <col style={{ width: 95 }} />
-                  <col style={{ width: 160 }} />
+                  <col style={{ width: 240 }} />
                 </colgroup>
               ) : (
                 <colgroup>
@@ -884,7 +884,7 @@ export default function EdgesPage() {
                   <col className="w-[110px]" />
                   <col className="w-[110px]" />
                   <col className="w-[145px]" />
-                  <col className="w-[280px]" />
+                  <col className="w-[320px]" />
                 </colgroup>
               )}
               <thead className="device-list-table__header border-b border-zinc-800/60 bg-zinc-950/40 text-[11px] uppercase tracking-wider text-zinc-500">


### PR DESCRIPTION
## Summary

Devices could only be named during creation, and Kubernetes-managed devices displayed their reported hostname ahead of the device name. Add an administrator-only rename action backed by the existing device PATCH endpoint; display the saved device name first while keeping the hostname column unchanged.

Unify device actions as View chart, Terminal, and Actions, including Kubernetes devices. Add an Actions icon and align controls vertically without exposing Kubernetes-managed role, deletion, or Edge lifecycle operations.

## Validation

- Device page: 16 tests passed, including rename success/error handling, blank-name rejection, read-only access, and Kubernetes chart device ID.
- Production frontend build and device-page/test ESLint checks passed. The API file has 11 existing mixed-indentation lint errors on unchanged lines.
- Test environment: visually verified equal 24 px action heights and aligned centers for both host and Kubernetes rows.
- A broad local test run encountered timeouts. A single-worker rerun passed 48/49 tests in the four affected suites; the remaining Sidebar timeout also reproduces on unmodified main. CI is checked before merge.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
