### PR TITLE
ci(web): serialize DOM-heavy test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,9 @@ jobs:
         run: npm ci
 
       - name: Test
+        # Keep DOM-heavy suites from competing for CPU within their test timeouts.
         run: >-
-          npm test -- --run
+          npm test -- --run --no-file-parallelism
           src/api/apm.test.ts
           src/components/apm
           src/pages/Apm


### PR DESCRIPTION
## Summary

Run frontend CI test files serially with Vitest's `--no-file-parallelism`. After the APM suites joined CI, the Kubernetes filtered Pod pagination test exceeded its 5-second timeout in two consecutive main runs (34567369360 and 34568011159), while the same code passed PR checks. Running DOM-heavy suites one file at a time avoids CPU contention without increasing timeouts or removing assertions.

## Validation

- Ran the exact updated CI test command locally: 132 tests across 21 files passed in 84.41 seconds, including all 38 Kubernetes tests.
- `git diff --check` passed. No application code changed.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md
