### PR TITLE
fix(llm): 保留 DeepSeek 思考内容以修复工具调用 400

### DIFF
--- a/db/migrations/20260910120000_add_chat_reasoning_content.down.sql
+++ b/db/migrations/20260910120000_add_chat_reasoning_content.down.sql
@@ -1,0 +1,3 @@
+-- 仅在所有实例回退旧版本、备份该列且确认不再需要思考历史后执行。
+-- 日常应用回滚应保留列，避免丢失协议回放数据。
+ALTER TABLE chat_messages DROP COLUMN reasoning_content;

--- a/db/migrations/20260910120000_add_chat_reasoning_content.up.sql
+++ b/db/migrations/20260910120000_add_chat_reasoning_content.up.sql
@@ -1,0 +1,4 @@
+-- MySQL 8.0.12+；先执行增量迁移再更新应用。旧版本可忽略新增列。
+ALTER TABLE chat_messages
+    ADD COLUMN reasoning_content LONGTEXT NULL,
+    ALGORITHM=INSTANT;

--- a/docs/install/deepseek-thinking-mode.md
+++ b/docs/install/deepseek-thinking-mode.md
@@ -1,0 +1,31 @@
+# DeepSeek 思考模式工具调用修复
+
+对应问题：ongridio/ongrid#400。
+
+工具调用续接以及后续用户轮次需要回传提供方返回的 reasoning_content。本修复在 SDK、内部消息、Eino 和持久化历史之间保留原值，不将该字段作为前端消息 JSON 输出。
+
+## 升级与回退
+
+MySQL 生产环境先备份，再执行 db/migrations/20260910120000_add_chat_reasoning_content.up.sql，最后更新应用。脚本使用 MySQL 8.0.12+ 的 INSTANT 新增列；不支持时应由维护者安排在线 DDL，不自动降级为阻塞操作。若实例已通过 AutoMigrate 或手工方式增加该列，先核对列为 nullable LONGTEXT，避免重复执行 ADD COLUMN。
+
+普通应用回滚保留新增列，以免丢失历史数据。配套 down.sql 仅用于所有实例已回退、备份完成且确认不再需要该列时的显式结构回退；它会删除思考历史，不能用于正常滚动回滚。
+
+旧消息的原始思考内容不可恢复。兼容逻辑仅在模型名称包含 deepseek 且请求携带工具时，为缺失值补显式空字符串；新消息的原值完整保留。自定义模型别名不含 deepseek 时不会启用空字段兼容。该兼容行为通过实际提供方验证，但不代表所有网关均接受空字段。
+
+## 验证
+
+受影响包应在启用 CGO 的 Linux 环境运行：
+
+```sh
+go test -race ./internal/pkg/llm ./internal/manager/biz/aiops/graph/callbacks ./internal/manager/biz/aiops/chatruntime ./internal/manager/data/aiops/store ./internal/manager/biz/aiops/agent
+```
+
+测试覆盖普通和 Stream 适配路径、多轮工具续接、旧历史、持久化长文本及 NULL、JSON 隐藏字段、请求体释放及错误传播。Stream 测试针对项目当前的流式适配层，不声称验证提供方原生 SSE 分片。
+
+协议模糊测试：
+
+```sh
+go test ./internal/pkg/llm -run '^$' -fuzz '^FuzzReasoningTransport_' -fuzztime=10s
+```
+
+真实提供方测试默认跳过，显式设置 ONGRID_REASONING_SMOKE=1 及 SMOKE_API_KEY、SMOKE_BASE_URL、SMOKE_MODEL 才启用；仅使用合成工具。凭据只通过环境变量传入，不写入仓库。迁移 up/down 应在一次性 MySQL 数据库演练；SQLite 持久化测试不替代 MySQL DDL 验证。

