### PR TITLE
fix(flow): match alert triggers by rule key or name

### DIFF
--- a/internal/manager/biz/alert/usecase.go
+++ b/internal/manager/biz/alert/usecase.go
@@ -68,7 +68,7 @@ type Investigator interface {
 // implicitly satisfies it. main.go injects.
 type WorkflowDispatcher interface {
 	// OnAlertFired MUST be non-blocking (same contract as Investigator).
-	OnAlertFired(incidentID uint64, rule, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time)
+	OnAlertFired(incidentID uint64, ruleKey, ruleName, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time)
 }
 
 // RuleCacheRefresher makes persisted rule migrations visible to the running
@@ -500,7 +500,7 @@ func (u *Usecase) RecordFiring(ctx context.Context, in FiringInput) (*FiringResu
 			_ = json.Unmarshal([]byte(incident.LabelsJSON), &labels)
 		}
 		// edge_id == device_id 1:1 post entity-split (see model comment).
-		u.workflowDispatcher.OnAlertFired(incident.ID, incident.RuleName, incident.Severity, devID, devID, labels, occurredAt)
+		u.workflowDispatcher.OnAlertFired(incident.ID, incident.Rule, incident.RuleName, incident.Severity, devID, devID, labels, occurredAt)
 	}
 
 	return &FiringResult{

--- a/internal/manager/biz/flow/dispatcher.go
+++ b/internal/manager/biz/flow/dispatcher.go
@@ -35,14 +35,14 @@ func NewDispatcher(uc *Usecase, log *slog.Logger) *Dispatcher {
 // OnAlertFired is non-blocking — the firing path can't wait on flow
 // execution. Scans + triggers on a detached goroutine. Signature matches
 // biz/alert.WorkflowDispatcher.
-func (d *Dispatcher) OnAlertFired(incidentID uint64, rule, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time) {
+func (d *Dispatcher) OnAlertFired(incidentID uint64, ruleKey, ruleName, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time) {
 	if d == nil || d.uc == nil {
 		return
 	}
-	go d.dispatch(incidentID, rule, severity, edgeID, deviceID, labels, firedAt)
+	go d.dispatch(incidentID, ruleKey, ruleName, severity, edgeID, deviceID, labels, firedAt)
 }
 
-func (d *Dispatcher) dispatch(incidentID uint64, rule, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time) {
+func (d *Dispatcher) dispatch(incidentID uint64, ruleKey, ruleName, severity string, edgeID, deviceID uint64, labels map[string]string, firedAt time.Time) {
 	ctx := context.Background()
 	flows, err := d.uc.ListEnabledFlows(ctx)
 	if err != nil {
@@ -51,7 +51,7 @@ func (d *Dispatcher) dispatch(incidentID uint64, rule, severity string, edgeID, 
 	}
 	payload := map[string]any{
 		"incident_id": incidentID,
-		"rule":        rule,
+		"rule":        ruleName,
 		"severity":    severity,
 		"edge_id":     edgeID,
 		"device_id":   deviceID,
@@ -67,7 +67,7 @@ func (d *Dispatcher) dispatch(incidentID uint64, rule, severity string, edgeID, 
 			if t.Type != NodeTriggerAlert {
 				continue
 			}
-			if !alertMatches(t.Config, rule, severity) {
+			if !alertMatches(t.Config, ruleKey, ruleName, severity) {
 				continue
 			}
 			if _, err := d.uc.TriggerEvent(ctx, f.ID, NodeTriggerAlert, payload); err != nil {
@@ -82,20 +82,21 @@ func (d *Dispatcher) dispatch(incidentID uint64, rule, severity string, edgeID, 
 
 // alertTriggerConfig is the trigger.alert_fired node's config.
 type alertTriggerConfig struct {
-	Rule        string `json:"rule"`         // optional: case-insensitive substring on rule name
+	Rule        string `json:"rule"`         // optional: case-insensitive substring on rule key or display name
 	MinSeverity string `json:"min_severity"` // optional: warning / error / critical
 }
 
 // severityRank orders severities for the min_severity gate.
 var severityRank = map[string]int{"info": 0, "warning": 1, "error": 2, "critical": 3}
 
-func alertMatches(cfgRaw json.RawMessage, rule, severity string) bool {
+func alertMatches(cfgRaw json.RawMessage, ruleKey, ruleName, severity string) bool {
 	var cfg alertTriggerConfig
 	if len(cfgRaw) > 0 {
 		_ = json.Unmarshal(cfgRaw, &cfg)
 	}
 	if want := strings.TrimSpace(cfg.Rule); want != "" {
-		if !strings.Contains(strings.ToLower(rule), strings.ToLower(want)) {
+		want = strings.ToLower(want)
+		if !strings.Contains(strings.ToLower(ruleKey), want) && !strings.Contains(strings.ToLower(ruleName), want) {
 			return false
 		}
 	}

--- a/internal/manager/biz/flow/dispatcher_test.go
+++ b/internal/manager/biz/flow/dispatcher_test.go
@@ -15,23 +15,25 @@ func TestAlertMatches(t *testing.T) {
 	cases := []struct {
 		name     string
 		cfg      json.RawMessage
-		rule     string
+		ruleKey  string
+		ruleName string
 		severity string
 		want     bool
 	}{
-		{"blank config matches anything", json.RawMessage(`{}`), "disk full", "warning", true},
-		{"nil config matches anything", nil, "cpu high", "info", true},
-		{"rule substring case-insensitive", cfg("DISK", ""), "node disk full", "warning", true},
-		{"rule substring miss", cfg("network", ""), "disk full", "critical", false},
-		{"min severity met", cfg("", "error"), "x", "critical", true},
-		{"min severity exact", cfg("", "error"), "x", "error", true},
-		{"min severity below", cfg("", "error"), "x", "warning", false},
-		{"unknown severity below gate", cfg("", "warning"), "x", "bogus", false},
-		{"both gates pass", cfg("disk", "error"), "disk full", "critical", true},
-		{"rule passes severity fails", cfg("disk", "critical"), "disk full", "error", false},
+		{"blank config matches anything", json.RawMessage(`{}`), "disk_full", "Disk Full", "warning", true},
+		{"nil config matches anything", nil, "cpu_high", "CPU High", "info", true},
+		{"rule key substring case-insensitive", cfg("DOWN_JOHN", ""), "redis_down_john", "Redis Down (John)", "warning", true},
+		{"rule name substring case-insensitive", cfg("REDIS DOWN", ""), "redis_down_john", "Redis Down (John)", "critical", true},
+		{"rule substring miss", cfg("network", ""), "disk_full", "Disk Full", "critical", false},
+		{"min severity met", cfg("", "error"), "x", "X", "critical", true},
+		{"min severity exact", cfg("", "error"), "x", "X", "error", true},
+		{"min severity below", cfg("", "error"), "x", "X", "warning", false},
+		{"unknown severity below gate", cfg("", "warning"), "x", "X", "bogus", false},
+		{"both gates pass", cfg("disk_full", "error"), "disk_full", "Disk Full", "critical", true},
+		{"rule passes severity fails", cfg("disk", "critical"), "disk_full", "Disk Full", "error", false},
 	}
 	for _, c := range cases {
-		if got := alertMatches(c.cfg, c.rule, c.severity); got != c.want {
+		if got := alertMatches(c.cfg, c.ruleKey, c.ruleName, c.severity); got != c.want {
 			t.Errorf("%s: alertMatches = %v, want %v", c.name, got, c.want)
 		}
 	}


### PR DESCRIPTION
## Summary

- Pass both the canonical alert rule key and display name to the flow dispatcher.
- Match trigger.alert_fired rule filters against either value while preserving case-insensitive substring and minimum-severity behavior.
- Keep the existing trigger payload compatible and add regression coverage for rule keys that differ from display names.

Fixes #410

## Testing

- go test ./internal/manager/biz/flow ./internal/manager/biz/alert -count=1
- go vet ./internal/manager/biz/flow ./internal/manager/biz/alert
- go test ./... was run locally; unrelated Windows-specific tests require Unix tools, symlink/file permission support, or ONNX build constraints.

## Author confirmation

- [x] I have read and agree to the project contribution guide. Guide: https://github.com/ongridio/ongrid/blob/main/CONTRIBUTING.md