### PR TITLE
perf(flow): 并发探测并缓存 MCP 工具，减少编辑器加载阻塞

### DIFF
--- a/cmd/ongrid/flow_mcp.go
+++ b/cmd/ongrid/flow_mcp.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	aiopstools "github.com/ongridio/ongrid/internal/manager/biz/aiops/tools"
+	model "github.com/ongridio/ongrid/internal/manager/model/mcp"
+	"github.com/ongridio/ongrid/internal/pkg/mcpclient"
+)
+
+// flowMCPBackend 是流程工具发现和调用需要的 MCP 能力。
+type flowMCPBackend interface {
+	ListEnabled(context.Context) ([]*model.Server, error)
+	BuildClient(context.Context, *model.Server) (*mcpclient.Client, error)
+	CallTool(context.Context, string, string, map[string]any) (string, error)
+}
+
+const (
+	flowMCPProbeTimeout = 3 * time.Second
+	flowMCPCacheTTL     = 15 * time.Second
+	flowMCPConcurrency  = 4
+)
+
+type flowMCPCache struct {
+	mu         sync.Mutex
+	key        [32]byte
+	expires    time.Time
+	entries    []mcpEntry
+	refreshing chan struct{}
+}
+
+// enumerate 缓存成功与失败结果；每次检查配置，禁用或删除的服务立即消失。
+// 同时到达的调用等待同一次刷新，取消等待不会阻塞其他请求。
+func (m *flowMCPSource) enumerate(ctx context.Context) []mcpEntry {
+	if m == nil || m.uc == nil {
+		return nil
+	}
+	servers, err := m.uc.ListEnabled(ctx)
+	if err != nil {
+		return nil
+	}
+	encoded, err := json.Marshal(servers)
+	if err != nil {
+		return nil
+	}
+	key := sha256.Sum256(encoded)
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		m.cache.mu.Lock()
+		if m.cache.key == key && time.Now().Before(m.cache.expires) {
+			out := cloneMCPEntries(m.cache.entries)
+			m.cache.mu.Unlock()
+			return out
+		}
+		if pending := m.cache.refreshing; pending != nil {
+			m.cache.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-pending:
+				continue
+			}
+		}
+		m.cache.refreshing = make(chan struct{})
+		m.cache.mu.Unlock()
+		return m.refreshEntries(ctx, key, servers)
+	}
+}
+
+func (m *flowMCPSource) refreshEntries(ctx context.Context, key [32]byte, servers []*model.Server) []mcpEntry {
+	// 包括异常退出在内都唤醒等待者；不在网络 IO 期间持锁。
+	defer func() {
+		m.cache.mu.Lock()
+		close(m.cache.refreshing)
+		m.cache.refreshing = nil
+		m.cache.mu.Unlock()
+	}()
+	entries := m.discoverEntries(ctx, servers)
+	if ctx.Err() == nil {
+		m.cache.mu.Lock()
+		m.cache.key, m.cache.entries = key, cloneMCPEntries(entries)
+		m.cache.expires = time.Now().Add(flowMCPCacheTTL)
+		m.cache.mu.Unlock()
+	}
+	return entries
+}
+
+func (m *flowMCPSource) discoverEntries(ctx context.Context, servers []*model.Server) []mcpEntry {
+	// 每个任务写独立槽位，最后按配置顺序合并，结果不受响应先后影响。
+	results := make([][]mcpEntry, len(servers))
+	var group errgroup.Group
+	group.SetLimit(flowMCPConcurrency)
+	for i, srv := range servers {
+		if ctx.Err() != nil {
+			break
+		}
+		group.Go(func() error {
+			defer func() {
+				if p := recover(); p != nil && m.log != nil {
+					m.log.Error("flow mcp: discovery panic", slog.Any("panic", p))
+				}
+			}()
+			if ctx.Err() != nil {
+				return nil
+			}
+			cctx, cancel := context.WithTimeout(ctx, flowMCPProbeTimeout)
+			defer cancel()
+			cli, err := m.uc.BuildClient(cctx, srv)
+			if err == nil {
+				err = cli.Initialize(cctx)
+			}
+			var tools []mcpclient.Tool
+			if err == nil {
+				tools, err = cli.ListTools(cctx)
+			}
+			if err != nil {
+				if m.log != nil {
+					m.log.Warn("flow mcp: list failed, skipping server", slog.String("server", srv.Name), slog.Any("err", err))
+				}
+				return nil
+			}
+			for _, tool := range tools {
+				results[i] = append(results[i], mcpEntry{wire: aiopstools.MCPToolName(srv.Name, tool.Name), server: srv.Name, bare: tool.Name, desc: tool.Description, schema: tool.InputSchema})
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil
+	}
+	var out []mcpEntry
+	for _, entries := range results {
+		out = append(out, entries...)
+	}
+	return out
+}
+
+// JSON schema 是可变字节切片，不能向调用者暴露缓存中的引用。
+func cloneMCPEntries(entries []mcpEntry) []mcpEntry {
+	out := append([]mcpEntry(nil), entries...)
+	for i := range out {
+		out[i].schema = append(json.RawMessage(nil), out[i].schema...)
+	}
+	return out
+}

--- a/cmd/ongrid/flow_mcp_test.go
+++ b/cmd/ongrid/flow_mcp_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	model "github.com/ongridio/ongrid/internal/manager/model/mcp"
+	"github.com/ongridio/ongrid/internal/pkg/mcpclient"
+)
+
+type flowMCPFake struct {
+	servers []*model.Server
+	build   func(context.Context, *model.Server) (*mcpclient.Client, error)
+}
+
+func (f *flowMCPFake) ListEnabled(context.Context) ([]*model.Server, error) { return f.servers, nil }
+func (f *flowMCPFake) BuildClient(ctx context.Context, s *model.Server) (*mcpclient.Client, error) {
+	if f.build != nil {
+		return f.build(ctx, s)
+	}
+	return mcpclient.NewHTTP(s.Endpoint, nil, 0), nil
+}
+func (f *flowMCPFake) CallTool(context.Context, string, string, map[string]any) (string, error) {
+	return "", fmt.Errorf("unexpected call")
+}
+
+func mcpTestServer(t *testing.T, probes *atomic.Int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Error(err)
+			return
+		}
+		if req.Method == "notifications/initialized" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var result any = map[string]any{}
+		if req.Method == "tools/list" {
+			probes.Add(1)
+			result = map[string]any{"tools": []mcpclient.Tool{{Name: "list", InputSchema: json.RawMessage(`{"type":"object"}`)}}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result}); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFlowMCPDiscoveryCachesTools(t *testing.T) {
+	var probes atomic.Int32
+	srv := mcpTestServer(t, &probes)
+	source := &flowMCPSource{uc: &flowMCPFake{servers: []*model.Server{{Name: "test", Endpoint: srv.URL}}}}
+	for i := 0; i < 2; i++ {
+		if got := source.enumerate(context.Background()); len(got) != 1 {
+			t.Fatalf("tools: %+v", got)
+		}
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probes=%d, want cached single probe", got)
+	}
+}
+
+func TestFlowMCPDiscoveryParallel(t *testing.T) {
+	var probes atomic.Int32
+	srv := mcpTestServer(t, &probes)
+	entered := make(chan struct{}, 2)
+	backend := &flowMCPFake{servers: []*model.Server{{Name: "one", Endpoint: srv.URL}, {Name: "two", Endpoint: srv.URL}}}
+	backend.build = func(ctx context.Context, s *model.Server) (*mcpclient.Client, error) {
+		entered <- struct{}{}
+		for len(entered) < 2 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				time.Sleep(time.Millisecond)
+			}
+		}
+		return mcpclient.NewHTTP(s.Endpoint, nil, 0), nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got := (&flowMCPSource{uc: backend}).enumerate(ctx)
+	if len(got) != 2 {
+		t.Fatalf("parallel discovery returned %d tools, want 2", len(got))
+	}
+}
+
+func TestFlowMCPCacheInvalidationAndIsolation(t *testing.T) {
+	var probes atomic.Int32
+	srv := mcpTestServer(t, &probes)
+	backend := &flowMCPFake{servers: []*model.Server{{Name: "old", Endpoint: srv.URL}}}
+	source := &flowMCPSource{uc: backend}
+	ctx := context.Background()
+	first := source.enumerate(ctx)
+	first[0].schema[0] = '!'
+	if got := source.enumerate(ctx); !json.Valid(got[0].schema) {
+		t.Fatal("caller mutated cached schema")
+	}
+	backend.servers[0].Name = "new"
+	if got := source.enumerate(ctx); len(got) != 1 || got[0].server != "new" {
+		t.Fatalf("stale config: %+v", got)
+	}
+	source.cache.mu.Lock()
+	source.cache.expires = time.Time{}
+	source.cache.mu.Unlock()
+	source.enumerate(ctx)
+	if got := probes.Load(); got != 3 {
+		t.Fatalf("probes=%d, want 3", got)
+	}
+	backend.servers = nil
+	if got := source.enumerate(ctx); len(got) != 0 {
+		t.Fatalf("removed server still visible: %+v", got)
+	}
+}
+
+func TestFlowMCPFailureCacheAndCancellation(t *testing.T) {
+	var builds atomic.Int32
+	backend := &flowMCPFake{servers: []*model.Server{{Name: "offline"}}}
+	backend.build = func(ctx context.Context, _ *model.Server) (*mcpclient.Client, error) {
+		builds.Add(1)
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > flowMCPProbeTimeout {
+			t.Error("missing discovery timeout")
+		}
+		return nil, fmt.Errorf("offline")
+	}
+	source := &flowMCPSource{uc: backend}
+	source.enumerate(context.Background())
+	source.enumerate(context.Background())
+	if builds.Load() != 1 {
+		t.Fatal("failed discovery was not cached")
+	}
+	source.cache.mu.Lock()
+	source.cache.expires = time.Time{}
+	source.cache.mu.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	source.enumerate(ctx)
+	source.enumerate(context.Background())
+	if builds.Load() != 2 {
+		t.Fatal("canceled discovery polluted the cache")
+	}
+}
+
+func TestFlowMCPConcurrentReaders(t *testing.T) {
+	var probes, builds atomic.Int32
+	srv := mcpTestServer(t, &probes)
+	backend := &flowMCPFake{servers: []*model.Server{{Name: "shared", Endpoint: srv.URL}}}
+	entered, release := make(chan struct{}), make(chan struct{})
+	backend.build = func(ctx context.Context, s *model.Server) (*mcpclient.Client, error) {
+		if builds.Add(1) == 1 {
+			close(entered)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+		}
+		return mcpclient.NewHTTP(s.Endpoint, nil, 0), nil
+	}
+	source := &flowMCPSource{uc: backend}
+	var group errgroup.Group
+	for i := 0; i < 16; i++ {
+		group.Go(func() (err error) {
+			defer func() {
+				if p := recover(); p != nil {
+					err = fmt.Errorf("panic: %v", p)
+				}
+			}()
+			if got := source.enumerate(context.Background()); len(got) != 1 {
+				return fmt.Errorf("tools=%d", len(got))
+			}
+			return nil
+		})
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+	// 刷新进行中，取消的等待者应立即返回，不取消共享探测。
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := source.enumerate(ctx); len(got) != 0 {
+		t.Error("canceled waiter returned tools")
+	}
+	close(release)
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if builds.Load() != 1 || probes.Load() != 1 {
+		t.Fatalf("duplicate discovery: builds=%d probes=%d", builds.Load(), probes.Load())
+	}
+}
+
+func TestFlowMCPConcurrencyLimitAndPartialResults(t *testing.T) {
+	var probes, active, maximum atomic.Int32
+	srv := mcpTestServer(t, &probes)
+	backend := &flowMCPFake{}
+	for i := 0; i < 12; i++ {
+		backend.servers = append(backend.servers, &model.Server{Name: fmt.Sprintf("server-%d", i), Endpoint: srv.URL})
+	}
+	backend.build = func(ctx context.Context, s *model.Server) (*mcpclient.Client, error) {
+		n := active.Add(1)
+		defer active.Add(-1)
+		for old := maximum.Load(); n > old; old = maximum.Load() {
+			if maximum.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		if s.Name == "server-0" {
+			return nil, fmt.Errorf("offline")
+		}
+		return mcpclient.NewHTTP(s.Endpoint, nil, 0), nil
+	}
+	got := (&flowMCPSource{uc: backend}).enumerate(context.Background())
+	if len(got) != 11 {
+		t.Fatalf("healthy tools=%d, want 11", len(got))
+	}
+	if maximum.Load() > flowMCPConcurrency {
+		t.Fatalf("concurrency=%d", maximum.Load())
+	}
+	for i, e := range got {
+		if want := fmt.Sprintf("server-%d", i+1); e.server != want {
+			t.Fatalf("unstable order: %s, want %s", e.server, want)
+		}
+	}
+}

--- a/cmd/ongrid/main.go
+++ b/cmd/ongrid/main.go
@@ -5131,14 +5131,11 @@ func coerceValue(v any, typ string) (any, bool) {
 	return v, false
 }
 
-// flowMCPSource live-queries the registered MCP servers (HLD-018) so the flow
-// tool palette and the `tool` node always reflect the CURRENT tool universe —
-// add/remove a server and it shows up / drops out without a restart (n8n's
-// McpClient live-listSearch pattern). MCP tools carry a JSON inputSchema, so
-// they are first-class deterministic nodes (skills, lacking a schema, are not).
+// flowMCPSource 为流程工具面板提供有界并发发现和短期缓存，调用时仍实时校验。
 type flowMCPSource struct {
-	uc  *managerbizmcp.Usecase
-	log *slog.Logger
+	uc    flowMCPBackend
+	log   *slog.Logger
+	cache flowMCPCache
 }
 
 // mcpEntry is one live MCP tool: its wire name + the (server, bareTool) needed
@@ -5149,47 +5146,6 @@ type mcpEntry struct {
 	bare   string
 	desc   string
 	schema json.RawMessage
-}
-
-// enumerate connects to every enabled server and lists its tools. Best-effort:
-// an unreachable server is logged and skipped (degradation, not a hard fail).
-func (m *flowMCPSource) enumerate(ctx context.Context) []mcpEntry {
-	if m == nil || m.uc == nil {
-		return nil
-	}
-	servers, err := m.uc.ListEnabled(ctx)
-	if err != nil {
-		return nil
-	}
-	var out []mcpEntry
-	for _, srv := range servers {
-		cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		cli, berr := m.uc.BuildClient(cctx, srv)
-		if berr == nil {
-			berr = cli.Initialize(cctx)
-		}
-		var tools []mcpclient.Tool
-		if berr == nil {
-			tools, berr = cli.ListTools(cctx)
-		}
-		cancel()
-		if berr != nil {
-			if m.log != nil {
-				m.log.Warn("flow mcp: list failed, skipping server", slog.String("server", srv.Name), slog.Any("err", berr))
-			}
-			continue
-		}
-		for _, t := range tools {
-			out = append(out, mcpEntry{
-				wire:   aiopstools.MCPToolName(srv.Name, t.Name),
-				server: srv.Name,
-				bare:   t.Name,
-				desc:   t.Description,
-				schema: t.InputSchema,
-			})
-		}
-	}
-	return out
 }
 
 // metas returns the live MCP tools as flow palette entries.
@@ -5649,8 +5605,8 @@ func (s flowNotifierShim) Notify(ctx context.Context, channelIDs []uint64, title
 // registry — surfaces every registered BaseTool to the canvas palette so
 // each becomes a draggable, form-driven `tool` node. Rebuilds the bag per
 // call (cheap, low-frequency: editor load) so newly registered tools show
-// up without a restart. mcp (optional) live-queries the registered MCP
-// servers each call so their tools appear/disappear without a restart too.
+// up without a restart. MCP discovery uses a short TTL cache; server
+// configuration changes invalidate it immediately.
 type flowToolCatalog struct {
 	reg *aiopstools.Registry
 	mcp *flowMCPSource


### PR DESCRIPTION
## 问题与行为

Refs #352（本 PR 处理工具列表加载延迟部分）

保留不可达的 MCP 服务时，每次打开流程编辑器都串行探测所有服务，单服务最多等待 10 秒。现在最多并发探测 4 个服务，单服务预算为 3 秒，成功和失败的发现结果都缓存 15 秒；同时加载的请求共享一次刷新。

每次请求仍读取已启用的服务配置，用配置摘要校验缓存，因此新增、改名、修改连接配置、禁用或删除服务无需等待 TTL。远端工具集合变化及离线服务恢复最多在缓存过期后的下一次查询体现。结果按服务配置顺序返回，失败服务不影响其他服务的工具；schema 深拷贝避免调用者修改共享缓存。取消的刷新不写缓存，等待者可独立取消。

这不是整个请求固定 3 秒的承诺：超过 4 个服务时按有界并发分批探测。流程实际工具调用仍实时检查服务及工具，不使用发现缓存执行。未新增依赖、数据库变更或 API 字段。

## 验证

- 新增缓存和并行回归测试在原串行实现上均失败，修复后通过。
- `go test -race ./cmd/ongrid -run TestFlowMCP -count=10` 通过，覆盖重复请求、16 个并发读取、配置变化、缓存过期、schema 隔离、失败缓存、取消、部分失败和结果顺序。
- `make build` 通过。
- `make test-race`：129 个包通过；仍有两个已在未修改主分支复现的环境失败：容器 root 权限导致 `TestFileBundleResolverReportsInaccessibleBundle` 失败，以及 DNS 为无效域名返回地址导致 `TestProbeDNS_Execute_Unresolvable` 失败。

## 范围与回滚

Issue 中的页面不可达提示及超时可配置项不在本次改动中，因此仅关联 Issue，不自动关闭。回滚可直接 revert 本提交。

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
