### PR TITLE
fix(edge): 修正路径大小写校验并补齐 Windows 原生测试

### DIFF
--- a/.github/workflows/ci-windows-cross.yml
+++ b/.github/workflows/ci-windows-cross.yml
@@ -1,13 +1,10 @@
 name: CI Windows Cross-Build
 
-# Windows 交叉编译 + vet gate。覆盖 edgeagent Windows 子包
-# （dpapi / edgedirs / install / config），配合 ci.yml 形成双平台覆盖。
-#
-# Linux runner 上通过 GOOS=windows 交叉编译，不启动 Windows VM。
-# 涉及 Windows SCM / DPAPI 实际行为的集成测试需要 windows-latest runner，
-# 将在 supervisor PR 落地后补充。
+# Linux 交叉编译覆盖 Windows 入口与测试；Windows runner 实际执行
+# supervisor / upgrademachine / upgradebundle / supervisorhealth 的 race 测试。
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -15,6 +12,9 @@ on:
       - 'internal/edgeagent/**'
       - 'cmd/ongrid-edge*/**'
       - '.github/workflows/ci-windows-cross.yml'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: read
@@ -39,35 +39,26 @@ jobs:
           go-version: '1.25.x'
           cache: true
 
-      - name: go build (GOOS=windows)
-        env:
-          GOOS: windows
-          GOARCH: amd64
-        # 4 个 Windows 子包（PR1 scope）+ 两个最终交付入口二进制——
-        # 仅最终命令依赖图或 Windows build tags 下才暴露的编译错误
-        # 必须在 PR CI 阶段被发现
-        run: |
-          go build ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
-          go build ./cmd/ongrid-edge ./cmd/ongrid-edge-supervisor
+      - name: Build, vet and compile Windows tests
+        run: make check-windows-cross
 
-      - name: go vet (GOOS=windows)
-        env:
-          GOOS: windows
-          GOARCH: amd64
-        run: |
-          # vet 覆盖 Windows 子包 + 两个最终交付入口（避免 Linux-only 文件的误报）
-          go vet ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
-          go vet ./cmd/ongrid-edge ./cmd/ongrid-edge-supervisor
+  windows-native-test:
+    name: Windows native tests (race)
+    runs-on: windows-latest
+    timeout-minutes: 20
 
-      - name: go test (GOOS=windows, no-cgo)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: Run Windows tests
+        shell: bash
         env:
-          GOOS: windows
-          GOARCH: amd64
-        # 注：Linux runner 上可以 GOOS=windows go test 编译 Windows test binary，
-        # 但 wine 层不稳定。这里只编译测试 binary（go test -c -o /dev/null），
-        # 不实际执行；实际执行留给后续 windows-latest runner job（PR2 落地后加）。
-        run: |
-          for pkg in ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...; do
-            echo "compile test binary: $pkg"
-            go test -c -o /dev/null "$pkg"
-          done
+          CGO_ENABLED: '1'
+        run: make test-windows-native SHELL=bash

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,27 @@ test: ## 单元测试
 test-race: ## 单元测试 + race
 	go test -race ./...
 
+# Windows 交叉编译与原生验证共用包清单，避免只编译入口而漏掉测试。
+WINDOWS_EDGE_BASE_PACKAGES := ./internal/edgeagent/dpapi/... ./internal/edgeagent/edgedirs/... ./internal/edgeagent/install/... ./internal/edgeagent/config/...
+WINDOWS_EDGE_UPGRADE_PACKAGES := ./cmd/ongrid-edge-supervisor ./internal/edgeagent/upgrademachine ./internal/edgeagent/upgradebundle ./internal/edgeagent/supervisorhealth
+WINDOWS_EDGE_PACKAGES := $(WINDOWS_EDGE_BASE_PACKAGES) $(WINDOWS_EDGE_UPGRADE_PACKAGES)
+
+.PHONY: check-windows-cross test-windows-native
+check-windows-cross: export GOOS := windows
+check-windows-cross: export GOARCH := amd64
+check-windows-cross: export CGO_ENABLED := 0
+check-windows-cross: ## 在 Linux 上交叉构建、vet 并编译 Windows Edge 测试
+	go build $(WINDOWS_EDGE_PACKAGES) ./cmd/ongrid-edge
+	go vet $(WINDOWS_EDGE_PACKAGES) ./cmd/ongrid-edge
+	@set -e; for pkg in $(WINDOWS_EDGE_PACKAGES); do \
+		echo "compile Windows test binary: $$pkg"; \
+		go test -c -o /dev/null "$$pkg"; \
+	done
+
+test-windows-native: ## 在 Windows 上实际执行 supervisor 与升级相关 race 测试
+	@test "$$(go env GOHOSTOS)" = windows || { echo "requires a native Windows Go toolchain"; exit 1; }
+	go test -race -count=1 -timeout=10m $(WINDOWS_EDGE_UPGRADE_PACKAGES)
+
 test-integration: ## 集成测试（build tag: integration）
 	go test -tags=integration ./...
 

