### PR TITLE
fix(setting): 阻止并发读取回填已失效配置

### DIFF
--- a/internal/manager/biz/setting/service.go
+++ b/internal/manager/biz/setting/service.go
@@ -55,6 +55,9 @@ type Service struct {
 
 	mu    sync.RWMutex
 	cache map[string]string // key = "category|key"
+	// 每次失效递增；旧读取只能返回自己的快照，不能回填已失效的缓存。
+	// 配置写入低频，使用单一版本号避免为已删除的 key 永久保留版本记录。
+	cacheGeneration uint64
 }
 
 // New builds the service. log may be nil.
@@ -86,6 +89,7 @@ func (s *Service) Get(ctx context.Context, category, key string) (string, bool, 
 
 	s.mu.RLock()
 	v, ok := s.cache[ck]
+	generation := s.cacheGeneration
 	s.mu.RUnlock()
 	if ok {
 		return v, true, nil
@@ -100,7 +104,9 @@ func (s *Service) Get(ctx context.Context, category, key string) (string, bool, 
 	}
 
 	s.mu.Lock()
-	s.cache[ck] = row.Value
+	if generation == s.cacheGeneration {
+		s.cache[ck] = row.Value
+	}
 	s.mu.Unlock()
 	return row.Value, true, nil
 }
@@ -118,6 +124,7 @@ func (s *Service) Set(ctx context.Context, category, key, value string, sensitiv
 		return err
 	}
 	s.mu.Lock()
+	s.cacheGeneration++
 	delete(s.cache, cacheKey(category, key))
 	s.mu.Unlock()
 	s.log.Info("setting updated",
@@ -149,6 +156,7 @@ func (s *Service) SetBatch(ctx context.Context, settings []model.Setting) error 
 	}
 
 	s.mu.Lock()
+	s.cacheGeneration++
 	for i := range settings {
 		delete(s.cache, cacheKey(settings[i].Category, settings[i].Key))
 	}
@@ -256,6 +264,7 @@ func (s *Service) Delete(ctx context.Context, category, key string) error {
 		return err
 	}
 	s.mu.Lock()
+	s.cacheGeneration++
 	delete(s.cache, cacheKey(category, key))
 	s.mu.Unlock()
 	return nil
@@ -266,6 +275,7 @@ func (s *Service) Delete(ctx context.Context, category, key string) error {
 // value (e.g. after a manual DB edit).
 func (s *Service) InvalidateAll() {
 	s.mu.Lock()
+	s.cacheGeneration++
 	s.cache = make(map[string]string)
 	s.mu.Unlock()
 }

--- a/internal/manager/biz/setting/service_cache_test.go
+++ b/internal/manager/biz/setting/service_cache_test.go
@@ -1,0 +1,127 @@
+package setting
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/setting"
+)
+
+// 暂停第一次读取的返回，让写入和失效操作在旧结果回填前完成。
+type delayedSettingRepo struct {
+	*fakeRepo
+	delayed atomic.Bool
+	read    chan struct{}
+	resume  chan struct{}
+}
+
+func (r *delayedSettingRepo) Get(ctx context.Context, category, key string) (*model.Setting, error) {
+	row, err := r.fakeRepo.Get(ctx, category, key)
+	if r.delayed.CompareAndSwap(false, true) {
+		close(r.read)
+		select {
+		case <-r.resume:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return row, err
+}
+
+func TestServiceGet_DelayedReadDoesNotRestoreInvalidatedValue(t *testing.T) {
+	for _, operation := range []string{"Set", "SetBatch", "Delete", "InvalidateAll"} {
+		for _, populateBeforeResume := range []bool{false, true} {
+			name := operation + "/empty_cache"
+			if populateBeforeResume {
+				name = operation + "/fresh_read_before_old_read"
+			}
+			t.Run(name, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				repo := &delayedSettingRepo{
+					fakeRepo: newFakeRepo(),
+					read:     make(chan struct{}),
+					resume:   make(chan struct{}),
+				}
+				const category, key = "llm", "openai_model"
+				if _, err := repo.Set(ctx, category, key, "old-model", false); err != nil {
+					t.Fatal(err)
+				}
+				svc := New(repo, nil)
+				done := make(chan struct{})
+				var resumeOnce sync.Once
+				resume := func() { resumeOnce.Do(func() { close(repo.resume) }) }
+				t.Cleanup(func() {
+					resume()
+					cancel()
+					<-done
+				})
+				go func() {
+					defer close(done)
+					defer func() {
+						if p := recover(); p != nil {
+							t.Errorf("delayed Get panicked: %v", p)
+						}
+					}()
+					// 与写入重叠的调用可以返回旧快照，但不能污染后续读取。
+					if _, _, err := svc.Get(ctx, category, key); err != nil && ctx.Err() == nil {
+						t.Errorf("delayed Get: %v", err)
+					}
+				}()
+				select {
+				case <-repo.read:
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for the old repository read")
+				}
+
+				want, wantFound := mutateSettingDuringRead(ctx, t, svc, repo, operation, category, key)
+				assertCurrentValue := func() {
+					t.Helper()
+					value, found, err := svc.Get(ctx, category, key)
+					if err != nil || value != want || found != wantFound {
+						t.Fatalf("Get = (%q, %v, %v); want (%q, %v, nil)", value, found, err, want, wantFound)
+					}
+				}
+				if populateBeforeResume {
+					assertCurrentValue()
+				}
+				resume()
+				select {
+				case <-done:
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for the delayed Get to finish")
+				}
+				assertCurrentValue()
+				assertCurrentValue()
+			})
+		}
+	}
+}
+
+func mutateSettingDuringRead(ctx context.Context, t *testing.T, svc *Service, repo Repo, operation, category, key string) (string, bool) {
+	t.Helper()
+	var err error
+	want, wantFound := "new-model", true
+	switch operation {
+	case "Set":
+		err = svc.Set(ctx, category, key, want, false)
+	case "SetBatch":
+		err = svc.SetBatch(ctx, []model.Setting{{Category: category, Key: key, Value: want}})
+	case "Delete":
+		err = svc.Delete(ctx, category, key)
+		want, wantFound = "", false
+	case "InvalidateAll":
+		// 模拟直接修改数据库后，调用公开失效入口刷新配置。
+		_, err = repo.Set(ctx, category, key, want, false)
+		svc.InvalidateAll()
+	default:
+		t.Fatalf("unknown operation: %s", operation)
+	}
+	if err != nil {
+		t.Fatalf("%s: %v", operation, err)
+	}
+	return want, wantFound
+}


### PR DESCRIPTION
## Summary

修复配置缓存并发读写时的旧值回填：一个 `Get` 已读取旧值但尚未返回，另一调用完成 `Set` / `SetBatch` / `Delete` 后，先前的读取仍可能把旧值写回缓存，导致后续请求持续使用旧配置。

- 使用受现有锁保护的缓存版本号，只允许未跨越失效操作的读取回填；同时覆盖 `InvalidateAll`。
- 数据库访问仍在锁外执行。与写入重叠的读取可以返回其旧快照，但不能污染后续读取。
- 使用一个全局版本号，避免为已删除的 key 保留版本记录；低频配置写入可能使无关的在途读取跳过回填，不清空无关的已有缓存。
- 增加基于 channel 同步的 8 个回归场景，覆盖四种失效操作，以及旧读取返回前是否已有新读取的两种顺序。

Fixes #358

## Validation

- 原代码：新增的 8 个回归场景全部失败，稳定复现旧值回填。
- 修复后：`go test -race ./internal/manager/biz/setting -count=1` 通过（Linux / Go 1.25）。
- 新增并发回归测试 `-race -count=20` 通过；`go vet ./internal/manager/biz/setting` 通过。
- `make build` 通过（Manager / Edge）。
- `make test-race` 未全绿：128 个包通过，3 个包失败。`TestFileBundleResolverReportsInaccessibleBundle` 在 root 容器下未产生预期权限错误；`TestProbeDNS_Execute_Unresolvable` 的测试域名被当前 DNS 返回了地址。这两项在未修改的基线 `292ac98` 上均连续 10 次复现。
- `TestCreateAPI200WhenSyncFails` 在全量测试中出现一次 `SetSyncResult never called`；该测试用固定 20ms 等待后台写入，基线和当前分支单独重跑各 10 次均通过，疑似时序波动。上述三个模块均未修改。

## Rollback

无 API、数据库或配置格式变更；回滚此提交即可恢复原实现。

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
