### PR TITLE
fix(web): 修复历史工具调用失败状态显示为成功

### DIFF
--- a/web/src/components/MessageBubble.toolStatus.test.tsx
+++ b/web/src/components/MessageBubble.toolStatus.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MessageBubble } from './MessageBubble';
+import type { ChatMessage } from '@/api/chat';
+import { setLocale } from '@/i18n/locale';
+
+afterEach(() => { cleanup(); setLocale('zh-CN'); });
+
+const toolName = 'mcp__iomp__iomp_read_ssh_start';
+function history(result: unknown): ChatMessage {
+  return { id: 'history', role: 'tool', tool_name: toolName,
+    content: typeof result === 'string' ? result : JSON.stringify(result) };
+}
+function icon() {
+  return screen.getByRole('button', { name: '工具调用 ' + toolName }).querySelector('svg');
+}
+
+describe('工具调用状态在实时结果和历史加载间保持一致', () => {
+  it('批次部分失败在重新加载后仍为红色', () => {
+    const result = { ok: false, data: { status: 'failed', done: true,
+      commands: [{ status: 'succeeded', exit_status: 0 }, { status: 'failed', exit_status: 127 }] } };
+    const view = render(<MessageBubble message={{ id: 'live', role: 'tool', kind: 'tool_card',
+      tool_call: { name: toolName, status: 'error', result } }} />);
+    expect(icon()).toHaveClass('text-red-400');
+    view.rerender(<MessageBubble message={history(result)} />);
+    expect(icon()).toHaveClass('text-red-400');
+    expect(screen.getByText('失败')).toBeInTheDocument();
+  });
+  it('调用成功返回业务失败也显示红色', () => {
+    render(<MessageBubble message={{ id: 'live', role: 'tool', kind: 'tool_card',
+      tool_call: { name: toolName, status: 'success', result: { ok: false } } }} />);
+    expect(icon()).toHaveClass('text-red-400');
+  });
+  it.each([{ error: 'connection refused' }, { isError: true }, { status: 'failed' },
+    { status: 'timeout' }, { exit_code: 1 }, { exit_status: 127 }])('历史失败结果 %j', (result) => {
+    render(<MessageBubble message={history(result)} />);
+    expect(icon()).toHaveClass('text-red-400');
+  });
+  it('成功结果中的业务告警不会被递归误判', () => {
+    render(<MessageBubble message={history({ ok: true, data: { status: 'failed', error: 'alarm' } })} />);
+    expect(icon()).toHaveClass('text-emerald-400');
+  });
+  it.each(['plain output', '{invalid', {}, null])('状态不明的旧结果不显示绿勾 %j', (result) => {
+    render(<MessageBubble message={history(result)} />);
+    expect(icon()).not.toHaveClass('text-emerald-400');
+    expect(screen.getByText('状态未知')).toBeInTheDocument();
+  });
+  it('未完成的实时调用继续显示运行中', () => {
+    render(<MessageBubble message={{ id: 'live', role: 'tool', kind: 'tool_card',
+      tool_call: { name: toolName, status: 'pending' } }} />);
+    expect(screen.getByText('运行中')).toBeInTheDocument();
+  });
+  it('显式错误优先于成功结果', () => {
+    render(<MessageBubble message={{ id: 'live', role: 'tool', kind: 'tool_card',
+      tool_call: { name: toolName, status: 'success', error: 'transport failed', result: { ok: true } } }} />);
+    expect(icon()).toHaveClass('text-red-400');
+  });
+});

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import { Hint } from '@/components/ui/Tooltip';
 import { useState, useEffect } from 'react';
+import { resolveToolStatus } from '@/lib/toolStatus';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -212,7 +213,7 @@ function ToolBubble({ message, onConfirmConfigDraft, hideActiveOperations }: Pro
       onConfirmConfigDraft={onConfirmConfigDraft}
       call={{
         name: message.tool_name ?? 'tool',
-        status: 'success',
+        // 历史消息没有执行状态，仅从明确的结果字段恢复。
         result,
       }}
       hideActiveOperations={hideActiveOperations}
@@ -239,7 +240,7 @@ function ToolCallSummaryBlock({
 	}) {
   const { tr } = useI18n();
   const [open, setOpen] = useState(false);
-  const status = call.status ?? (call.error ? 'error' : 'success');
+  const status = resolveToolStatus(call);
   const isPending = status === 'pending';
   const isError = status === 'error' || status === 'timeout' || !!call.error;
   const hint = argSummary(call.arguments);
@@ -286,6 +287,7 @@ function ToolCallSummaryBlock({
           {typeof call.duration_ms === 'number' && call.duration_ms > 0 && (
             <span>{formatDuration(call.duration_ms)}</span>
           )}
+          {status === 'unknown' && <span className="text-zinc-500">{tr('状态未知', 'Status unknown')}</span>}
           {isPending && <span className="text-blue-400">{tr('运行中', 'Running')}</span>}
           {isError && <span className="text-red-400">{tr('失败', 'Failed')}</span>}
           {open ? (
@@ -872,7 +874,8 @@ function StatusIcon({ status }: { status?: string }) {
   if (status === 'error' || status === 'timeout') {
     return <AlertCircle size={13} className="text-red-400" />;
   }
-  return <CheckCircle2 size={13} className="text-emerald-400" />;
+  if (status === 'success') return <CheckCircle2 size={13} className="text-emerald-400" />;
+  return <AlertCircle size={13} className="text-zinc-500" />;
 }
 
 // argSummary picks a compact one-line preview from the arguments object.

--- a/web/src/lib/toolStatus.ts
+++ b/web/src/lib/toolStatus.ts
@@ -1,0 +1,27 @@
+// 仅识别工具结果的顶层状态，不递归扫描查询返回的业务数据。
+type ToolStatus = 'pending' | 'success' | 'error' | 'timeout' | 'unknown';
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown> : undefined;
+}
+
+export function resolveToolStatus(call: { status?: string; error?: string; result?: unknown }): ToolStatus {
+  if (call.status === 'timeout') return 'timeout';
+  if (call.status === 'error' || call.error) return 'error';
+  if (call.status === 'pending') return 'pending';
+
+  const result = record(call.result);
+  if (result) {
+    if (result.status === 'timeout') return 'timeout';
+    if (result.ok === false || result.isError === true ||
+        result.status === 'error' || result.status === 'failed' ||
+        (typeof result.error === 'string' && result.error.trim() !== '') ||
+        record(result.error) ||
+        (typeof result.exit_code === 'number' && result.exit_code !== 0) ||
+        (typeof result.exit_status === 'number' && result.exit_status !== 0)) return 'error';
+    if (result.ok === true || result.status === 'success' || result.status === 'succeeded' ||
+        result.exit_code === 0 || result.exit_status === 0) return 'success';
+  }
+  return call.status === 'success' ? 'success' : 'unknown';
+}


### PR DESCRIPTION
## Summary

修复工具调用实时显示失败，但切换会话或刷新后变为绿色成功状态的问题。原因是历史工具卡片将状态固定为 `success`。

- 统一实时与历史卡片的状态判断，识别明确的失败标志和非零退出码。
- 保留显式错误、超时和运行中状态。
- 无法判断状态的历史结果显示灰色“状态未知”。
- 仅检查结果顶层字段，避免将查询返回的业务告警误判为调用失败。

本次仅涉及前端显示和回归测试，不修改工具执行逻辑。

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
