### PR TITLE
feat(k8s): add kube_get_pods and kube_events basetools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
@@ -138,7 +139,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect

--- a/internal/edgeagent/k8s/readonly.go
+++ b/internal/edgeagent/k8s/readonly.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
+	defaultPodListLimit       = 50
 	defaultPodLogTailLines    = 100
 	defaultPodLogLimitBytes   = 16 * 1024
 	defaultPodLogSinceSeconds = int64(3600)
+	maxPodListLimit           = 100
 	maxPodLogTailLines        = 500
 	maxPodLogLimitBytes       = 64 * 1024
 	maxPodLogSinceSeconds     = int64(24 * 3600)
@@ -30,6 +32,24 @@ func (p *InventoryPusher) RegisterHandlers() {
 	if p == nil || p.client == nil || p.api == nil {
 		return
 	}
+	p.client.RegisterHandler(tunnel.MethodListK8sPods,
+		func(ctx context.Context, _ tunnel.Session, _ string, body []byte) ([]byte, error) {
+			var req tunnel.KubernetesListPodsRequest
+			if len(body) > 0 {
+				if err := json.Unmarshal(body, &req); err != nil {
+					return nil, fmt.Errorf("list_k8s_pods: decode: %w", err)
+				}
+			}
+			if req.ClusterID != 0 && req.ClusterID != p.info.ClusterID {
+				return nil, fmt.Errorf("list_k8s_pods: cluster_id %d does not match controller cluster_id %d", req.ClusterID, p.info.ClusterID)
+			}
+			req.ClusterID = p.info.ClusterID
+			resp, err := p.api.listPodsLive(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(resp)
+		})
 	p.client.RegisterHandler(tunnel.MethodDescribeK8sResource,
 		func(ctx context.Context, _ tunnel.Session, _ string, body []byte) ([]byte, error) {
 			var req tunnel.KubernetesDescribeResourceRequest
@@ -84,6 +104,66 @@ func (p *InventoryPusher) RegisterHandlers() {
 			}
 			return json.Marshal(resp)
 		})
+}
+
+func (c *apiClient) listPodsLive(ctx context.Context, req tunnel.KubernetesListPodsRequest) (*tunnel.KubernetesListPodsResponse, error) {
+	namespace := strings.TrimSpace(req.Namespace)
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultPodListLimit
+	}
+	if limit > maxPodListLimit {
+		limit = maxPodListLimit
+	}
+	apiPath := "/api/v1/pods"
+	if namespace != "" {
+		apiPath = "/api/v1/namespaces/" + url.PathEscape(namespace) + "/pods"
+	}
+	q := url.Values{}
+	q.Set("limit", strconv.Itoa(limit))
+	if selector := strings.TrimSpace(req.LabelSelector); selector != "" {
+		q.Set("labelSelector", selector)
+	}
+	if token := strings.TrimSpace(req.Continue); token != "" {
+		q.Set("continue", token)
+	}
+	raw, err := c.getRaw(ctx, apiPath+"?"+q.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("list_k8s_pods: get pods: %w", err)
+	}
+	var list struct {
+		Metadata struct {
+			Continue string `json:"continue"`
+		} `json:"metadata"`
+		Items []struct {
+			Metadata struct {
+				Namespace string `json:"namespace"`
+				Name      string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				NodeName string `json:"nodeName"`
+			} `json:"spec"`
+			Status struct {
+				Phase             string `json:"phase"`
+				Reason            string `json:"reason"`
+				ContainerStatuses []struct {
+					RestartCount int `json:"restartCount"`
+				} `json:"containerStatuses"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("list_k8s_pods: decode Kubernetes response: %w", err)
+	}
+	pods := make([]tunnel.KubernetesPodSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		restarts := 0
+		for _, status := range item.Status.ContainerStatuses {
+			restarts += status.RestartCount
+		}
+		pods = append(pods, tunnel.KubernetesPodSummary{Namespace: item.Metadata.Namespace, Name: item.Metadata.Name, NodeName: item.Spec.NodeName, Phase: item.Status.Phase, Reason: item.Status.Reason, RestartCount: restarts})
+	}
+	return &tunnel.KubernetesListPodsResponse{ClusterID: req.ClusterID, Namespace: namespace, Pods: pods, Continue: list.Metadata.Continue, FetchedAt: time.Now().Unix()}, nil
 }
 
 func (c *apiClient) describeResource(ctx context.Context, req tunnel.KubernetesDescribeResourceRequest) (*tunnel.KubernetesDescribeResourceResponse, error) {

--- a/internal/edgeagent/k8s/readonly.go
+++ b/internal/edgeagent/k8s/readonly.go
@@ -16,10 +16,12 @@ import (
 
 const (
 	defaultPodListLimit       = 50
+	defaultEventListLimit     = 50
 	defaultPodLogTailLines    = 100
 	defaultPodLogLimitBytes   = 16 * 1024
 	defaultPodLogSinceSeconds = int64(3600)
 	maxPodListLimit           = 100
+	maxEventListLimit         = 200
 	maxPodLogTailLines        = 500
 	maxPodLogLimitBytes       = 64 * 1024
 	maxPodLogSinceSeconds     = int64(24 * 3600)
@@ -45,6 +47,24 @@ func (p *InventoryPusher) RegisterHandlers() {
 			}
 			req.ClusterID = p.info.ClusterID
 			resp, err := p.api.listPodsLive(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(resp)
+		})
+	p.client.RegisterHandler(tunnel.MethodListK8sEvents,
+		func(ctx context.Context, _ tunnel.Session, _ string, body []byte) ([]byte, error) {
+			var req tunnel.KubernetesListEventsRequest
+			if len(body) > 0 {
+				if err := json.Unmarshal(body, &req); err != nil {
+					return nil, fmt.Errorf("list_k8s_events: decode: %w", err)
+				}
+			}
+			if req.ClusterID != 0 && req.ClusterID != p.info.ClusterID {
+				return nil, fmt.Errorf("list_k8s_events: cluster_id %d does not match controller cluster_id %d", req.ClusterID, p.info.ClusterID)
+			}
+			req.ClusterID = p.info.ClusterID
+			resp, err := p.api.listEventsLive(ctx, req)
 			if err != nil {
 				return nil, err
 			}
@@ -164,6 +184,59 @@ func (c *apiClient) listPodsLive(ctx context.Context, req tunnel.KubernetesListP
 		pods = append(pods, tunnel.KubernetesPodSummary{Namespace: item.Metadata.Namespace, Name: item.Metadata.Name, NodeName: item.Spec.NodeName, Phase: item.Status.Phase, Reason: item.Status.Reason, RestartCount: restarts})
 	}
 	return &tunnel.KubernetesListPodsResponse{ClusterID: req.ClusterID, Namespace: namespace, Pods: pods, Continue: list.Metadata.Continue, FetchedAt: time.Now().Unix()}, nil
+}
+
+// listEventsLive reads a bounded, filtered page of live Kubernetes Events.
+// Unlike the inventory snapshot, this goes straight to the live API and keeps
+// the result small enough for a single tool response.
+func (c *apiClient) listEventsLive(ctx context.Context, req tunnel.KubernetesListEventsRequest) (*tunnel.KubernetesListEventsResponse, error) {
+	namespace := strings.TrimSpace(req.Namespace)
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultEventListLimit
+	}
+	if limit > maxEventListLimit {
+		limit = maxEventListLimit
+	}
+
+	events, _, err := c.listEvents(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	wantType := strings.TrimSpace(req.Type)
+	wantReason := strings.TrimSpace(req.Reason)
+	wantInvolvedKind := strings.TrimSpace(req.InvolvedKind)
+	wantInvolvedName := strings.TrimSpace(req.InvolvedName)
+
+	total := 0
+	filtered := make([]tunnel.KubernetesEventSnapshot, 0, limit)
+	for _, ev := range events {
+		if wantType != "" && ev.Type != wantType {
+			continue
+		}
+		if wantReason != "" && ev.Reason != wantReason {
+			continue
+		}
+		if wantInvolvedKind != "" && ev.InvolvedKind != wantInvolvedKind {
+			continue
+		}
+		if wantInvolvedName != "" && ev.InvolvedName != wantInvolvedName {
+			continue
+		}
+		total++
+		if len(filtered) < limit {
+			filtered = append(filtered, ev)
+		}
+	}
+
+	return &tunnel.KubernetesListEventsResponse{
+		ClusterID: req.ClusterID,
+		Namespace: namespace,
+		Events:    filtered,
+		Total:     total,
+		FetchedAt: time.Now().Unix(),
+	}, nil
 }
 
 func (c *apiClient) describeResource(ctx context.Context, req tunnel.KubernetesDescribeResourceRequest) (*tunnel.KubernetesDescribeResourceResponse, error) {

--- a/internal/edgeagent/k8s/readonly_test.go
+++ b/internal/edgeagent/k8s/readonly_test.go
@@ -127,6 +127,38 @@ func TestRegisterHandlersDescribePod(t *testing.T) {
 	}
 }
 
+func TestRegisterHandlersListPods(t *testing.T) {
+	var gotPath, gotLimit, gotSelector, gotContinue string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotLimit = r.URL.Path, r.URL.Query().Get("limit")
+		gotSelector, gotContinue = r.URL.Query().Get("labelSelector"), r.URL.Query().Get("continue")
+		writeTestResponse(t, w, `{"metadata":{"continue":"next"},"items":[{"metadata":{"namespace":"default","name":"api-1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running","containerStatuses":[{"restartCount":2},{"restartCount":1}]}}]}`)
+	}))
+	defer srv.Close()
+	fc := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	p := &InventoryPusher{client: fc, info: tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"}, api: &apiClient{baseURL: srv.URL, token: "test-token", http: srv.Client()}}
+	p.RegisterHandlers()
+	h := fc.handlers[tunnel.MethodListK8sPods]
+	if h == nil {
+		t.Fatalf("handler %q not registered", tunnel.MethodListK8sPods)
+	}
+	body, _ := json.Marshal(tunnel.KubernetesListPodsRequest{ClusterID: 7, Namespace: "default", LabelSelector: "app=api", Limit: 999, Continue: "old"})
+	out, err := h(context.Background(), tunnel.Session{}, tunnel.MethodListK8sPods, body)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if gotPath != "/api/v1/namespaces/default/pods" || gotLimit != "100" || gotSelector != "app=api" || gotContinue != "old" {
+		t.Fatalf("unexpected request path=%q limit=%q selector=%q continue=%q", gotPath, gotLimit, gotSelector, gotContinue)
+	}
+	var resp tunnel.KubernetesListPodsResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Continue != "next" || len(resp.Pods) != 1 || resp.Pods[0].RestartCount != 3 || resp.Pods[0].NodeName != "node-a" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
 func TestDescribeResourceRejectsDisallowedKind(t *testing.T) {
 	api := &apiClient{baseURL: "http://127.0.0.1", token: "token", http: http.DefaultClient}
 	_, err := api.describeResource(context.Background(), tunnel.KubernetesDescribeResourceRequest{

--- a/internal/edgeagent/k8s/readonly_test.go
+++ b/internal/edgeagent/k8s/readonly_test.go
@@ -159,6 +159,92 @@ func TestRegisterHandlersListPods(t *testing.T) {
 	}
 }
 
+func TestRegisterHandlersListEvents(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		writeTestResponse(t, w, `{"metadata":{"resourceVersion":"42"},"items":[
+			{
+				"metadata":{"name":"api-1.1","namespace":"default","uid":"event-1"},
+				"involvedObject":{"kind":"Pod","namespace":"default","name":"api-1","uid":"pod-uid"},
+				"type":"Warning",
+				"reason":"BackOff",
+				"message":"Back-off restarting failed container",
+				"source":{"component":"kubelet","host":"node-a"},
+				"count":3,
+				"firstTimestamp":"2026-09-07T00:00:00Z",
+				"lastTimestamp":"2026-09-07T01:00:00Z"
+			},
+			{
+				"metadata":{"name":"api-1.2","namespace":"default","uid":"event-2"},
+				"involvedObject":{"kind":"Pod","namespace":"default","name":"api-1","uid":"pod-uid"},
+				"type":"Normal",
+				"reason":"Started",
+				"message":"Started container"
+			}
+		]}`)
+	}))
+	defer srv.Close()
+
+	fc := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	p := &InventoryPusher{
+		client: fc,
+		info:   tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"},
+		api:    &apiClient{baseURL: srv.URL, token: "test-token", http: srv.Client()},
+	}
+	p.RegisterHandlers()
+
+	h := fc.handlers[tunnel.MethodListK8sEvents]
+	if h == nil {
+		t.Fatalf("handler %q not registered", tunnel.MethodListK8sEvents)
+	}
+	body, _ := json.Marshal(tunnel.KubernetesListEventsRequest{
+		ClusterID:    7,
+		Namespace:    "default",
+		Type:         "Warning",
+		Reason:       "BackOff",
+		InvolvedKind: "Pod",
+		InvolvedName: "api-1",
+		Limit:        50,
+	})
+	out, err := h(context.Background(), tunnel.Session{}, tunnel.MethodListK8sEvents, body)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if gotPath != "/api/v1/namespaces/default/events" {
+		t.Fatalf("unexpected request path=%q", gotPath)
+	}
+	var resp tunnel.KubernetesListEventsResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ClusterID != 7 || resp.Total != 1 || len(resp.Events) != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Events[0].Reason != "BackOff" || resp.Events[0].Count != 3 {
+		t.Fatalf("unexpected event: %+v", resp.Events[0])
+	}
+}
+
+func TestListEventsLiveRejectsMismatchedCluster(t *testing.T) {
+	fc := &fakeTunnelClient{handlers: map[string]tunnel.Handler{}}
+	p := &InventoryPusher{
+		client: fc,
+		info:   tunnel.KubernetesInfo{ClusterID: 7, Role: "controller"},
+		api:    &apiClient{baseURL: "http://127.0.0.1", token: "token", http: http.DefaultClient},
+	}
+	p.RegisterHandlers()
+
+	h := fc.handlers[tunnel.MethodListK8sEvents]
+	if h == nil {
+		t.Fatalf("handler %q not registered", tunnel.MethodListK8sEvents)
+	}
+	body, _ := json.Marshal(tunnel.KubernetesListEventsRequest{ClusterID: 99})
+	if _, err := h(context.Background(), tunnel.Session{}, tunnel.MethodListK8sEvents, body); err == nil {
+		t.Fatal("handler should reject mismatched cluster_id")
+	}
+}
+
 func TestDescribeResourceRejectsDisallowedKind(t *testing.T) {
 	api := &apiClient{baseURL: "http://127.0.0.1", token: "token", http: http.DefaultClient}
 	_, err := api.describeResource(context.Background(), tunnel.KubernetesDescribeResourceRequest{

--- a/internal/manager/biz/aiops/tools/inventory_bridge.go
+++ b/internal/manager/biz/aiops/tools/inventory_bridge.go
@@ -191,7 +191,8 @@ func classifyToolCategory(name string) string {
 		"rank_edges", "find_outlier_edges", "correlate_incident":
 		return "diagnostic"
 	case "query_promql", "list_metric_catalog", "query_logql", "query_traceql",
-		"query_k8s_snapshot", "describe_k8s_resource", "query_k8s_logs":
+		"query_k8s_snapshot", "kube_get_pods", "kube_events",
+		"describe_k8s_resource", "query_k8s_logs":
 		return "telemetry"
 	case "agent", "send_message", "task_stop", "tool_search":
 		return "agent"

--- a/internal/manager/biz/aiops/tools/inventory_bridge_test.go
+++ b/internal/manager/biz/aiops/tools/inventory_bridge_test.go
@@ -5,6 +5,8 @@ import "testing"
 func TestClassifyToolCategoryGroupsKubernetesToolsIntoExistingCategories(t *testing.T) {
 	tests := map[string]string{
 		"query_k8s_snapshot":    "telemetry",
+		"kube_get_pods":         "telemetry",
+		"kube_events":           "telemetry",
 		"describe_k8s_resource": "telemetry",
 		"query_k8s_logs":        "telemetry",
 		"execute_k8s_action":    "other",

--- a/internal/manager/biz/aiops/tools/kube_events.go
+++ b/internal/manager/biz/aiops/tools/kube_events.go
@@ -1,0 +1,153 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+const ToolNameKubeEvents = "kube_events"
+
+const KubeEventsDescription = "List a bounded page of live Kubernetes Events through the cluster controller edge. " +
+	"Use for current/live event triage; use query_k8s_snapshot for manager DB snapshots."
+
+var KubeEventsSchema = json.RawMessage(`{
+  "type":"object", "required":["cluster_id"], "properties": {
+    "cluster_id":{"type":"integer","minimum":1,"description":"Kubernetes cluster id in Ongrid."},
+    "namespace":{"type":"string","description":"Optional namespace. Empty lists Events cluster-wide."},
+    "type":{"type":"string","enum":["Normal","Warning"],"description":"Optional event type filter."},
+    "reason":{"type":"string","description":"Optional reason filter, for example BackOff or FailedScheduling."},
+    "involved_kind":{"type":"string","description":"Optional involved object kind, for example Pod or Deployment."},
+    "involved_name":{"type":"string","description":"Optional involved object name."},
+    "limit":{"type":"integer","minimum":1,"maximum":200,"description":"Max events to return. Default 50, maximum 200."}
+  }
+}`)
+
+const kubeEventsWhenToUse = "Use when the user asks about recent or live Kubernetes Events for a cluster or namespace. " +
+	"This reads the live Kubernetes API and returns bounded, already-redacted Event summaries; " +
+	"it is not for full object state (use describe_k8s_resource) or historical DB inventory (use query_k8s_snapshot with resource=events)."
+
+const kubeEventsCallTimeout = 15 * time.Second
+
+type KubeEventsTool struct {
+	caller Caller
+	reader K8sSnapshotReader
+	log    *slog.Logger
+}
+
+func NewKubeEventsTool(caller Caller, reader K8sSnapshotReader, log *slog.Logger) *KubeEventsTool {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &KubeEventsTool{caller: caller, reader: reader, log: log}
+}
+
+func (t *KubeEventsTool) Info(_ context.Context) (*basetool.ToolInfo, error) {
+	return &basetool.ToolInfo{
+		Name:        ToolNameKubeEvents,
+		Description: KubeEventsDescription,
+		WhenToUse:   kubeEventsWhenToUse,
+		Parameters:  KubeEventsSchema,
+		Class:       "read",
+	}, nil
+}
+
+type KubeEventsArgs struct {
+	ClusterID    uint64 `json:"cluster_id"`
+	Namespace    string `json:"namespace,omitempty"`
+	Type         string `json:"type,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	InvolvedKind string `json:"involved_kind,omitempty"`
+	InvolvedName string `json:"involved_name,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+}
+
+type kubeEventsResponse struct {
+	Source           string                              `json:"source"`
+	ControllerEdgeID uint64                              `json:"controller_edge_id"`
+	Result           tunnel.KubernetesListEventsResponse `json:"result"`
+}
+
+func (t *KubeEventsTool) InvokableRun(ctx context.Context, argsJSON string, _ ...basetool.InvokeOption) (string, error) {
+	if t.caller == nil {
+		return "", fmt.Errorf("%s: tunnel caller not configured", ToolNameKubeEvents)
+	}
+	if t.reader == nil {
+		return "", fmt.Errorf("%s: k8s snapshot reader not configured", ToolNameKubeEvents)
+	}
+	var in KubeEventsArgs
+	if err := json.Unmarshal([]byte(argsJSON), &in); err != nil {
+		return "", fmt.Errorf("%s: bad args: %w", ToolNameKubeEvents, err)
+	}
+	if in.ClusterID == 0 {
+		return "", fmt.Errorf("%s: cluster_id is required", ToolNameKubeEvents)
+	}
+
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	req := tunnel.KubernetesListEventsRequest{
+		ClusterID:    in.ClusterID,
+		Namespace:    strings.TrimSpace(in.Namespace),
+		Type:         strings.TrimSpace(in.Type),
+		Reason:       strings.TrimSpace(in.Reason),
+		InvolvedKind: strings.TrimSpace(in.InvolvedKind),
+		InvolvedName: strings.TrimSpace(in.InvolvedName),
+		Limit:        limit,
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, kubeEventsCallTimeout)
+	defer cancel()
+
+	cluster, err := t.reader.GetCluster(callCtx, req.ClusterID)
+	if err != nil {
+		return "", fmt.Errorf("%s: get cluster %d: %w", ToolNameKubeEvents, req.ClusterID, err)
+	}
+	if cluster.ControllerEdgeID == nil || *cluster.ControllerEdgeID == 0 {
+		return "", fmt.Errorf("%s: cluster %d has no online controller edge", ToolNameKubeEvents, req.ClusterID)
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("%s: marshal request: %w", ToolNameKubeEvents, err)
+	}
+	respBody, err := t.caller.Call(callCtx, *cluster.ControllerEdgeID, tunnel.MethodListK8sEvents, body)
+	if err != nil {
+		return "", fmt.Errorf("%s: dispatch: %w", ToolNameKubeEvents, err)
+	}
+	var resp tunnel.KubernetesListEventsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("%s: decode response: %w", ToolNameKubeEvents, err)
+	}
+
+	out, err := json.Marshal(kubeEventsResponse{
+		Source:           "kubernetes_api",
+		ControllerEdgeID: *cluster.ControllerEdgeID,
+		Result:           resp,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%s: marshal response: %w", ToolNameKubeEvents, err)
+	}
+	return string(out), nil
+}
+
+func (r *Registry) executeKubeEvents(ctx context.Context, args json.RawMessage) (ExecuteResult, error) {
+	out, err := NewKubeEventsTool(r.caller, r.k8sSnapshot, r.log).InvokableRun(ctx, string(args))
+	if err != nil {
+		return ExecuteResult{}, err
+	}
+	return ExecuteResult{ResultJSON: json.RawMessage(out)}, nil
+}
+
+var _ basetool.BaseTool = (*KubeEventsTool)(nil)

--- a/internal/manager/biz/aiops/tools/kube_events_test.go
+++ b/internal/manager/biz/aiops/tools/kube_events_test.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+func TestKubeEventsToolCallsControllerEdge(t *testing.T) {
+	fc := &fakeCaller{
+		respBody: mustMarshal(tunnel.KubernetesListEventsResponse{
+			ClusterID: 1,
+			Namespace: "default",
+			Events: []tunnel.KubernetesEventSnapshot{{
+				Namespace:    "default",
+				Name:         "api-1.17c1a2",
+				Type:         "Warning",
+				Reason:       "BackOff",
+				InvolvedKind: "Pod",
+				InvolvedName: "api-1",
+			}},
+			Total:     1,
+			FetchedAt: 42,
+		}),
+	}
+	tool := NewKubeEventsTool(fc, newFakeK8sSnapshotReader(), slog.Default())
+
+	out, err := tool.InvokableRun(context.Background(), `{"cluster_id":1,"namespace":"default","type":"Warning","reason":"BackOff","involved_kind":"Pod","involved_name":"api-1","limit":200}`)
+	if err != nil {
+		t.Fatalf("InvokableRun: %v", err)
+	}
+	if fc.lastID != 77 {
+		t.Fatalf("caller edge_id=%d want 77", fc.lastID)
+	}
+	if fc.lastName != tunnel.MethodListK8sEvents {
+		t.Fatalf("caller method=%q want %q", fc.lastName, tunnel.MethodListK8sEvents)
+	}
+	var sent tunnel.KubernetesListEventsRequest
+	if err := json.Unmarshal(fc.lastBody, &sent); err != nil {
+		t.Fatalf("decode sent body: %v", err)
+	}
+	if sent.ClusterID != 1 || sent.Namespace != "default" || sent.Type != "Warning" || sent.Reason != "BackOff" {
+		t.Fatalf("unexpected sent request: %+v", sent)
+	}
+	if sent.InvolvedKind != "Pod" || sent.InvolvedName != "api-1" || sent.Limit != 200 {
+		t.Fatalf("unexpected sent filters: %+v", sent)
+	}
+
+	var got struct {
+		Source           string `json:"source"`
+		ControllerEdgeID uint64 `json:"controller_edge_id"`
+		Result           struct {
+			Total  int `json:"total"`
+			Events []struct {
+				Reason string `json:"reason"`
+			} `json:"events"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, out)
+	}
+	if got.Source != "kubernetes_api" || got.ControllerEdgeID != 77 || got.Result.Total != 1 {
+		t.Fatalf("unexpected output: %+v", got)
+	}
+	if len(got.Result.Events) != 1 || got.Result.Events[0].Reason != "BackOff" {
+		t.Fatalf("unexpected events: %+v", got.Result.Events)
+	}
+}
+
+func TestKubeEventsToolClampsLimit(t *testing.T) {
+	fc := &fakeCaller{
+		respBody: mustMarshal(tunnel.KubernetesListEventsResponse{ClusterID: 1}),
+	}
+	tool := NewKubeEventsTool(fc, newFakeK8sSnapshotReader(), slog.Default())
+
+	if _, err := tool.InvokableRun(context.Background(), `{"cluster_id":1,"limit":9999}`); err != nil {
+		t.Fatalf("InvokableRun: %v", err)
+	}
+	var sent tunnel.KubernetesListEventsRequest
+	if err := json.Unmarshal(fc.lastBody, &sent); err != nil {
+		t.Fatalf("decode sent body: %v", err)
+	}
+	if sent.Limit != 200 {
+		t.Fatalf("limit should clamp to 200, got %d", sent.Limit)
+	}
+}
+
+func TestKubeEventsToolRequiresClusterID(t *testing.T) {
+	tool := NewKubeEventsTool(&fakeCaller{}, newFakeK8sSnapshotReader(), slog.Default())
+	if _, err := tool.InvokableRun(context.Background(), `{"namespace":"default"}`); err == nil {
+		t.Fatal("InvokableRun should reject missing cluster_id")
+	}
+}
+
+func TestKubeEventsRegisteredInClosureAndBaseToolPaths(t *testing.T) {
+	reg := NewRegistry(&fakeCaller{}, nil, nil, nil, nil, nil, nil, slog.Default())
+	reg.SetK8sSnapshotReader(newFakeK8sSnapshotReader())
+
+	if !containsName(schemaNames(reg.Schemas()), ToolNameKubeEvents) {
+		t.Fatalf("closure registry missing %q", ToolNameKubeEvents)
+	}
+	names := toolInfoNames(t, reg.BuildBaseTools().AllTools())
+	if !containsName(names, ToolNameKubeEvents) {
+		t.Fatalf("base tool registry missing %q: %v", ToolNameKubeEvents, names)
+	}
+	if toolTier(NewKubeEventsTool(&fakeCaller{}, newFakeK8sSnapshotReader(), slog.Default())) != "core" {
+		t.Fatalf("%s should be a core tool", ToolNameKubeEvents)
+	}
+}
+
+var _ basetool.BaseTool = (*KubeEventsTool)(nil)

--- a/internal/manager/biz/aiops/tools/kube_get_pods.go
+++ b/internal/manager/biz/aiops/tools/kube_get_pods.go
@@ -1,0 +1,124 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ongridio/ongrid/internal/manager/biz/aiops/tools/basetool"
+	"github.com/ongridio/ongrid/internal/pkg/tunnel"
+)
+
+const ToolNameKubeGetPods = "kube_get_pods"
+
+const KubeGetPodsDescription = "List a bounded page of live Kubernetes Pods through the cluster controller edge. " +
+	"Use for current Pod state; use query_k8s_snapshot for manager snapshots."
+
+var KubeGetPodsSchema = json.RawMessage(`{
+  "type":"object", "required":["cluster_id"], "properties": {
+    "cluster_id":{"type":"integer","minimum":1,"description":"Kubernetes cluster id in Ongrid."},
+    "namespace":{"type":"string","description":"Optional namespace. Empty lists Pods cluster-wide."},
+    "label_selector":{"type":"string","description":"Optional Kubernetes label selector, for example app=api."},
+    "limit":{"type":"integer","minimum":1,"maximum":100,"description":"Page size. Default 50, maximum 100."},
+    "continue":{"type":"string","description":"Continuation token returned by a previous call."}
+  }
+}`)
+
+const kubeGetPodsWhenToUse = "Use for a current/live Pod list or a namespace/label-filtered Pod query. " +
+	"This is read-only and paginated; it does not retrieve logs, execute commands, or change Kubernetes resources."
+
+const kubeGetPodsCallTimeout = 15 * time.Second
+
+type KubeGetPodsTool struct {
+	caller Caller
+	reader K8sSnapshotReader
+	log    *slog.Logger
+}
+
+func NewKubeGetPodsTool(caller Caller, reader K8sSnapshotReader, log *slog.Logger) *KubeGetPodsTool {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &KubeGetPodsTool{caller: caller, reader: reader, log: log}
+}
+
+func (t *KubeGetPodsTool) Info(_ context.Context) (*basetool.ToolInfo, error) {
+	return &basetool.ToolInfo{Name: ToolNameKubeGetPods, Description: KubeGetPodsDescription, WhenToUse: kubeGetPodsWhenToUse, Parameters: KubeGetPodsSchema, Class: "read"}, nil
+}
+
+type KubeGetPodsArgs struct {
+	ClusterID     uint64 `json:"cluster_id"`
+	Namespace     string `json:"namespace,omitempty"`
+	LabelSelector string `json:"label_selector,omitempty"`
+	Limit         int    `json:"limit,omitempty"`
+	Continue      string `json:"continue,omitempty"`
+}
+
+type kubeGetPodsResponse struct {
+	Source           string                            `json:"source"`
+	ControllerEdgeID uint64                            `json:"controller_edge_id"`
+	Result           tunnel.KubernetesListPodsResponse `json:"result"`
+}
+
+func (t *KubeGetPodsTool) InvokableRun(ctx context.Context, argsJSON string, _ ...basetool.InvokeOption) (string, error) {
+	if t.caller == nil {
+		return "", fmt.Errorf("%s: tunnel caller not configured", ToolNameKubeGetPods)
+	}
+	if t.reader == nil {
+		return "", fmt.Errorf("%s: k8s snapshot reader not configured", ToolNameKubeGetPods)
+	}
+	var in KubeGetPodsArgs
+	if err := json.Unmarshal([]byte(argsJSON), &in); err != nil {
+		return "", fmt.Errorf("%s: bad args: %w", ToolNameKubeGetPods, err)
+	}
+	if in.ClusterID == 0 {
+		return "", fmt.Errorf("%s: cluster_id is required", ToolNameKubeGetPods)
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	req := tunnel.KubernetesListPodsRequest{ClusterID: in.ClusterID, Namespace: strings.TrimSpace(in.Namespace), LabelSelector: strings.TrimSpace(in.LabelSelector), Limit: limit, Continue: strings.TrimSpace(in.Continue)}
+	callCtx, cancel := context.WithTimeout(ctx, kubeGetPodsCallTimeout)
+	defer cancel()
+	cluster, err := t.reader.GetCluster(callCtx, req.ClusterID)
+	if err != nil {
+		return "", fmt.Errorf("%s: get cluster %d: %w", ToolNameKubeGetPods, req.ClusterID, err)
+	}
+	if cluster.ControllerEdgeID == nil || *cluster.ControllerEdgeID == 0 {
+		return "", fmt.Errorf("%s: cluster %d has no online controller edge", ToolNameKubeGetPods, req.ClusterID)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("%s: marshal request: %w", ToolNameKubeGetPods, err)
+	}
+	respBody, err := t.caller.Call(callCtx, *cluster.ControllerEdgeID, tunnel.MethodListK8sPods, body)
+	if err != nil {
+		return "", fmt.Errorf("%s: dispatch: %w", ToolNameKubeGetPods, err)
+	}
+	var resp tunnel.KubernetesListPodsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("%s: decode response: %w", ToolNameKubeGetPods, err)
+	}
+	out, err := json.Marshal(kubeGetPodsResponse{Source: "kubernetes_api", ControllerEdgeID: *cluster.ControllerEdgeID, Result: resp})
+	if err != nil {
+		return "", fmt.Errorf("%s: marshal response: %w", ToolNameKubeGetPods, err)
+	}
+	return string(out), nil
+}
+
+func (r *Registry) executeKubeGetPods(ctx context.Context, args json.RawMessage) (ExecuteResult, error) {
+	out, err := NewKubeGetPodsTool(r.caller, r.k8sSnapshot, r.log).InvokableRun(ctx, string(args))
+	if err != nil {
+		return ExecuteResult{}, err
+	}
+	return ExecuteResult{ResultJSON: json.RawMessage(out)}, nil
+}
+
+var _ basetool.BaseTool = (*KubeGetPodsTool)(nil)

