### PR TITLE
fix(topology): 按设备身份原子绑定节点，修复同名设备注册冲突

### DIFF
--- a/internal/manager/biz/topology/repo.go
+++ b/internal/manager/biz/topology/repo.go
@@ -41,6 +41,8 @@ type RelationListFilter struct {
 
 // NodeRepo is the persistence contract for Node rows.
 type NodeRepo interface {
+	// EnsureForDevice 原子地读取或创建设备的节点关联。
+	EnsureForDevice(ctx context.Context, deviceID uint64, name string) (*model.Node, error)
 	Create(ctx context.Context, n *model.Node) error
 	Update(ctx context.Context, id uint64, name, propsJSON string) error
 	Get(ctx context.Context, id uint64) (*model.Node, error)

--- a/internal/manager/biz/topology/usecase.go
+++ b/internal/manager/biz/topology/usecase.go
@@ -297,20 +297,7 @@ func (u *Usecase) DeleteRelation(ctx context.Context, id uint64) error {
 
 // ---------- DeviceMirror ----------------------------------------------------
 
-// EnsureNodeForDevice is the device→topology mirror entry point. Called
-// from the edge register flow (via edge.Usecase.NodeMirror) after a
-// fresh device row lands. Look up an existing Node by
-// (type='device', name=deviceName) — keyed on name because that's
-// what the device row already carries; if not found, create one.
-// Returns the node id either way; caller writes it back to
-// device.node_id.
-//
-// Implementation note: we do NOT key the lookup on device.id (e.g. a
-// props_jsonb.device_id field) because the migration backfill might
-// race with a real-time write. Keying on (type, name) is good enough
-// for v1 since device names are operator-edited and a duplicate name
-// already means "the operator is treating these as the same logical
-// thing".
+// EnsureNodeForDevice 按设备 ID 复用已有关联，节点创建与绑定由仓储原子完成。
 func (u *Usecase) EnsureNodeForDevice(ctx context.Context, deviceID uint64, deviceName string) (uint64, error) {
 	if u.nodes == nil {
 		return 0, errs.ErrNotWiredYet
@@ -319,22 +306,11 @@ func (u *Usecase) EnsureNodeForDevice(ctx context.Context, deviceID uint64, devi
 	if deviceName == "" {
 		return 0, fmt.Errorf("%w: device name required", errs.ErrInvalid)
 	}
-	rows, err := u.nodes.List(ctx, NodeListFilter{
-		Type:  string(model.NodeTypeDevice),
-		Q:     deviceName,
-		Limit: 50,
-	})
+	if deviceID == 0 {
+		return 0, fmt.Errorf("%w: device ID required", errs.ErrInvalid)
+	}
+	n, err := u.nodes.EnsureForDevice(ctx, deviceID, deviceName)
 	if err != nil {
-		return 0, err
-	}
-	for _, n := range rows {
-		// Q is substring (case-insensitive); require exact match here.
-		if strings.EqualFold(n.Name, deviceName) {
-			return n.ID, nil
-		}
-	}
-	n := &model.Node{Type: string(model.NodeTypeDevice), Name: deviceName}
-	if err := u.nodes.Create(ctx, n); err != nil {
 		return 0, err
 	}
 	if u.log != nil {

--- a/internal/manager/biz/topology/usecase_test.go
+++ b/internal/manager/biz/topology/usecase_test.go
@@ -637,3 +637,51 @@ func TestDeleteRelationTypeGuards(t *testing.T) {
 		t.Fatalf("delete with refs: want ErrConflict, got %v", err)
 	}
 }
+
+// 不同设备即使同名也不能共享节点；重命名不应改变已有拓扑身份。
+func TestDeviceMirrorIdentity(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("CREATE TABLE devices (id INTEGER PRIMARY KEY, node_id INTEGER UNIQUE, deleted_at datetime)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.Node{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("INSERT INTO devices (id) VALUES (1), (2), (3)").Error; err != nil {
+		t.Fatal(err)
+	}
+	uc := biz.NewUsecase(store.NewNodeRepo(db), nil, nil, nil, nil)
+	ctx := context.Background()
+	first, err := uc.EnsureNodeForDevice(ctx, 1, "VM-0-6-ubuntu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[uint64]bool{first: true}
+	for _, id := range []uint64{2, 3} {
+		second, err := uc.EnsureNodeForDevice(ctx, id, "vm-0-6-ubuntu")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[second] {
+			t.Fatalf("device %d reused node %d", id, second)
+		}
+		seen[second] = true
+	}
+	renamed, err := uc.EnsureNodeForDevice(ctx, 1, "renamed-host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renamed != first {
+		t.Fatalf("rename changed node: %d -> %d", first, renamed)
+	}
+	var linked uint64
+	if err := db.Raw("SELECT node_id FROM devices WHERE id = 1").Scan(&linked).Error; err != nil {
+		t.Fatal(err)
+	}
+	if linked != first {
+		t.Fatalf("device linked to %d, want %d", linked, first)
+	}
+}

--- a/internal/manager/data/topology/store/device_mirror_test.go
+++ b/internal/manager/data/topology/store/device_mirror_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	model "github.com/ongridio/ongrid/internal/manager/model/topology"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func mirrorDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "mirror.db")+"?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(8)
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := db.AutoMigrate(&model.Node{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("CREATE TABLE devices (id INTEGER PRIMARY KEY, name TEXT, node_id INTEGER UNIQUE, deleted_at datetime)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("INSERT INTO devices (id, name) VALUES (1, 'host')").Error; err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestEnsureForDeviceConcurrentBackfill(t *testing.T) {
+	db := mirrorDB(t)
+	start := make(chan struct{})
+	results := make(chan error, 16)
+	for i := 0; i < 16; i++ {
+		go func(i int) {
+			// 确保 panic 可报告，且每个工作协程都能结束。
+			defer func() {
+				if v := recover(); v != nil {
+					results <- fmt.Errorf("panic: %v", v)
+				}
+			}()
+			<-start
+			if i%2 == 0 {
+				results <- backfillDeviceNodes(db)
+				return
+			}
+			_, err := NewNodeRepo(db).EnsureForDevice(context.Background(), 1, "renamed")
+			results <- err
+		}(i)
+	}
+	close(start)
+	for i := 0; i < 16; i++ {
+		if err := <-results; err != nil {
+			t.Error(err)
+		}
+	}
+	var count int64
+	if err := db.Model(&model.Node{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("created %d nodes, want 1", count)
+	}
+	var linked uint64
+	if err := db.Raw("SELECT node_id FROM devices WHERE id = 1").Scan(&linked).Error; err != nil {
+		t.Fatal(err)
+	}
+	node, err := NewNodeRepo(db).EnsureForDevice(context.Background(), 1, "another-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked == 0 || node.ID != linked {
+		t.Fatalf("binding changed: %d -> %d", linked, node.ID)
+	}
+}
+
+func TestEnsureForDevicePreservesExistingNode(t *testing.T) {
+	db := mirrorDB(t)
+	node := model.Node{Type: "device", Name: "legacy-name", PropsJSON: `{"owner":"ops"}`}
+	if err := db.Create(&node).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("UPDATE devices SET node_id = ? WHERE id = 1", node.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewNodeRepo(db).EnsureForDevice(context.Background(), 1, "new-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != node.ID || got.Name != node.Name || got.PropsJSON != node.PropsJSON {
+		t.Fatalf("existing node changed: %+v", got)
+	}
+}
+
+func TestEnsureForDeviceRollback(t *testing.T) {
+	db := mirrorDB(t)
+	if err := db.Exec("CREATE TRIGGER reject_binding BEFORE UPDATE OF node_id ON devices WHEN NEW.node_id IS NOT NULL BEGIN SELECT RAISE(ABORT, 'reject binding'); END").Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewNodeRepo(db).EnsureForDevice(context.Background(), 1, "host"); err == nil {
+		t.Fatal("expected binding failure")
+	}
+	var count int64
+	if err := db.Model(&model.Node{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("failed binding left %d orphan nodes", count)
+	}
+}
+
+func TestEnsureForDeviceInvalidBinding(t *testing.T) {
+	for _, scenario := range []string{"missing-device", "deleted-device", "missing-node", "deleted-node", "wrong-type"} {
+		t.Run(scenario, func(t *testing.T) {
+			db := mirrorDB(t)
+			want := errs.ErrNotFound
+			query := "DELETE FROM devices WHERE id = 1"
+			var args []any
+			switch scenario {
+			case "deleted-device":
+				query = "UPDATE devices SET deleted_at = CURRENT_TIMESTAMP WHERE id = 1"
+			case "missing-node":
+				query = "UPDATE devices SET node_id = 999 WHERE id = 1"
+			case "deleted-node", "wrong-type":
+				node := model.Node{Type: "service", Name: "existing"}
+				if scenario == "deleted-node" {
+					node.Type = "device"
+				}
+				if err := db.Create(&node).Error; err != nil {
+					t.Fatal(err)
+				}
+				if scenario == "deleted-node" {
+					if err := db.Delete(&node).Error; err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					want = errs.ErrConflict
+				}
+				query = "UPDATE devices SET node_id = ? WHERE id = 1"
+				args = []any{node.ID}
+			}
+			if err := db.Exec(query, args...).Error; err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewNodeRepo(db).EnsureForDevice(context.Background(), 1, "host"); !errors.Is(err, want) {
+				t.Fatalf("got %v, want %v", err, want)
+			}
+		})
+	}
+}

--- a/internal/manager/data/topology/store/migrate.go
+++ b/internal/manager/data/topology/store/migrate.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -11,6 +12,7 @@ import (
 
 	model "github.com/ongridio/ongrid/internal/manager/model/topology"
 	"github.com/ongridio/ongrid/internal/pkg/dbx"
+	"github.com/ongridio/ongrid/internal/pkg/errs"
 )
 
 // Migrate registers nodes / relations / relation_types with GORM
@@ -84,12 +86,12 @@ func backfillDeviceNodes(db *gorm.DB) error {
 		if name == "" {
 			name = fmt.Sprintf("device-%d", d.ID)
 		}
-		n := &model.Node{Type: string(model.NodeTypeDevice), Name: name}
-		if err := db.Create(n).Error; err != nil {
+		if _, err := NewNodeRepo(db).EnsureForDevice(db.Statement.Context, d.ID, name); err != nil {
+			// 设备可能在扫描后被删除，无需再回填。
+			if errors.Is(err, errs.ErrNotFound) {
+				continue
+			}
 			return fmt.Errorf("backfill node for device %d: %w", d.ID, err)
-		}
-		if err := db.Exec("UPDATE devices SET node_id = ? WHERE id = ?", n.ID, d.ID).Error; err != nil {
-			return fmt.Errorf("backfill device.node_id for %d: %w", d.ID, err)
 		}
 	}
 	return nil

--- a/internal/manager/data/topology/store/node_repo.go
+++ b/internal/manager/data/topology/store/node_repo.go
@@ -124,3 +124,47 @@ func applyNodeFilter(q *gorm.DB, f biz.NodeListFilter) *gorm.DB {
 	}
 	return q
 }
+
+// EnsureForDevice 使用已有 devices.node_id 作为身份来源，不通过可变名称匹配。
+// 与回填共用事务，避免并发注册或回填产生孤立节点、覆盖已有绑定。
+func (r *NodeRepo) EnsureForDevice(ctx context.Context, deviceID uint64, name string) (*model.Node, error) {
+	var node model.Node
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 先获取写锁：MySQL 锁定设备行，SQLite 获取写事务锁，避免读后升级锁失败。
+		// 不改变字段值，也不触发 GORM 的 updated_at 更新。
+		if err := tx.Exec("UPDATE devices SET node_id = node_id WHERE id = ? AND deleted_at IS NULL", deviceID).Error; err != nil {
+			return err
+		}
+		var device struct {
+			ID     uint64
+			NodeID *uint64
+		}
+		if err := tx.Table("devices").Select("id, node_id").Where("id = ? AND deleted_at IS NULL", deviceID).Take(&device).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errs.ErrNotFound
+			}
+			return err
+		}
+		if device.NodeID != nil {
+			if err := tx.First(&node, *device.NodeID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return errs.ErrNotFound
+				}
+				return err
+			}
+			if node.Type != string(model.NodeTypeDevice) {
+				return errs.ErrConflict
+			}
+			return nil
+		}
+		node = model.Node{Type: string(model.NodeTypeDevice), Name: name}
+		if err := tx.Create(&node).Error; err != nil {
+			return err
+		}
+		return tx.Exec("UPDATE devices SET node_id = ? WHERE id = ?", node.ID, deviceID).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &node, nil
+}


### PR DESCRIPTION
## 问题与修复

Closes #357

不同设备的名称为 `VM-0-6-ubuntu` 和 `vm-0-6-ubuntu` 时，原先按名称忽略大小写查找节点，导致两个设备复用同一节点，触发 `devices.node_id` 唯一约束。现在按设备 ID 读取已有 `devices.node_id`，仅为尚未绑定的设备创建独立节点；完全同名的设备也保持独立。

节点创建与设备绑定在同一事务内完成，先通过设备行的无值变更 UPDATE 获取写锁，兼容 MySQL 行锁与 SQLite 写事务。历史回填使用相同事务路径，避免并发注册与回填覆盖绑定或遗留孤立节点。已有节点的 ID、名称、属性保持不变；缺失/已删除的关联节点和类型错误会返回错误，不擅自替换。没有 schema 或依赖变更。

## 验证

- 新增回归测试在原版明确失败：两个不同设备得到同一个节点 ID；修复后通过。
- 拓扑业务与仓储 `go test -race ... -count=10` 通过，覆盖名称大小写/完全同名、重命名幂等、保留历史节点、绑定失败回滚，以及 16 个并发注册/回填任务（文件 SQLite、WAL、多连接）。
- `make build` 通过。
- `make test-race`：129 个包通过，2 个包因已在原版复现的环境问题失败：容器 root 用户绕过权限限制的 `TestFileBundleResolverReportsInaccessibleBundle`；测试 DNS 为无效域名返回地址的 `TestProbeDNS_Execute_Unresolvable`。本次未运行独立 MySQL 集成测试。

回滚可直接 revert 本提交，无需数据库迁移。

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