--- a/internal/edgeagent/upgrademachine/validate.go
+++ b/internal/edgeagent/upgrademachine/validate.go
@@ -184,7 +184,7 @@ func ensureWithinDir(rootDir, path string) error {
 	if err != nil {
 		return fmt.Errorf("canonical %s: %w", path, err)
 	}
-	if pathCanon == rootCanon {
+	if strings.EqualFold(pathCanon, rootCanon) {
 		return nil
 	}
 	rootPrefix := rootCanon + string(filepath.Separator)

--- a/internal/edgeagent/upgrademachine/validate_test.go
+++ b/internal/edgeagent/upgrademachine/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -46,10 +47,6 @@ func TestDestBaseWhitelist_Membership(t *testing.T) {
 
 func TestValidateEntry_DestWhitelist(t *testing.T) {
 	binDir := t.TempDir()
-	// 大小写变体用例需要大小写不敏感文件系统（Windows/NTFS）；Linux CI 跳过
-	if _, err := filepath.EvalSymlinks(strings.ToUpper(binDir)); err != nil {
-		t.Skipf("文件系统大小写敏感，大小写变体用例不适用: %v", err)
-	}
 
 	cases := []struct {
 		name    string
@@ -59,7 +56,6 @@ func TestValidateEntry_DestWhitelist(t *testing.T) {
 		{"worker 合法", filepath.Join(binDir, WorkerBinaryName), false},
 		{"supervisor 合法", filepath.Join(binDir, SupervisorBinaryName), false},
 		{"plugin 合法", filepath.Join(binDir, "windows_exporter.exe"), false},
-		{"大小写变体合法（NTFS 不区分大小写）", filepath.Join(strings.ToUpper(binDir), strings.ToUpper(WorkerBinaryName)), false},
 		{"系统镜像被拒", filepath.Join(binDir, "svchost.exe"), true},
 		{"任意文件名被拒", filepath.Join(binDir, "evil.exe"), true},
 		{"受管根外被拒", filepath.Join(t.TempDir(), WorkerBinaryName), true},
@@ -74,6 +70,56 @@ func TestValidateEntry_DestWhitelist(t *testing.T) {
 			err := validateDest(binDir, tc.dest)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("validateDest(%q) err=%v, wantErr=%v", tc.dest, err, tc.wantErr)
+			}
+		})
+	}
+	t.Run("大小写变体合法（NTFS 不区分大小写）", func(t *testing.T) {
+		requireCaseInsensitiveDir(t, binDir)
+		dest := filepath.Join(strings.ToUpper(binDir), strings.ToUpper(WorkerBinaryName))
+		if err := validateDest(binDir, dest); err != nil {
+			t.Fatalf("validateDest(%q): %v", dest, err)
+		}
+	})
+}
+
+// 只跳过不支持大小写变体的用例，其他白名单与越界检查仍在 Linux 执行。
+func requireCaseInsensitiveDir(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.Stat(strings.ToUpper(dir)); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Fatalf("Windows 回归测试需要大小写不敏感目录: %v", err)
+		}
+		t.Skipf("文件系统不支持大小写变体: %v", err)
+	}
+}
+
+func TestEnsureWithinDir_CaseInsensitivePaths(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "managed")
+	child := filepath.Join(root, "plugins")
+	sibling := filepath.Join(parent, "managed-evil")
+	for _, dir := range []string{child, sibling} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	requireCaseInsensitiveDir(t, root)
+	for _, tc := range []struct {
+		name    string
+		root    string
+		path    string
+		wantErr bool
+	}{
+		{"same directory with upper-case path", root, strings.ToUpper(root), false},
+		{"same directory with upper-case root", strings.ToUpper(root), root, false},
+		{"child with upper-case path", root, strings.ToUpper(child), false},
+		{"sibling prefix still rejected", root, strings.ToUpper(sibling), true},
+		{"parent still rejected", root, strings.ToUpper(parent), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ensureWithinDir(tc.root, tc.path)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ensureWithinDir(%q, %q) = %v, wantErr=%v", tc.root, tc.path, err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

同一个受管目录仅改变路径大小写时，`ensureWithinDir` 的根目录相等判断会将其误判为越界，导致合法 Windows 升级目标被拒绝。根目录相等判断改用 `strings.EqualFold`，与已有的子目录比较语义保持一致；符号链接解析、父目录和兄弟目录边界检查保持有效。

- 增加根目录/目标大小写变体、子目录、父目录及兄弟目录前缀的回归用例。
- 仅跳过依赖大小写不敏感文件系统的子测试，让 Linux 继续执行其余 Dest 白名单检查；Windows 上缺少预期文件系统能力会直接失败。
- 通过 Makefile 统一 Windows 构建、vet、测试编译和原生执行入口。交叉编译清单新增 supervisor、upgrademachine、upgradebundle、supervisorhealth。
- 增加 `windows-latest` 原生 `-race` 测试任务，支持手动触发，并将 Makefile 和 Go 依赖变动纳入工作流触发范围。

Fixes #359

## Validation

- 在 macOS 大小写不敏感文件系统上，修复前的大小写 Dest 用例及两个根目录大小写变体稳定失败；修复后路径白名单、大小写、父目录/兄弟目录及 symlink 检查通过。
- Linux：三个升级相关包的 `go test -race` 通过。
- `make check-windows-cross` 通过：Windows 入口构建、vet 和全部八项包/包模式的测试编译。
- `actionlint v1.7.12` 检查修改的工作流通过。
- `make build` 通过（Manager / Edge）。
- `make test-race`：129 个包通过，2 个包受本地环境影响失败（root 容器下权限拒绝测试、DNS 返回测试域名的地址）。两项均已在未修改的基线 `292ac98` 上复现，相关代码未修改。
- [Fork 验证运行](https://github.com/Dragonzz27/ongrid/actions/runs/34448657493) 全部通过：`windows-latest` 原生 `-race` 测试和 `ubuntu-24.04` Windows 构建/vet/测试编译。验证提交 `84f9524` 与本 PR 的 `afcc1e9` 仅差临时验证分支的 push 触发条件，测试代码一致。

## Rollback

无 API、数据库或配置格式变更；回滚此 PR 可恢复原路径判断及 Windows CI 配置。

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