--- a/internal/manager/biz/aiops/tools/registry.go
+++ b/internal/manager/biz/aiops/tools/registry.go
@@ -194,6 +194,12 @@ func (r *Registry) SetK8sSnapshotReader(k K8sSnapshotReader) {
 		})
 		if r.caller != nil {
 			r.Register(Tool{
+				Name:        ToolNameKubeGetPods,
+				Description: KubeGetPodsDescription,
+				Schema:      KubeGetPodsSchema,
+				Execute:     r.executeKubeGetPods,
+			})
+			r.Register(Tool{
 				Name:        ToolNameDescribeK8sResource,
 				Description: DescribeK8sResourceDescription,
 				Schema:      DescribeK8sResourceSchema,

--- a/internal/manager/biz/aiops/tools/registry.go
+++ b/internal/manager/biz/aiops/tools/registry.go
@@ -200,6 +200,12 @@ func (r *Registry) SetK8sSnapshotReader(k K8sSnapshotReader) {
 				Execute:     r.executeKubeGetPods,
 			})
 			r.Register(Tool{
+				Name:        ToolNameKubeEvents,
+				Description: KubeEventsDescription,
+				Schema:      KubeEventsSchema,
+				Execute:     r.executeKubeEvents,
+			})
+			r.Register(Tool{
 				Name:        ToolNameDescribeK8sResource,
 				Description: DescribeK8sResourceDescription,
 				Schema:      DescribeK8sResourceSchema,

--- a/internal/manager/biz/aiops/tools/registry_basetool.go
+++ b/internal/manager/biz/aiops/tools/registry_basetool.go
@@ -125,6 +125,7 @@ func (r *Registry) BuildBaseTools() *ToolBag {
 	if r.k8sSnapshot != nil {
 		out = append(out, NewQueryK8sSnapshotTool(r.k8sSnapshot, r.log))
 		if r.caller != nil {
+			out = append(out, NewKubeGetPodsTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewDescribeK8sResourceTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewQueryK8sLogsTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewExecuteK8sActionTool(r.caller, r.k8sSnapshot, r.log))

--- a/internal/manager/biz/aiops/tools/registry_basetool.go
+++ b/internal/manager/biz/aiops/tools/registry_basetool.go
@@ -126,6 +126,7 @@ func (r *Registry) BuildBaseTools() *ToolBag {
 		out = append(out, NewQueryK8sSnapshotTool(r.k8sSnapshot, r.log))
 		if r.caller != nil {
 			out = append(out, NewKubeGetPodsTool(r.caller, r.k8sSnapshot, r.log))
+			out = append(out, NewKubeEventsTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewDescribeK8sResourceTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewQueryK8sLogsTool(r.caller, r.k8sSnapshot, r.log))
 			out = append(out, NewExecuteK8sActionTool(r.caller, r.k8sSnapshot, r.log))

--- a/internal/manager/biz/aiops/tools/toolbag.go
+++ b/internal/manager/biz/aiops/tools/toolbag.go
@@ -64,6 +64,8 @@ var tierByName = map[string]string{
 	"query_logql":             "core",
 	"query_traceql":           "core",
 	"query_k8s_snapshot":      "core",
+	"kube_get_pods":           "core",
+	"kube_events":             "core",
 	"describe_k8s_resource":   "core",
 	"query_k8s_logs":          "core",
 	"query_knowledge":         "core",

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -26,6 +26,7 @@ const (
 	MethodProbeNetworkSNMP     = "probe_network_snmp"
 	MethodPushK8sInventory     = "push_k8s_inventory"
 	MethodListK8sPods          = "list_k8s_pods"
+	MethodListK8sEvents        = "list_k8s_events"
 	MethodDescribeK8sResource  = "describe_k8s_resource"
 	MethodQueryK8sLogs         = "query_k8s_logs"
 	MethodExecuteK8sAction     = "execute_k8s_action"
@@ -684,6 +685,33 @@ type KubernetesListPodsResponse struct {
 	Pods      []KubernetesPodSummary `json:"pods"`
 	Continue  string                 `json:"continue,omitempty"`
 	FetchedAt int64                  `json:"fetched_at"`
+}
+
+// ---------------------------------------------------------------------
+// list_k8s_events (cloud -> edge controller)
+// ---------------------------------------------------------------------
+
+// KubernetesListEventsRequest asks the cluster controller for a bounded, live
+// Kubernetes Events list. It exposes only the filters a fault-triage agent
+// needs; full event correlation stays in the manager DB snapshot.
+type KubernetesListEventsRequest struct {
+	ClusterID    uint64 `json:"cluster_id"`
+	Namespace    string `json:"namespace,omitempty"`
+	Type         string `json:"type,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	InvolvedKind string `json:"involved_kind,omitempty"`
+	InvolvedName string `json:"involved_name,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+}
+
+// KubernetesListEventsResponse carries live Events already sanitized for
+// model consumption. Total is the filtered count before the Limit is applied.
+type KubernetesListEventsResponse struct {
+	ClusterID uint64                    `json:"cluster_id"`
+	Namespace string                    `json:"namespace,omitempty"`
+	Events    []KubernetesEventSnapshot `json:"events"`
+	Total     int                       `json:"total"`
+	FetchedAt int64                     `json:"fetched_at"`
 }
 
 // ---------------------------------------------------------------------

--- a/internal/pkg/tunnel/messages.go
+++ b/internal/pkg/tunnel/messages.go
@@ -25,6 +25,7 @@ const (
 	MethodPushNetworkDiscovery = "push_network_discovery"
 	MethodProbeNetworkSNMP     = "probe_network_snmp"
 	MethodPushK8sInventory     = "push_k8s_inventory"
+	MethodListK8sPods          = "list_k8s_pods"
 	MethodDescribeK8sResource  = "describe_k8s_resource"
 	MethodQueryK8sLogs         = "query_k8s_logs"
 	MethodExecuteK8sAction     = "execute_k8s_action"
@@ -650,6 +651,39 @@ type KubernetesInventoryResponse struct {
 	AcceptedWorkloads int `json:"accepted_workloads"`
 	AcceptedPods      int `json:"accepted_pods"`
 	AcceptedEvents    int `json:"accepted_events"`
+}
+
+// ---------------------------------------------------------------------
+// list_k8s_pods (cloud -> edge controller)
+// ---------------------------------------------------------------------
+
+// KubernetesListPodsRequest asks the cluster controller for a bounded, live
+// Pod list. It deliberately exposes only namespace and label filtering.
+type KubernetesListPodsRequest struct {
+	ClusterID     uint64 `json:"cluster_id"`
+	Namespace     string `json:"namespace,omitempty"`
+	LabelSelector string `json:"label_selector,omitempty"`
+	Limit         int    `json:"limit,omitempty"`
+	Continue      string `json:"continue,omitempty"`
+}
+
+// KubernetesPodSummary is a deliberately small, non-sensitive view of a Pod.
+// Full live objects remain available through describe_k8s_resource.
+type KubernetesPodSummary struct {
+	Namespace    string `json:"namespace"`
+	Name         string `json:"name"`
+	NodeName     string `json:"node_name,omitempty"`
+	Phase        string `json:"phase,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	RestartCount int    `json:"restart_count,omitempty"`
+}
+
+type KubernetesListPodsResponse struct {
+	ClusterID uint64                 `json:"cluster_id"`
+	Namespace string                 `json:"namespace,omitempty"`
+	Pods      []KubernetesPodSummary `json:"pods"`
+	Continue  string                 `json:"continue,omitempty"`
+	FetchedAt int64                  `json:"fetched_at"`
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

基于 Roadmap F.1.2 补齐 Kubernetes 实时只读工具，让 AIOps 能通过 manager → frontier/tunnel → edge → Kubernetes API 数据面查询 live Pod 与 Event：

- 新增 `kube_get_pods`：实时列 Pod，支持 namespace / label selector 过滤与分页（默认 50，上限 100）。
- 新增 `kube_events`：实时列 Event，支持 namespace / type / reason / involved_kind / involved_name 过滤与分页（默认 50，上限 200），复用现有 `listEvents` + `eventSnapshotFromItem` 脱敏链路。

关键实现点：

- `internal/pkg/tunnel/messages.go` 新增 `list_k8s_pods` / `list_k8s_events` wire method 与请求/响应契约，保持现有 `describe_k8s_resource` / `query_k8s_logs` / `execute_k8s_action` 命名不变。
- `internal/edgeagent/k8s/readonly.go` 注册对应 handler，统一做 `cluster_id` 校验。
- `internal/manager/biz/aiops/tools/` 新增两个 `Class="read"` BaseTool，接入 closure 与 BaseTool 双注册路径，`kube_get_pods` / `kube_events` 归入 `core` tier 与 `telemetry` 技能分类。
- 新增单元测试覆盖调用分发、limit 钳制、参数校验、tier/分类、cluster_id 不匹配拒绝。

验证情况：

- `go build ./internal/pkg/tunnel/... ./internal/edgeagent/k8s/... ./internal/manager/biz/aiops/tools/...` 通过。
- `go test -race ./internal/pkg/tunnel/...` 通过。
- `go test -tags=integration ./internal/edgeagent/plugins/logs/` 通过。
- 完整的 `go test -race ./...` 需在 Linux CI 上执行确认（本地 `httptest` 端口绑定受限）。

## Author confirmation

- [ ✅ ] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md