--- a/internal/manager/biz/aiops/agent/agent.go
+++ b/internal/manager/biz/aiops/agent/agent.go
@@ -466,6 +466,7 @@ func (a *Agent) runInternal(ctx context.Context, sessionID string, userID uint64
 			SessionID:        sess.ID,
 			Role:             model.RoleAssistant,
 			Content:          asstContentPtr,
+			ReasoningContent: stringPtrIfSet(resp.Assistant.ReasoningContent),
 			Model:            stringPtrIfSet(modelTag),
 			PromptTokens:     &pt,
 			CompletionTokens: &ct,
@@ -843,6 +844,9 @@ func (a *Agent) buildMessages(history []*model.Message) []llm.Message {
 				content = *m.Content
 			}
 			msg := llm.Message{Role: m.Role, Content: content}
+			if m.ReasoningContent != nil {
+				msg.ReasoningContent = *m.ReasoningContent
+			}
 			if ok {
 				msg.ToolCalls = make([]llm.ToolCall, 0, len(calls))
 				for _, tc := range calls {

--- a/internal/manager/biz/aiops/chatruntime/reasoning_test.go
+++ b/internal/manager/biz/aiops/chatruntime/reasoning_test.go
@@ -1,0 +1,23 @@
+package chatruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/aiops"
+)
+
+func TestHistory_ReasoningSurvivesNextUserTurn(t *testing.T) {
+	for _, reason := range []*string{nil, strPtr("original protocol field")} {
+		rows := []*model.Message{{ID: "a", Role: model.RoleAssistant, Content: strPtr("answer"), ReasoningContent: reason}, {ID: "u", Role: model.RoleUser, Content: strPtr("next")}}
+		got := buildEinoHistory(rows)
+		require.Len(t, got, 1)
+		require.Equal(t, "answer", got[0].Content)
+		if reason != nil {
+			require.Equal(t, *reason, got[0].ReasoningContent)
+		} else {
+			require.Empty(t, got[0].ReasoningContent)
+		}
+	}
+}

--- a/internal/manager/biz/aiops/chatruntime/runtime.go
+++ b/internal/manager/biz/aiops/chatruntime/runtime.go
@@ -1256,6 +1256,9 @@ func buildEinoHistory(rows []*aiopsmodel.Message) []*schema.Message {
 				Role:    schema.RoleType(m.Role),
 				Content: content,
 			}
+			if m.ReasoningContent != nil {
+				msg.ReasoningContent = *m.ReasoningContent
+			}
 			if ok {
 				msg.ToolCalls = make([]schema.ToolCall, 0, len(calls))
 				for _, tc := range calls {

--- a/internal/manager/biz/aiops/graph/callbacks/persistence.go
+++ b/internal/manager/biz/aiops/graph/callbacks/persistence.go
@@ -488,6 +488,10 @@ func (h *PersistenceHandler) persistAssistant(ctx context.Context, mo *einomodel
 		c := msg.Content
 		row.Content = &c
 	}
+	if msg.ReasoningContent != "" {
+		reasoning := msg.ReasoningContent
+		row.ReasoningContent = &reasoning
+	}
 	if mo.TokenUsage != nil {
 		pt := mo.TokenUsage.PromptTokens
 		ct := mo.TokenUsage.CompletionTokens

--- a/internal/manager/biz/aiops/graph/callbacks/reasoning_test.go
+++ b/internal/manager/biz/aiops/graph/callbacks/reasoning_test.go
@@ -1,0 +1,34 @@
+package callbacks
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	einomodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistence_ReasoningStoredButNotExposedAsJSON(t *testing.T) {
+	for _, reason := range []string{"", "synthetic protocol fixture"} {
+		t.Run(reason, func(t *testing.T) {
+			repo := newFakeSessionRepo()
+			h := NewPersistenceHandler(PersistenceDeps{SessionID: "test", Repo: repo})
+			h.OnEnd(context.Background(), chatModelInfo(), &einomodel.CallbackOutput{Message: &schema.Message{Role: schema.Assistant, Content: "visible", ReasoningContent: reason}})
+			require.Len(t, repo.messages, 1)
+			row := repo.messages[0]
+			if reason == "" {
+				require.Nil(t, row.ReasoningContent)
+			} else {
+				require.NotNil(t, row.ReasoningContent)
+				require.Equal(t, reason, *row.ReasoningContent)
+			}
+			wire, err := json.Marshal(row)
+			require.NoError(t, err)
+			require.NotContains(t, string(wire), "ReasoningContent")
+			require.NotContains(t, string(wire), "synthetic protocol fixture")
+			require.Equal(t, "visible", *row.Content)
+		})
+	}
+}

--- a/internal/manager/data/aiops/store/reasoning_test.go
+++ b/internal/manager/data/aiops/store/reasoning_test.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/aiops"
+)
+
+func TestMessages_ReasoningDatabaseRoundTrip(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	s := &model.Session{UserID: 1, Title: "reasoning fixture"}
+	require.NoError(t, repo.CreateSession(ctx, s))
+	// 覆盖超过普通 TEXT 容量的协议字段与旧记录 NULL。
+	for i, reason := range []*string{nil, strp(strings.Repeat("x", 70000))} {
+		row := &model.Message{CreatedAt: time.Unix(int64(i), 0).UTC(), SessionID: s.ID, Role: model.RoleAssistant, Content: strp("visible"), ReasoningContent: reason}
+		require.NoError(t, repo.AppendMessage(ctx, row))
+	}
+	rows, err := repo.ListMessages(ctx, s.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Nil(t, rows[0].ReasoningContent)
+	require.NotNil(t, rows[1].ReasoningContent)
+	require.Len(t, *rows[1].ReasoningContent, 70000)
+}

--- a/internal/manager/model/aiops/model.go
+++ b/internal/manager/model/aiops/model.go
@@ -152,6 +152,8 @@ type Message struct {
 	AttachmentIDs []string     `gorm:"-" json:"-"`
 	ToolCallID    *string      `gorm:"size:64;column:tool_call_id"`
 	ToolName      *string      `gorm:"size:64;column:tool_name"`
+	// ReasoningContent 仅供模型协议回放，禁止通过消息 JSON 暴露给前端。
+	ReasoningContent *string `gorm:"type:longtext;column:reasoning_content" json:"-"`
 	// Model is the LLM model id that produced this message — only set on
 	// role=assistant rows. Lets the SPA show per-message provenance ("the
 	// answer above came from glm-4-plus; the answer below from opus") and

--- a/internal/pkg/llm/budget_callback.go
+++ b/internal/pkg/llm/budget_callback.go
@@ -205,6 +205,7 @@ func estimateEinoPromptTokens(msgs []*schema.Message) int {
 		}
 		total += perMsgOverhead
 		total += len(m.Content) / 4
+		total += len(m.ReasoningContent) / 4
 		for _, tc := range m.ToolCalls {
 			total += len(tc.Function.Name) / 4
 			total += len(tc.Function.Arguments) / 4
@@ -239,4 +240,3 @@ func extractUsage(mo *einomodel.CallbackOutput) *Usage {
 	}
 	return nil
 }
-

--- a/internal/pkg/llm/client.go
+++ b/internal/pkg/llm/client.go
@@ -66,12 +66,14 @@ type Config struct {
 //     ToolName is an optional hint for logs.
 //   - "system" : system prompt; Content is required.
 type Message struct {
-	Role       string
-	Content    string
-	ToolCalls  []ToolCall
-	ToolCallID string
-	ToolName   string
-	Images     []ImageInput
+	// ReasoningContent 保留模型返回的协议字段，供后续工具调用回传；不作为用户可见正文。
+	ReasoningContent string
+	Role             string
+	Content          string
+	ToolCalls        []ToolCall
+	ToolCallID       string
+	ToolName         string
+	Images           []ImageInput
 }
 
 type ImageInput struct {
@@ -326,7 +328,7 @@ func (c *openaiClient) sdkFor(apiKey, baseURL string) *openai.Client {
 	if baseURL != "" {
 		sdkCfg.BaseURL = baseURL
 	}
-	transport := http.RoundTripper(NewHTTPTransport(c.cfg.TLSInsecure))
+	transport := http.RoundTripper(&deepSeekReasoningTransport{base: NewHTTPTransport(c.cfg.TLSInsecure)})
 	if zhipuauth.LooksLikeZhipuURL(baseURL) && zhipuauth.LooksLikeZhipuKey(apiKey) {
 		sdkCfg.HTTPClient = &http.Client{
 			Transport: &zhipuJWTTransport{apiKey: apiKey, base: transport},
@@ -438,6 +440,11 @@ func (c *openaiClient) Chat(ctx context.Context, req ChatReq) (*ChatResp, error)
 	}
 
 	// 4. Issue the request through the SDK matching the resolved creds.
+	// 旧消息没有可恢复的思考字段；DeepSeek 接受显式空值，但 SDK 的
+	// omitempty 会删掉它。仅对需要此兼容处理的请求补齐空字段。
+	if needsDeepSeekReasoningCompatibility(sdkReq) {
+		callCtx = context.WithValue(callCtx, deepSeekReasoningKey{}, true)
+	}
 	sdk := c.sdkFor(apiKey, baseURL)
 	start := time.Now()
 	sdkResp, err := sdk.CreateChatCompletion(callCtx, sdkReq)
@@ -580,10 +587,11 @@ func (c *openaiClient) toOpenAIReq(req ChatReq, model string) (openai.ChatComple
 
 func toOpenAIMessage(m Message) (openai.ChatCompletionMessage, error) {
 	out := openai.ChatCompletionMessage{
-		Role:       m.Role,
-		Content:    m.Content,
-		Name:       m.ToolName,
-		ToolCallID: m.ToolCallID,
+		ReasoningContent: m.ReasoningContent,
+		Role:             m.Role,
+		Content:          m.Content,
+		Name:             m.ToolName,
+		ToolCallID:       m.ToolCallID,
 	}
 	if len(m.Images) > 0 {
 		out.Content = ""
@@ -615,10 +623,11 @@ func toOpenAIMessage(m Message) (openai.ChatCompletionMessage, error) {
 
 func fromOpenAIMessage(m openai.ChatCompletionMessage) (Message, error) {
 	out := Message{
-		Role:       m.Role,
-		Content:    m.Content,
-		ToolName:   m.Name,
-		ToolCallID: m.ToolCallID,
+		ReasoningContent: m.ReasoningContent,
+		Role:             m.Role,
+		Content:          m.Content,
+		ToolName:         m.Name,
+		ToolCallID:       m.ToolCallID,
 	}
 	if len(m.ToolCalls) > 0 {
 		out.ToolCalls = make([]ToolCall, 0, len(m.ToolCalls))
@@ -746,6 +755,7 @@ func estimatePromptTokens(msgs []Message) int {
 		total += perMsgOverhead
 		total += len(m.Content) / 4
 		total += len(m.Images) * 256
+		total += len(m.ReasoningContent) / 4
 		for _, tc := range m.ToolCalls {
 			total += len(tc.Name) / 4
 			total += len(tc.Args) / 4

--- a/internal/pkg/llm/deepseek_reasoning.go
+++ b/internal/pkg/llm/deepseek_reasoning.go
@@ -1,0 +1,93 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type deepSeekReasoningKey struct{}
+
+func needsDeepSeekReasoningCompatibility(req openai.ChatCompletionRequest) bool {
+	if len(req.Tools) == 0 || !strings.Contains(strings.ToLower(req.Model), "deepseek") {
+		return false
+	}
+	for _, m := range req.Messages {
+		if m.Role == openai.ChatMessageRoleAssistant && m.ReasoningContent == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// deepSeekReasoningTransport 弥补 SDK string+omitempty 无法发送空字段的问题。
+// 原模型输出原样回传；历史缺失值只发送空字符串，不伪造思考内容。
+type deepSeekReasoningTransport struct {
+	base http.RoundTripper
+}
+
+func (t *deepSeekReasoningTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if enabled, _ := req.Context().Value(deepSeekReasoningKey{}).(bool); !enabled {
+		return t.base.RoundTrip(req)
+	}
+	// 兼容分支发送的是请求副本；原请求体仍由本 RoundTripper 负责关闭。
+	// 包括构造副本失败的路径，并保留原始错误链。
+	defer func() {
+		if req.Body != nil {
+			if closeErr := req.Body.Close(); closeErr != nil && resp == nil {
+				err = errors.Join(err, fmt.Errorf("llm: close original reasoning request: %w", closeErr))
+			}
+		}
+	}()
+	if req.GetBody == nil {
+		return nil, fmt.Errorf("llm: reasoning compatibility requires a replayable request body")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, fmt.Errorf("llm: copy reasoning request: %w", err)
+	}
+	raw, readErr := io.ReadAll(body)
+	closeErr := body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("llm: read reasoning request: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("llm: close reasoning request: %w", closeErr)
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("llm: decode reasoning request: %w", err)
+	}
+	var messages []map[string]json.RawMessage
+	if err := json.Unmarshal(payload["messages"], &messages); err != nil {
+		return nil, fmt.Errorf("llm: decode reasoning messages: %w", err)
+	}
+	for _, m := range messages {
+		if string(m["role"]) == `"assistant"` {
+			if _, present := m["reasoning_content"]; !present {
+				m["reasoning_content"] = json.RawMessage(`""`)
+			}
+		}
+	}
+	payload["messages"], err = json.Marshal(messages)
+	if err != nil {
+		return nil, fmt.Errorf("llm: encode reasoning messages: %w", err)
+	}
+	raw, err = json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("llm: encode reasoning request: %w", err)
+	}
+	cloned := req.Clone(req.Context())
+	cloned.Body = io.NopCloser(bytes.NewReader(raw))
+	cloned.ContentLength = int64(len(raw))
+	cloned.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(raw)), nil
+	}
+	return t.base.RoundTrip(cloned)
+}

--- a/internal/pkg/llm/eino_routing.go
+++ b/internal/pkg/llm/eino_routing.go
@@ -432,10 +432,11 @@ func (c *clientChatModel) buildChatReq(input []*schema.Message, common *model.Op
 // Preserves text, tool calls, and user image inputs.
 func einoMessageToLLM(m *schema.Message) Message {
 	out := Message{
-		Role:       string(m.Role),
-		Content:    m.Content,
-		ToolCallID: m.ToolCallID,
-		ToolName:   m.ToolName,
+		ReasoningContent: m.ReasoningContent,
+		Role:             string(m.Role),
+		Content:          m.Content,
+		ToolCallID:       m.ToolCallID,
+		ToolName:         m.ToolName,
 	}
 	for _, part := range m.UserInputMultiContent {
 		if part.Type != schema.ChatMessagePartTypeImageURL || part.Image == nil || part.Image.Base64Data == nil {
@@ -468,11 +469,12 @@ func einoMessageFromChatResp(resp *ChatResp) *schema.Message {
 		return nil
 	}
 	m := &schema.Message{
-		Role:       schema.RoleType(resp.Assistant.Role),
-		Content:    resp.Assistant.Content,
-		Name:       resp.Assistant.ToolName,
-		ToolCallID: resp.Assistant.ToolCallID,
-		ToolName:   resp.Assistant.ToolName,
+		Role:             schema.RoleType(resp.Assistant.Role),
+		ReasoningContent: resp.Assistant.ReasoningContent,
+		Content:          resp.Assistant.Content,
+		Name:             resp.Assistant.ToolName,
+		ToolCallID:       resp.Assistant.ToolCallID,
+		ToolName:         resp.Assistant.ToolName,
 	}
 	if len(resp.Assistant.ToolCalls) > 0 {
 		m.ToolCalls = make([]schema.ToolCall, 0, len(resp.Assistant.ToolCalls))

--- a/internal/pkg/llm/reasoning_live_test.go
+++ b/internal/pkg/llm/reasoning_live_test.go
@@ -1,0 +1,42 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// 显式启用的真实上游冒烟；只使用合成测试工具，不访问设备或业务数据。
+func TestReasoningLive_LegacyHistoryThenToolContinuation(t *testing.T) {
+	if os.Getenv("ONGRID_REASONING_SMOKE") != "1" {
+		t.Skip("opt-in live provider smoke")
+	}
+	client := New(Config{APIKey: os.Getenv("SMOKE_API_KEY"), BaseURL: os.Getenv("SMOKE_BASE_URL"), Model: os.Getenv("SMOKE_MODEL"), TLSInsecure: os.Getenv("SMOKE_TLS_INSECURE") == "true"}, nil, prometheus.NewRegistry())
+	cm, err := NewClientChatModel(ClientChatModelConfig{Client: client})
+	require.NoError(t, err)
+	require.NoError(t, cm.BindTools([]*schema.ToolInfo{{Name: "test_value", Desc: "Returns a synthetic test value. Call once when asked to read the test value."}}))
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	history := []*schema.Message{{Role: schema.User, Content: "Hello"}, {Role: schema.Assistant, Content: "Hello."}, {Role: schema.User, Content: "Call test_value once now, then report its value briefly. This is a synthetic protocol test."}}
+	msg, err := cm.Generate(ctx, history)
+	require.NoError(t, err)
+	require.NotEmpty(t, msg.ReasoningContent)
+	require.Len(t, msg.ToolCalls, 1)
+	require.Equal(t, "test_value", msg.ToolCalls[0].Function.Name)
+	history = append(history, msg, &schema.Message{Role: schema.Tool, ToolCallID: msg.ToolCalls[0].ID, Content: `{"value":7}`})
+	msg, err = cm.Generate(ctx, history)
+	require.NoError(t, err)
+	require.Empty(t, msg.ToolCalls)
+	require.Contains(t, msg.Content, "7")
+	history = append(history, msg, &schema.Message{Role: schema.User, Content: "What was the synthetic value? Answer briefly from history; do not call tools."})
+	msg, err = cm.Generate(ctx, history)
+	require.NoError(t, err)
+	require.Empty(t, msg.ToolCalls)
+	require.Contains(t, msg.Content, "7")
+	t.Log("legacy history, tool continuation, and next user turn succeeded")
+}

--- a/internal/pkg/llm/reasoning_test.go
+++ b/internal/pkg/llm/reasoning_test.go
@@ -1,0 +1,156 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// 覆盖 HTTP 响应解码 → Eino 消息 → 工具结果 → 下一次 HTTP 请求，
+// 包含连续工具调用及跨用户轮次的普通 assistant 消息。
+func TestReasoning_MultipleToolRounds_PreservesProviderContent(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%v", streaming), func(t *testing.T) {
+			var calls atomic.Int32
+			reasons := []string{" 合成协议样本一\n", "合成协议样本二", "合成最终回答样本", "合成新轮次样本"}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request struct {
+					Messages []struct {
+						Role      string  `json:"role"`
+						Reasoning *string `json:"reasoning_content"`
+					} `json:"messages"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+					w.WriteHeader(400)
+					return
+				}
+				n := int(calls.Add(1)) - 1
+				if n >= len(reasons) {
+					t.Error("unexpected extra request")
+					w.WriteHeader(400)
+					return
+				}
+				seen := 0
+				for _, m := range request.Messages {
+					if m.Role != "assistant" {
+						continue
+					}
+					if seen >= n || m.Reasoning == nil || *m.Reasoning != reasons[seen] {
+						t.Errorf("request %d: assistant %d lost reasoning", n, seen)
+						w.WriteHeader(400)
+						return
+					}
+					seen++
+				}
+				if seen != n {
+					t.Errorf("request %d: got %d prior assistants", n, seen)
+					w.WriteHeader(400)
+					return
+				}
+				message := map[string]any{"role": "assistant", "content": "test answer", "reasoning_content": reasons[n]}
+				if n < 2 {
+					message["tool_calls"] = []any{map[string]any{"id": fmt.Sprintf("call_%d", n), "type": "function", "function": map[string]any{"name": "test_value", "arguments": "{}"}}}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{"choices": []any{map[string]any{"message": message}}}); err != nil {
+					t.Error(err)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			client := New(Config{APIKey: "test", BaseURL: srv.URL + "/v1", Model: "deepseek/deepseek-v4-flash"}, nil, prometheus.NewRegistry())
+			cm, err := NewClientChatModel(ClientChatModelConfig{Client: client})
+			require.NoError(t, err)
+			require.NoError(t, cm.BindTools([]*schema.ToolInfo{{Name: "test_value", Desc: "Synthetic tool"}}))
+			history := []*schema.Message{{Role: schema.User, Content: "test"}}
+			for n := 0; n < 4; n++ {
+				var msg *schema.Message
+				if streaming {
+					s, err := cm.Stream(context.Background(), history)
+					require.NoError(t, err)
+					msg, err = s.Recv()
+					s.Close()
+					require.NoError(t, err)
+				} else {
+					msg, err = cm.Generate(context.Background(), history)
+					require.NoError(t, err)
+				}
+				require.Equal(t, reasons[n], msg.ReasoningContent)
+				require.Equal(t, "test answer", msg.Content)
+				history = append(history, msg)
+				if n < 2 {
+					require.Len(t, msg.ToolCalls, 1)
+					history = append(history, &schema.Message{Role: schema.Tool, ToolCallID: msg.ToolCalls[0].ID, Content: "7"})
+				} else {
+					history = append(history, &schema.Message{Role: schema.User, Content: "next question"})
+				}
+			}
+			require.EqualValues(t, 4, calls.Load())
+		})
+	}
+}
+
+func TestReasoning_LegacyHistory_OnlyDeepSeekToolsGetsEmptyField(t *testing.T) {
+	for _, tc := range []struct {
+		name, model string
+		tools, want bool
+	}{
+		{"deepseek tools", "deepseek/deepseek-v4-flash", true, true},
+		{"deepseek no tools", "deepseek-v4-flash", false, false},
+		{"other provider", "gpt-4o", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				var body struct {
+					Messages []map[string]json.RawMessage `json:"messages"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+					w.WriteHeader(400)
+					return
+				}
+				if len(body.Messages) != 3 {
+					t.Error("history changed")
+					w.WriteHeader(400)
+					return
+				}
+				_, present := body.Messages[1]["reasoning_content"]
+				if present != tc.want {
+					t.Errorf("reasoning field present=%v, want=%v", present, tc.want)
+				}
+				if tc.want && string(body.Messages[1]["reasoning_content"]) != `""` {
+					t.Error("missing reasoning was fabricated")
+				}
+				if _, ok := body.Messages[0]["reasoning_content"]; ok {
+					t.Error("user message changed")
+				}
+				if string(body.Messages[2]["reasoning_content"]) != `"original"` {
+					t.Error("existing reasoning overwritten")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`)); err != nil {
+					t.Error(err)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			c := New(Config{APIKey: "test", BaseURL: srv.URL + "/v1", Model: tc.model}, nil, prometheus.NewRegistry())
+			req := ChatReq{Messages: []Message{{Role: "user", Content: "hi"}, {Role: "assistant", Content: "old answer"}, {Role: "assistant", Content: "new answer", ReasoningContent: "original"}}}
+			if tc.tools {
+				req.Tools = []ToolSchema{{Name: "test_value", Parameters: json.RawMessage(`{"type":"object"}`)}}
+			}
+			_, err := c.Chat(context.Background(), req)
+			require.NoError(t, err)
+			require.EqualValues(t, 1, calls.Load())
+		})
+	}
+}

--- a/internal/pkg/llm/reasoning_transport_test.go
+++ b/internal/pkg/llm/reasoning_transport_test.go
@@ -1,0 +1,134 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type reasoningRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f reasoningRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type reasoningTrackedBody struct {
+	io.Reader
+	closed   bool
+	readErr  error
+	closeErr error
+}
+
+func (b *reasoningTrackedBody) Read(p []byte) (int, error) {
+	if b.readErr != nil {
+		return 0, b.readErr
+	}
+	return b.Reader.Read(p)
+}
+
+func (b *reasoningTrackedBody) Close() error {
+	b.closed = true
+	return b.closeErr
+}
+
+func TestReasoningTransport_ClosesOriginalBodyOnSuccessAndFailure(t *testing.T) {
+	sentinel := errors.New("synthetic IO failure")
+	for _, scenario := range []string{"success", "no replay", "copy error", "read error", "close error", "invalid json", "invalid messages", "upstream error", "original close error"} {
+		t.Run(scenario, func(t *testing.T) {
+			const payload = `{"messages":[{"role":"assistant","content":"old"}],"model":"deepseek-v4-flash"}`
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.invalid/v1/chat/completions", strings.NewReader(payload))
+			require.NoError(t, err)
+			req = req.WithContext(context.WithValue(req.Context(), deepSeekReasoningKey{}, true))
+			original := &reasoningTrackedBody{Reader: strings.NewReader(payload)}
+			copyBody := &reasoningTrackedBody{Reader: strings.NewReader(payload)}
+			req.Body = original
+			req.GetBody = func() (io.ReadCloser, error) { return copyBody, nil }
+			switch scenario {
+			case "no replay":
+				req.GetBody = nil
+			case "copy error":
+				req.GetBody = func() (io.ReadCloser, error) { return nil, sentinel }
+			case "read error":
+				copyBody.readErr = sentinel
+			case "close error":
+				copyBody.closeErr = sentinel
+			case "invalid json":
+				copyBody.Reader = strings.NewReader("{")
+			case "invalid messages":
+				copyBody.Reader = strings.NewReader(`{"messages":1}`)
+			case "original close error":
+				original.closeErr = sentinel
+				req.GetBody = nil
+			}
+			called := false
+			transport := &deepSeekReasoningTransport{base: reasoningRoundTripFunc(func(sent *http.Request) (*http.Response, error) {
+				called = true
+				require.NotSame(t, req, sent)
+				require.Same(t, original, req.Body)
+				require.Equal(t, req.Context(), sent.Context())
+				data, readErr := io.ReadAll(sent.Body)
+				require.NoError(t, readErr)
+				require.NoError(t, sent.Body.Close())
+				require.Contains(t, string(data), `"reasoning_content":""`)
+				require.EqualValues(t, len(data), sent.ContentLength)
+				replay, replayErr := sent.GetBody()
+				require.NoError(t, replayErr)
+				replayData, replayErr := io.ReadAll(replay)
+				require.NoError(t, replayErr)
+				require.NoError(t, replay.Close())
+				require.Equal(t, data, replayData)
+				if scenario == "upstream error" {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+			})}
+			_, err = transport.RoundTrip(req)
+			require.True(t, original.closed)
+			require.Equal(t, scenario == "success" || scenario == "upstream error", called)
+			if scenario == "success" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			switch scenario {
+			case "copy error", "read error", "close error", "upstream error", "original close error":
+				require.ErrorIs(t, err, sentinel)
+			}
+			if scenario != "no replay" && scenario != "copy error" && scenario != "original close error" {
+				require.True(t, copyBody.closed)
+			}
+		})
+	}
+}
+
+func FuzzReasoningTransport_DoesNotPanicOrLeakBody(f *testing.F) {
+	for _, seed := range []string{
+		`{"messages":[{"role":"assistant","content":"hello"}]}`,
+		`{"messages":[{"role":"assistant","reasoning_content":"原文"}]}`,
+		`{"messages":null}`, `{"messages":1}`, `null`, `{`,
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, payload string) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.invalid", strings.NewReader(payload))
+		require.NoError(t, err)
+		req = req.WithContext(context.WithValue(req.Context(), deepSeekReasoningKey{}, true))
+		body := &reasoningTrackedBody{Reader: strings.NewReader(payload)}
+		req.Body = body
+		transport := &deepSeekReasoningTransport{base: reasoningRoundTripFunc(func(sent *http.Request) (*http.Response, error) {
+			require.NoError(t, sent.Body.Close())
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		})}
+		resp, err := transport.RoundTrip(req)
+		// 任意输入可以被拒绝；成功响应必须有效，两种路径均须关闭原请求体。
+		if err == nil {
+			require.NotNil(t, resp)
+		}
+		require.True(t, body.closed)
+	})
+}


### PR DESCRIPTION
## Summary

修复 DeepSeek 思考模式下，工具执行成功后续接请求因缺少 `reasoning_content` 返回 HTTP 400 的问题。

- 在模型适配、消息转换、持久化和历史恢复中完整保留该字段。
- 为 DeepSeek 携带工具的请求兼容旧历史缺失字段的情况。
- 补充数据库迁移及回退脚本、回归测试和维护说明。

验证：5 个受影响包的 Linux 竞态测试及静态检查通过；协议模糊测试、MySQL 8.0.46 迁移与回退演练通过。

关联：#400


## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
